### PR TITLE
💄 style(toast): align toast radius and offsets with desktop layout container

### DIFF
--- a/src/features/DesktopLayoutContainer/index.tsx
+++ b/src/features/DesktopLayoutContainer/index.tsx
@@ -1,6 +1,6 @@
 import { Flexbox } from '@lobehub/ui';
 import { type FC, type PropsWithChildren } from 'react';
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { useIsDark } from '@/hooks/useIsDark';
 import { useGlobalStore } from '@/store/global';
@@ -21,6 +21,20 @@ const DesktopLayoutContainer: FC<PropsWithChildren> = ({ children }) => {
     () => getInnerCssVariables({ isDark: isDarkMode }),
     [isDarkMode],
   );
+
+  // Toast viewport is portaled to body, so it can't inherit the container-scoped vars
+  useEffect(() => {
+    const vars: Record<string, string> = {
+      '--toast-border-radius': innerCssVariables['--container-border-radius'],
+      '--toast-viewport-offset-x': '24px',
+      '--toast-viewport-offset-y': '24px',
+    };
+    const root = document.documentElement;
+    for (const [key, value] of Object.entries(vars)) root.style.setProperty(key, value);
+    return () => {
+      for (const key of Object.keys(vars)) root.style.removeProperty(key);
+    };
+  }, [innerCssVariables]);
 
   return (
     <Flexbox


### PR DESCRIPTION
### What

Sets three toast CSS variables on `:root` while `DesktopLayoutContainer` is mounted:

- `--toast-border-radius` ← reuses `--container-border-radius` (12px on macOS 26+, antd radius otherwise)
- `--toast-viewport-offset-x/y: 24px` (8px outer padding + 16px inset), so toasts visually sit inside the rounded content container

Vars are set via effect because the toast viewport is portaled to `body` and can't inherit the container-scoped inline vars. Mobile/auth layouts don't mount this container, so they fall back to lobe-ui defaults.

### Note

Consumed by `@lobehub/ui` >= 5.33.3 (lobehub/lobe-ui@53e2bd58, b7696a0a); inert no-op until the dependency picks it up.

https://claude.ai/code/session_01F5bKqpXLdDD6rN6dsEJHeJ