### PR TITLE
🐛 fix(skill): preserve market identifiers in agent imports

### DIFF
--- a/apps/server/src/services/skill/importer.test.ts
+++ b/apps/server/src/services/skill/importer.test.ts
@@ -958,6 +958,61 @@ description: A nested skill
       expect(second.skill.id).toBe(first.skill.id);
     });
 
+    it.each([
+      { importedContent: '# Same Content', label: 'unchanged' },
+      { importedContent: '# Updated Content', label: 'changed' },
+    ])(
+      'should self-heal a legacy marketplace identifier when content is $label',
+      async ({ importedContent }) => {
+        const downloadUrl =
+          'https://market.lobehub.com/api/v1/skills/openclaw-skills-homebrew/download';
+        const canonicalIdentifier = 'openclaw-skills-homebrew';
+        const legacyIdentifier =
+          'url.market.lobehub.com.api.v1.skills.openclaw-skills-homebrew.download';
+        const [legacySkill] = await db
+          .insert(agentSkills)
+          .values({
+            content: '# Same Content',
+            description: 'Legacy description',
+            identifier: legacyIdentifier,
+            manifest: { description: 'Legacy description', name: 'Homebrew' },
+            name: 'Homebrew',
+            source: 'market',
+            userId,
+          })
+          .returning();
+
+        mockSsrfSafeFetch.mockResolvedValue({
+          arrayBuffer: async () => new ArrayBuffer(8),
+          headers: { get: () => 'application/zip' },
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+        });
+        mockParserInstance.parseZipPackage.mockResolvedValue({
+          content: importedContent,
+          manifest: { description: 'Market description', name: 'Homebrew' },
+          resources: new Map(),
+          zipHash: undefined,
+        });
+
+        const result = await importer.importFromUrl(
+          { url: downloadUrl },
+          { identifier: canonicalIdentifier, source: 'market' },
+        );
+
+        expect(result.status).toBe('updated');
+        expect(result.skill.id).toBe(legacySkill.id);
+        expect(result.skill.identifier).toBe(canonicalIdentifier);
+        expect(result.skill.content).toBe(importedContent);
+
+        const rows = await db.query.agentSkills.findMany({
+          where: eq(agentSkills.userId, userId),
+        });
+        expect(rows).toHaveLength(1);
+      },
+    );
+
     it('should throw INVALID_URL error for invalid URL', async () => {
       await expect(importer.importFromUrl({ url: 'not-a-valid-url' })).rejects.toThrow(
         SkillImportError,
@@ -1290,6 +1345,57 @@ description: A nested skill
       });
       expect(dbSkill?.name).toBe('pdf');
       expect(dbSkill?.workspaceId).toBe(workspaceId);
+    });
+
+    it('does not self-heal a legacy market skill owned by another workspace member', async () => {
+      const downloadUrl =
+        'https://market.lobehub.com/api/v1/skills/openclaw-skills-homebrew/download';
+      const legacyIdentifier =
+        'url.market.lobehub.com.api.v1.skills.openclaw-skills-homebrew.download';
+      const [legacySkill] = await db
+        .insert(agentSkills)
+        .values({
+          content: '# Same Content',
+          description: 'Legacy description',
+          identifier: legacyIdentifier,
+          manifest: { description: 'Legacy description', name: 'Homebrew' },
+          name: 'Homebrew',
+          source: 'market',
+          userId,
+          workspaceId,
+        })
+        .returning();
+      const memberId = `member-${userId}`;
+      await db.insert(users).values({ id: memberId });
+      const memberImporter = new SkillImporter(db, memberId, workspaceId);
+
+      mockSsrfSafeFetch.mockResolvedValue({
+        arrayBuffer: async () => new ArrayBuffer(8),
+        headers: { get: () => 'application/zip' },
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      });
+      mockParserInstance.parseZipPackage.mockResolvedValue({
+        content: '# Same Content',
+        manifest: { description: 'Market description', name: 'Homebrew' },
+        resources: new Map(),
+        zipHash: undefined,
+      });
+
+      await expect(
+        memberImporter.importFromUrl(
+          { url: downloadUrl },
+          { identifier: 'openclaw-skills-homebrew', source: 'market' },
+        ),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+      const unchangedSkill = await db.query.agentSkills.findFirst({
+        where: eq(agentSkills.id, legacySkill.id),
+      });
+      expect(unchangedSkill?.identifier).toBe(legacyIdentifier);
+
+      await db.delete(users).where(eq(users.id, memberId));
     });
   });
 });

--- a/apps/server/src/services/skill/importer.ts
+++ b/apps/server/src/services/skill/importer.ts
@@ -415,11 +415,29 @@ export class SkillImporter {
       .replace(/^\//, '') // Remove leading slash
       .replace(/\.md$/i, '') // Remove .md extension
       .replaceAll('/', '.'); // Replace slashes with dots
-    const identifier = options?.identifier || `url.${url.host}.${pathPart || 'skill'}`;
+    const urlIdentifier = `url.${url.host}.${pathPart || 'skill'}`;
+    const identifier = options?.identifier || urlIdentifier;
     log('importFromUrl: identifier=%s', identifier);
 
     // 5. Check for existing skill
-    const existing = await this.skillModel.findByIdentifier(identifier);
+    let existing = await this.skillModel.findByIdentifier(identifier);
+    let shouldUpgradeIdentifier = false;
+
+    // Older marketplace imports through the server runtime omitted the canonical identifier,
+    // so they were persisted with the URL-derived fallback. A canonical market reinstall should
+    // repair that exact row rather than attempting to create a duplicate with the same name.
+    if (
+      !existing &&
+      options?.identifier &&
+      options.source === 'market' &&
+      identifier !== urlIdentifier
+    ) {
+      const legacy = await this.skillModel.findByIdentifier(urlIdentifier);
+      if (legacy?.source === 'market') {
+        existing = legacy;
+        shouldUpgradeIdentifier = legacy.identifier !== identifier;
+      }
+    }
 
     // 6. Build manifest with source URL
     const fullManifest: SkillManifest = {
@@ -466,20 +484,23 @@ export class SkillImporter {
       // Use nullish coalescing to handle null/undefined comparison correctly
       const existingHash = existing.zipFileHash ?? undefined;
       const isSameContent = existing.content === skillContent && existingHash === zipFileHash;
-      if (isSameContent) {
+      if (isSameContent && !shouldUpgradeIdentifier) {
         log('importFromUrl: skill unchanged, skipping update id=%s', existing.id);
         return { skill: existing, status: 'unchanged' };
       }
 
       this.assertCanOverwrite(existing);
-      log('importFromUrl: skill exists but content changed, updating id=%s', existing.id);
+      log('importFromUrl: skill requires an update, updating id=%s', existing.id);
       const skill = await this.skillModel.update(existing.id, {
-        content: skillContent,
-        description: manifest.description,
-        manifest: fullManifest,
-        name: manifest.name,
-        ...(resourceMap && { resources: resourceMap }),
-        ...(zipFileHash && { zipFileHash }),
+        ...(shouldUpgradeIdentifier && { identifier, source: 'market' }),
+        ...(!isSameContent && {
+          content: skillContent,
+          description: manifest.description,
+          manifest: fullManifest,
+          name: manifest.name,
+          ...(resourceMap && { resources: resourceMap }),
+          ...(zipFileHash && { zipFileHash }),
+        }),
       });
       log('importFromUrl: updated skill id=%s', skill.id);
       return { skill, status: 'updated' };

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skillStore.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skillStore.test.ts
@@ -2,8 +2,10 @@ import { RBAC_PERMISSIONS } from '@lobechat/const/rbac';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  getSkillDownloadUrl: vi.fn(),
   getUserSettings: vi.fn(),
   hasAnyPermission: vi.fn(),
+  importFromUrl: vi.fn(),
   SkillImporter: vi.fn(),
 }));
 
@@ -32,7 +34,9 @@ vi.mock('@/database/models/user', () => ({
 }));
 
 vi.mock('@/server/services/market', () => ({
-  MarketService: vi.fn(() => ({})),
+  MarketService: vi.fn(() => ({
+    getSkillDownloadUrl: mocks.getSkillDownloadUrl,
+  })),
 }));
 
 vi.mock('@/server/services/skill/importer', () => ({
@@ -57,6 +61,9 @@ describe('skillStoreRuntime', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.SkillImporter.mockImplementation(function (this: any) {
+      this.importFromUrl = mocks.importFromUrl;
+    });
     mocks.getUserSettings.mockResolvedValue({ market: { accessToken: 'market-token' } });
     // Default: caller is allowed to manage workspace skills.
     mocks.hasAnyPermission.mockResolvedValue(true);
@@ -125,5 +132,29 @@ describe('skillStoreRuntime', () => {
 
     expect(mocks.hasAnyPermission).not.toHaveBeenCalled();
     expect(mocks.SkillImporter).toHaveBeenCalledWith(serverDB, 'user-1', undefined);
+  });
+
+  it('forwards the canonical identifier when importing a marketplace skill', async () => {
+    const downloadUrl =
+      'https://market.lobehub.com/api/v1/skills/openclaw-skills-homebrew/download';
+    mocks.getSkillDownloadUrl.mockReturnValue(downloadUrl);
+    mocks.importFromUrl.mockResolvedValue({
+      skill: { id: 'skill-1', name: 'Homebrew' },
+      status: 'created',
+    });
+    const { skillStoreRuntime } = await import('../skillStore');
+
+    const runtime = (await skillStoreRuntime.factory({
+      serverDB,
+      toolManifestMap: {},
+      userId: 'user-1',
+    })) as any;
+
+    await runtime.service.importFromMarket('openclaw-skills-homebrew');
+
+    expect(mocks.importFromUrl).toHaveBeenCalledWith(
+      { url: downloadUrl },
+      { identifier: 'openclaw-skills-homebrew', source: 'market' },
+    );
   });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/skillStore.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skillStore.ts
@@ -153,9 +153,12 @@ class SkillStoreServerRuntimeService implements SkillStoreRuntimeService {
     }
   };
 
-  importFromZipUrl = async (url: string): Promise<SkillImportServiceResult> => {
+  importFromZipUrl = async (
+    url: string,
+    options?: { identifier?: string; source?: 'market' | 'user' },
+  ): Promise<SkillImportServiceResult> => {
     try {
-      const result = await this.importer.importFromUrl({ url });
+      const result = await this.importer.importFromUrl({ url }, options);
       await this.emitSkillOutcome({
         apiName: 'importFromZipUrl',
         intentClass: 'tool_command',
@@ -220,7 +223,10 @@ class SkillStoreServerRuntimeService implements SkillStoreRuntimeService {
       const downloadUrl = this.marketService.getSkillDownloadUrl(identifier);
       log('Download URL: %s', downloadUrl);
 
-      const result = await this.importFromZipUrl(downloadUrl);
+      const result = await this.importFromZipUrl(downloadUrl, {
+        identifier,
+        source: 'market',
+      });
       log('Import from market result: %O', result);
       return result;
     } catch (error) {


### PR DESCRIPTION
## Summary

- forward the canonical marketplace identifier and source through the server-side skill-store runtime;
- make canonical marketplace reinstalls find the exact legacy URL-derived market row and upgrade it in place;
- preserve the existing ownership check and leave ordinary URL/user imports unchanged.

The previous server runtime imported marketplace ZIPs without metadata, so the importer persisted a URL-derived identifier. A later canonical reinstall could not find that row and attempted a second insert, which collided with the scoped skill-name uniqueness constraint. This change repairs the legacy row lazily during reinstall; it does not introduce a broad database migration.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

The new tests fail on `canary` before the implementation: the runtime omits the identifier, and both unchanged-content and changed-content reinstalls hit the duplicate-name constraint.

Validated with:

- `pnpm exec vitest run --silent='passed-only' 'apps/server/src/services/toolExecution/serverRuntimes/__tests__/skillStore.test.ts' 'apps/server/src/services/skill/importer.test.ts'` — 44 tests passed;
- repository change checker — lint/format and 44 related tests passed;
- `pnpm run type-check` — passed.

#### 🔗 Related Issue

Fixes #18708
