### PR TITLE
🐛 fix: align chat output cost estimate ratio

### DIFF
--- a/packages/model-runtime/src/core/usageConverters/utils/estimateChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/estimateChatCost.test.ts
@@ -21,9 +21,9 @@ describe('estimateChatCost', () => {
     });
 
     it('uses the effective request or model cap when provided', () => {
-      expect(estimateChatOutputTokens(100_000, 32_000)).toBe(10_000);
-      expect(estimateChatOutputTokens(100_000, 12_000)).toBe(10_000);
-      expect(estimateChatOutputTokens(100_000, 4096)).toBe(4096);
+      expect(estimateChatOutputTokens(400_000, 32_000)).toBe(32_000);
+      expect(estimateChatOutputTokens(400_000, 12_000)).toBe(12_000);
+      expect(estimateChatOutputTokens(400_000, 4096)).toBe(4096);
     });
   });
 

--- a/packages/model-runtime/src/core/usageConverters/utils/estimateChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/estimateChatCost.test.ts
@@ -11,19 +11,19 @@ import {
 describe('estimateChatCost', () => {
   describe('estimateChatOutputTokens', () => {
     it('applies the output ratio below the cap', () => {
-      expect(estimateChatOutputTokens(4000)).toBe(2000);
-      expect(estimateChatOutputTokens(1000)).toBe(500);
+      expect(estimateChatOutputTokens(4000)).toBe(400);
+      expect(estimateChatOutputTokens(1000)).toBe(100);
     });
 
     it('uses 8192 as the fallback cap for large inputs', () => {
-      expect(estimateChatOutputTokens(20_000)).toBe(8192);
+      expect(estimateChatOutputTokens(100_000)).toBe(8192);
       expect(estimateChatOutputTokens(1_000_000)).toBe(8192);
     });
 
     it('uses the effective request or model cap when provided', () => {
-      expect(estimateChatOutputTokens(40_000, 32_000)).toBe(20_000);
-      expect(estimateChatOutputTokens(40_000, 12_000)).toBe(12_000);
-      expect(estimateChatOutputTokens(40_000, 4096)).toBe(4096);
+      expect(estimateChatOutputTokens(100_000, 32_000)).toBe(10_000);
+      expect(estimateChatOutputTokens(100_000, 12_000)).toBe(10_000);
+      expect(estimateChatOutputTokens(100_000, 4096)).toBe(4096);
     });
   });
 
@@ -207,7 +207,7 @@ describe('estimateChatCost', () => {
 
       const estimate = estimateChatCostFromTokens(pricing, {
         maxOutputTokens: 12_000,
-        textTokens: 40_000,
+        textTokens: 200_000,
       });
 
       expect(estimate?.estimatedOutputTokens).toBe(12_000);
@@ -288,7 +288,7 @@ describe('estimateChatCost', () => {
 
       const estimate = estimateChatCostFromMessages(
         pricing,
-        [{ content: 'hello world', role: 'user' }],
+        [{ content: 'hello world '.repeat(100), role: 'user' }],
         { maxOutputTokens: 1 },
       );
 

--- a/packages/model-runtime/src/core/usageConverters/utils/estimateChatCost.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/estimateChatCost.ts
@@ -13,7 +13,7 @@ import { computeChatCost } from './computeChatCost';
 
 const DEFAULT_IMAGE_INPUT_TOKEN_ESTIMATE = 1000;
 const DEFAULT_VIDEO_INPUT_TOKEN_ESTIMATE = 1000;
-const OUTPUT_INPUT_RATIO = 0.5;
+const OUTPUT_INPUT_RATIO = 0.1;
 const OUTPUT_TOKEN_CAP = 8192;
 
 export interface ChatInputTokenEstimate {
@@ -113,7 +113,7 @@ const hasPricingUnit = (pricing: Pricing | undefined, unitName: PricingUnitName)
 /**
  * Estimates output tokens for budget pre-checks and UI hints.
  *
- * The default heuristic assumes output is half of total input tokens. A request/model limit caps
+ * The default heuristic assumes output is one tenth of total input tokens. A request/model limit caps
  * the estimate when provided; otherwise 8192 tokens is used as a fallback cap.
  */
 export function estimateChatOutputTokens(


### PR DESCRIPTION
## Brief

Adjust the shared chat output-token estimate from 50% to 10% of input tokens while preserving request/model caps and the existing fallback cap.

## Key Decisions / Non-goals

- Keep one shared heuristic for all estimator callers.
- Preserve the existing public API and cap behavior.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/core/usageConverters/utils/estimateChatCost.test.ts
```
