### PR TITLE
👷 ci(openapi): run the openapi package's tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Packages
     env:
-      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
+      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents @lobechat/openapi'
 
     steps:
       - name: Checkout

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -2334,6 +2334,83 @@ paths:
           description: Internal server error
       tags:
         - agents
+  /api/v1/anthropic/v1/messages:
+    post:
+      operationId: postApiV1AnthropicV1Messages
+      description: "Anthropic Messages-compatible relay for a server-default
+        heterogeneous agent (Claude Code). Authenticated by an internal
+        operation token rather than an API key: the token carries the provider
+        and model selection, and the request `model` must match it. `stream`
+        must be `true` — the response is an Anthropic SSE stream, not a JSON
+        body."
+      summary: Relay an Anthropic Messages request
+      tags:
+        - anthropic
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                properties:
+                  data:
+                    additionalProperties: true
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    const: true
+                    type: boolean
+                  timestamp:
+                    format: date-time
+                    type: string
+                required:
+                  - success
+                  - timestamp
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Invalid request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Authentication required
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Insufficient permission
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Resource not found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Resource conflict
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Rate limit exceeded
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Internal server error
   /api/v1/api-keys:
     get:
       operationId: getApiV1ApiKeys
@@ -7741,6 +7818,82 @@ paths:
           description: Internal server error
       tags:
         - models
+  /api/v1/openai/v1/responses:
+    post:
+      operationId: postApiV1OpenaiV1Responses
+      description: "OpenAI Responses-compatible relay for a server-default
+        heterogeneous agent (Codex). Authenticated by an internal operation
+        token rather than an API key: the token carries the provider and model
+        selection, and the request `model` must match it. `stream` must be
+        `true` — the response is a Responses SSE stream, not a JSON body."
+      summary: Relay an OpenAI Responses request
+      tags:
+        - openai
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                properties:
+                  data:
+                    additionalProperties: true
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    const: true
+                    type: boolean
+                  timestamp:
+                    format: date-time
+                    type: string
+                required:
+                  - success
+                  - timestamp
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Invalid request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Authentication required
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Insufficient permission
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Resource not found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Resource conflict
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Rate limit exceeded
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+          description: Internal server error
   /api/v1/permissions:
     get:
       operationId: getApiV1Permissions

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -5,6 +5,8 @@
   "main": "./src/index.ts",
   "scripts": {
     "generate:openapi": "bun scripts/generate-openapi.ts",
+    "test": "vitest",
+    "test:coverage": "vitest --coverage --silent='passed-only'",
     "test:response-compliance": "./scripts/compliance-test.sh"
   },
   "dependencies": {

--- a/packages/openapi/src/routes/anthropic.route.ts
+++ b/packages/openapi/src/routes/anthropic.route.ts
@@ -6,6 +6,7 @@ import { isRecord } from '@lobechat/utils/object';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { describeRoute } from 'hono-openapi';
 
 import type { HeteroOperationJwtClaims } from '@/libs/trpc/utils/internalJwt';
 
@@ -20,50 +21,60 @@ import {
 
 const app = new Hono();
 
-app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
-  const request = await c.req.json().catch(() => null);
-  if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
-  const context = c as Context;
-  const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
-  if (!claims.provider_id || !claims.model) {
-    throw new HTTPException(403, { message: 'Operation token has no server model selection' });
-  }
-  if (!isServerDefaultHeterogeneousModel(request.model, claims.model)) {
-    throw new HTTPException(400, { message: 'model must match the server operation selection' });
-  }
-  if (request.stream !== true) {
-    throw new HTTPException(400, { message: 'server-default Anthropic requests must stream' });
-  }
-  const workspaceId = context.get('workspaceId');
-  const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
+app.post(
+  '/v1/messages',
+  describeRoute({
+    description:
+      'Anthropic Messages-compatible relay for a server-default heterogeneous agent (Claude Code). Authenticated by an internal operation token rather than an API key: the token carries the provider and model selection, and the request `model` must match it. `stream` must be `true` — the response is an Anthropic SSE stream, not a JSON body.',
+    summary: 'Relay an Anthropic Messages request',
+    tags: ['anthropic'],
+  }),
+  requireHeteroModelInvocation,
+  async (c) => {
+    const request = await c.req.json().catch(() => null);
+    if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
+    const context = c as Context;
+    const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
+    if (!claims.provider_id || !claims.model) {
+      throw new HTTPException(403, { message: 'Operation token has no server model selection' });
+    }
+    if (!isServerDefaultHeterogeneousModel(request.model, claims.model)) {
+      throw new HTTPException(400, { message: 'model must match the server operation selection' });
+    }
+    if (request.stream !== true) {
+      throw new HTTPException(400, { message: 'server-default Anthropic requests must stream' });
+    }
+    const workspaceId = context.get('workspaceId');
+    const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
 
-  // Anything the model runtime throws has to be turned into an Anthropic error
-  // envelope here. Letting it escape hands the client a bodyless 500 — see
-  // `describeRelayFailure` for what that cost.
-  let body: ReadableStream<Uint8Array> | null;
-  try {
-    const { response } = await invokeServerDefaultModel({
-      agentType: 'claude-code',
-      model: claims.model,
-      payload: normalizeAnthropicRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
-      signal: c.req.raw.signal,
-      userId: String(context.get('userId')),
-      workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+    // Anything the model runtime throws has to be turned into an Anthropic error
+    // envelope here. Letting it escape hands the client a bodyless 500 — see
+    // `describeRelayFailure` for what that cost.
+    let body: ReadableStream<Uint8Array> | null;
+    try {
+      const { response } = await invokeServerDefaultModel({
+        agentType: 'claude-code',
+        model: claims.model,
+        payload: normalizeAnthropicRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
+        signal: c.req.raw.signal,
+        userId: String(context.get('userId')),
+        workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+      });
+      body = response.body;
+    } catch (error) {
+      const { message, status } = describeRelayFailure(error);
+      return c.json({ error: { message, type: 'api_error' }, type: 'error' }, status);
+    }
+    if (!body) {
+      return c.json(
+        { error: { message: 'Upstream returned no stream', type: 'api_error' }, type: 'error' },
+        502,
+      );
+    }
+    return new Response(encodeAnthropicStream(body, requestModel), {
+      headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
     });
-    body = response.body;
-  } catch (error) {
-    const { message, status } = describeRelayFailure(error);
-    return c.json({ error: { message, type: 'api_error' }, type: 'error' }, status);
-  }
-  if (!body) {
-    return c.json(
-      { error: { message: 'Upstream returned no stream', type: 'api_error' }, type: 'error' },
-      502,
-    );
-  }
-  return new Response(encodeAnthropicStream(body, requestModel), {
-    headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
-  });
-});
+  },
+);
 
 export default app;

--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -6,6 +6,7 @@ import { isRecord } from '@lobechat/utils/object';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { describeRoute } from 'hono-openapi';
 
 import type { HeteroOperationJwtClaims } from '@/libs/trpc/utils/internalJwt';
 
@@ -20,46 +21,56 @@ import {
 
 const app = new Hono();
 
-app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
-  const request = await c.req.json().catch(() => null);
-  if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
-  const context = c as Context;
-  const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
-  if (!claims.provider_id || !claims.model) {
-    throw new HTTPException(403, { message: 'Operation token has no server model selection' });
-  }
-  if (!isServerDefaultHeterogeneousModel(request.model, claims.model)) {
-    throw new HTTPException(400, { message: 'model must match the server operation selection' });
-  }
-  if (request.stream !== true) {
-    throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
-  }
-  const workspaceId = context.get('workspaceId');
-  const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
+app.post(
+  '/v1/responses',
+  describeRoute({
+    description:
+      'OpenAI Responses-compatible relay for a server-default heterogeneous agent (Codex). Authenticated by an internal operation token rather than an API key: the token carries the provider and model selection, and the request `model` must match it. `stream` must be `true` — the response is a Responses SSE stream, not a JSON body.',
+    summary: 'Relay an OpenAI Responses request',
+    tags: ['openai'],
+  }),
+  requireHeteroModelInvocation,
+  async (c) => {
+    const request = await c.req.json().catch(() => null);
+    if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
+    const context = c as Context;
+    const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
+    if (!claims.provider_id || !claims.model) {
+      throw new HTTPException(403, { message: 'Operation token has no server model selection' });
+    }
+    if (!isServerDefaultHeterogeneousModel(request.model, claims.model)) {
+      throw new HTTPException(400, { message: 'model must match the server operation selection' });
+    }
+    if (request.stream !== true) {
+      throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
+    }
+    const workspaceId = context.get('workspaceId');
+    const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
 
-  // Same reasoning as the Anthropic relay: an escaping runtime rejection reaches
-  // the client as a bodyless 500. See `describeRelayFailure`.
-  let body: ReadableStream<Uint8Array> | null;
-  try {
-    const { response } = await invokeServerDefaultModel({
-      agentType: 'codex',
-      model: claims.model,
-      payload: normalizeResponsesRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
-      signal: c.req.raw.signal,
-      userId: String(context.get('userId')),
-      workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+    // Same reasoning as the Anthropic relay: an escaping runtime rejection reaches
+    // the client as a bodyless 500. See `describeRelayFailure`.
+    let body: ReadableStream<Uint8Array> | null;
+    try {
+      const { response } = await invokeServerDefaultModel({
+        agentType: 'codex',
+        model: claims.model,
+        payload: normalizeResponsesRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
+        signal: c.req.raw.signal,
+        userId: String(context.get('userId')),
+        workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+      });
+      body = response.body;
+    } catch (error) {
+      const { message, status } = describeRelayFailure(error);
+      return c.json({ error: { message, type: 'api_error' } }, status);
+    }
+    if (!body) {
+      return c.json({ error: { message: 'Upstream returned no stream', type: 'api_error' } }, 502);
+    }
+    return new Response(encodeResponsesStream(body, requestModel), {
+      headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
     });
-    body = response.body;
-  } catch (error) {
-    const { message, status } = describeRelayFailure(error);
-    return c.json({ error: { message, type: 'api_error' } }, status);
-  }
-  if (!body) {
-    return c.json({ error: { message: 'Upstream returned no stream', type: 'api_error' } }, 502);
-  }
-  return new Response(encodeResponsesStream(body, requestModel), {
-    headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
-  });
-});
+  },
+);
 
 export default app;

--- a/packages/openapi/vitest.config.mts
+++ b/packages/openapi/vitest.config.mts
@@ -13,6 +13,10 @@ export default defineConfig({
     },
   },
   test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
     environment: 'node',
   },
 });


### PR DESCRIPTION
`packages/openapi` has **26 test files and 168 tests that have never run in CI**. Three reasons stacked up, each of which alone would have been enough:

- the package has no `test` / `test:coverage` script, while every covered package has one;
- it is absent from the hardcoded `PACKAGES` allowlist in `.github/workflows/test.yml`;
- the root `vitest.config.mts` excludes `**/packages/**`, so `Test Web App` / `Test Server` never reach it either.

#### The gap already let a regression land

`scripts/generate-openapi.test.ts` asserts that every registered route appears in `openapi.yml`. On canary it **fails**:

```
✗ 2 route(s) missing from the spec (no hono-openapi validator/describeRoute attached):
  - POST /api/v1/anthropic/v1/messages
  - POST /api/v1/openai/v1/responses
```

Both are the server-default heterogeneous relays. They reached the router without OpenAPI metadata, so they were silently absent from the published spec and nothing caught it — the check that exists to catch exactly this was never being run.

Both now carry `describeRoute`. That is **metadata only**: these handlers parse the body by hand (`c.req.json()`) and must stream, so attaching a `zValidator` instead would have changed runtime behaviour. `openapi.yml` is regenerated and gains exactly those two paths, with zero deletions.

#### Test

Verified with the command CI actually runs:

```bash
bun run --filter @lobechat/openapi test:coverage
# Test Files  26 passed (26)
#      Tests  168 passed (168)
```

`coverage/lcov.info` is produced, so the existing Codecov step picks the package up under the `packages/openapi` flag (its `-f lcov.info` guard meant it was silently skipping before).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

The two undocumented relays came from #18558 / #18621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)