### PR TITLE
💄 style(home): let the home promo banner wrap instead of truncating

### DIFF
--- a/src/features/Home/HomeHeader.tsx
+++ b/src/features/Home/HomeHeader.tsx
@@ -10,6 +10,9 @@ import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/se
 import AgentSelect from './AgentSelect';
 
 const styles = createStaticStyles(({ css }) => ({
+  // The promo track sizes to its content instead of a fixed cap: marketing copy
+  // is server-driven and unbounded, so a hard width cut the text mid-glyph. It
+  // wraps once it runs out of room.
   // The measure comes from the layout (`--home-greeting-measure`), which derives
   // it from the container width: it has to clear the portrait's bubble, and it
   // must not depend on the rail, or collapsing would re-wrap the headline and
@@ -28,13 +31,9 @@ const styles = createStaticStyles(({ css }) => ({
     letter-spacing: -0.01em;
   `,
   promo: css`
-    overflow: hidden;
     justify-self: center;
-
     min-width: 0;
-    max-width: 100%;
-
-    white-space: nowrap;
+    max-width: min(100%, 720px);
 
     @container home (width <= 720px) {
       justify-self: end;
@@ -48,7 +47,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   toolbar: css`
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 480px) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, max-content) minmax(0, 1fr);
     align-items: center;
 
     width: 100%;


### PR DESCRIPTION
The home header's promo slot was a fixed `minmax(0, 480px)` grid track with `white-space: nowrap` + `overflow: hidden`. Promo copy is server-driven and unbounded, so anything longer than the track got cut mid-glyph — with no ellipsis.

- promo track sizes to its content (`minmax(0, max-content)`) instead of a hard 480px cap
- promo wraps when it runs out of room (`nowrap` / `overflow: hidden` removed), with `max-width: min(100%, 720px)` as the outer bound
- the `<= 720px` container branch is unchanged (still end-aligned, 280px), it just wraps now instead of clipping

The banner's own styles live in the cloud overlay (`HomePromoBanner/styles.ts`) and are updated in a matching cloud PR: label drops `nowrap`, `height` becomes `min-height` so a wrapped label isn't squashed.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure CSS layout change; `bun run check src/features/Home/HomeHeader.tsx` passes.