### PR TITLE
💄 style(share): center skeleton hero to match hydrated layout

### DIFF
--- a/apps/share/src/features/topic/SharedTopicView.tsx
+++ b/apps/share/src/features/topic/SharedTopicView.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 import { useParams } from 'react-router';
 import useSWR from 'swr';
 
 import ShareShell, { ShareHero } from '@/business/client/features/ShareShell';
+import { CONVERSATION_MIN_WIDTH } from '@/const/layoutTokens';
 import { shareKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 import { loadRouteWithBuiltinToolSurfaces } from '@/spa/initialize/toolSurfaces';
@@ -30,12 +32,22 @@ const SharedTopicView = memo(() => {
   const marketIdentifier = data?.agentMeta?.marketIdentifier;
   const openUrl = marketIdentifier ? `/community/agent/${marketIdentifier}` : '/community/agent';
 
+  // Mirror WideScreenContainer's centered column so the pre-hydration document
+  // matches the hydrated ChatList headerSlot layout instead of hugging the left.
   const hero = data ? (
-    <ShareHero
-      avatar={<TopicAvatar data={data} size={40} />}
-      byline={buildTopicByline(data)}
-      title={data.title}
-    />
+    <Flexbox width={'100%'}>
+      <Flexbox
+        paddingInline={16}
+        style={{ alignSelf: 'center' }}
+        width={`min(${CONVERSATION_MIN_WIDTH}px, 100%)`}
+      >
+        <ShareHero
+          avatar={<TopicAvatar data={data} size={40} />}
+          byline={buildTopicByline(data)}
+          title={data.title}
+        />
+      </Flexbox>
+    </Flexbox>
   ) : null;
 
   return (

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -224,7 +224,7 @@ const ChatList = memo<ChatListProps>(
       // server-rendered title the moment the list mounts to fetch.
       return (
         <Flexbox height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }}>
-          {headerSlot}
+          {headerSlot && <WideScreenContainer>{headerSlot}</WideScreenContainer>}
           <SkeletonList />
         </Flexbox>
       );


### PR DESCRIPTION
The share topic page's pre-hydration skeleton rendered the hero (avatar + title + byline) hugging the left edge, while the hydrated ChatList centers it inside a `min(960px, 100%)` column — a jarring horizontal jump once JS loads.

Two gaps, both fixed:

1. **SSR fallback hero** (`apps/share/.../SharedTopicView.tsx`): the `clientOnly` fallback rendered `ShareHero` bare in `ShareShell`. Wrapped it in the same centered column `WideScreenContainer` produces (`min(960px, 100%)` + `align-self: center` + 16px inline padding), mirrored manually to keep `store/global` out of the worker SSR bundle.
2. **ChatList skeleton branch** (`src/features/Conversation/ChatList/index.tsx`): the `showSkeleton` branch rendered `headerSlot` bare (left-aligned) while the message skeletons were centered; the hero only snapped into place once messages loaded. Now wraps `headerSlot` in `WideScreenContainer`.

| Before | After |
| ------ | ----- |
| Hero pinned to the left edge (h1 x=24, full width) while skeletons center | Hero centered in the 960px column (h1 x=360), identical across no-JS skeleton → loading skeleton → hydrated |

#### Test

Verified against the local share worker dev (`bun run dev:rr`) on `/share/t/8XbZcsbM` with Playwright: measured `h1.getBoundingClientRect().x` in three phases (no-JS SSR, hydrated with `message.getMessages` stalled, fully loaded) — all `x=360` at a 1600px viewport after the fix (was 24/24/360); re-checked at 2000px and in dark mode. Full evidence: https://app.lobehub.com/acceptance/50f2e496-b74d-4284-8ce0-d55f86e1abdb

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None

https://claude.ai/code/session_01TQcoZnDo12NGCxWZDJpciZ