### PR TITLE
🐛 fix(search): improve multi-keyword Search1API queries

### DIFF
--- a/apps/server/src/services/search/impls/search1api/index.integration.test.ts
+++ b/apps/server/src/services/search/impls/search1api/index.integration.test.ts
@@ -34,7 +34,7 @@ describeIfKey('Search1APIImpl integration', { timeout: 30_000 }, () => {
     expect(Array.isArray(result.results)).toBe(true);
   });
 
-  it('should keep using auto mode when searchEngines are provided', async () => {
+  it('should handle legacy multiple searchEngines', async () => {
     const result = await impl.query('TypeScript', {
       searchEngines: ['google', 'bing'],
     });
@@ -57,7 +57,7 @@ describeIfKey('Search1APIImpl integration', { timeout: 30_000 }, () => {
     }
   });
 
-  it('should handle legacy single search engine param with auto mode', async () => {
+  it('should handle a legacy single search engine param', async () => {
     const result = await impl.query('OpenAI', {
       searchEngines: ['google'],
     });

--- a/apps/server/src/services/search/impls/search1api/index.test.ts
+++ b/apps/server/src/services/search/impls/search1api/index.test.ts
@@ -46,14 +46,12 @@ describe('Search1APIImpl', () => {
     delete process.env.SEARCH1API_API_KEY;
   });
 
-  it('should advertise automatic engine selection', () => {
-    expect(impl.useAutoSearchEngineSelection).toBe(true);
-  });
-
-  it('should use auto mode even when searchEngines are provided', async () => {
+  it('should use Google for multi-keyword queries without changing the query', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(createMockResponse({ results: [] }));
 
-    await impl.query('TypeScript', { searchEngines: ['google', 'bing'] });
+    const query = 'point cloud semantic segmentation transformer survey';
+
+    await impl.query(query);
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
@@ -63,26 +61,25 @@ describe('Search1APIImpl', () => {
       crawl_results: 0,
       image: false,
       max_results: 15,
-      query: 'TypeScript',
+      query,
+      search_service: 'google',
     });
-    expect(body[0].search_service).toBeUndefined();
   });
 
-  it('should keep time range while using auto mode', async () => {
+  it('should keep time range while using Google', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(createMockResponse({ results: [] }));
 
     await impl.query('latest AI news', {
-      searchEngines: ['google'],
       searchTimeRange: 'week',
     });
 
     const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
 
-    expect(body[0].search_service).toBeUndefined();
+    expect(body[0].search_service).toBe('google');
     expect(body[0].time_range).toBe('month');
   });
 
-  it('should not emit an empty engine for auto results', async () => {
+  it('should not emit an empty engine when the response omits the search service', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       createMockResponse(makeSearch1ApiResponse({ query: 'test' })),
     );

--- a/apps/server/src/services/search/impls/search1api/index.ts
+++ b/apps/server/src/services/search/impls/search1api/index.ts
@@ -1,14 +1,10 @@
-import {
-  type SearchParams,
-  type UniformSearchResponse,
-  type UniformSearchResult,
-} from '@lobechat/types';
+import type { SearchParams, UniformSearchResponse, UniformSearchResult } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import urlJoin from 'url-join';
 
-import { type SearchServiceImpl } from '../type';
-import { type Search1ApiRawResponse, type TimeRange } from './type';
+import type { SearchServiceImpl } from '../type';
+import type { Search1ApiRawResponse, SearchService, TimeRange } from './type';
 
 const timeRangeMapping: Record<string, TimeRange | undefined> = {
   day: 'day',
@@ -25,6 +21,7 @@ interface Search1APIQueryParams {
   language?: string;
   max_results: number;
   query: string;
+  search_service: SearchService;
   time_range?: string;
 }
 
@@ -35,8 +32,6 @@ const log = debug('lobe-search:search1api');
  * Primarily used for web crawling
  */
 export class Search1APIImpl implements SearchServiceImpl {
-  readonly useAutoSearchEngineSelection = true;
-
   private get apiKey(): string | undefined {
     return process.env.SEARCH1API_SEARCH_API_KEY || process.env.SEARCH1API_API_KEY;
   }
@@ -55,6 +50,7 @@ export class Search1APIImpl implements SearchServiceImpl {
       image: false,
       max_results: 15, // Default max results
       query,
+      search_service: 'google',
     };
 
     const body: Search1APIQueryParams[] = [
@@ -67,10 +63,10 @@ export class Search1APIImpl implements SearchServiceImpl {
       },
     ];
 
-    // Search1API's auto mode chooses the search service per query. Forwarding
-    // searchEngines expands one query into multiple service calls.
-    // Note: Other SearchParams like searchCategories and Search1API specific
-    // params like include_sites, exclude_sites, language are not currently mapped.
+    // Use a deterministic general web-search engine so ambiguous leading keywords
+    // do not redirect multi-keyword queries to an unrelated vertical search.
+    // Note: searchCategories, searchEngines, and Search1API-specific params like
+    // include_sites, exclude_sites, and language are not currently mapped.
 
     log('Constructed request body: %o', body);
 


### PR DESCRIPTION
Use Google explicitly for Search1API general web searches so ambiguous leading keywords do not redirect multi-keyword queries to unrelated vertical search services. The complete query string remains unchanged.

| Before | After |
| ------ | ----- |
| Search1API auto-selected a search service and could over-weight ambiguous leading keywords such as `point`, `vs`, or `open`. | Search1API uses Google for general web queries while preserving the complete query string. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check --lint --test --type apps/server/src/services/search/impls/search1api/index.ts apps/server/src/services/search/impls/search1api/index.test.ts apps/server/src/services/search/impls/search1api/index.integration.test.ts
```

- Lint: passed for all 3 changed files.
- Unit tests: 4 passed.
- Full type-check: blocked by unrelated existing `.next/dev` route declarations and `@lobehub/ui/base-ui` export mismatches in the local `canary` workspace.
- Live Search1API integration tests were not run because no Search1API API key is configured locally.

Regression coverage includes the multi-keyword query `point cloud semantic segmentation transformer survey` and asserts both complete query preservation and explicit Google selection.

#### 🔗 Related Issue

Fixes #18704
