### PR TITLE
✨ feat: support GLM-5.3-Flash

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -106,6 +106,7 @@
   "dashboard.task.viewAll": "View all",
   "homePromoBanner.cta": "Try now",
   "homePromoBanner.dismiss": "Dismiss",
+  "homePromoBanner.glm53FlashReveal": "Ox Alpha revealed as GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} is now available",
   "inbox.author.scheduled": "Scheduled",
   "inbox.error.title": "Run failed",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -106,7 +106,7 @@
   "dashboard.task.viewAll": "View all",
   "homePromoBanner.cta": "Try now",
   "homePromoBanner.dismiss": "Dismiss",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha revealed as GLM-5.3-Flash",
+  "homePromoBanner.glm53FlashReveal": "Ox Alpha unmasked: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} is now available",
   "inbox.author.scheduled": "Scheduled",
   "inbox.error.title": "Run failed",

--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -834,6 +834,7 @@
   "lobehub.gemini-3.7-flash.description": "Gemini 3.7 Flash is Google's most capable Flash model, built for complex coding, agentic workflows, and reliable multi-step execution.",
   "lobehub.glm-5.1.description": "Zai's latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. Excels at long-horizon tasks with autonomous work up to 8 hours, an ideal foundation for Autonomous Agents and long-horizon Coding Agents.",
   "lobehub.glm-5.2.description": "GLM-5.2 is the first open-source model to approach the performance of the latest-generation Claude Opus released in the same period.",
+  "lobehub.glm-5.3-flash.description": "GLM-5.3-Flash brings frontier intelligence, native vision, and a 1M-token context window at roughly one-tenth the price of flagship models.",
   "lobehub.glm-5.3.description": "Z.ai's latest flagship. Same base as GLM-5.2 with scaled post-training — 50% stronger coding, open-source SOTA on Terminal Bench 3.0, and a large jump in cyber capability. Thinking is always on.",
   "lobehub.gpt-4-turbo.description": "GPT-4 Turbo is a cost-effective multimodal model that balances accuracy and efficiency for real-time tasks.",
   "lobehub.gpt-4.1-mini.description": "GPT-4.1 mini balances intelligence, speed, and cost, making it attractive for many use cases.",

--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -834,7 +834,7 @@
   "lobehub.gemini-3.7-flash.description": "Gemini 3.7 Flash is Google's most capable Flash model, built for complex coding, agentic workflows, and reliable multi-step execution.",
   "lobehub.glm-5.1.description": "Zai's latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. Excels at long-horizon tasks with autonomous work up to 8 hours, an ideal foundation for Autonomous Agents and long-horizon Coding Agents.",
   "lobehub.glm-5.2.description": "GLM-5.2 is the first open-source model to approach the performance of the latest-generation Claude Opus released in the same period.",
-  "lobehub.glm-5.3-flash.description": "GLM-5.3-Flash brings frontier intelligence, native vision, and a 1M-token context window at roughly one-tenth the price of flagship models.",
+  "lobehub.glm-5.3-flash.description": "The first GLM-5 that can see — stronger than GLM-5.2, coding that approaches Opus 4.8, at about one-tenth the flagship price.",
   "lobehub.glm-5.3.description": "Z.ai's latest flagship. Same base as GLM-5.2 with scaled post-training — 50% stronger coding, open-source SOTA on Terminal Bench 3.0, and a large jump in cyber capability. Thinking is always on.",
   "lobehub.gpt-4-turbo.description": "GPT-4 Turbo is a cost-effective multimodal model that balances accuracy and efficiency for real-time tasks.",
   "lobehub.gpt-4.1-mini.description": "GPT-4.1 mini balances intelligence, speed, and cost, making it attractive for many use cases.",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -106,6 +106,7 @@
   "dashboard.task.viewAll": "查看全部",
   "homePromoBanner.cta": "立即体验",
   "homePromoBanner.dismiss": "关闭",
+  "homePromoBanner.glm53FlashReveal": "Ox Alpha 正式揭晓：GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} 现已上线",
   "inbox.author.scheduled": "定时触发",
   "inbox.error.title": "运行失败",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -106,7 +106,7 @@
   "dashboard.task.viewAll": "查看全部",
   "homePromoBanner.cta": "立即体验",
   "homePromoBanner.dismiss": "关闭",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha 正式揭晓：GLM-5.3-Flash",
+  "homePromoBanner.glm53FlashReveal": "Ox Alpha 现真身：GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} 现已上线",
   "inbox.author.scheduled": "定时触发",
   "inbox.error.title": "运行失败",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -834,6 +834,7 @@
   "lobehub.gemini-3.7-flash.description": "Gemini 3.7 Flash 是 Google 最强的 Flash 模型，面向复杂编程、智能体工作流和可靠的多步执行。",
   "lobehub.glm-5.1.description": "Zai 的最新旗舰模型，在整体和编码能力上与 Claude Opus 4.6 对齐。擅长长时间任务，支持长达 8 小时的自主工作，是自主代理和长时间编码代理的理想基础。",
   "lobehub.glm-5.2.description": "GLM-5.2 是首个接近同期发布的最新一代 Claude Opus 性能的开源模型。",
+  "lobehub.glm-5.3-flash.description": "GLM-5.3-Flash 以约旗舰模型十分之一的价格，提供前沿智能、原生视觉能力与 1M 上下文窗口。",
   "lobehub.glm-5.3.description": "Z.ai 的最新旗舰产品。与 GLM-5.2 具有相同的基础，但经过扩展的后训练——编码能力提升 50%，在 Terminal Bench 3.0 上达到开源 SOTA，并在网络能力方面有显著提升。思维始终在线。",
   "lobehub.gpt-4-turbo.description": "GPT-4 Turbo 是一个成本效益高的多模态模型，在实时任务中平衡了准确性和效率。",
   "lobehub.gpt-4.1-mini.description": "GPT-4.1 mini 在智能、速度与成本之间实现平衡，适用于多种场景。",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -834,7 +834,7 @@
   "lobehub.gemini-3.7-flash.description": "Gemini 3.7 Flash 是 Google 最强的 Flash 模型，面向复杂编程、智能体工作流和可靠的多步执行。",
   "lobehub.glm-5.1.description": "Zai 的最新旗舰模型，在整体和编码能力上与 Claude Opus 4.6 对齐。擅长长时间任务，支持长达 8 小时的自主工作，是自主代理和长时间编码代理的理想基础。",
   "lobehub.glm-5.2.description": "GLM-5.2 是首个接近同期发布的最新一代 Claude Opus 性能的开源模型。",
-  "lobehub.glm-5.3-flash.description": "GLM-5.3-Flash 以约旗舰模型十分之一的价格，提供前沿智能、原生视觉能力与 1M 上下文窗口。",
+  "lobehub.glm-5.3-flash.description": "GLM-5 系列第一款能看图的模型。比 GLM-5.2 更强，编码逼近 Opus 4.8，价格却只有旗舰的十分之一。",
   "lobehub.glm-5.3.description": "Z.ai 的最新旗舰产品。与 GLM-5.2 具有相同的基础，但经过扩展的后训练——编码能力提升 50%，在 Terminal Bench 3.0 上达到开源 SOTA，并在网络能力方面有显著提升。思维始终在线。",
   "lobehub.gpt-4-turbo.description": "GPT-4 Turbo 是一个成本效益高的多模态模型，在实时任务中平衡了准确性和效率。",
   "lobehub.gpt-4.1-mini.description": "GPT-4.1 mini 在智能、速度与成本之间实现平衡，适用于多种场景。",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -48,7 +48,7 @@ export default {
   'cardBindingPromoBanner.label': 'Add your first payment method and get 1M credits free',
   'homePromoBanner.cta': 'Try now',
   'homePromoBanner.dismiss': 'Dismiss',
-  'homePromoBanner.glm53FlashReveal': 'Ox Alpha revealed as GLM-5.3-Flash',
+  'homePromoBanner.glm53FlashReveal': 'Ox Alpha unmasked: GLM-5.3-Flash',
   'homePromoBanner.label': '{{model}} is now available',
   'dashboard.chat.empty': 'No recent conversations',
   'dashboard.chat.recents': 'Recent topics',

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -48,6 +48,7 @@ export default {
   'cardBindingPromoBanner.label': 'Add your first payment method and get 1M credits free',
   'homePromoBanner.cta': 'Try now',
   'homePromoBanner.dismiss': 'Dismiss',
+  'homePromoBanner.glm53FlashReveal': 'Ox Alpha revealed as GLM-5.3-Flash',
   'homePromoBanner.label': '{{model}} is now available',
   'dashboard.chat.empty': 'No recent conversations',
   'dashboard.chat.recents': 'Recent topics',

--- a/packages/locales/src/lobehubOnlineModelDescriptions.test.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.test.ts
@@ -12,6 +12,7 @@ const addedDescriptionKeys = [
   'lobehub.gemini-3.1-flash-image.description',
   'lobehub.gemini-3.1-flash-image:image.description',
   'lobehub.gemini-3.7-flash.description',
+  'lobehub.glm-5.3-flash.description',
   'lobehub.qwen3.8-max.description',
   'lobehub.grok-4.6.description',
 ] as const;

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -81,7 +81,7 @@ export const lobeHubOnlineModelDescriptions = {
   'lobehub.glm-5.2.description':
     'GLM-5.2 is the first open-source model to approach the performance of the latest-generation Claude Opus released in the same period.',
   'lobehub.glm-5.3-flash.description':
-    'GLM-5.3-Flash brings frontier intelligence, native vision, and a 1M-token context window at roughly one-tenth the price of flagship models.',
+    'The first GLM-5 that can see — stronger than GLM-5.2, coding that approaches Opus 4.8, at about one-tenth the flagship price.',
   'lobehub.glm-5.3.description':
     "Z.ai's latest flagship. Same base as GLM-5.2 with scaled post-training — 50% stronger coding, open-source SOTA on Terminal Bench 3.0, and a large jump in cyber capability. Thinking is always on.",
   'lobehub.gpt-4-turbo.description':

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -80,6 +80,8 @@ export const lobeHubOnlineModelDescriptions = {
     "Zai's latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. Excels at long-horizon tasks with autonomous work up to 8 hours, an ideal foundation for Autonomous Agents and long-horizon Coding Agents.",
   'lobehub.glm-5.2.description':
     'GLM-5.2 is the first open-source model to approach the performance of the latest-generation Claude Opus released in the same period.',
+  'lobehub.glm-5.3-flash.description':
+    'GLM-5.3-Flash brings frontier intelligence, native vision, and a 1M-token context window at roughly one-tenth the price of flagship models.',
   'lobehub.glm-5.3.description':
     "Z.ai's latest flagship. Same base as GLM-5.2 with scaled post-training — 50% stronger coding, open-source SOTA on Terminal Bench 3.0, and a large jump in cyber capability. Thinking is always on.",
   'lobehub.gpt-4-turbo.description':

--- a/packages/model-runtime/src/providers/zhipu/index.test.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.test.ts
@@ -422,6 +422,7 @@ describe('LobeZhipuAI - custom features', () => {
         ['glm-5.1', true, true],
         ['glm-5.2', true, true],
         ['glm-5.3', true, true],
+        ['glm-5.3-flash', true, true],
         ['glm-6', true, true],
         ['glm-4.5', true, undefined],
         ['glm-5-turbo', true, undefined],
@@ -546,19 +547,22 @@ describe('LobeZhipuAI - custom features', () => {
     });
 
     describe('GLM-5.3 always-on thinking', () => {
-      it('should coerce disabled thinking to enabled', () => {
-        const payload = params.chatCompletion.handlePayload({
-          max_tokens: 4096,
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-5.3',
-          reasoning_effort: 'low',
-          temperature: 1,
-          thinking: { type: 'disabled' },
-        });
+      it.each(['glm-5.3', 'glm-5.3-flash'])(
+        'should coerce disabled thinking to enabled for %s',
+        (model) => {
+          const payload = params.chatCompletion.handlePayload({
+            max_tokens: 4096,
+            messages: [{ content: 'Hello', role: 'user' }],
+            model,
+            reasoning_effort: 'low',
+            temperature: 1,
+            thinking: { type: 'disabled' },
+          });
 
-        expect(payload.reasoning_effort).toBe('low');
-        expect(payload.thinking).toEqual({ type: 'enabled' });
-      });
+          expect(payload.reasoning_effort).toBe('low');
+          expect(payload.thinking).toEqual({ type: 'enabled' });
+        },
+      );
 
       it('should enable thinking when the payload omits it', () => {
         const payload = params.chatCompletion.handlePayload({

--- a/packages/model-runtime/src/providers/zhipu/modelId.test.ts
+++ b/packages/model-runtime/src/providers/zhipu/modelId.test.ts
@@ -49,6 +49,7 @@ describe('isToolStreamSupportedGLMModel', () => {
 
   it('should support future mainline GLM versions without new allowlist entries', () => {
     expect(isToolStreamSupportedGLMModel('glm-5.3')).toBe(true);
+    expect(isToolStreamSupportedGLMModel('glm-5.3-flash')).toBe(true);
     expect(isToolStreamSupportedGLMModel('glm-6')).toBe(true);
   });
 
@@ -63,6 +64,7 @@ describe('isToolStreamSupportedGLMModel', () => {
 describe('isAlwaysOnThinkingGLMModel', () => {
   it('should require thinking from GLM-5.3 onward', () => {
     expect(isAlwaysOnThinkingGLMModel('glm-5.3')).toBe(true);
+    expect(isAlwaysOnThinkingGLMModel('glm-5.3-flash')).toBe(true);
     expect(isAlwaysOnThinkingGLMModel('glm-5.4')).toBe(true);
     expect(isAlwaysOnThinkingGLMModel('glm-6')).toBe(true);
   });

--- a/packages/model-runtime/src/providers/zhipu/modelId.ts
+++ b/packages/model-runtime/src/providers/zhipu/modelId.ts
@@ -30,8 +30,21 @@ export const parseGLMModelId = (model: string): ParsedGLMModelId | undefined => 
   };
 };
 
+/**
+ * GLM-5.3-Flash uses the GLM-5.3 text parameter contract, including always-on thinking and
+ * streaming tool calls. Keep the alias exact so unrelated Flash, Turbo, and vision variants do
+ * not accidentally inherit mainline capabilities.
+ *
+ * @see https://docs.z.ai/guides/vlm/glm-5.3-flash
+ */
+const normalizeGLMParameterModelId = (model: string) => {
+  const normalizedModelId = model.trim().toLowerCase();
+
+  return normalizedModelId === 'glm-5.3-flash' ? 'glm-5.3' : normalizedModelId;
+};
+
 export const isToolStreamSupportedGLMModel = (model: string): boolean => {
-  const parsed = parseGLMModelId(model);
+  const parsed = parseGLMModelId(normalizeGLMParameterModelId(model));
   if (!parsed) return false;
 
   if (parsed.majorVersion >= 5) return true;
@@ -44,9 +57,10 @@ export const isToolStreamSupportedGLMModel = (model: string): boolean => {
  * callers can only vary `reasoning_effort` (`low` | `high` | `max`).
  *
  * @see https://z.ai/blog/glm-5.3
+ * @see https://docs.z.ai/guides/vlm/glm-5.3-flash
  */
 export const isAlwaysOnThinkingGLMModel = (model: string): boolean => {
-  const parsed = parseGLMModelId(model);
+  const parsed = parseGLMModelId(normalizeGLMParameterModelId(model));
   if (!parsed) return false;
 
   if (parsed.majorVersion > 5) return true;


### PR DESCRIPTION
## Summary

- recognize `glm-5.3-flash` as using the GLM-5.3 parameter contract for streaming tool calls and always-on thinking
- add the homepage reveal locale key and provider-scoped model description
- cover the exact model alias and payload coercion with regression tests

## Key Decisions / Non-goals

- Normalize only the exact `glm-5.3-flash` ID so unrelated Flash, Turbo, and vision variants do not inherit GLM-5.3 behavior.
- Model availability, routing, and billing configuration are outside this PR.

#### Test

- [x] Tested locally
- [x] Added/updated tests

```bash
bun run check
bun run check --type
```

Results: 104 related tests passed; types clean.
