### PR TITLE
💄 style: register dedicated skeletons for all lazy routes

### DIFF
--- a/.agents/skills/spa-routes/SKILL.md
+++ b/.agents/skills/spa-routes/SKILL.md
@@ -81,6 +81,15 @@ Each feature should:
    - **Web-only or Electron-only route:** add it to the corresponding thin `desktopRouter.config.tsx` adapter. Keep platform-only differences explicit and small.
    - **Mobile-only flow:** use `mobileRouter.config.tsx`; mobile does not consume the shared desktop tree.
 
+6. **Register a route skeleton (REQUIRED for every lazy route)**
+   - Every lazy route inside the main area renders `RouteSegmentSkeleton` (`src/components/Skeleton/RouteSegment.tsx`) while its chunk loads. It resolves via `handle.meta.Skeleton` (deepest match wins, walking up through parent routes) and only then falls back to path-guessing — never rely on the guess.
+   - Pick the skeleton when adding or restructuring a route:
+     - A close-enough generic shape exists → `Skeleton: createSurfaceSkeleton('list' | 'form' | 'grid' | 'editor' | 'detail')` from `@/components/Skeleton/Surface`.
+     - The page has a distinctive layout (dashboard, multi-panel, conversation) → author a bespoke component under `src/components/Skeleton/` and register it (see `Home.tsx`, `Generation.tsx`, `Conversation/`).
+   - Where to put it: on the route's `routeMeta` (feature `routeMeta.ts` or inline in `desktopRouter.shared.tsx`). A whole subtree sharing one shape can register once on the parent/layout route's `handle` — children with their own `Skeleton` still override.
+   - When changing a page's layout, update its registered skeleton in the same PR — a stale skeleton that no longer matches the page is a regression.
+   - Skeleton-only parent handles are safe for titles: title/icon resolution also walks deepest-first, and leaf metas keep winning.
+
 ---
 
 ## 3a. Shared desktop route definition and platform adapters

--- a/package.json
+++ b/package.json
@@ -585,6 +585,7 @@
       "workerd"
     ],
     "overrides": {
+      "@lobehub/ui": "5.33.1",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.33.1",
+    "@lobehub/ui": "^5.33.3",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",
@@ -585,7 +585,6 @@
       "workerd"
     ],
     "overrides": {
-      "@lobehub/ui": "5.33.1",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",

--- a/packages/builtin-tool-group-management/src/client/Intervention/ExecuteTasks.tsx
+++ b/packages/builtin-tool-group-management/src/client/Intervention/ExecuteTasks.tsx
@@ -2,15 +2,8 @@
 
 import { DEFAULT_AVATAR } from '@lobechat/const';
 import type { BuiltinInterventionProps } from '@lobechat/types';
-import {
-  Accordion,
-  AccordionItem,
-  Avatar,
-  Flexbox,
-  Icon,
-  stopPropagation,
-  Tooltip,
-} from '@lobehub/ui';
+import { Accordion, AccordionItem, Flexbox, Icon, stopPropagation, Tooltip } from '@lobehub/ui';
+import { Avatar } from '@lobehub/ui/base-ui';
 import { Input, InputNumber } from 'antd';
 import { createStaticStyles, useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';

--- a/packages/builtin-tool-web-browsing/src/client/Portal/PageContent/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Portal/PageContent/index.tsx
@@ -1,15 +1,7 @@
 import type { CrawlResult } from '@lobechat/types';
 import type { CrawlSuccessResult } from '@lobechat/web-crawler';
-import {
-  CopyButton,
-  Flexbox,
-  Highlighter,
-  Icon,
-  Markdown,
-  stopPropagation,
-  Text,
-} from '@lobehub/ui';
-import { Alert, Segmented } from '@lobehub/ui/base-ui';
+import { CopyButton, Flexbox, Highlighter, Icon, Markdown, stopPropagation } from '@lobehub/ui';
+import { Alert, Segmented, Text } from '@lobehub/ui/base-ui';
 import { Descriptions } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { ExternalLink } from 'lucide-react';

--- a/src/components/AsyncBoundary/index.test.tsx
+++ b/src/components/AsyncBoundary/index.test.tsx
@@ -9,6 +9,7 @@ import AsyncBoundary from './index';
 // hoists this above the imports regardless of position.
 vi.mock('@lobehub/ui/base-ui', () => ({
   Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+  Text: ({ children }: any) => <span>{children}</span>,
 }));
 
 const DATA = <div>DATA_CONTENT</div>;

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar as LobeAvatar, type AvatarProps as LobeAvatarProps } from '@lobehub/ui';
+import { Avatar as LobeAvatar, type AvatarProps as LobeAvatarProps } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
 import { remoteAvatarSrc, resolveAvatar } from './fallback';

--- a/src/components/ChatGroupWizard/ChatGroupWizard.tsx
+++ b/src/components/ChatGroupWizard/ChatGroupWizard.tsx
@@ -1,17 +1,7 @@
 'use client';
 
-import {
-  Avatar,
-  Collapse,
-  Empty,
-  Flexbox,
-  List,
-  SearchBar,
-  stopPropagation,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
-import { Button, Checkbox, Switch } from '@lobehub/ui/base-ui';
+import { Collapse, Empty, Flexbox, List, SearchBar, stopPropagation, Tooltip } from '@lobehub/ui';
+import { Avatar, Button, Checkbox, Switch, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { omit } from 'es-toolkit/compat';
 import { Users } from 'lucide-react';

--- a/src/components/Skeleton/Generation.tsx
+++ b/src/components/Skeleton/Generation.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Flexbox, Grid } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+
+import SkeletonBar from './Bar';
+
+const styles = createStaticStyles(({ css }) => ({
+  panel: css`
+    flex-shrink: 0;
+    width: 280px;
+    border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    @media (width <= 900px) {
+      display: none;
+    }
+  `,
+  prompt: css`
+    height: 96px;
+    border: 1px solid ${cssVar.colorFill};
+    border-radius: ${cssVar.borderRadiusLG};
+    background: ${cssVar.colorBgElevated};
+  `,
+}));
+
+const GenerationSkeleton = () => (
+  <Flexbox aria-busy horizontal flex={1} height={'100%'} style={{ overflow: 'hidden' }}>
+    <Flexbox className={styles.panel} gap={20} padding={16}>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Flexbox gap={8} key={index}>
+          <SkeletonBar height={12} width={72 + (index % 2) * 32} />
+          <SkeletonBar height={32} radius={cssVar.borderRadius} />
+        </Flexbox>
+      ))}
+    </Flexbox>
+    <Flexbox flex={1} justify={'space-between'} padding={16} style={{ minWidth: 0 }}>
+      <Grid gap={12} maxItemWidth={200} rows={2} width={'100%'}>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <SkeletonBar height={200} key={index} radius={cssVar.borderRadiusLG} />
+        ))}
+      </Grid>
+      <div className={styles.prompt} />
+    </Flexbox>
+  </Flexbox>
+);
+
+export default GenerationSkeleton;

--- a/src/components/Skeleton/Home.tsx
+++ b/src/components/Skeleton/Home.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+
+import SkeletonBar from './Bar';
+
+const styles = createStaticStyles(({ css }) => ({
+  composer: css`
+    overflow: hidden;
+
+    height: 106px;
+    border: 1px solid ${cssVar.colorFill};
+    border-radius: ${cssVar.borderRadiusLG};
+
+    background: ${cssVar.colorBgElevated};
+  `,
+  grid: css`
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 394px;
+    gap: 24px 28px;
+    width: 100%;
+
+    @media (width <= 1100px) {
+      grid-template-columns: 1fr;
+    }
+  `,
+  rail: css`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-inline-end: 14px;
+
+    @media (width <= 1100px) {
+      display: none;
+    }
+  `,
+  railCard: css`
+    border-radius: ${cssVar.borderRadiusLG};
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  row: css`
+    border-radius: ${cssVar.borderRadiusLG};
+    background: ${cssVar.colorFillQuaternary};
+  `,
+}));
+
+const ComposerSkeleton = () => (
+  <Flexbox className={styles.composer}>
+    <Flexbox flex={1} paddingBlock={'14px 8px'} paddingInline={14}>
+      <SkeletonBar height={14} width={'32%'} />
+    </Flexbox>
+    <Flexbox horizontal align={'center'} height={44} justify={'space-between'} paddingInline={10}>
+      <Flexbox horizontal gap={6}>
+        <SkeletonBar height={28} radius={'50%'} width={28} />
+        <SkeletonBar height={28} radius={'50%'} width={28} />
+      </Flexbox>
+      <SkeletonBar height={32} radius={16} width={64} />
+    </Flexbox>
+  </Flexbox>
+);
+
+const HomeSkeleton = () => (
+  <Flexbox
+    aria-busy
+    flex={1}
+    height={'100%'}
+    style={{ overflow: 'hidden', paddingBlock: '32px 24px', paddingInline: 24 }}
+    width={'100%'}
+  >
+    <Flexbox style={{ marginInline: 'auto', maxWidth: 1240 }} width={'100%'}>
+      <div className={styles.grid}>
+        <Flexbox gap={16} style={{ minWidth: 0 }}>
+          <Flexbox gap={10} paddingBlock={'24px 8px'}>
+            <SkeletonBar height={26} width={'38%'} />
+          </Flexbox>
+          <ComposerSkeleton />
+          <Flexbox gap={8} paddingBlock={12}>
+            <SkeletonBar height={14} width={96} />
+            {Array.from({ length: 3 }).map((_, index) => (
+              <Flexbox
+                horizontal
+                align={'center'}
+                className={styles.row}
+                gap={10}
+                key={index}
+                padding={'12px 14px'}
+              >
+                <SkeletonBar height={24} radius={'50%'} width={24} />
+                <Flexbox flex={1} gap={6}>
+                  <SkeletonBar height={13} width={`${32 + (index % 3) * 14}%`} />
+                  <SkeletonBar height={11} width={`${52 + (index % 2) * 20}%`} />
+                </Flexbox>
+              </Flexbox>
+            ))}
+          </Flexbox>
+        </Flexbox>
+        <div className={styles.rail}>
+          <Flexbox className={styles.railCard} gap={10} padding={16}>
+            <SkeletonBar height={14} width={120} />
+            <SkeletonBar height={12} width={'82%'} />
+            <SkeletonBar height={12} width={'64%'} />
+          </Flexbox>
+          <Flexbox className={styles.railCard} gap={10} padding={16}>
+            <SkeletonBar height={14} width={96} />
+            <SkeletonBar height={12} width={'74%'} />
+            <SkeletonBar height={12} width={'58%'} />
+          </Flexbox>
+        </div>
+      </div>
+    </Flexbox>
+  </Flexbox>
+);
+
+export default HomeSkeleton;

--- a/src/components/Skeleton/RouteSegment.tsx
+++ b/src/components/Skeleton/RouteSegment.tsx
@@ -41,7 +41,8 @@ const RouteSegmentSkeleton = () => {
   const segments = pathname.split('/').filter(Boolean);
 
   if (Skeleton) return <Skeleton />;
-  if (pathname.startsWith('/settings/')) return <SettingsPageSkeleton />;
+  // `settings` at any depth: workspace settings live at /:slug/settings/*
+  if (segments.includes('settings')) return <SettingsPageSkeleton />;
   if (segments[0] === 'apps') return <AppsSkeleton />;
   if (isConversationPath(pathname)) return <ConversationLayoutSkeleton />;
   if (segments[0] === 'memory' && segments.length === 1) return <MemorySkeleton />;

--- a/src/components/Skeleton/Surface.tsx
+++ b/src/components/Skeleton/Surface.tsx
@@ -2,10 +2,11 @@
 
 import { Flexbox, FormGroup, Grid } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
+import type { ReactElement } from 'react';
 
 import SkeletonBar from './Bar';
 
-export type SurfaceSkeletonVariant = 'editor' | 'form' | 'grid' | 'list';
+export type SurfaceSkeletonVariant = 'detail' | 'editor' | 'form' | 'grid' | 'list';
 
 interface SurfaceSkeletonProps {
   header?: boolean;
@@ -106,6 +107,32 @@ const GridSkeleton = () => (
   </Grid>
 );
 
+const DetailSkeleton = () => (
+  <Flexbox align={'center'} padding={'32px 24px'}>
+    <Flexbox gap={24} width={'min(960px, 100%)'}>
+      <Flexbox horizontal align={'center'} gap={16}>
+        <SkeletonBar height={64} radius={'50%'} width={64} />
+        <Flexbox flex={1} gap={8}>
+          <SkeletonBar height={22} width={'32%'} />
+          <SkeletonBar height={14} width={'48%'} />
+        </Flexbox>
+        <SkeletonBar height={36} radius={18} width={104} />
+      </Flexbox>
+      <Flexbox horizontal gap={8}>
+        <SkeletonBar height={22} radius={11} width={72} />
+        <SkeletonBar height={22} radius={11} width={96} />
+        <SkeletonBar height={22} radius={11} width={64} />
+      </Flexbox>
+      <Flexbox gap={12}>
+        <SkeletonBar height={14} width={'94%'} />
+        <SkeletonBar height={14} width={'88%'} />
+        <SkeletonBar height={14} width={'62%'} />
+        <SkeletonBar height={180} radius={cssVar.borderRadiusLG} />
+      </Flexbox>
+    </Flexbox>
+  </Flexbox>
+);
+
 const EditorSkeleton = () => (
   <Flexbox align={'center'} flex={1} padding={'32px 24px'}>
     <Flexbox
@@ -131,8 +158,22 @@ const SurfaceSkeleton = ({ header = true, variant = 'list' }: SurfaceSkeletonPro
       {variant === 'form' && <FormSkeleton />}
       {variant === 'grid' && <GridSkeleton />}
       {variant === 'editor' && <EditorSkeleton />}
+      {variant === 'detail' && <DetailSkeleton />}
     </Flexbox>
   </Flexbox>
 );
+
+const surfaceSkeletonCache = new Map<string, () => ReactElement>();
+
+export const createSurfaceSkeleton = (variant: SurfaceSkeletonVariant, header = true) => {
+  const key = `${variant}:${header}`;
+  const cached = surfaceSkeletonCache.get(key);
+  if (cached) return cached;
+
+  const Component = () => <SurfaceSkeleton header={header} variant={variant} />;
+  Component.displayName = `SurfaceSkeleton(${key})`;
+  surfaceSkeletonCache.set(key, Component);
+  return Component;
+};
 
 export default SurfaceSkeleton;

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -3,6 +3,7 @@ export { default as SkeletonBar } from './Bar';
 export { default as ConversationLayoutSkeleton } from './Conversation/Layout';
 export { default as ConversationListSkeleton } from './Conversation/List';
 export { default as ConversationSegmentSkeleton } from './Conversation/Segment';
+export { default as HomeSkeleton } from './Home';
 export { default as NavPanelSkeletonList } from './NavPanel/List';
 export {
   DEFAULT_NAV_SKELETON_SHAPE,

--- a/src/features/Acceptance/Viewer/CheckList.tsx
+++ b/src/features/Acceptance/Viewer/CheckList.tsx
@@ -7,19 +7,8 @@ import type {
   ReviewAdjudication,
   ReviewProposalEdit,
 } from '@lobechat/types';
-import {
-  ActionIcon,
-  copyToClipboard,
-  Empty,
-  Flexbox,
-  Icon,
-  Image,
-  Tag,
-  Text,
-  TextArea,
-  Tooltip,
-} from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { copyToClipboard, Empty, Flexbox, Icon, Image, TextArea, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Button, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import dayjs from 'dayjs';
 import {

--- a/src/features/Acceptance/Viewer/TopicPanel.test.ts
+++ b/src/features/Acceptance/Viewer/TopicPanel.test.ts
@@ -8,10 +8,13 @@ import { describe, expect, it, vi } from 'vitest';
 import TopicPanel from './TopicPanel';
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: ({ onClick, title }: { onClick?: () => void; title?: string }) =>
-    createElement('button', { onClick, title }, title),
   Flexbox: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   Icon: () => null,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: () => void; title?: string }) =>
+    createElement('button', { onClick, title }, title),
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 

--- a/src/features/Acceptance/Workspace/AcceptanceListPanel.tsx
+++ b/src/features/Acceptance/Workspace/AcceptanceListPanel.tsx
@@ -3,7 +3,6 @@
 import {
   Accordion,
   AccordionItem,
-  ActionIcon,
   Center,
   DraggablePanel,
   DraggablePanelContainer,
@@ -11,10 +10,9 @@ import {
   Empty,
   Flexbox,
   Icon,
-  Text,
 } from '@lobehub/ui';
 import type { DropdownItem } from '@lobehub/ui/base-ui';
-import { DropdownMenu } from '@lobehub/ui/base-ui';
+import { ActionIcon, DropdownMenu, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import {

--- a/src/features/Acceptance/routeMeta.ts
+++ b/src/features/Acceptance/routeMeta.ts
@@ -1,6 +1,7 @@
 import { ClipboardCheckIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
 import { routeMeta } from '@/spa/router/routeMeta';
@@ -22,6 +23,7 @@ const AcceptanceDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => 
 export const acceptanceRouteMeta = routeMeta({
   DynamicMeta: AcceptanceDynamicMeta,
   icon: ClipboardCheckIcon,
+  Skeleton: createSurfaceSkeleton('detail'),
 });
 
 const VerifyDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
@@ -46,9 +48,11 @@ const VerifyDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
 export const verifyRouteMeta = routeMeta({
   DynamicMeta: VerifyDynamicMeta,
   icon: ClipboardCheckIcon,
+  Skeleton: createSurfaceSkeleton('detail'),
 });
 
 export const verifyReportsRouteMeta = routeMeta({
   icon: ClipboardCheckIcon,
+  Skeleton: createSurfaceSkeleton('list'),
   titleKey: 'navigation.verifyReports',
 });

--- a/src/features/AgentBuilder/TopicSelector.test.tsx
+++ b/src/features/AgentBuilder/TopicSelector.test.tsx
@@ -10,13 +10,16 @@ const switchTopic = vi.fn();
 const useFetchTopics = vi.fn();
 
 vi.mock('@lobehub/ui', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  Flexbox: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
   ActionIcon: ({ disabled, onClick, title }: any) => (
     <button disabled={disabled} type="button" onClick={onClick}>
       {title}
     </button>
   ),
-  DropdownMenu: ({ children }: any) => <div>{children}</div>,
-  Flexbox: ({ children }: any) => <div>{children}</div>,
 }));
 
 vi.mock('antd-style', () => ({

--- a/src/features/AgentDocumentPage/routeMeta.ts
+++ b/src/features/AgentDocumentPage/routeMeta.ts
@@ -1,5 +1,6 @@
 import { FileTextIcon } from 'lucide-react';
 
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
 import { useClientDataSWR } from '@/libs/swr';
@@ -30,5 +31,6 @@ const AgentDocumentDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) 
 export const agentDocumentRouteMeta = routeMeta({
   DynamicMeta: AgentDocumentDynamicMeta,
   icon: FileTextIcon,
+  Skeleton: createSurfaceSkeleton('editor'),
   titleKey: 'navigation.document',
 });

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
@@ -45,7 +45,21 @@ vi.mock('@lobehub/ui/icons', () => ({
   SkillsIcon: () => null,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  ActionIcon: ({
+    icon,
+    onClick,
+    title,
+  }: {
+    icon?: { displayName?: string; name?: string };
+    onClick?: () => void;
+    title?: string;
+  }) => (
+    <button aria-label={title} data-icon={icon?.displayName ?? icon?.name} onClick={onClick}>
+      {title}
+    </button>
+  ),
   confirmModal: modalConfirm,
   DropdownMenu: ({
     children,

--- a/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
@@ -29,11 +29,15 @@ vi.mock('@lobehub/ui', () => ({
   Skeleton: {
     Button: (props: Record<string, unknown>) => <div {...props} />,
   },
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ContextMenuTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
   Tag: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Text: ({ children, style }: { children?: ReactNode; style?: CSSProperties }) => (
     <span style={style}>{children}</span>
   ),
-  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('antd-style', () => ({

--- a/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
@@ -1,18 +1,8 @@
 import type { TaskDetailActivity } from '@lobechat/types';
 import { useEditor } from '@lobehub/editor/react';
 import { LexicalRenderer } from '@lobehub/editor/renderer';
-import {
-  ActionIcon,
-  Avatar,
-  Block,
-  type DropdownItem,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Markdown,
-  Text,
-} from '@lobehub/ui';
-import { Button, confirmModal } from '@lobehub/ui/base-ui';
+import { Block, type DropdownItem, DropdownMenu, Flexbox, Icon, Markdown } from '@lobehub/ui';
+import { ActionIcon, Avatar, Button, confirmModal, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { MessageCircle, MoreHorizontal, Pencil, Trash } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';

--- a/src/features/AgentTasks/AgentTaskDetail/RunSubtasksPreview.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/RunSubtasksPreview.tsx
@@ -1,6 +1,5 @@
 import { Block, Flexbox } from '@lobehub/ui';
-import { Text } from '@lobehub/ui/base-ui';
-import { Tag } from 'antd';
+import { Tag, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
@@ -59,11 +59,18 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: () => void; title?: string }) => (
+    <button type="button" onClick={onClick}>
+      {title}
+    </button>
+  ),
   Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
     <button type="button" onClick={onClick}>
       {children}
     </button>
   ),
+  Tag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   confirmModal: (opts: unknown) => mocks.confirmModal(opts),
 }));
 

--- a/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
@@ -1,15 +1,6 @@
 import type { TaskDetailWorkspaceNode } from '@lobechat/types';
-import {
-  ActionIcon,
-  Block,
-  type DropdownItem,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Tag,
-  Text,
-} from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
+import { Block, type DropdownItem, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, confirmModal, Tag, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { FileLock2Icon, FileTextIcon, MoreHorizontal, Package, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
@@ -1,13 +1,5 @@
-import {
-  ActionIcon,
-  Block,
-  type DropdownItem,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Text,
-} from '@lobehub/ui';
-import { confirmModal, toast } from '@lobehub/ui/base-ui';
+import { Block, type DropdownItem, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, confirmModal, Text, toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Check, ChevronDownIcon, ChevronUpIcon, MoreHorizontal, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.test.tsx
@@ -46,7 +46,9 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ title }: { title?: string }) => <button type="button">{title}</button>,
   confirmModal: (opts: unknown) => mocks.confirmModal(opts),
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 vi.mock('antd', () => ({

--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.test.tsx
@@ -109,7 +109,19 @@ vi.mock('antd-style', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick }: { onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      action
+    </button>
+  ),
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   confirmModal: vi.fn(),
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
 }));
 
 vi.mock('react-i18next', () => ({

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.test.tsx
@@ -13,6 +13,24 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick }: { onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      action
+    </button>
+  ),
+  Avatar: () => <span>avatar</span>,
+  Tag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  confirmModal: vi.fn(),
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
 vi.mock('@/store/task', () => ({
   useTaskStore: (selector: (state: any) => unknown) =>
     selector({

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -1,17 +1,13 @@
 import type { TaskDetailActivity } from '@lobechat/types';
 import {
-  ActionIcon,
-  Avatar,
   Block,
   type DropdownItem,
   DropdownMenu,
   Flexbox,
   Markdown,
   stopPropagation,
-  Tag,
-  Text,
 } from '@lobehub/ui';
-import { confirmModal, toast } from '@lobehub/ui/base-ui';
+import { ActionIcon, Avatar, confirmModal, Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import {
   ChevronDown,

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
@@ -60,30 +60,6 @@ const serializeSize = (size: unknown) =>
   size === undefined ? '' : typeof size === 'string' ? size : JSON.stringify(size);
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: ({
-    disabled,
-    icon,
-    onClick,
-    size,
-    title,
-  }: {
-    disabled?: boolean;
-    icon?: { name?: string };
-    onClick?: () => void;
-    size?: unknown;
-    title?: string;
-  }) => (
-    <button
-      data-icon={icon?.name}
-      data-size={serializeSize(size)}
-      data-testid="header-action-icon"
-      disabled={disabled}
-      title={title}
-      onClick={onClick}
-    >
-      {title}
-    </button>
-  ),
   copyToClipboard: vi.fn(),
   DropdownMenu: ({
     children,
@@ -113,12 +89,46 @@ vi.mock('@lobehub/ui', () => ({
     style?: CSSProperties;
   }) => <div style={{ flex, ...style }}>{children}</div>,
   Freeze: ({ children }: { children?: ReactNode; frozen?: boolean }) => <>{children}</>,
-  Text: ({ children, style }: { children?: ReactNode; style?: CSSProperties }) => (
-    <span style={style}>{children}</span>
-  ),
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    disabled,
+    icon,
+    onClick,
+    size,
+    title,
+  }: {
+    disabled?: boolean;
+    icon?: { name?: string };
+    onClick?: () => void;
+    size?: unknown;
+    title?: string;
+  }) => (
+    <button
+      data-icon={icon?.name}
+      data-size={serializeSize(size)}
+      data-testid="header-action-icon"
+      disabled={disabled}
+      title={title}
+      onClick={onClick}
+    >
+      {title}
+    </button>
+  ),
+  Tag: ({ children, title }: { children?: ReactNode; title?: string }) => (
+    <span title={title}>{children}</span>
+  ),
+  Text: ({ children, style }: { children?: ReactNode; style?: CSSProperties }) => (
+    <span style={style}>{children}</span>
+  ),
+  confirmModal: vi.fn(),
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
   FloatingPanel: ({
     actions,
     children,

--- a/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.test.tsx
+++ b/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.test.tsx
@@ -44,6 +44,26 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       {children}
     </button>
   ),
+  ActionIcon: ({
+    onClick,
+    style,
+    title,
+  }: {
+    onClick?: () => void;
+    style?: CSSProperties;
+    title?: string;
+  }) => (
+    <div
+      aria-label={title}
+      role="button"
+      style={{ height: 24, width: 24, ...style }}
+      onClick={onClick}
+    >
+      {title}
+    </div>
+  ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 vi.mock('@/features/EditorCanvas', () => ({

--- a/src/features/AgentTasks/features/TaskSubtaskProgressTag.test.tsx
+++ b/src/features/AgentTasks/features/TaskSubtaskProgressTag.test.tsx
@@ -36,6 +36,10 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
 vi.mock('antd', () => ({
   Progress: () => <span>progress</span>,
 }));

--- a/src/features/AgentTasks/routeMeta.ts
+++ b/src/features/AgentTasks/routeMeta.ts
@@ -1,5 +1,6 @@
 import { ListTodoIcon } from 'lucide-react';
 
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import TasksSkeleton from '@/components/Skeleton/Tasks';
 import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
@@ -34,5 +35,6 @@ const TaskDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
 export const taskRouteMeta = routeMeta({
   DynamicMeta: TaskDynamicMeta,
   icon: ListTodoIcon,
+  Skeleton: createSurfaceSkeleton('detail'),
   titleKey: 'navigation.task',
 });

--- a/src/features/AgentTopicManager/Toolbar.tsx
+++ b/src/features/AgentTopicManager/Toolbar.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import {
-  ActionIcon,
-  type DropdownItem,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
-import { confirmModal, Tabs, toast } from '@lobehub/ui/base-ui';
+import { type DropdownItem, DropdownMenu, Flexbox, Icon, Tooltip } from '@lobehub/ui';
+import { ActionIcon, confirmModal, Tabs, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   Archive,

--- a/src/features/AgentViewAll/AgentCard.tsx
+++ b/src/features/AgentViewAll/AgentCard.tsx
@@ -3,16 +3,8 @@
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
 import type { SidebarAgentItem } from '@lobechat/types';
 import { agentDisplayName, agentSecondaryDisplayName } from '@lobechat/types';
-import {
-  Avatar,
-  Block,
-  ContextMenuTrigger,
-  Flexbox,
-  type MenuProps,
-  Tag,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
+import { Block, ContextMenuTrigger, Flexbox, type MenuProps, Tooltip } from '@lobehub/ui';
+import { Avatar, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, responsive } from 'antd-style';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/AgentViewAll/AgentRow.tsx
+++ b/src/features/AgentViewAll/AgentRow.tsx
@@ -3,16 +3,8 @@
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
 import type { SidebarAgentItem } from '@lobechat/types';
 import { agentDisplayName, agentSecondaryDisplayName } from '@lobechat/types';
-import {
-  ActionIcon,
-  Avatar,
-  ContextMenuTrigger,
-  Flexbox,
-  type MenuProps,
-  Tag,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
+import { ContextMenuTrigger, Flexbox, type MenuProps, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Avatar, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import dayjs from 'dayjs';
 import { EyeIcon, EyeOffIcon } from 'lucide-react';

--- a/src/features/AgentViewAll/routeMeta.ts
+++ b/src/features/AgentViewAll/routeMeta.ts
@@ -1,8 +1,10 @@
 import { BotIcon } from 'lucide-react';
 
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { routeMeta } from '@/spa/router/routeMeta';
 
 export const agentsRouteMeta = routeMeta({
   icon: BotIcon,
+  Skeleton: createSurfaceSkeleton('grid'),
   titleKey: 'navigation.agents',
 });

--- a/src/features/ArtworkStudio/Content.tsx
+++ b/src/features/ArtworkStudio/Content.tsx
@@ -3,18 +3,8 @@
 import { imageUrl } from '@lobechat/const';
 import type { AgentArtworkComposition, AgentArtworkStyle } from '@lobechat/prompts';
 import { AGENT_ARTWORK_STYLES } from '@lobechat/prompts';
-import {
-  Accordion,
-  AccordionItem,
-  ActionIcon,
-  Avatar,
-  Center,
-  Flexbox,
-  Icon,
-  Input,
-  Text,
-} from '@lobehub/ui';
-import { Alert, Button, useModalContext } from '@lobehub/ui/base-ui';
+import { Accordion, AccordionItem, Center, Flexbox, Icon, Input } from '@lobehub/ui';
+import { ActionIcon, Alert, Avatar, Button, Text, useModalContext } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   CircleUserRound,

--- a/src/features/AuthShell/AuthLangButton.tsx
+++ b/src/features/AuthShell/AuthLangButton.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import {
-  DropdownMenu,
-  type DropdownMenuCheckboxItem,
-  Flexbox,
-  Text,
-} from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { DropdownMenu, type DropdownMenuCheckboxItem, Flexbox } from '@lobehub/ui';
+import { Button, Text } from '@lobehub/ui/base-ui';
 import { GlobeIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/CommunityWorkspaceSettings/index.tsx
+++ b/src/features/CommunityWorkspaceSettings/index.tsx
@@ -1,19 +1,8 @@
 'use client';
 
 import { OFFICIAL_URL } from '@lobechat/const';
-import {
-  Avatar,
-  Block,
-  Center,
-  Flexbox,
-  Icon,
-  Input,
-  Tag,
-  Text,
-  TextArea,
-  Tooltip,
-} from '@lobehub/ui';
-import { Button, Tabs, toast } from '@lobehub/ui/base-ui';
+import { Block, Center, Flexbox, Icon, Input, TextArea, Tooltip } from '@lobehub/ui';
+import { Avatar, Button, Tabs, Tag, Text, toast } from '@lobehub/ui/base-ui';
 import type { TableColumnsType, UploadProps } from 'antd';
 import { Input as AntInput, Table, Upload } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';

--- a/src/features/Conversation/ChatInput/VerifyTray/GoalModal.test.tsx
+++ b/src/features/Conversation/ChatInput/VerifyTray/GoalModal.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       {children}
     </button>
   ),
+  Text: ({ children }: any) => <span>{children}</span>,
   createModal: vi.fn(),
   useModalContext: () => ({ close: mocks.close }),
 }));

--- a/src/features/Conversation/ChatItem/components/Avatar.tsx
+++ b/src/features/Conversation/ChatItem/components/Avatar.tsx
@@ -1,5 +1,5 @@
 import { agentDisplayName } from '@lobechat/types';
-import { type CSSProperties } from 'react';
+import { type CSSProperties, type MouseEventHandler } from 'react';
 import { memo } from 'react';
 
 import A from '@/components/Avatar';
@@ -10,7 +10,7 @@ export interface AvatarProps {
   alt?: string;
   avatar: ChatItemProps['avatar'];
   loading?: boolean;
-  onClick?: ChatItemProps['onAvatarClick'];
+  onClick?: ChatItemProps['onAvatarClick'] | MouseEventHandler<HTMLDivElement>;
   size?: number;
   style?: CSSProperties;
   unoptimized?: boolean;

--- a/src/features/Conversation/ChatItem/type.ts
+++ b/src/features/Conversation/ChatItem/type.ts
@@ -1,5 +1,5 @@
-import type { AvatarProps, DivProps, FlexboxProps } from '@lobehub/ui';
-import { type AlertProps } from '@lobehub/ui/base-ui';
+import type { DivProps, FlexboxProps } from '@lobehub/ui';
+import { type AlertProps, type AvatarProps } from '@lobehub/ui/base-ui';
 import type { EditableMessageProps, MetaData } from '@lobehub/ui/chat';
 import type { ReactNode } from 'react';
 

--- a/src/features/Conversation/ConversationProvider.test.tsx
+++ b/src/features/Conversation/ConversationProvider.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       {children}
     </button>
   ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('react-i18next', () => ({

--- a/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx
@@ -29,6 +29,19 @@ const mockOpenDocument = vi.fn();
 const mockOpenTaskDetail = vi.fn();
 const mockOpenVerifyReport = vi.fn();
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: (props: { onClick?: (e: unknown) => void; title?: string }) => (
+    <button
+      aria-label={props.title}
+      data-side-browser={(props as Record<string, unknown>)['data-side-browser']}
+      type="button"
+      onClick={props.onClick}
+    />
+  ),
+  Avatar: ({ alt }: { alt?: string }) => <span>{alt}</span>,
+  Text: ({ children }: { children?: unknown }) => <span>{children as never}</span>,
+}));
+
 vi.mock('@/business/client/hooks/useWorkspaces', () => ({
   useWorkspaces: () => [{ id: 'ws-1', slug: 'lobe-team' }],
 }));

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.test.tsx
@@ -8,30 +8,37 @@ import { describe, expect, it, vi } from 'vitest';
 import Arguments from './index';
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: ({
-    active,
-    icon: IconComponent,
-    onClick,
-    title,
-  }: {
-    active?: boolean;
-    icon?: ComponentType;
-    onClick?: () => void;
-    title?: string;
-  }) => (
-    <button aria-pressed={active} type="button" onClick={onClick}>
-      {title}
-      {IconComponent ? <IconComponent /> : null}
-    </button>
-  ),
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Highlighter: ({ children, wrap }: { children?: ReactNode; wrap?: boolean }) => (
     <pre data-testid="highlighter" data-wrap={String(Boolean(wrap))}>
       {children}
     </pre>
   ),
-  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
+
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    ActionIcon: ({
+      active,
+      icon: IconComponent,
+      onClick,
+      title,
+    }: {
+      active?: boolean;
+      icon?: ComponentType;
+      onClick?: () => void;
+      title?: string;
+    }) => (
+      <button aria-pressed={active} type="button" onClick={onClick}>
+        {title}
+        {IconComponent ? <IconComponent /> : null}
+      </button>
+    ),
+    Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  };
+});
 
 vi.mock('antd', () => ({
   Divider: () => <hr />,

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -81,6 +81,23 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    icon: IconComponent,
+    onClick,
+    title,
+  }: {
+    icon?: ComponentType;
+    onClick?: (e: unknown) => void;
+    title?: string;
+  }) => (
+    <button aria-label={title} type="button" onClick={onClick}>
+      {IconComponent ? <IconComponent /> : null}
+    </button>
+  ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
 vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
   m: {

--- a/src/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
@@ -195,10 +195,14 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('@lobehub/ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   ActionIcon: ({ onClick }: { onClick?: () => void }) => (
     <button type={'button'} onClick={onClick} />
   ),
+}));
+
+vi.mock('@lobehub/ui', () => ({
   Center: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   copyToClipboard: vi.fn(),
   Empty: ({ description }: { description?: ReactNode }) => <div>{description}</div>,

--- a/src/features/Conversation/WorkingSidebar/Files/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/index.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import type { ProjectFileIndexEntry } from '@lobechat/electron-client-ipc';
-import {
-  ActionIcon,
-  Center,
-  copyToClipboard,
-  Empty,
-  Flexbox,
-  Icon,
-  stopPropagation,
-} from '@lobehub/ui';
-import { Input, toast } from '@lobehub/ui/base-ui';
+import { Center, copyToClipboard, Empty, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { ActionIcon, Input, toast } from '@lobehub/ui/base-ui';
 import type { GitStatusEntry } from '@pierre/trees';
 import { createStaticStyles } from 'antd-style';
 import { FileIcon, SearchIcon, XIcon } from 'lucide-react';

--- a/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -24,13 +24,20 @@ const useParamsMock = vi.hoisted(() => vi.fn());
 const documentExplorerShouldThrow = vi.hoisted(() => ({ current: false }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: (e: React.MouseEvent) => void; title?: string }) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+    </button>
+  ),
   Alert: ({ message, title }: { message?: ReactNode; title?: ReactNode }) => (
     <div role="alert">
       <div>{title}</div>
       <div>{message}</div>
     </div>
   ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
   confirmModal: modalConfirm,
+  createModal: vi.fn(),
   toast: { error: messageError, success: messageSuccess },
 }));
 

--- a/src/features/Conversation/WorkingSidebar/Review/__tests__/FileItem.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/Review/__tests__/FileItem.test.tsx
@@ -5,6 +5,16 @@ import { FileItemHeader } from '../FileItem';
 
 const mockRevealInFilesTab = vi.fn();
 
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    ActionIcon: ({ icon: _icon, title, onClick, ...rest }: any) => (
+      <button aria-label={title} type="button" onClick={onClick} {...rest} />
+    ),
+  };
+});
+
 vi.mock('@/store/global', () => ({
   useGlobalStore: (selector: (s: any) => any) =>
     selector({ revealInFilesTab: mockRevealInFilesTab }),

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -279,10 +279,15 @@ vi.mock('@lobehub/ui', () => ({
   Skeleton: () => <div data-testid="params-loading" />,
 }));
 
-vi.mock('@lobehub/ui/base-ui', async () => {
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
   const { useState } = await import('react');
+  const actual = (await importOriginal()) as Record<string, unknown>;
 
   return {
+    ...actual,
+    ActionIcon: ({ onClick, title }: { onClick?: () => void; title?: string }) => (
+      <button aria-label={title} type="button" onClick={onClick} />
+    ),
     ContextMenuTrigger: ({ children, items }: { children: ReactNode; items: any[] }) => {
       const [open, setOpen] = useState(false);
       const menuItems = items.filter((item) => item && item.type !== 'divider');
@@ -334,9 +339,13 @@ vi.mock('@lobehub/ui/base-ui', async () => {
   };
 });
 
-vi.mock('antd-style', () => ({
-  createStaticStyles: () => () => ({}),
-}));
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createStaticStyles: () => () => ({}),
+  };
+});
 
 beforeEach(() => {
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {

--- a/src/features/EditingPopover/AgentContent.tsx
+++ b/src/features/EditingPopover/AgentContent.tsx
@@ -1,15 +1,6 @@
 import { DEFAULT_AVATAR } from '@lobechat/const';
-import {
-  ActionIcon,
-  Avatar,
-  Block,
-  Flexbox,
-  Icon,
-  Input,
-  stopPropagation,
-  Tooltip,
-} from '@lobehub/ui';
-import { toast } from '@lobehub/ui/base-ui';
+import { Block, Flexbox, Icon, Input, stopPropagation, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Avatar, toast } from '@lobehub/ui/base-ui';
 import { type InputRef } from 'antd';
 import { Check, PaletteIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';

--- a/src/features/EditingPopover/GroupContent.tsx
+++ b/src/features/EditingPopover/GroupContent.tsx
@@ -1,14 +1,5 @@
-import {
-  ActionIcon,
-  Avatar,
-  Block,
-  Flexbox,
-  Icon,
-  Input,
-  stopPropagation,
-  Tooltip,
-} from '@lobehub/ui';
-import { toast } from '@lobehub/ui/base-ui';
+import { Block, Flexbox, Icon, Input, stopPropagation, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Avatar, toast } from '@lobehub/ui/base-ui';
 import { type InputRef } from 'antd';
 import { Check, PaletteIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';

--- a/src/features/EditorCanvas/InternalEditor.readonly.test.tsx
+++ b/src/features/EditorCanvas/InternalEditor.readonly.test.tsx
@@ -33,6 +33,14 @@ vi.mock('@lobehub/editor', () => ({
   ReactToolbarPlugin: vi.fn(),
 }));
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: (e: any) => void; title?: string }) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+    </button>
+  ),
+}));
+
 vi.mock('@/features/ChatInput/InputEditor/plugins', () => ({
   createChatInputRichPlugins: () => [],
 }));

--- a/src/features/ExplorerTree/view/ExplorerTree.test.tsx
+++ b/src/features/ExplorerTree/view/ExplorerTree.test.tsx
@@ -37,8 +37,14 @@ vi.mock('@lobehub/ui/icons', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: () => void; title?: string }) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+    </button>
+  ),
   confirmModal: vi.fn(),
   DropdownMenu: ({ children }: { children: ReactNode }) => children,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('antd', () => ({

--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -17,6 +17,24 @@ const sheetHandlers = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    onClick,
+    title,
+    ...rest
+  }: {
+    onClick?: () => void;
+    title?: string;
+    [key: string]: unknown;
+  }) => (
+    <button
+      data-testid={(rest as any)['data-testid']}
+      title={title}
+      type="button"
+      onClick={onClick}
+    >
+      {title}
+    </button>
+  ),
   FloatingSheet: ({
     children,
     dismissible,

--- a/src/features/HeteroSessionImport/SidebarTree.tsx
+++ b/src/features/HeteroSessionImport/SidebarTree.tsx
@@ -1,14 +1,7 @@
 import type { HeteroSessionDirGroup, HeteroSessionDirPref } from '@lobechat/types';
 import { ClaudeCode, Codex } from '@lobehub/icons';
-import {
-  ActionIcon,
-  DraggablePanel,
-  Flexbox,
-  Icon,
-  ScrollShadow,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
+import { DraggablePanel, Flexbox, Icon, ScrollShadow, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { ChevronRight, Eye, EyeOff, Folder, FolderGit2, Timer, X } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/Home/InputArea/InputBanner.tsx
+++ b/src/features/Home/InputArea/InputBanner.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { X } from 'lucide-react';
 import type { MouseEvent, MouseEventHandler, ReactNode } from 'react';

--- a/src/features/Home/Recents/Item.tsx
+++ b/src/features/Home/Recents/Item.tsx
@@ -1,4 +1,5 @@
-import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { FileTextIcon, HashIcon, MoreHorizontalIcon } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
@@ -53,7 +54,7 @@ const RecentListItem = memo<RecentItem>((item) => {
         disabled={editing}
         title={title}
         actions={
-          <DropdownMenu items={dropdownMenu()} nativeButton={false}>
+          <DropdownMenu items={dropdownMenu()}>
             <ActionIcon icon={MoreHorizontalIcon} size={'small'} style={{ flex: 'none' }} />
           </DropdownMenu>
         }

--- a/src/features/Home/Recents/index.tsx
+++ b/src/features/Home/Recents/index.tsx
@@ -1,13 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
-import {
-  AccordionItem,
-  ActionIcon,
-  ContextMenuTrigger,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Text,
-} from '@lobehub/ui';
+import { AccordionItem, ContextMenuTrigger, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import {
   ArrowDownIcon,
   ArrowUpIcon,
@@ -144,7 +137,7 @@ const Recents = memo<RecentsProps>(({ itemKey }) => {
       paddingBlock={4}
       paddingInline={'8px 4px'}
       action={
-        <DropdownMenu items={dropdownMenu} nativeButton={false}>
+        <DropdownMenu items={dropdownMenu}>
           <ActionIcon icon={MoreHorizontalIcon} size={'small'} style={{ flex: 'none' }} />
         </DropdownMenu>
       }

--- a/src/features/HomeSidebar/Body/Agent/Actions.tsx
+++ b/src/features/HomeSidebar/Body/Agent/Actions.tsx
@@ -1,5 +1,6 @@
 import type { MenuProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu, Flexbox } from '@lobehub/ui';
+import { DropdownMenu, Flexbox } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon, PlusIcon } from 'lucide-react';
 import { memo } from 'react';
 
@@ -12,10 +13,10 @@ interface ActionsProps {
 const Actions = memo<ActionsProps>(({ dropdownMenu, addMenuItems, isLoading }) => {
   return (
     <Flexbox horizontal gap={2}>
-      <DropdownMenu items={dropdownMenu} nativeButton={false}>
+      <DropdownMenu items={dropdownMenu}>
         <ActionIcon icon={MoreHorizontalIcon} size={'small'} style={{ flex: 'none' }} />
       </DropdownMenu>
-      <DropdownMenu items={addMenuItems} nativeButton={false}>
+      <DropdownMenu items={addMenuItems}>
         <ActionIcon icon={PlusIcon} loading={isLoading} size={'small'} style={{ flex: 'none' }} />
       </DropdownMenu>
     </Flexbox>

--- a/src/features/HomeSidebar/Body/Agent/CreateAgentButton.tsx
+++ b/src/features/HomeSidebar/Body/Agent/CreateAgentButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ActionIcon, Block, Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
-import { DropdownMenu } from '@lobehub/ui/base-ui';
+import { Block, Center, Flexbox, Icon, Tooltip } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDownIcon, PlusIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';
@@ -144,7 +144,7 @@ const CreateAgentButton = memo<CreateAgentButtonProps>(({ groupId, className, vi
             e.stopPropagation();
           }}
         >
-          <DropdownMenu items={dropdownItems} nativeButton={false}>
+          <DropdownMenu items={dropdownItems}>
             <ActionIcon
               color={cssVar.colorTextQuaternary}
               icon={ChevronDownIcon}

--- a/src/features/HomeSidebar/Body/index.tsx
+++ b/src/features/HomeSidebar/Body/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { MenuProps } from '@lobehub/ui';
-import { Accordion, ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { Accordion, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { EyeOffIcon, MoreHorizontalIcon, SlidersHorizontalIcon } from 'lucide-react';
 import type { Key, ReactElement } from 'react';
 import { memo, useCallback, useMemo } from 'react';
@@ -175,7 +176,7 @@ const Body = memo(() => {
             icon={navItem.icon}
             title={navItem.title}
             actions={
-              <DropdownMenu items={getContextMenuItems(key)} nativeButton={false}>
+              <DropdownMenu items={getContextMenuItems(key)}>
                 <ActionIcon icon={MoreHorizontalIcon} size={'small'} style={{ flex: 'none' }} />
               </DropdownMenu>
             }

--- a/src/features/HomeSidebar/Footer/index.test.tsx
+++ b/src/features/HomeSidebar/Footer/index.test.tsx
@@ -6,6 +6,27 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const analyticsTrack = vi.fn();
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    onClick,
+    title,
+    ...rest
+  }: {
+    onClick?: (e: any) => void;
+    title?: string;
+    [key: string]: unknown;
+  }) => (
+    <button
+      aria-label={(rest as any)['aria-label'] ?? title}
+      title={title}
+      type="button"
+      onClick={onClick}
+    >
+      {title}
+    </button>
+  ),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     i18n: { language: 'en-US' },

--- a/src/features/HomeSidebar/hooks/useCreateModal.test.tsx
+++ b/src/features/HomeSidebar/hooks/useCreateModal.test.tsx
@@ -100,6 +100,12 @@ vi.mock('@/services/skill', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: (e: React.MouseEvent) => void; title?: string }) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+    </button>
+  ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
   Button: ({
     children,
     disabled,

--- a/src/features/MCPPluginDetail/Deployment/index.tsx
+++ b/src/features/MCPPluginDetail/Deployment/index.tsx
@@ -1,16 +1,7 @@
 import { SiApple, SiLinux } from '@icons-pack/react-simple-icons';
 import { Microsoft } from '@lobehub/icons';
-import {
-  ActionIcon,
-  Block,
-  Collapse,
-  Empty,
-  Flexbox,
-  Icon,
-  Popover,
-  Snippet,
-  Tag,
-} from '@lobehub/ui';
+import { Block, Collapse, Empty, Flexbox, Icon, Popover, Snippet } from '@lobehub/ui';
+import { ActionIcon, Tag } from '@lobehub/ui/base-ui';
 import { Divider, Steps } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { startCase } from 'es-toolkit/compat';

--- a/src/features/MCPPluginDetail/Header.tsx
+++ b/src/features/MCPPluginDetail/Header.tsx
@@ -1,17 +1,8 @@
 'use client';
 
 import { Github } from '@lobehub/icons';
-import {
-  ActionIcon,
-  Avatar,
-  Flexbox,
-  Icon,
-  stopPropagation,
-  Tag,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
-import { Button, toast } from '@lobehub/ui/base-ui';
+import { Flexbox, Icon, stopPropagation, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Avatar, Button, Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
 import {
   BookmarkIcon,

--- a/src/features/Messenger/IntegrationDetail/Wechat.test.tsx
+++ b/src/features/Messenger/IntegrationDetail/Wechat.test.tsx
@@ -41,7 +41,8 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   Button: ({
     children,
     disabled,
@@ -97,7 +98,8 @@ vi.mock('antd', () => ({
   ),
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   createStaticStyles: () => ({ error: 'error', qrSlot: 'qrSlot', setup: 'setup' }),
 }));
 

--- a/src/features/Messenger/IntegrationDetail/shared.test.tsx
+++ b/src/features/Messenger/IntegrationDetail/shared.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@lobehub/ui', () => ({
 const mockConfirmModal = vi.fn();
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  Avatar: ({ avatar }: { avatar?: string }) => <span data-avatar={avatar} />,
   Button: ({
     children,
     disabled,
@@ -77,6 +78,26 @@ vi.mock('@lobehub/ui/base-ui', () => ({
         </div>
       ))}
     </div>
+  ),
+  Tag: ({ children }: { children?: ReactNode }) => (
+    <span data-testid="personal-tag">{children}</span>
+  ),
+  Text: ({
+    children,
+    ellipsis,
+  }: {
+    children?: ReactNode;
+    ellipsis?: boolean | { tooltip?: boolean | string };
+  }) => (
+    <span
+      title={
+        typeof ellipsis === 'object' && typeof ellipsis.tooltip === 'string'
+          ? ellipsis.tooltip
+          : undefined
+      }
+    >
+      {children}
+    </span>
   ),
   confirmModal: (...args: unknown[]) => mockConfirmModal(...args),
 }));

--- a/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  ActionIcon,
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
@@ -11,6 +10,7 @@ import {
   Icon,
   menuSharedStyles,
 } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { cssVar, cx } from 'antd-style';
 import { LucideArrowRight, LucideBolt } from 'lucide-react';
 import type { ComponentType } from 'react';

--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -1,5 +1,4 @@
 import {
-  ActionIcon,
   Block,
   DropdownMenuPopup,
   DropdownMenuPortal,
@@ -10,6 +9,7 @@ import {
   Icon,
   menuSharedStyles,
 } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { cssVar, cx } from 'antd-style';
 import { LucideArrowRight, LucideBolt } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';

--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -11,8 +11,8 @@ import {
   DropdownMenuSubmenuTrigger,
   Flexbox,
   menuSharedStyles,
-  Tag,
 } from '@lobehub/ui';
+import { Tag } from '@lobehub/ui/base-ui';
 import { cx } from 'antd-style';
 import { Check } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx
+++ b/src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx
@@ -58,7 +58,8 @@ vi.mock('@lobehub/icons', () => ({
   ProviderIcon: () => <span />,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   createStaticStyles: () => ({
     container: 'container',
     detailPopup: 'detailPopup',

--- a/src/features/Onboarding/steps/AgentPickerStep/index.test.tsx
+++ b/src/features/Onboarding/steps/AgentPickerStep/index.test.tsx
@@ -11,13 +11,17 @@ import AgentPickerStep from './index';
 
 // base-ui Button needs a MotionProvider the app wires globally but the unit env
 // lacks; stub it to a native button so the assertions can run.
-vi.mock('@lobehub/ui/base-ui', () => ({
-  Button: ({ children, disabled, onClick }: any) => (
-    <button disabled={disabled} type="button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-}));
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    Button: ({ children, disabled, onClick }: any) => (
+      <button disabled={disabled} type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+  };
+});
 
 const navigate = vi.fn();
 const finishOnboarding = vi.fn().mockResolvedValue(undefined);

--- a/src/features/Onboarding/steps/InterestsStep.test.tsx
+++ b/src/features/Onboarding/steps/InterestsStep.test.tsx
@@ -12,13 +12,17 @@ const mocks = vi.hoisted(() => ({
 
 // base-ui Button needs a MotionProvider the app wires globally but the unit env
 // lacks; stub it to a native button so the assertions can run.
-vi.mock('@lobehub/ui/base-ui', () => ({
-  Button: ({ children, disabled, onClick }: any) => (
-    <button disabled={disabled} type="button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-}));
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    Button: ({ children, disabled, onClick }: any) => (
+      <button disabled={disabled} type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+  };
+});
 
 vi.mock('@lobehub/ui', () => ({
   Block: ({

--- a/src/features/Pages/PageLayout/Body/index.tsx
+++ b/src/features/Pages/PageLayout/Body/index.tsx
@@ -8,8 +8,8 @@ import {
   ContextMenuTrigger,
   Flexbox,
   Icon,
-  Text,
 } from '@lobehub/ui';
+import { Text } from '@lobehub/ui/base-ui';
 import { PlusIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/Pages/routeMeta.ts
+++ b/src/features/Pages/routeMeta.ts
@@ -1,5 +1,6 @@
 import { FilePenIcon } from 'lucide-react';
 
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
 import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
@@ -29,5 +30,6 @@ const PageDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
 export const pageRouteMeta = routeMeta({
   DynamicMeta: PageDynamicMeta,
   icon: FilePenIcon,
+  Skeleton: createSurfaceSkeleton('editor'),
   titleKey: 'navigation.page',
 });

--- a/src/features/Portal/AcceptanceCheck/Body.test.tsx
+++ b/src/features/Portal/AcceptanceCheck/Body.test.tsx
@@ -39,6 +39,8 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       {children}
     </button>
   ),
+  Tag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('antd', () => ({

--- a/src/features/Portal/LocalFile/Body.test.tsx
+++ b/src/features/Portal/LocalFile/Body.test.tsx
@@ -13,7 +13,8 @@ vi.mock('@lobechat/const', async (importOriginal) => ({
   isDesktop: true,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   createStaticStyles: () => ({
     card: 'card',
     key: 'key',
@@ -35,7 +36,6 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: () => null,
   Center: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Empty: ({ description }: { description?: ReactNode }) => <div>{description}</div>,
   Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -45,7 +45,9 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  ActionIcon: () => null,
   Tabs: () => null,
 }));
 

--- a/src/features/ProfileEditor/AgentUserTools/UserToolsSection.test.tsx
+++ b/src/features/ProfileEditor/AgentUserTools/UserToolsSection.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@lobehub/ui', () => ({
 }));
 vi.mock('@lobehub/ui/base-ui', () => ({
   Button: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+  Text: ({ children }: { children: ReactNode }) => <span data-testid="label">{children}</span>,
 }));
 
 // Apply the real selectors against the mock state.

--- a/src/features/Projects/List/index.tsx
+++ b/src/features/Projects/List/index.tsx
@@ -1,17 +1,15 @@
 'use client';
 
+import { Center, ContextMenuTrigger, Empty, Flexbox, Icon, SearchBar, Tooltip } from '@lobehub/ui';
 import {
   ActionIcon,
-  Center,
-  ContextMenuTrigger,
-  Empty,
-  Flexbox,
-  Icon,
-  SearchBar,
+  Button,
+  confirmModal,
+  type DropdownItem,
+  DropdownMenu,
   Text,
-  Tooltip,
-} from '@lobehub/ui';
-import { Button, confirmModal, type DropdownItem, DropdownMenu, toast } from '@lobehub/ui/base-ui';
+  toast,
+} from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import {

--- a/src/features/Projects/routeMeta.ts
+++ b/src/features/Projects/routeMeta.ts
@@ -1,8 +1,10 @@
 import { FolderClosedIcon } from 'lucide-react';
 
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { routeMeta } from '@/spa/router/routeMeta';
 
 export const projectsRouteMeta = routeMeta({
   icon: FolderClosedIcon,
+  Skeleton: createSurfaceSkeleton('grid'),
   titleKey: 'navigation.projects',
 });

--- a/src/features/ResourcePermission/Collaborators/AddCollaboratorsContent.tsx
+++ b/src/features/ResourcePermission/Collaborators/AddCollaboratorsContent.tsx
@@ -1,17 +1,8 @@
 'use client';
 
 import { MAX_RESOURCE_COLLABORATORS_PER_ADD } from '@lobechat/const';
-import {
-  Avatar,
-  Empty,
-  Flexbox,
-  Icon,
-  SearchBar,
-  SkeletonAvatar,
-  SkeletonTitle,
-  Text,
-} from '@lobehub/ui';
-import { Button, toast, useModalContext } from '@lobehub/ui/base-ui';
+import { Empty, Flexbox, Icon, SearchBar, SkeletonAvatar, SkeletonTitle } from '@lobehub/ui';
+import { Avatar, Button, Text, toast, useModalContext } from '@lobehub/ui/base-ui';
 import { useHover } from 'ahooks';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { CheckIcon, SearchXIcon, UsersIcon } from 'lucide-react';

--- a/src/features/Settings/apikey/features/ApiKey.test.tsx
+++ b/src/features/Settings/apikey/features/ApiKey.test.tsx
@@ -33,8 +33,11 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => {
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
   return {
+    ...actual,
     Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
       <button {...props}>{children}</button>
     ),

--- a/src/features/Settings/creds/features/CreateCredModal/OAuthCredForm.tsx
+++ b/src/features/Settings/creds/features/CreateCredModal/OAuthCredForm.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { Button, Select } from '@lobehub/ui/base-ui';
+import { Avatar, Button, Select } from '@lobehub/ui/base-ui';
 import { useMutation } from '@tanstack/react-query';
-import { Avatar, Empty, Form, Input, Spin } from 'antd';
+import { Empty, Form, Input, Spin } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { type FC } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -58,7 +58,7 @@ const OAuthCredForm: FC<OAuthCredFormProps> = ({ credsApi, disabled, onBack, onS
     return {
       label: (
         <span className={styles.connectionOption}>
-          {conn.avatar && <Avatar size="small" src={conn.avatar} />}
+          {conn.avatar && <Avatar avatar={conn.avatar} size={24} />}
           <span>
             <span className={styles.provider}>{provider}</span>
             {displayName && <span className={styles.username}> - {displayName}</span>}

--- a/src/features/Settings/creds/features/CredItem.tsx
+++ b/src/features/Settings/creds/features/CredItem.tsx
@@ -2,8 +2,7 @@
 
 import { type UserCredSummary } from '@lobechat/types';
 import { DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
-import { Avatar, Button, confirmModal } from '@lobehub/ui/base-ui';
-import { Tag } from 'antd';
+import { Avatar, Button, confirmModal, Tag } from '@lobehub/ui/base-ui';
 import {
   Eye,
   File,

--- a/src/features/Settings/labs/index.test.tsx
+++ b/src/features/Settings/labs/index.test.tsx
@@ -69,6 +69,7 @@ vi.mock('@lobehub/ui', () => ({
 vi.mock('@lobehub/ui/base-ui', () => ({
   Alert: ({ title }: { title: ReactNode }) => <div role={'note'}>{title}</div>,
   Switch: () => <button />,
+  Tag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('@/features/Settings/features/SettingHeader', () => ({

--- a/src/features/Settings/provider/ProviderMenu/List.tsx
+++ b/src/features/Settings/provider/ProviderMenu/List.tsx
@@ -3,12 +3,11 @@
 import {
   Accordion,
   AccordionItem,
-  ActionIcon,
   ContextMenuTrigger,
   Flexbox,
   stopPropagation,
-  Text,
 } from '@lobehub/ui';
+import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { ArrowDownUpIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -1,6 +1,6 @@
 import { Flexbox, Popover } from '@lobehub/ui';
-import { Select, Switch } from '@lobehub/ui/base-ui';
-import { Space, Tag, theme, Typography } from 'antd';
+import { Select, Switch, Tag } from '@lobehub/ui/base-ui';
+import { Space, theme, Typography } from 'antd';
 import { type ExtendParamsType } from 'model-bank';
 import { memo, type ReactNode, type SyntheticEvent, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -661,9 +661,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
                   />
                 }
               >
-                <Tag bordered={false} color={'processing'}>
-                  {def.label}
-                </Tag>
+                <Tag color={'processing'}>{def.label}</Tag>
               </Popover>
             );
           })}

--- a/src/features/Settings/provider/features/ModelList/SearchResult.test.tsx
+++ b/src/features/Settings/provider/features/ModelList/SearchResult.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SearchResult from './SearchResult';
@@ -6,6 +7,15 @@ import SearchResult from './SearchResult';
 const mocks = vi.hoisted(() => ({
   batchToggleAiModels: vi.fn(),
   canManageProvider: false,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({ onClick, title }: { onClick?: (e: any) => void; title?: string }) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+    </button>
+  ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('react-i18next', () => ({

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
@@ -22,15 +22,23 @@ vi.mock('@lobehub/icons', () => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: () => <button type="button" />,
-  Avatar: ({ avatar, title }: { avatar?: string | null; title?: string }) => (
-    <span aria-label={title} data-testid="active-user-avatar">
-      {avatar}
-    </span>
-  ),
   Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Modal: () => null,
 }));
+
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    ActionIcon: () => <button type="button" />,
+    Avatar: ({ avatar, title }: { avatar?: string | null; title?: string }) => (
+      <span aria-label={title} data-testid="active-user-avatar">
+        {avatar}
+      </span>
+    ),
+  };
+});
 
 vi.mock('@/components/StatisticCard', () => ({
   default: ({ statistic }: { statistic: { description?: ReactNode; value?: ReactNode } }) => (

--- a/src/features/SkillStore/SkillList/Builtin/Item.tsx
+++ b/src/features/SkillStore/SkillList/Builtin/Item.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import {
-  ActionIcon,
-  Avatar,
-  Block,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  stopPropagation,
-} from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
+import { Block, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { ActionIcon, Avatar, confirmModal } from '@lobehub/ui/base-ui';
 import { MoreVerticalIcon, Plus, Trash2 } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -63,7 +55,6 @@ const Item = memo<ItemProps>(({ avatar, description, identifier, onOpenDetail, t
     if (isInstalled) {
       return (
         <DropdownMenu
-          nativeButton={false}
           placement="bottomRight"
           items={[
             {

--- a/src/features/SkillsList/SkillsList.tsx
+++ b/src/features/SkillsList/SkillsList.tsx
@@ -1,13 +1,7 @@
 import { EMPTY_ARRAY } from '@lobechat/const';
 import type { SFSymbol } from '@lobechat/electron-client-ipc';
-import {
-  ContextMenuTrigger,
-  Flexbox,
-  type GenericItemType,
-  Icon,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
+import { ContextMenuTrigger, Flexbox, type GenericItemType, Icon, Tooltip } from '@lobehub/ui';
+import { Text } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { createStaticStyles, cx } from 'antd-style';
 import { ChevronRightIcon, FileIcon, FolderIcon, type LucideIcon } from 'lucide-react';

--- a/src/features/Workspace/routeMeta.ts
+++ b/src/features/Workspace/routeMeta.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useWorkspaces } from '@/business/client/hooks/useWorkspaces';
+import HomeSkeleton from '@/components/Skeleton/Home';
 import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
 import { routeMeta } from '@/spa/router/routeMeta';
@@ -24,5 +25,6 @@ const WorkspaceHomeDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) 
 
 export const workspaceHomeRouteMeta = routeMeta({
   DynamicMeta: WorkspaceHomeDynamicMeta,
+  Skeleton: HomeSkeleton,
   titleKey: 'navigation.home',
 });

--- a/src/features/WorkspaceSetting/Layout.test.tsx
+++ b/src/features/WorkspaceSetting/Layout.test.tsx
@@ -10,7 +10,7 @@ vi.mock('@/features/NavHeader', () => ({
     React.createElement('header', undefined, children),
 }));
 
-vi.mock('@lobehub/ui', () => ({
+vi.mock('@lobehub/ui/base-ui', () => ({
   Text: ({ children }: { children?: React.ReactNode }) =>
     React.createElement(React.Fragment, undefined, children),
 }));

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationMediaModeSegment.test.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationMediaModeSegment.test.tsx
@@ -21,14 +21,15 @@ const componentMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: ({ title }: { title?: ReactNode }) => (
-    <button aria-label={typeof title === 'string' ? title : 'action'} type="button" />
-  ),
   Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Icon: () => <span data-testid="mode-icon" />,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  ActionIcon: ({ title }: { title?: ReactNode }) => (
+    <button aria-label={typeof title === 'string' ? title : 'action'} type="button" />
+  ),
   Segmented: (props: SegmentedCapture) => {
     componentMocks.segmented = props;
     return (
@@ -42,7 +43,8 @@ vi.mock('@lobehub/ui/base-ui', () => ({
   Select: () => <div data-testid="mode-select" />,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   createStaticStyles: () => ({
     heroSelect: 'hero-select',
     heroText: 'hero-text',

--- a/src/routes/(main)/(create)/image/_layout/Sidebar/Content.test.tsx
+++ b/src/routes/(main)/(create)/image/_layout/Sidebar/Content.test.tsx
@@ -40,7 +40,8 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   Tabs: () => <div />,
 }));
 

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ActionButtons.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ActionButtons.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { type ActionIconGroupProps, type ActionIconProps } from '@lobehub/ui';
+import { type ActionIconGroupProps } from '@lobehub/ui';
 import { ActionIconGroup } from '@lobehub/ui';
+import { type ActionIconProps } from '@lobehub/ui/base-ui';
 import { Dices, Download, Trash2 } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/agent/channel/detail/permission.test.tsx
+++ b/src/routes/(main)/agent/channel/detail/permission.test.tsx
@@ -194,7 +194,21 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  ActionIcon: ({
+    disabled,
+    onClick,
+    title,
+  }: {
+    disabled?: boolean;
+    onClick?: () => void;
+    title?: string;
+  }) => (
+    <button aria-label={title} disabled={disabled} onClick={onClick}>
+      {title}
+    </button>
+  ),
   Alert: ({
     description,
     message,

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import HeaderActions from './index';
 
-vi.mock('@lobehub/ui', () => ({
+vi.mock('@lobehub/ui/base-ui', () => ({
   ActionIcon: ({ title, onClick }: { title?: string; onClick?: () => void }) => (
     <button
       aria-label={title}
@@ -12,6 +12,9 @@ vi.mock('@lobehub/ui', () => ({
       onClick={onClick}
     />
   ),
+}));
+
+vi.mock('@lobehub/ui', () => ({
   DropdownMenu: ({ children, header }: { children?: ReactNode; header?: ReactNode }) => (
     <div>
       {header}

--- a/src/routes/(main)/agent/features/Conversation/Header/ShareButton/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/ShareButton/index.test.tsx
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@lobehub/ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   ActionIcon: ({
     disabled,
     onClick,

--- a/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   toggleTerminalPanel: vi.fn(),
 }));
 
-vi.mock('@lobehub/ui', () => ({
+vi.mock('@lobehub/ui/base-ui', () => ({
   ActionIcon: ({ active, onClick }: { active?: boolean; onClick?: () => void }) => (
     <button data-active={String(active)} data-testid="terminal-panel-toggle" onClick={onClick} />
   ),

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -223,6 +223,27 @@ vi.mock('@lobehub/ui', async () => {
 });
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    onClick,
+    title,
+    disabled,
+  }: {
+    disabled?: boolean;
+    onClick?: (e: React.MouseEvent) => void;
+    title?: string;
+  }) => (
+    <button
+      aria-label={title}
+      data-testid={title ? 'calendar' : 'refresh'}
+      disabled={disabled}
+      type="button"
+      onClick={onClick}
+    />
+  ),
+  RadioGroup: () => null,
+  Switch: () => null,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  createModal: vi.fn(),
   Button: ({
     children,
     disabled,

--- a/src/routes/(main)/agent/features/routeMeta.ts
+++ b/src/routes/(main)/agent/features/routeMeta.ts
@@ -11,6 +11,7 @@ import { lazy } from 'react';
 
 import ConversationLayoutSkeleton from '@/components/Skeleton/Conversation/Layout';
 import ProfileSkeleton from '@/components/Skeleton/Profile';
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import TopicsSkeleton from '@/components/Skeleton/Topics';
 import { routeMeta } from '@/spa/router/routeMeta';
 
@@ -70,23 +71,27 @@ export const agentProfileRouteMeta = routeMeta({
 export const agentChannelRouteMeta = routeMeta({
   DynamicMeta: ChannelDynamicMeta,
   icon: RadioTowerIcon,
+  Skeleton: createSurfaceSkeleton('grid'),
   titleKey: 'navigation.channels',
 });
 
 export const agentStatisticsRouteMeta = routeMeta({
   DynamicMeta: StatisticsDynamicMeta,
   icon: ChartColumnBigIcon,
+  Skeleton: createSurfaceSkeleton('grid'),
   titleKey: 'navigation.stats',
 });
 
 export const agentSelfLearningRouteMeta = routeMeta({
   DynamicMeta: SelfLearningDynamicMeta,
   icon: GraduationCapIcon,
+  Skeleton: createSurfaceSkeleton('list'),
   titleKey: 'navigation.selfLearning',
 });
 
 export const agentPermissionRouteMeta = routeMeta({
   DynamicMeta: PermissionDynamicMeta,
   icon: UsersIcon,
+  Skeleton: createSurfaceSkeleton('form'),
   titleKey: 'navigation.permission',
 });

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -129,6 +129,17 @@ vi.mock('@/components/InfoTooltip', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    'aria-label': ariaLabel,
+    'aria-pressed': ariaPressed,
+    onClick,
+  }: {
+    'aria-label'?: string;
+    'aria-pressed'?: boolean;
+    'onClick'?: (e: any) => void;
+  }) => (
+    <button aria-label={ariaLabel} aria-pressed={ariaPressed} type="button" onClick={onClick} />
+  ),
   toast: {
     error: (...args: unknown[]) => messageError(...args),
   },

--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -78,7 +78,6 @@ const renderMenuItems = (items: MockDropdownItem[]) =>
 const getLatestExportedBlob = () => vi.mocked(URL.createObjectURL).mock.calls.at(-1)?.[0] as Blob;
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: () => <button aria-label="more" type="button" />,
   DropdownMenu: ({
     children,
     items = [],
@@ -95,6 +94,7 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: () => <button aria-label="more" type="button" />,
   confirmModal: vi.fn(),
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
@@ -82,6 +82,24 @@ vi.mock('@lobehub/ui', () => ({
   Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  ActionIcon: (props: Record<string, unknown>) => {
+    mocks.actionIconProps.all.push(props);
+    return (
+      <button type="button" onClick={props.onClick as () => void}>
+        {props.title as string}
+      </button>
+    );
+  },
+  Button: (props: Record<string, unknown>) => (
+    <button type="button" onClick={props.onClick as () => void}>
+      {props.children as ReactNode}
+    </button>
+  ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
 vi.mock('antd', () => ({
   message: { error: vi.fn() },
 }));

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
@@ -3,8 +3,8 @@
 import { type HeterogeneousProviderConfig, type UserCredSummary } from '@lobechat/types';
 import { Github } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
-import { Button, Select } from '@lobehub/ui/base-ui';
-import { Avatar, Input, Spin, Tag, Typography } from 'antd';
+import { Avatar, Button, Select, Tag } from '@lobehub/ui/base-ui';
+import { Input, Spin, Typography } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { CheckCircle2, KeyRound, X } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -317,7 +317,7 @@ const CloudHeterogeneousConfig = memo<CloudHeterogeneousConfigProps>(
     const githubCredOptions = githubCreds.map((cred) => ({
       label: (
         <span className={styles.credOption}>
-          {cred.oauthAvatar ? <Avatar size={16} src={cred.oauthAvatar} /> : <Github size={14} />}
+          {cred.oauthAvatar ? <Avatar avatar={cred.oauthAvatar} size={16} /> : <Github size={14} />}
           <span>{cred.name}</span>
           {cred.oauthUsername && (
             <Typography.Text style={{ fontSize: 12 }} type="secondary">

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.test.tsx
@@ -50,19 +50,6 @@ vi.mock('@lobechat/heterogeneous-agents/client', () => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: ({
-    'aria-label': ariaLabel,
-    className,
-    onClick,
-  }: {
-    'aria-label'?: string;
-    'className'?: string;
-    'onClick'?: () => void;
-  }) => (
-    <button aria-label={ariaLabel} className={className} type="button" onClick={onClick}>
-      Refresh
-    </button>
-  ),
   CopyButton: () => <button type="button">Copy</button>,
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Icon: () => <span>Icon</span>,
@@ -94,13 +81,24 @@ vi.mock('@lobehub/ui', () => ({
       }}
     />
   ),
-  Tag: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
-  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
   Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   TooltipGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: ({
+    'aria-label': ariaLabel,
+    className,
+    onClick,
+  }: {
+    'aria-label'?: string;
+    'className'?: string;
+    'onClick'?: () => void;
+  }) => (
+    <button aria-label={ariaLabel} className={className} type="button" onClick={onClick}>
+      Refresh
+    </button>
+  ),
   Button: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
     <button type="button" onClick={onClick}>
       {children}
@@ -160,6 +158,8 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       )}
     </select>
   ),
+  Tag: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('antd-style', () => ({

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
@@ -12,18 +12,8 @@ import type {
   HeterogeneousAuthMode,
   HeterogeneousProviderConfig,
 } from '@lobechat/types';
-import {
-  ActionIcon,
-  CopyButton,
-  Flexbox,
-  Icon,
-  Input,
-  Tag,
-  Text,
-  Tooltip,
-  TooltipGroup,
-} from '@lobehub/ui';
-import { Button, Segmented, Select } from '@lobehub/ui/base-ui';
+import { CopyButton, Flexbox, Icon, Input, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { ActionIcon, Button, Segmented, Select, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Loader2Icon, PencilLine, RefreshCw, XCircle } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
@@ -12,10 +12,10 @@ import {
   Button,
   createModal,
   Select,
+  Tag,
   Text,
   useModalContext,
 } from '@lobehub/ui/base-ui';
-import { Tag } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { t as i18nT } from 'i18next';
 import { BotIcon, CheckCircle2, MonitorSmartphone, RefreshCw, XCircle } from 'lucide-react';

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/WorkspaceAgentDevicePolicy.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/WorkspaceAgentDevicePolicy.test.tsx
@@ -24,7 +24,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   Select: ({
     disabled,
     loading,

--- a/src/routes/(main)/community/(detail)/_layout/Header.test.tsx
+++ b/src/routes/(main)/community/(detail)/_layout/Header.test.tsx
@@ -10,10 +10,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
   ActionIcon: ({ onClick }: { onClick?: () => void }) => (
     <button data-testid="back-button" onClick={onClick} />
   ),
-  Flexbox: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('@/features/NavHeader', () => ({

--- a/src/routes/(main)/community/(detail)/features/ShareButton.tsx
+++ b/src/routes/(main)/community/(detail)/features/ShareButton.tsx
@@ -1,16 +1,5 @@
-import {
-  ActionIcon,
-  Avatar,
-  Center,
-  CopyButton,
-  Flexbox,
-  Icon,
-  Input,
-  Skeleton,
-  Tag,
-  Text,
-} from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { Center, CopyButton, Flexbox, Icon, Input, Skeleton } from '@lobehub/ui';
+import { ActionIcon, Avatar, Button, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { startCase } from 'es-toolkit/compat';
 import { LinkIcon, Share2Icon } from 'lucide-react';

--- a/src/routes/(main)/community/(detail)/group_agent/features/Details/SystemRole/TagList.tsx
+++ b/src/routes/(main)/community/(detail)/group_agent/features/Details/SystemRole/TagList.tsx
@@ -1,4 +1,5 @@
-import { Flexbox,Tag as AntdTag } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
+import { Tag as AntdTag } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
 interface TagListProps {

--- a/src/routes/(main)/community/(detail)/organization/features/Header/index.test.tsx
+++ b/src/routes/(main)/community/(detail)/organization/features/Header/index.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { render, screen } from '@testing-library/react';
-import type { ElementType, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -15,9 +16,8 @@ vi.mock('@lobehub/ui/base-ui', () => ({
     <span>{alt ?? String(avatar ?? '')}</span>
   ),
   Tag: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
-  Text: ({ as: As = 'span', children }: { as?: ElementType; children?: ReactNode }) => (
-    <As>{children}</As>
-  ),
+  Text: ({ as = 'span', children }: { as?: string; children?: ReactNode }) =>
+    createElement(as, undefined, children),
 }));
 
 vi.mock('react-i18next', () => ({

--- a/src/routes/(main)/community/(detail)/organization/features/Header/index.test.tsx
+++ b/src/routes/(main)/community/(detail)/organization/features/Header/index.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { render, screen } from '@testing-library/react';
+import type { ElementType, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -7,6 +8,17 @@ import {
   OrganizationDetailProvider,
 } from '../DetailProvider';
 import OrganizationHeader from './index';
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  ActionIcon: () => <button type="button" />,
+  Avatar: ({ avatar, alt }: { alt?: string; avatar?: string }) => (
+    <span>{alt ?? String(avatar ?? '')}</span>
+  ),
+  Tag: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Text: ({ as: As = 'span', children }: { as?: ElementType; children?: ReactNode }) => (
+    <As>{children}</As>
+  ),
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),

--- a/src/routes/(main)/community/(detail)/user/features/UserAgentCard.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/UserAgentCard.tsx
@@ -1,19 +1,15 @@
 'use client';
 
 import {
-  Avatar,
   Block,
   DropdownMenu,
   Flexbox,
   Icon,
   stopPropagation,
-  Tag as AntTag,
-  Tag,
-  Text,
   Tooltip,
   TooltipGroup,
 } from '@lobehub/ui';
-import { toast } from '@lobehub/ui/base-ui';
+import { Avatar, Tag as AntTag, Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import {
   AlertTriangle,

--- a/src/routes/(main)/community/(detail)/user/features/UserGroupCard.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/UserGroupCard.tsx
@@ -1,18 +1,15 @@
 'use client';
 
 import {
-  Avatar,
   Block,
   DropdownMenu,
   Flexbox,
   Icon,
   stopPropagation,
-  Tag as AntTag,
-  Tag,
-  Text,
   Tooltip,
   TooltipGroup,
 } from '@lobehub/ui';
+import { Avatar, Tag as AntTag, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import {
   AlertTriangle,

--- a/src/routes/(main)/community/(list)/mcp/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/mcp/features/List/Item.tsx
@@ -1,18 +1,9 @@
 'use client';
 
 import { Github } from '@lobehub/icons';
-import {
-  ActionIcon,
-  Avatar,
-  Block,
-  Flexbox,
-  Icon,
-  stopPropagation,
-  Tag,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
+import { Block, Flexbox, Icon, stopPropagation, Tooltip } from '@lobehub/ui';
 import { Spotlight } from '@lobehub/ui/awesome';
+import { ActionIcon, Avatar, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ClockIcon } from 'lucide-react';
 import { memo, useCallback } from 'react';

--- a/src/routes/(main)/community/features/UserAvatar/index.test.tsx
+++ b/src/routes/(main)/community/features/UserAvatar/index.test.tsx
@@ -13,14 +13,21 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  Avatar: ({ avatar, onClick }: { avatar?: string | null; onClick?: () => void }) => (
-    <button data-avatar={avatar ?? ''} data-testid="community-user-avatar" onClick={onClick} />
-  ),
-  Button: ({ children }: { children?: string }) => <button>{children}</button>,
   Skeleton: {
     Avatar: () => <div data-testid="avatar-skeleton" />,
   },
 }));
+
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    Avatar: ({ avatar, onClick }: { avatar?: string | null; onClick?: () => void }) => (
+      <button data-avatar={avatar ?? ''} data-testid="community-user-avatar" onClick={onClick} />
+    ),
+    Button: ({ children }: { children?: string }) => <button>{children}</button>,
+  };
+});
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/BatchResumeModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/BatchResumeModal/Content.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Checkbox } from '@lobehub/ui/base-ui';
-import { Badge, Skeleton, Table, Tag, Tooltip, Typography } from 'antd';
+import { Checkbox, Tag } from '@lobehub/ui/base-ui';
+import { Badge, Skeleton, Table, Tooltip, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { type FC, memo, useCallback, useEffect, useMemo, useState } from 'react';

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
@@ -3,8 +3,7 @@
 import { AGENT_PROFILE_URL } from '@lobechat/const';
 import type { AgentEvalRunDetail } from '@lobechat/types';
 import { copyToClipboard, Flexbox, Highlighter, Markdown } from '@lobehub/ui';
-import { ActionIcon, Avatar, Button, confirmModal, toast } from '@lobehub/ui/base-ui';
-import { Tag } from 'antd';
+import { ActionIcon, Avatar, Button, confirmModal, Tag, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   ArrowLeft,

--- a/src/routes/(main)/group/features/Conversation/Header/ShareButton/index.test.tsx
+++ b/src/routes/(main)/group/features/Conversation/Header/ShareButton/index.test.tsx
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@lobehub/ui', () => ({
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   ActionIcon: ({
     disabled,
     onClick,

--- a/src/routes/(main)/group/features/routeMeta.ts
+++ b/src/routes/(main)/group/features/routeMeta.ts
@@ -3,6 +3,7 @@ import { lazy } from 'react';
 
 import ConversationLayoutSkeleton from '@/components/Skeleton/Conversation/Layout';
 import { GroupProfileRouteSkeleton } from '@/components/Skeleton/Profile';
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { routeMeta } from '@/spa/router/routeMeta';
 
 const GroupDynamicMeta = lazy(() => import('@/features/RouteMeta/GroupDynamicMeta'));
@@ -34,5 +35,6 @@ export const groupProfileRouteMeta = routeMeta({
 export const groupPermissionRouteMeta = routeMeta({
   DynamicMeta: GroupPermissionDynamicMeta,
   icon: UsersIcon,
+  Skeleton: createSurfaceSkeleton('form'),
   titleKey: 'navigation.permission',
 });

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -28,9 +28,11 @@ import BrandTextLoading from '@/components/Loading/BrandTextLoading';
 import AppsSkeleton from '@/components/Skeleton/Apps';
 import ConversationLayoutSkeleton from '@/components/Skeleton/Conversation/Layout';
 import ConversationSegmentSkeleton from '@/components/Skeleton/Conversation/Segment';
+import GenerationSkeleton from '@/components/Skeleton/Generation';
 import HomeSkeleton from '@/components/Skeleton/Home';
 import MemorySkeleton from '@/components/Skeleton/Memory';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
+import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { agentDocumentRouteMeta } from '@/features/AgentDocumentPage/routeMeta';
 import { goalDetailRouteMeta, goalsRouteMeta } from '@/features/AgentGoals/routeMeta';
 import { taskRouteMeta, tasksRouteMeta } from '@/features/AgentTasks/routeMeta';
@@ -499,6 +501,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
           'Desktop > Discover > List > Layout',
           { preloadId: 'community' },
         ),
+        handle: { meta: routeMeta({ Skeleton: createSurfaceSkeleton('grid') }) },
       },
       // Detail routes (with DetailLayout)
       {
@@ -564,6 +567,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
           () => import('@/routes/(main)/community/(detail)/_layout'),
           'Desktop > Discover > Detail > Layout',
         ),
+        handle: { meta: routeMeta({ Skeleton: createSurfaceSkeleton('detail') }) },
       },
     ],
     element: dynamicElement(
@@ -646,7 +650,11 @@ export const sharedMainAreaChildren: RouteObject[] = [
               'Desktop > Resource > Library > Permission',
             ),
             handle: {
-              meta: routeMeta({ icon: LibraryBigIcon, titleKey: 'navigation.knowledgeBase' }),
+              meta: routeMeta({
+                icon: LibraryBigIcon,
+                Skeleton: createSurfaceSkeleton('form'),
+                titleKey: 'navigation.knowledgeBase',
+              }),
             },
             path: 'permission',
           },
@@ -674,6 +682,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
       { preloadId: 'resource' },
     ),
     errorElement: <ErrorBoundary />,
+    handle: { meta: routeMeta({ Skeleton: createSurfaceSkeleton('list') }) },
     path: 'resource',
   },
 
@@ -752,6 +761,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
       { preloadId: 'memory' },
     ),
     errorElement: <ErrorBoundary />,
+    handle: { meta: routeMeta({ Skeleton: createSurfaceSkeleton('list') }) },
     path: 'memory',
   },
 
@@ -771,6 +781,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
       { preloadId: 'video' },
     ),
     errorElement: <ErrorBoundary />,
+    handle: { meta: routeMeta({ Skeleton: GenerationSkeleton }) },
     path: 'video',
   },
 
@@ -793,6 +804,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
       { preloadId: 'image' },
     ),
     errorElement: <ErrorBoundary />,
+    handle: { meta: routeMeta({ Skeleton: GenerationSkeleton }) },
     path: 'image',
   },
 
@@ -877,6 +889,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
       { preloadId: 'eval' },
     ),
     errorElement: <ErrorBoundary />,
+    handle: { meta: routeMeta({ Skeleton: createSurfaceSkeleton('list') }) },
     path: 'eval',
   },
 
@@ -988,7 +1001,11 @@ export const sharedMainAreaChildren: RouteObject[] = [
           preloadId: 'page',
         }),
         handle: {
-          meta: routeMeta({ icon: FilePenIcon, titleKey: 'navigation.pages' }),
+          meta: routeMeta({
+            icon: FilePenIcon,
+            Skeleton: createSurfaceSkeleton('list'),
+            titleKey: 'navigation.pages',
+          }),
         },
         index: true,
       },

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -28,6 +28,7 @@ import BrandTextLoading from '@/components/Loading/BrandTextLoading';
 import AppsSkeleton from '@/components/Skeleton/Apps';
 import ConversationLayoutSkeleton from '@/components/Skeleton/Conversation/Layout';
 import ConversationSegmentSkeleton from '@/components/Skeleton/Conversation/Segment';
+import HomeSkeleton from '@/components/Skeleton/Home';
 import MemorySkeleton from '@/components/Skeleton/Memory';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import { agentDocumentRouteMeta } from '@/features/AgentDocumentPage/routeMeta';
@@ -1344,6 +1345,7 @@ const createMainAreaChildrenDefinition = (options: MainAreaRouteOptions = {}): R
     handle: {
       meta: routeMeta({
         icon: HomeIcon,
+        Skeleton: HomeSkeleton,
         tabTitleKey: 'navigation.home',
         titleKey: 'navigation.home',
       }),


### PR DESCRIPTION
Lazy routes with no registered `Skeleton` fell through `RouteSegmentSkeleton` to the generic `SurfaceSkeleton` list variant — an avatar-list layout that mismatches most pages (home dashboard, image/video workspaces, workspace settings, discover, projects, …).

This PR gives every main-area lazy route a suitable skeleton and makes the registration convention explicit.

### Changes

- **`HomeSkeleton`** (new): mirrors the home dashboard — greeting, 106px composer card, recents rows, 380px right rail (hidden ≤ 1100px). Registered on `/` and `/:workspaceSlug` home metas.
- **`GenerationSkeleton`** (new): config panel + canvas grid + prompt bar, for `/image` and `/video`.
- **`SurfaceSkeleton`**: new `detail` variant (hero avatar + tags + content) and a `createSurfaceSkeleton(variant)` factory so route metas can pick a variant explicitly instead of relying on path-guessing.
- **Explicit registrations** across feature `routeMeta` files and `desktopRouter.shared.tsx`: agents/projects/channel/statistics → grid; permissions → form; docs/pages → editor; task/acceptance/verify/discover-detail → detail; self-learning/memory/resource/eval/verify-reports → list. Subtrees sharing one shape register once on the parent layout `handle` (deepest `Skeleton` still wins).
- **`RouteSegment` fix**: workspace settings (`/:slug/settings/*`) now match the settings branch — previously only `/settings/*` did, so ~20 workspace settings tabs got the generic list skeleton.
- **`spa-routes` skill**: new required step — every lazy route must register a `Skeleton` (factory variant or bespoke), and layout changes must update the skeleton in the same PR.

### Before / After

Captured on local dev with CDP network throttling (300 ms latency / 150 KB/s, cache disabled) during the lazy-chunk Suspense window.

| Route | Before | After |
| ----- | ------ | ----- |
| `/image` | ![before-image](https://gist.githubusercontent.com/Innei/00f32bd9b34760658ae773eba213d15c/raw/before-image.png) | ![after-image](https://gist.githubusercontent.com/Innei/00f32bd9b34760658ae773eba213d15c/raw/after-image.png) |
| `/community/agent/:slug` | ![before-detail](https://gist.githubusercontent.com/Innei/00f32bd9b34760658ae773eba213d15c/raw/before-detail.png) | ![after-detail](https://gist.githubusercontent.com/Innei/00f32bd9b34760658ae773eba213d15c/raw/after-detail.png) |
| `/projects` (grid) | same generic avatar list | ![after-projects](https://gist.githubusercontent.com/Innei/00f32bd9b34760658ae773eba213d15c/raw/after-projects.png) |
| `/memory/identities` (list via parent handle) | same generic avatar list | ![after-memory](https://gist.githubusercontent.com/Innei/00f32bd9b34760658ae773eba213d15c/raw/after-memory.png) |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Skeleton presentation only; `desktopRouter.sync.test.tsx` (40) and `useRouteSkeleton.test.ts` (3) pass.