### PR TITLE
♻️ refactor(desktop): scope renderer OTA by release version

### DIFF
--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -200,23 +200,25 @@ runs:
           '{ cloudRef: $cloudRef, mainHash: $mainHash, version: $version }' \
           > /tmp/renderer-ota-base.json
 
-        LATEST=$(find release/renderer-ota -name latest.json | head -n 1)
-        SNAPSHOT=$(find release/renderer-ota -path '*/versions/r0.json' | head -n 1)
-        if [ ! -d release/renderer-ota/files ] || [ -z "$LATEST" ] || [ -z "$SNAPSHOT" ]; then
+        RENDERER_ROOT="release/renderer-ota/$CHANNEL/$VERSION/renderer"
+        LATEST="$RENDERER_ROOT/latest.json"
+        SNAPSHOT="$RENDERER_ROOT/versions/r0.json"
+        if [ ! -d "$RENDERER_ROOT/files" ] || [ ! -f "$LATEST" ] || [ ! -f "$SNAPSHOT" ]; then
           echo "Renderer OTA r0 artifacts are incomplete"
           exit 1
         fi
 
-        aws s3 sync release/renderer-ota/files "s3://$S3_BUCKET/renderer/files" \
+        S3_RENDERER_ROOT="s3://$S3_BUCKET/$CHANNEL/$VERSION/renderer"
+        aws s3 sync "$RENDERER_ROOT/files" "$S3_RENDERER_ROOT/files" \
           --size-only \
           --content-encoding gzip \
           --content-type application/octet-stream \
           --cache-control public,max-age=31536000,immutable \
           $ENDPOINT_ARG
-        aws s3 cp "$SNAPSHOT" "s3://$S3_BUCKET/renderer/$CHANNEL/$MAIN_HASH/versions/r0.json" \
+        aws s3 cp "$SNAPSHOT" "$S3_RENDERER_ROOT/versions/r0.json" \
           --cache-control no-store $ENDPOINT_ARG
-        aws s3 cp "$LATEST" "s3://$S3_BUCKET/renderer/$CHANNEL/$MAIN_HASH/latest.json" \
+        aws s3 cp "$LATEST" "$S3_RENDERER_ROOT/latest.json" \
           --cache-control no-store $ENDPOINT_ARG
-        aws s3 cp /tmp/renderer-ota-base.json "s3://$S3_BUCKET/renderer/$CHANNEL/base.json" \
+        aws s3 cp /tmp/renderer-ota-base.json "s3://$S3_BUCKET/$CHANNEL/base.json" \
           --cache-control no-store $ENDPOINT_ARG
-        echo "Published renderer OTA r0 for $CHANNEL/$MAIN_HASH"
+        echo "Published renderer OTA r0 for $CHANNEL/$VERSION"

--- a/.github/workflows/release-desktop-renderer-ota.yml
+++ b/.github/workflows/release-desktop-renderer-ota.yml
@@ -3,12 +3,12 @@ name: Release Desktop Renderer OTA
 # ============================================
 # Renderer 热更 patch 发布
 # ============================================
-# 前提: renderer/<channel>/base.json 由全量发版流程写入 (desktop-publish-s3)。
+# 前提: <channel>/base.json 由全量发版流程写入 (desktop-publish-s3)。
 # 门禁: HEAD 的 mainHash 必须等于该 marker —— main 变了只能走全量发版,
 #       此工作流会直接跳过。
-# 产物: renderer/<channel>/<mainHash>/latest.json (签名 manifest + zstd tree delta)
-#       renderer/<channel>/<mainHash>/versions/rN.json (打下一版差分用的文件清单)
-#       renderer/files/<sha256>.bin (gzip CAS: 原文或 zstd --patch-from 补丁)
+# 产物: <channel>/<appVersion>/renderer/latest.json (签名 manifest + zstd tree delta)
+#       <channel>/<appVersion>/renderer/versions/rN.json (打下一版差分用的文件清单)
+#       <channel>/<appVersion>/renderer/files/<sha256>.bin (gzip CAS)
 # delta: r0 + 最近 2 个 rN，客户端只下一份对得上的 fromVersion
 # ============================================
 
@@ -47,14 +47,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve update server base URL
+        env:
+          UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}
+        run: |
+          set -euo pipefail
+          UPDATE_SERVER_BASE_URL="${UPDATE_SERVER_URL%/}"
+          case "$UPDATE_SERVER_BASE_URL" in
+            */stable|*/nightly|*/canary|*/beta) UPDATE_SERVER_BASE_URL="${UPDATE_SERVER_BASE_URL%/*}" ;;
+          esac
+          echo "UPDATE_SERVER_BASE_URL=$UPDATE_SERVER_BASE_URL" >> "$GITHUB_ENV"
+
       - name: Load shipped base
         id: base
         env:
-          UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}
           CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
-          BASE=$(curl -sf "$UPDATE_SERVER_URL/renderer/$CHANNEL/base.json" || true)
+          BASE=$(curl -sf "$UPDATE_SERVER_BASE_URL/$CHANNEL/base.json" || true)
           if [ -z "$BASE" ]; then
             echo "::warning::no renderer OTA base metadata found; run a full release first"
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -64,10 +74,12 @@ jobs:
           MAIN_HASH=$(jq -er '.mainHash | select(type == "string" and test("^[0-9a-f]{64}$"))' <<< "$BASE")
           CLOUD_REF=$(jq -er '.cloudRef | select(type == "string" and test("^[0-9a-f]{40}$"))' <<< "$BASE")
           APP_VERSION=$(jq -er '.version | select(type == "string" and test("^[0-9A-Za-z.+-]+$"))' <<< "$BASE")
-          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "cloud_ref=$CLOUD_REF" >> "$GITHUB_OUTPUT"
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "main_hash=$MAIN_HASH" >> "$GITHUB_OUTPUT"
+          {
+            echo "app_version=$APP_VERSION"
+            echo "cloud_ref=$CLOUD_REF"
+            echo "found=true"
+            echo "main_hash=$MAIN_HASH"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup build environment
         if: steps.base.outputs.found == 'true'
@@ -104,11 +116,10 @@ jobs:
         id: version
         if: steps.gate.outputs.allowed == 'true'
         env:
-          UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}
+          APP_VERSION: ${{ steps.base.outputs.app_version }}
           CHANNEL: ${{ inputs.channel }}
-          MAIN_HASH: ${{ steps.gate.outputs.main_hash }}
         run: |
-          CURRENT=$(curl -sf "$UPDATE_SERVER_URL/renderer/$CHANNEL/$MAIN_HASH/latest.json" | node -e "
+          CURRENT=$(curl -sf "$UPDATE_SERVER_BASE_URL/$CHANNEL/$APP_VERSION/renderer/latest.json" | node -e "
             let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
               try { console.log(JSON.parse(d).version) } catch { console.log('r0') }
             })" || echo "r0")
@@ -132,7 +143,7 @@ jobs:
         if: steps.gate.outputs.allowed == 'true'
         env:
           RENDERER_OTA_PRIVATE_KEY: ${{ secrets.RENDERER_OTA_PRIVATE_KEY }}
-          UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}
+          APP_VERSION: ${{ steps.base.outputs.app_version }}
           CHANNEL: ${{ inputs.channel }}
           MAIN_HASH: ${{ steps.gate.outputs.main_hash }}
         run: |
@@ -146,8 +157,8 @@ jobs:
             --channel=${{ inputs.channel }} \
             --version=${{ steps.version.outputs.version }} \
             --mainHash=${{ steps.gate.outputs.main_hash }} \
-            --feed-url="$UPDATE_SERVER_URL/renderer/$CHANNEL/$MAIN_HASH" \
-            --cas-base-url="$UPDATE_SERVER_URL/renderer/files"
+            --feed-url="$UPDATE_SERVER_BASE_URL/$CHANNEL/$APP_VERSION/renderer" \
+            --cas-base-url="$UPDATE_SERVER_BASE_URL/$CHANNEL/$APP_VERSION/renderer/files"
 
       - name: Upload to S3
         if: steps.gate.outputs.allowed == 'true'
@@ -157,27 +168,29 @@ jobs:
           AWS_REGION: ${{ secrets.UPDATE_S3_REGION }}
           S3_BUCKET: ${{ secrets.UPDATE_S3_BUCKET }}
           S3_ENDPOINT: ${{ secrets.UPDATE_S3_ENDPOINT }}
+          APP_VERSION: ${{ steps.base.outputs.app_version }}
           CHANNEL: ${{ inputs.channel }}
-          MAIN_HASH: ${{ steps.gate.outputs.main_hash }}
         run: |
-          ENDPOINT_ARG=""
+          ENDPOINT_ARGS=()
           if [ -n "$S3_ENDPOINT" ]; then
-            ENDPOINT_ARG="--endpoint-url $S3_ENDPOINT"
+            ENDPOINT_ARGS=(--endpoint-url "$S3_ENDPOINT")
           fi
 
           # CAS objects first (immutable, skip existing), manifest last so a
           # client never sees a manifest whose files are not yet uploaded.
-          aws s3 sync renderer-ota-out/files "s3://$S3_BUCKET/renderer/files" \
+          RENDERER_ROOT="renderer-ota-out/$CHANNEL/$APP_VERSION/renderer"
+          S3_RENDERER_ROOT="s3://$S3_BUCKET/$CHANNEL/$APP_VERSION/renderer"
+          aws s3 sync "$RENDERER_ROOT/files" "$S3_RENDERER_ROOT/files" \
             --size-only \
             --content-encoding gzip \
             --content-type application/octet-stream \
             --cache-control public,max-age=31536000,immutable \
-            $ENDPOINT_ARG
-          aws s3 cp "renderer-ota-out/$CHANNEL/$MAIN_HASH/latest.json" \
-            "s3://$S3_BUCKET/renderer/$CHANNEL/$MAIN_HASH/latest.json" \
-            --cache-control no-store $ENDPOINT_ARG
-          aws s3 cp "renderer-ota-out/$CHANNEL/$MAIN_HASH/versions/${{ steps.version.outputs.version }}.json" \
-            "s3://$S3_BUCKET/renderer/$CHANNEL/$MAIN_HASH/versions/${{ steps.version.outputs.version }}.json" \
-            --cache-control no-store $ENDPOINT_ARG
+            "${ENDPOINT_ARGS[@]}"
+          aws s3 cp "$RENDERER_ROOT/latest.json" \
+            "$S3_RENDERER_ROOT/latest.json" \
+            --cache-control no-store "${ENDPOINT_ARGS[@]}"
+          aws s3 cp "$RENDERER_ROOT/versions/${{ steps.version.outputs.version }}.json" \
+            "$S3_RENDERER_ROOT/versions/${{ steps.version.outputs.version }}.json" \
+            --cache-control no-store "${ENDPOINT_ARGS[@]}"
 
-          echo "✅ Published renderer patch ${{ steps.version.outputs.version }} for $CHANNEL/$MAIN_HASH"
+          echo "✅ Published renderer patch ${{ steps.version.outputs.version }} for $CHANNEL/$APP_VERSION"

--- a/apps/desktop/scripts/__tests__/buildRendererManifest.test.mjs
+++ b/apps/desktop/scripts/__tests__/buildRendererManifest.test.mjs
@@ -1,0 +1,61 @@
+import { execFile } from 'node:child_process';
+import { generateKeyPairSync } from 'node:crypto';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const script = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../buildRendererManifest.mjs',
+);
+
+let tempDir;
+
+afterEach(async () => {
+  if (tempDir) await rm(tempDir, { force: true, recursive: true });
+});
+
+describe('buildRendererManifest', () => {
+  it('writes a self-contained renderer feed under its channel and app version', async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'renderer-manifest-'));
+    const rendererDir = path.join(tempDir, 'renderer');
+    const outDir = path.join(tempDir, 'out');
+    await mkdir(rendererDir);
+    await writeFile(path.join(rendererDir, 'index.html'), '<html>renderer</html>');
+
+    const { privateKey } = generateKeyPairSync('ed25519');
+    const appVersion = '2.2.15-canary.72';
+    const mainHash = 'a'.repeat(64);
+    await execFileAsync(
+      process.execPath,
+      [
+        script,
+        `--renderer=${rendererDir}`,
+        `--out=${outDir}`,
+        '--channel=canary',
+        '--version=r0',
+        `--appVersion=${appVersion}`,
+        `--mainHash=${mainHash}`,
+      ],
+      {
+        env: {
+          ...process.env,
+          RENDERER_OTA_PRIVATE_KEY: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+        },
+      },
+    );
+
+    const rendererRoot = path.join(outDir, 'canary', appVersion, 'renderer');
+    const manifest = JSON.parse(await readFile(path.join(rendererRoot, 'latest.json'), 'utf8'));
+    expect(manifest).toMatchObject({ appVersion, mainHash, version: 'r0' });
+    await expect(access(path.join(rendererRoot, 'versions', 'r0.json'))).resolves.toBeUndefined();
+    await expect(
+      access(path.join(rendererRoot, 'files', `${manifest.files[0].sha256}.bin`)),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/scripts/buildRendererManifest.mjs
+++ b/apps/desktop/scripts/buildRendererManifest.mjs
@@ -266,6 +266,8 @@ async function main() {
   if (!version) throw new Error('--version=r<N> is required');
   if (!privateKeyPem) throw new Error('RENDERER_OTA_PRIVATE_KEY env is required');
 
+  const rendererRoot = path.join(outDir, channel, appVersion, 'renderer');
+  const casDir = path.join(rendererRoot, 'files');
   const mainHash = args.mainHash ?? computeMainHash();
   const unsigned = buildManifest({ appVersion, mainHash, rendererDir, version });
   const { rm } = await import('node:fs/promises');
@@ -281,7 +283,6 @@ async function main() {
 
   if (bases.length > 0) {
     unsigned.deltas = [];
-    const casDir = path.join(outDir, 'files');
     for (const base of bases) {
       const { delta, downloadedBytes, fullBytes, patches } = await buildDelta({
         fromFiles: base.files,
@@ -304,7 +305,6 @@ async function main() {
 
   const manifest = signManifest(unsigned, privateKeyPem);
 
-  const casDir = path.join(outDir, 'files');
   mkdirSync(casDir, { recursive: true });
   for (const file of manifest.files) {
     const target = path.join(casDir, `${file.sha256}.bin`);
@@ -316,7 +316,7 @@ async function main() {
     await writeCasObject(casDir, file.sha256, readFileSync(path.join(rendererDir, file.path)));
   }
 
-  const feedDir = path.join(outDir, channel, mainHash);
+  const feedDir = rendererRoot;
   mkdirSync(path.join(feedDir, 'versions'), { recursive: true });
   writeFileSync(path.join(feedDir, 'latest.json'), JSON.stringify(manifest, null, 2));
   writeFileSync(
@@ -325,7 +325,7 @@ async function main() {
   );
 
   console.log(
-    `renderer-ota manifest: ${channel}/${mainHash}/latest.json (${manifest.files.length} files, version ${version})`,
+    `renderer-ota manifest: ${channel}/${appVersion}/renderer/latest.json (${manifest.files.length} files, version ${version})`,
   );
 }
 

--- a/apps/desktop/scripts/renderer-ota-test/README.md
+++ b/apps/desktop/scripts/renderer-ota-test/README.md
@@ -44,7 +44,8 @@ RENDERER_OTA_PRIVATE_KEY="$(cat /tmp/ota-priv.pem)" \
 node scripts/renderer-ota-test/serveOta.mjs /tmp/ota-feed 8787
 ```
 
-注意 `--channel` 要和应用实际渠道一致 (dev 默认 stable; 日志 `feedUrl` 可确认)。
+注意 `--channel` 要和应用实际渠道一致 (dev 默认 stable; feed 路径为
+`/<channel>/<appVersion>/renderer`)。
 
 ## 4. 验收 happy path
 

--- a/apps/desktop/scripts/renderer-ota-test/serveOta.mjs
+++ b/apps/desktop/scripts/renderer-ota-test/serveOta.mjs
@@ -7,13 +7,8 @@ const port = Number(process.argv[3] ?? 8787);
 
 const server = http.createServer((req, res) => {
   const url = new URL(req.url, 'http://localhost');
-  if (!url.pathname.startsWith('/renderer/')) {
-    res.writeHead(404).end('not an ota path');
-    return;
-  }
-
-  const file = path.join(root, url.pathname.slice('/renderer/'.length));
-  if (!file.startsWith(root) || !existsSync(file) || !statSync(file).isFile()) {
+  const file = path.resolve(root, `.${url.pathname}`);
+  if (!file.startsWith(`${root}${path.sep}`) || !existsSync(file) || !statSync(file).isFile()) {
     res.writeHead(404).end('not found');
     console.log(`404 ${url.pathname}`);
     return;
@@ -33,5 +28,5 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(port, () => {
-  console.log(`renderer OTA feed: http://127.0.0.1:${port}/renderer/ -> ${root}`);
+  console.log(`renderer OTA feed: http://127.0.0.1:${port}/ -> ${root}`);
 });

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
@@ -39,8 +39,11 @@ const LOAD_PING_TIMEOUT = 3000;
 const MAX_BOOT_CRASHES = 2;
 const CHECK_INTERVAL = 60 * 60 * 1000;
 
+const APP_VERSION = electronApp.getVersion();
 const MAIN_HASH = process.env.MAIN_HASH || '';
 const PUBLIC_KEY = process.env.RENDERER_OTA_PUBLIC_KEY || '';
+const UPDATE_SERVER_BASE_URL =
+  UPDATE_SERVER_URL?.replace(/\/(stable|nightly|canary|beta)\/?$/, '').replace(/\/$/, '') || '';
 // Local e2e escape hatches (never set in packaged builds): force-enable in
 // dev and shorten the first scheduled check.
 const FORCE_IN_DEV = process.env['RENDERER_OTA_FORCE'] === '1';
@@ -196,7 +199,8 @@ export class RendererUpdateManager {
     this.state = 'checking';
 
     try {
-      const manifest = await this.fetchManifest(channel);
+      const rendererUrl = this.rendererUrl(channel);
+      const manifest = await this.fetchManifest(rendererUrl);
       if (!manifest || generation !== this.checkGeneration) return;
 
       const currentN = pointer.current ? patchNumber(pointer.current) : 0;
@@ -209,7 +213,7 @@ export class RendererUpdateManager {
       }
 
       this.state = 'downloading';
-      await this.downloadAndStage(manifest, otaDir, pointer);
+      await this.downloadAndStage(manifest, otaDir, pointer, rendererUrl);
       if (generation !== this.checkGeneration) return;
 
       this.stagedManifest = manifest;
@@ -235,27 +239,33 @@ export class RendererUpdateManager {
     return BUILD_CHANNEL === 'beta' && channel === 'canary' ? 'beta' : channel;
   }
 
-  private feedUrl(channel: RendererOtaChannel) {
-    return `${UPDATE_SERVER_URL}/renderer/${channel}/${MAIN_HASH}/latest.json`;
+  private rendererUrl(channel: RendererOtaChannel) {
+    return `${UPDATE_SERVER_BASE_URL}/${channel}/${APP_VERSION}/renderer`;
   }
 
-  private fileUrl(sha256: string) {
-    return `${UPDATE_SERVER_URL}/renderer/files/${sha256}.bin`;
+  private fileUrl(rendererUrl: string, sha256: string) {
+    return `${rendererUrl}/files/${sha256}.bin`;
   }
 
-  private async fetchManifest(channel: RendererOtaChannel): Promise<RendererManifest | null> {
-    const res = await fetch(this.feedUrl(channel), { cache: 'no-store' });
+  private async fetchManifest(rendererUrl: string): Promise<RendererManifest | null> {
+    const res = await fetch(`${rendererUrl}/latest.json`, { cache: 'no-store' });
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`Manifest fetch failed: ${res.status}`);
 
     const raw = await res.json();
     if (!isValidManifestShape(raw)) throw new Error('Manifest shape invalid');
+    if (raw.appVersion !== APP_VERSION) throw new Error('Manifest appVersion mismatch');
     if (raw.mainHash !== MAIN_HASH) throw new Error('Manifest mainHash mismatch');
     if (!verifyManifestSignature(raw, PUBLIC_KEY)) throw new Error('Manifest signature invalid');
     return raw;
   }
 
-  private async downloadAndStage(manifest: RendererManifest, otaDir: string, pointer: OtaPointer) {
+  private async downloadAndStage(
+    manifest: RendererManifest,
+    otaDir: string,
+    pointer: OtaPointer,
+    rendererUrl: string,
+  ) {
     const stagingRoot = path.join(otaDir, 'staging');
     rmSync(stagingRoot, { force: true, recursive: true });
     const stagingDir = path.join(stagingRoot, manifest.version);
@@ -268,13 +278,13 @@ export class RendererUpdateManager {
 
     if (delta && canApplyDelta(delta, byHash)) {
       logger.info(`Renderer ${manifest.version}: applying delta from ${delta.fromVersion}`);
-      await this.stageDelta(delta, stagingDir, byHash);
+      await this.stageDelta(delta, stagingDir, byHash, rendererUrl);
     } else {
       const { missing, reusable } = diffManifest(manifest, localHashes);
       logger.info(
         `Renderer ${manifest.version}: ${reusable.length} files reused, ${missing.length} to download`,
       );
-      await this.stageCas(stagingDir, missing, reusable);
+      await this.stageCas(stagingDir, missing, reusable, rendererUrl);
     }
 
     for (const file of manifest.files) {
@@ -304,16 +314,26 @@ export class RendererUpdateManager {
     stagingDir: string,
     missing: RendererManifestFile[],
     reusable: Array<{ file: RendererManifestFile; localPath: string }>,
+    rendererUrl: string,
   ) {
     for (const { file, localPath } of reusable) {
       await this.placeLocalFile(localPath, path.join(stagingDir, file.path));
     }
     for (const file of missing) {
-      await this.writeStaged(stagingDir, file.path, await this.fetchCas(file.sha256, file.path));
+      await this.writeStaged(
+        stagingDir,
+        file.path,
+        await this.fetchCas(rendererUrl, file.sha256, file.path),
+      );
     }
   }
 
-  private async stageDelta(delta: RendererDelta, stagingDir: string, byHash: Map<string, string>) {
+  private async stageDelta(
+    delta: RendererDelta,
+    stagingDir: string,
+    byHash: Map<string, string>,
+    rendererUrl: string,
+  ) {
     for (const op of delta.ops) {
       const target = path.join(stagingDir, op.path);
       if (op.op === 'copy') {
@@ -323,13 +343,17 @@ export class RendererUpdateManager {
         continue;
       }
       if (op.op === 'full') {
-        await this.writeStaged(stagingDir, op.path, await this.fetchCas(op.sha256, op.path));
+        await this.writeStaged(
+          stagingDir,
+          op.path,
+          await this.fetchCas(rendererUrl, op.sha256, op.path),
+        );
         continue;
       }
       const localPath = byHash.get(op.fromSha256);
       if (!localPath) throw new Error(`Delta patch missing base ${op.fromSha256}`);
       const oldContent = await readFile(localPath);
-      const patch = await this.fetchCas(op.patchSha256, op.path);
+      const patch = await this.fetchCas(rendererUrl, op.patchSha256, op.path);
       const next = await applyZstdPatch(oldContent, patch);
       await this.writeStaged(stagingDir, op.path, next);
     }
@@ -350,8 +374,8 @@ export class RendererUpdateManager {
     await writeFile(target, content);
   }
 
-  private async fetchCas(sha256: string, label: string) {
-    const res = await fetch(this.fileUrl(sha256));
+  private async fetchCas(rendererUrl: string, sha256: string, label: string) {
+    const res = await fetch(this.fileUrl(rendererUrl, sha256));
     if (!res.ok) throw new Error(`Asset fetch failed (${res.status}): ${label}`);
     return decodeCasPayload(Buffer.from(await res.arrayBuffer()));
   }

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
@@ -12,6 +12,7 @@ import { readPointer } from '../pointer';
 
 const { privateKey, publicKey } = generateKeyPairSync('ed25519');
 const PUBLIC_KEY_PEM = publicKey.export({ format: 'pem', type: 'spki' }).toString();
+const APP_VERSION = '1.0.0';
 const MAIN_HASH = 'a'.repeat(64);
 const SERVER = 'https://updates.test';
 
@@ -22,7 +23,7 @@ const { updaterConfigMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('electron', () => ({
-  app: { getPath: () => userDataDir },
+  app: { getPath: () => userDataDir, getVersion: () => APP_VERSION },
 }));
 vi.mock('@/const/dir', () => ({
   get rendererDir() {
@@ -35,7 +36,7 @@ vi.mock('@/modules/updater/configs', () => ({
     return updaterConfigMock.buildChannel;
   },
   UPDATE_CHANNEL: 'stable',
-  UPDATE_SERVER_URL: 'https://updates.test',
+  UPDATE_SERVER_URL: 'https://updates.test/stable',
   coerceStoredUpdateChannel: (channel?: string) => (channel === 'canary' ? 'canary' : 'stable'),
 }));
 vi.mock('@/utils/logger', () => ({
@@ -72,7 +73,7 @@ const buildFeed = (version: string, files: Record<string, string>) => {
     return { path: filePath, sha256, size: content.byteLength };
   });
   const manifest = signManifest({
-    appVersion: '1.0.0',
+    appVersion: APP_VERSION,
     files: manifestFiles,
     mainHash: MAIN_HASH,
     version,
@@ -87,7 +88,7 @@ const stubFetch = (
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string) => {
-      if (url === `${SERVER}/renderer/${channel}/${MAIN_HASH}/latest.json`) {
+      if (url === `${SERVER}/${channel}/${APP_VERSION}/renderer/latest.json`) {
         if (!feed) return new Response('nope', { status: 404 });
         return Response.json(feed.manifest);
       }
@@ -156,6 +157,7 @@ describe('RendererUpdateManager full path', () => {
     });
 
     const fetchedUrls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+    expect(fetchedUrls[0]).toBe(`${SERVER}/stable/${APP_VERSION}/renderer/latest.json`);
     const casFetches = fetchedUrls.filter((u: string) => u.includes('/renderer/files/'));
     expect(casFetches).toHaveLength(4);
 
@@ -245,8 +247,10 @@ describe('RendererUpdateManager full path', () => {
 
     const fetchedUrls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
     const casFetches = fetchedUrls.filter((u: string) => u.includes('/renderer/files/'));
-    expect(casFetches).toContain(`${SERVER}/renderer/files/${patchSha}.bin`);
-    expect(casFetches).not.toContain(`${SERVER}/renderer/files/${sharedFile.sha256}.bin`);
+    expect(casFetches).toContain(`${SERVER}/stable/${APP_VERSION}/renderer/files/${patchSha}.bin`);
+    expect(casFetches).not.toContain(
+      `${SERVER}/stable/${APP_VERSION}/renderer/files/${sharedFile.sha256}.bin`,
+    );
     expect(readPointer(channelDir(), MAIN_HASH).staged).toBe('r1');
     expect(readFileSync(path.join(channelDir(), 'versions', 'r1', 'chunk.bin'))).toEqual(newChunk);
   });
@@ -263,7 +267,7 @@ describe('RendererUpdateManager full path', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string) => {
-        if (url === `${SERVER}/renderer/stable/${MAIN_HASH}/latest.json`) {
+        if (url === `${SERVER}/stable/${APP_VERSION}/renderer/latest.json`) {
           return Response.json(feed.manifest);
         }
         const match = /\/renderer\/files\/([0-9a-f]{64})\.bin$/.exec(url);


### PR DESCRIPTION
## Summary

- move the renderer OTA base marker to `/<channel>/base.json`
- keep manifests, version snapshots, and CAS files under `/<channel>/<appVersion>/renderer`
- normalize legacy channel-suffixed update server URLs and validate manifest app versions
- update the local OTA feed and behavior coverage for the new public path contract

## Verification

- `bun run check <8 changed files>` — 14 tests passed
- `cd apps/desktop && bun run type-check`
- `actionlint .github/workflows/release-desktop-renderer-ota.yml`
- `git diff --check`

Existing top-level `/renderer/*` objects are intentionally left untouched; the next full release seeds the new version-scoped r0 feed.