### PR TITLE
🐛 fix(home): align recommendation icon sizes

### DIFF
--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import BriefCardSummary from '@/features/DailyBrief/BriefCardSummary';
 import { styles as briefStyles } from '@/features/DailyBrief/style';
 import { homeType } from '@/features/Home/components/homeType';
+import { RECOMMENDATION_ICON_SIZE } from '@/features/Recommendations/iconSize';
 
 import { ConnectorAuthRow } from './ConnectorAuthRow';
 import { resolveTemplateIcon } from './resolveTemplateIcon';
@@ -81,7 +82,7 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(
           >
             <Flexbox horizontal align={'flex-start'} gap={10} style={{ width: '100%' }}>
               <Flexbox flex={'none'} paddingBlock={2}>
-                <TemplateBriefIcon spec={iconSpec} tileSize={20} />
+                <TemplateBriefIcon spec={iconSpec} tileSize={RECOMMENDATION_ICON_SIZE.compact} />
               </Flexbox>
               <Text
                 className={cx(homeType.itemTitleProse, styles.compactTitle)}
@@ -129,7 +130,7 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(
             gap={8}
             style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
           >
-            <TemplateBriefIcon spec={iconSpec} />
+            <TemplateBriefIcon spec={iconSpec} tileSize={RECOMMENDATION_ICON_SIZE.regular} />
             <Flexbox
               horizontal
               align={'center'}

--- a/src/features/RecommendTaskTemplates/TaskTemplateCardSkeleton.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCardSkeleton.tsx
@@ -4,6 +4,7 @@ import { cssVar, cx } from 'antd-style';
 import { memo } from 'react';
 
 import { styles as briefStyles } from '@/features/DailyBrief/style';
+import { RECOMMENDATION_ICON_SIZE } from '@/features/Recommendations/iconSize';
 
 import { styles } from './style';
 
@@ -26,7 +27,7 @@ export const TaskTemplateCardSkeleton = memo<TaskTemplateCardSkeletonProps>(
           <Skeleton.Avatar
             active
             shape={'square'}
-            size={20}
+            size={RECOMMENDATION_ICON_SIZE.compact}
             style={{ borderRadius: cssVar.borderRadius, flex: 'none' }}
           />
           <Skeleton.Button active style={{ height: 16, width: '70%' }} />
@@ -52,7 +53,7 @@ export const TaskTemplateCardSkeleton = memo<TaskTemplateCardSkeletonProps>(
             <Skeleton.Avatar
               active
               shape={'square'}
-              size={28}
+              size={RECOMMENDATION_ICON_SIZE.regular}
               style={{ borderRadius: cssVar.borderRadius, flex: 'none' }}
             />
             <Flexbox

--- a/src/features/RecommendTaskTemplates/TemplateBriefIcon.tsx
+++ b/src/features/RecommendTaskTemplates/TemplateBriefIcon.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from 'lucide-react';
 import { memo } from 'react';
 
 import { INTEREST_AREAS } from '@/features/Onboarding/config';
+import { RECOMMENDATION_ICON_SIZE } from '@/features/Recommendations/iconSize';
 
 import type { TemplateIconSpec } from './resolveTemplateIcon';
 
@@ -17,34 +18,36 @@ interface TemplateBriefIconProps {
 }
 
 /** Square tile with secondary fill — used by the recommend card (28) and detail modal (36). */
-export const TemplateBriefIcon = memo<TemplateBriefIconProps>(({ spec, tileSize = 28 }) => {
-  const glyphSize = Math.round(tileSize * 0.6);
-  return (
-    <Block
-      align={'center'}
-      height={tileSize}
-      justify={'center'}
-      style={{ background: cssVar.colorFillSecondary, flexShrink: 0 }}
-      width={tileSize}
-    >
-      {spec.kind === 'url' ? (
-        <Image
-          alt={''}
-          height={glyphSize}
-          src={spec.src}
-          style={{ flex: 'none' }}
-          width={glyphSize}
-        />
-      ) : (
-        <Icon
-          color={cssVar.colorTextSecondary}
-          fill={cssVar.colorTextSecondary}
-          icon={spec.Comp}
-          size={glyphSize}
-        />
-      )}
-    </Block>
-  );
-});
+export const TemplateBriefIcon = memo<TemplateBriefIconProps>(
+  ({ spec, tileSize = RECOMMENDATION_ICON_SIZE.regular }) => {
+    const glyphSize = Math.round(tileSize * 0.6);
+    return (
+      <Block
+        align={'center'}
+        height={tileSize}
+        justify={'center'}
+        style={{ background: cssVar.colorFillSecondary, flexShrink: 0 }}
+        width={tileSize}
+      >
+        {spec.kind === 'url' ? (
+          <Image
+            alt={''}
+            height={glyphSize}
+            src={spec.src}
+            style={{ flex: 'none' }}
+            width={glyphSize}
+          />
+        ) : (
+          <Icon
+            color={cssVar.colorTextSecondary}
+            fill={cssVar.colorTextSecondary}
+            icon={spec.Comp}
+            size={glyphSize}
+          />
+        )}
+      </Block>
+    );
+  },
+);
 
 TemplateBriefIcon.displayName = 'TemplateBriefIcon';

--- a/src/features/Recommendations/RecommendationCard.tsx
+++ b/src/features/Recommendations/RecommendationCard.tsx
@@ -9,6 +9,7 @@ import BriefCardSummary from '@/features/DailyBrief/BriefCardSummary';
 import { styles as briefStyles } from '@/features/DailyBrief/style';
 import { homeType } from '@/features/Home/components/homeType';
 
+import { RECOMMENDATION_ICON_SIZE } from './iconSize';
 import { styles } from './style';
 
 interface RecommendationCardProps {
@@ -17,15 +18,15 @@ interface RecommendationCardProps {
   ctaKey: string;
   descriptionKey: string;
   i18nValues?: Record<string, string>;
-  icon: ReactNode;
   /** Async handler for the primary CTA. */
   onAction: () => Promise<void>;
+  renderIcon: (size: number) => ReactNode;
   tagKey?: string;
   titleKey: string;
 }
 
 export const RecommendationCard = memo<RecommendationCardProps>(
-  ({ compact, ctaKey, descriptionKey, i18nValues, icon, onAction, tagKey, titleKey }) => {
+  ({ compact, ctaKey, descriptionKey, i18nValues, onAction, renderIcon, tagKey, titleKey }) => {
     const { t } = useTranslation('home');
 
     const [loading, setLoading] = useState(false);
@@ -53,7 +54,7 @@ export const RecommendationCard = memo<RecommendationCardProps>(
         <Button className={styles.compactRow} loading={loading} type={'text'} onClick={handleClick}>
           <Flexbox horizontal align={'flex-start'} gap={10} style={{ width: '100%' }}>
             <Flexbox flex={'none'} paddingBlock={2}>
-              {icon}
+              {renderIcon(RECOMMENDATION_ICON_SIZE.compact)}
             </Flexbox>
             <Text className={cx(homeType.itemTitleProse, styles.compactTitle)} style={{ flex: 1 }}>
               {title}
@@ -77,7 +78,7 @@ export const RecommendationCard = memo<RecommendationCardProps>(
             gap={8}
             style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
           >
-            {icon}
+            {renderIcon(RECOMMENDATION_ICON_SIZE.regular)}
             <Text ellipsis fontSize={16} weight={500}>
               {title}
             </Text>

--- a/src/features/Recommendations/actions/heteroAgent.test.ts
+++ b/src/features/Recommendations/actions/heteroAgent.test.ts
@@ -2,14 +2,24 @@ import { HETEROGENEOUS_AGENT_CLIENT_CONFIGS } from '@lobechat/heterogeneous-agen
 import { isValidElement } from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { RECOMMENDATION_ICON_SIZE } from '../iconSize';
 import { buildHeteroAgentAction } from './heteroAgent';
 
 describe('buildHeteroAgentAction', () => {
-  it.each(HETEROGENEOUS_AGENT_CLIENT_CONFIGS)('builds a valid icon for $type', (config) => {
-    const { icon } = buildHeteroAgentAction(config);
+  it.each(HETEROGENEOUS_AGENT_CLIENT_CONFIGS)(
+    'renders $type at the requested icon size',
+    (config) => {
+      const { renderIcon } = buildHeteroAgentAction(config);
 
-    expect(isValidElement(icon)).toBe(true);
-    if (!isValidElement(icon)) throw new Error(`Expected a React element for ${config.type}`);
-    expect(icon.type).toBeDefined();
-  });
+      for (const size of Object.values(RECOMMENDATION_ICON_SIZE)) {
+        const icon = renderIcon(size);
+
+        expect(isValidElement(icon)).toBe(true);
+        if (!isValidElement<{ size: number }>(icon)) {
+          throw new Error(`Expected a React element for ${config.type}`);
+        }
+        expect(icon.props.size).toBe(size);
+      }
+    },
+  );
 });

--- a/src/features/Recommendations/actions/heteroAgent.ts
+++ b/src/features/Recommendations/actions/heteroAgent.ts
@@ -45,11 +45,6 @@ export const buildHeteroAgentAction = (
     descriptionKey: 'recommendations.heteroAgent.description',
     execute: (ctx) => ctx.createHeteroAgent(config),
     i18nValues: { name: config.title },
-    icon: createElement(Avatar, {
-      shape: 'square',
-      size: 28,
-      style: { borderRadius: 8 },
-    }),
     id: `hetero-agent:${config.type}`,
     isEligible: (ctx) => {
       if (!ctx.isDesktop) return false;
@@ -57,6 +52,12 @@ export const buildHeteroAgentAction = (
       return !ctx.agents.some((a) => a.heterogeneousType === config.type);
     },
     priority: 10,
+    renderIcon: (size) =>
+      createElement(Avatar, {
+        shape: 'square',
+        size,
+        style: { borderRadius: 8 },
+      }),
     tagKey: 'recommendations.heteroAgent.tag',
     titleKey: 'recommendations.heteroAgent.title',
   };

--- a/src/features/Recommendations/actions/types.ts
+++ b/src/features/Recommendations/actions/types.ts
@@ -26,11 +26,11 @@ export interface RecommendedAction {
   execute: (ctx: ActionContext) => Promise<void>;
   /** i18n interpolation values for title/description/cta */
   i18nValues?: Record<string, string>;
-  icon: ReactNode;
   id: string;
   isEligible: (ctx: ActionContext) => boolean;
   /** Higher = shown earlier. Defaults to 0. */
   priority?: number;
+  renderIcon: (size: number) => ReactNode;
   tagKey?: string;
 
   titleKey: string;

--- a/src/features/Recommendations/iconSize.ts
+++ b/src/features/Recommendations/iconSize.ts
@@ -1,0 +1,4 @@
+export const RECOMMENDATION_ICON_SIZE = {
+  compact: 20,
+  regular: 28,
+} as const;

--- a/src/features/Recommendations/index.tsx
+++ b/src/features/Recommendations/index.tsx
@@ -103,8 +103,8 @@ const Recommendations = memo<RecommendationsProps>(({ variant = 'default' }) => 
           ctaKey={action.ctaKey}
           descriptionKey={action.descriptionKey}
           i18nValues={action.i18nValues}
-          icon={action.icon}
           key={action.id}
+          renderIcon={action.renderIcon}
           tagKey={action.tagKey}
           titleKey={action.titleKey}
           onAction={action.run}


### PR DESCRIPTION
Align recommendation icons across the Home suggestions card.

- centralize compact and regular recommendation icon sizes
- render heterogeneous agent avatars at the size requested by the card
- reuse the same icon specification for task templates and skeletons

| Before | After |
| ------ | ----- |
| Heterogeneous agent avatars stayed at 28px in the compact rail | All compact recommendation icons use 20px; regular cards use 28px |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verification:

- `bun run check <changed-files>` — lint clean, 11 tests passed
- `bun run check --type` — types clean

#### 🔗 Related Issue

No matching issue found.