### PR TITLE
🐛 fix(bot): use thread state for Telegram slash commands

### DIFF
--- a/apps/server/src/services/bot/BotMessageRouter.ts
+++ b/apps/server/src/services/bot/BotMessageRouter.ts
@@ -125,8 +125,8 @@ interface CommandContext {
    *  surface only the ID, not a friendly label. */
   authorUserName?: string;
   /** Read the conversation's persisted state (topicId / toolMode / …).
-   *  Wired to `thread.state` on text dispatch and `channel.state` on native
-   *  slash dispatch — the same store `setState` writes to on each path. */
+   *  Wired to `thread.state` on text dispatch and Telegram native slash
+   *  dispatch; other native-slash platforms retain their channel state. */
   getState: () => Promise<Record<string, any> | null>;
   post: (text: string) => Promise<any>;
   /**
@@ -1947,15 +1947,28 @@ export class BotMessageRouter {
       caller: string,
     ) => Promise<boolean>,
   ): void {
-    // --- Native slash commands (Slack, Discord) ---
+    // --- Native slash commands (Telegram, Slack, Discord) ---
     for (const cmd of commands) {
       bot.onSlashCommand(`/${cmd.name}`, async (event) => {
+        // Telegram's adapter encodes the exact conversation in the slash
+        // Channel id (`telegram:<chatId>[:<messageThreadId>]`), but Chat SDK
+        // keeps Channel and Thread state in different buckets. Normal messages
+        // use Thread state, so resolve the same Thread handle here or `/new`
+        // would clear `channel-state:*` while the next message continued from
+        // the unchanged `thread-state:*`. The synchronous lookup preserves DM,
+        // group, and forum-topic identity without opening a separate DM.
+        //
+        // Other adapters keep their existing channel-backed slash semantics;
+        // changing those requires platform-specific conversation mapping.
+        const commandStateTarget =
+          client.id === 'telegram' ? bot.thread(event.channel.id) : event.channel;
+
         // Native slash-command events expose a Channel (Postable, so it has
         // `id` / `isDM` / `post`) and the invoking user. Project both into
         // the gate-friendly thread/author shape.
         const threadLike = {
-          id: event.channel.id,
-          isDM: event.channel.isDM,
+          id: commandStateTarget.id,
+          isDM: commandStateTarget.isDM,
           post: (t: string) => event.channel.post(t),
         };
         const authorLike = {
@@ -1970,7 +1983,7 @@ export class BotMessageRouter {
           args: event.text,
           authorUserId: authorLike.userId,
           authorUserName: authorLike.userName,
-          getState: () => event.channel.state,
+          getState: () => commandStateTarget.state,
           post: (text) => event.channel.post(text),
           // Wire chat-sdk's `postEphemeral` so commands that want a private
           // reply (e.g. `/feedback`) can opt in. `fallbackToDM: true` so
@@ -1984,16 +1997,15 @@ export class BotMessageRouter {
             : undefined,
           // Native slash-command events don't carry a Chat SDK Message, so
           // there's no per-sender locale field to read; use the channel
-          // default. Telegram/Feishu/etc. dispatch via the text-based path
-          // below, which DOES have per-message locale.
+          // default. Text-dispatched commands below DO have per-message locale.
           replyLocale,
-          setState: (state, opts) => event.channel.setState(state, opts),
-          threadId: event.channel.id,
+          setState: (state, opts) => commandStateTarget.setState(state, opts),
+          threadId: commandStateTarget.id,
         });
       });
     }
 
-    // --- Text-based slash commands (Telegram, Feishu, etc.) ---
+    // --- Fallback text-based slash commands (Feishu and similar adapters) ---
     // Platforms that don't support native onSlashCommand send /commands as
     // regular text messages. This handler intercepts them in unsubscribed
     // threads (e.g. first command in a group chat or DM).

--- a/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
+++ b/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
@@ -74,6 +74,7 @@ const mockOnNewMention = vi.hoisted(() => vi.fn());
 const mockOnSubscribedMessage = vi.hoisted(() => vi.fn());
 const mockOnNewMessage = vi.hoisted(() => vi.fn());
 const mockOnSlashCommand = vi.hoisted(() => vi.fn());
+const mockThread = vi.hoisted(() => vi.fn());
 // Default state mocks for the participant tracking. Tests that
 // care about the multi-human transition reassign `mockGetList` to seed the
 // pre-existing participant list.
@@ -94,6 +95,7 @@ vi.mock('chat', () => ({
     onNewMessage: mockOnNewMessage,
     onSlashCommand: mockOnSlashCommand,
     onSubscribedMessage: mockOnSubscribedMessage,
+    thread: mockThread,
     webhooks: {},
   })),
   ConsoleLogger: vi.fn(),
@@ -454,6 +456,12 @@ describe('BotMessageRouter', () => {
     mockGetList.mockResolvedValue([]);
     mockAppendToList.mockResolvedValue(undefined);
     mockStateSetIfNotExists.mockResolvedValue(true);
+    mockThread.mockImplementation((id: string) => ({
+      id,
+      isDM: false,
+      setState: vi.fn().mockResolvedValue(undefined),
+      state: Promise.resolve(null),
+    }));
     // Reset pairing-store + provider-model mocks to safe defaults so a
     // previous test's stub doesn't leak into the next one.
     mockPeekPairingRequest.mockResolvedValue(null);
@@ -2355,7 +2363,16 @@ describe('BotMessageRouter', () => {
         dmPolicy: 'disabled',
         groupPolicy: 'open',
       });
-      const channel = makeChannel({ isDM: true });
+      // chat-sdk creates native slash Channels without the Telegram DM flag.
+      // The canonical Thread recovers it from the encoded conversation id.
+      const channel = makeChannel({ id: 'telegram:12345', isDM: false });
+      const thread = {
+        id: channel.id,
+        isDM: true,
+        setState: vi.fn().mockResolvedValue(undefined),
+        state: Promise.resolve(null),
+      };
+      mockThread.mockReturnValueOnce(thread);
       const event = {
         channel,
         text: '',
@@ -2368,6 +2385,7 @@ describe('BotMessageRouter', () => {
       expect(channel.post).toHaveBeenCalledTimes(1);
       expect(channel.post.mock.calls[0][0]).toMatch(/direct message/i);
       expect(channel.setState).not.toHaveBeenCalled();
+      expect(thread.setState).not.toHaveBeenCalled();
     });
 
     it('blocks a native slash command in a non-allowlisted group channel', async () => {
@@ -2797,12 +2815,12 @@ describe('BotMessageRouter', () => {
   });
 
   describe('/mode command (per-conversation agent/chat switch)', () => {
-    async function loadModeHandlers() {
+    async function loadModeHandlers(platform = 'telegram') {
       mockFindEnabledByPlatform.mockResolvedValue([
         makeProvider({ applicationId: 'app-1', settings: { allowFrom: 'alice-id' } }),
       ]);
       const router = new BotMessageRouter();
-      const webhookHandler = router.getWebhookHandler('telegram', 'app-1');
+      const webhookHandler = router.getWebhookHandler(platform, 'app-1');
       const req = new Request('https://example.com/webhook', { body: '{}', method: 'POST' });
       await webhookHandler(req);
 
@@ -2849,6 +2867,8 @@ describe('BotMessageRouter', () => {
     it('switches to agent mode via the native slash path', async () => {
       const { slashMode } = await loadModeHandlers();
       const channel = makeThread();
+      const thread = makeThread();
+      mockThread.mockReturnValueOnce(thread);
       const event = {
         channel,
         text: 'agent',
@@ -2857,8 +2877,78 @@ describe('BotMessageRouter', () => {
 
       await slashMode(event);
 
-      expect(channel.setState).toHaveBeenCalledWith({ toolMode: 'agent' }, undefined);
+      expect(mockThread).toHaveBeenCalledWith(channel.id);
+      expect(thread.setState).toHaveBeenCalledWith({ toolMode: 'agent' }, undefined);
+      expect(channel.setState).not.toHaveBeenCalled();
       expect(channel.post.mock.calls[0][0]).toContain('Agent Mode');
+    });
+
+    it('uses the canonical Telegram thread state for native /new', async () => {
+      mockFindEnabledByPlatform.mockResolvedValue([
+        makeProvider({ applicationId: 'app-1', settings: { allowFrom: 'alice-id' } }),
+      ]);
+      const router = new BotMessageRouter();
+      const webhookHandler = router.getWebhookHandler('telegram', 'app-1');
+      await webhookHandler(
+        new Request('https://example.com/webhook', { body: '{}', method: 'POST' }),
+      );
+      const slashNewCall = mockOnSlashCommand.mock.calls.find((call) => call[0] === '/new');
+      if (!slashNewCall) throw new Error('/new slash handler not registered');
+
+      const slashNew = slashNewCall[1] as (event: any) => Promise<void>;
+      const channel = makeThread();
+      channel.id = 'telegram:12345';
+      const thread = makeThread({ toolMode: 'chat', topicId: 'topic-1' });
+      thread.id = channel.id;
+      thread.isDM = true;
+      mockThread.mockReturnValueOnce(thread);
+
+      await slashNew({
+        channel,
+        text: '',
+        user: { isBot: false, userId: 'alice-id', userName: 'alice' },
+      });
+
+      expect(mockThread).toHaveBeenCalledWith('telegram:12345');
+      expect(thread.setState).toHaveBeenCalledWith(
+        { toolMode: 'chat', topicId: undefined },
+        { replace: true },
+      );
+      expect(channel.setState).not.toHaveBeenCalled();
+      expect(channel.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps Telegram forum topic ids intact when resolving slash-command state', async () => {
+      const { slashMode } = await loadModeHandlers();
+      const channel = makeThread();
+      channel.id = 'telegram:-100123:42';
+      const thread = makeThread();
+      thread.id = channel.id;
+      mockThread.mockReturnValueOnce(thread);
+
+      await slashMode({
+        channel,
+        text: 'chat',
+        user: { isBot: false, userId: 'alice-id', userName: 'alice' },
+      });
+
+      expect(mockThread).toHaveBeenCalledWith('telegram:-100123:42');
+      expect(thread.setState).toHaveBeenCalledWith({ toolMode: 'chat' }, undefined);
+    });
+
+    it('preserves channel-backed slash-command state on non-Telegram platforms', async () => {
+      const { slashMode } = await loadModeHandlers('discord');
+      const channel = makeThread();
+      channel.id = 'discord:guild:channel';
+
+      await slashMode({
+        channel,
+        text: 'agent',
+        user: { isBot: false, userId: 'alice-id', userName: 'alice' },
+      });
+
+      expect(mockThread).not.toHaveBeenCalled();
+      expect(channel.setState).toHaveBeenCalledWith({ toolMode: 'agent' }, undefined);
     });
 
     it('reports the explicit mode on no-arg /mode without writing state', async () => {


### PR DESCRIPTION
## Summary

- resolve Telegram native slash commands to the canonical Chat SDK `Thread` before applying access gates or conversation state changes
- keep slash replies on the original channel and preserve the existing channel-backed behavior for non-Telegram adapters
- add regressions for `/new`, `/mode`, DM policy detection, forum-topic IDs, and the non-Telegram compatibility boundary

Telegram's adapter emits native slash commands with the exact conversation ID, but Chat SDK exposes that event as a `Channel`. The previous dispatcher therefore wrote `/new` to `channel-state:*`, while the next normal message read the unchanged `thread-state:*` and continued the old topic. `bot.thread(event.channel.id)` creates the matching thread handle synchronously, without opening a different DM or making a network request.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```text
pnpm exec tsx .agents/scripts/check/cli.ts apps/server/src/services/bot/BotMessageRouter.ts apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
✓ 2 files · lint clean · tests 106 passed

pnpm run type-check
✓ tsgo --noEmit

git diff --check
✓
```

#### 🔗 Related Issue

Fixes #18725
