### PR TITLE
👷 ci(desktop): read the overlay repository from a variable instead of hardcoding

### DIFF
--- a/.github/actions/desktop-build-setup/action.yml
+++ b/.github/actions/desktop-build-setup/action.yml
@@ -6,9 +6,11 @@ inputs:
     description: Node.js version
     required: true
   cloud-repository:
-    description: Cloud repository to overlay for commercial desktop builds
+    description: >-
+      Overlay repository (owner/name) for commercial desktop builds — pass the
+      OVERLAY_REPOSITORY repository variable; deliberately no hardcoded default.
     required: false
-    default: lobehub/lobehub-cloud
+    default: ''
   cloud-ref:
     description: Optional Cloud repository ref
     required: false
@@ -37,6 +39,8 @@ runs:
         CLOUD_TOKEN: ${{ inputs.cloud-token }}
       run: |
         set -euo pipefail
+        # Fail loudly rather than silently shipping an OSS-only commercial build.
+        : "${CLOUD_REPOSITORY:?cloud-repository input is empty — pass the OVERLAY_REPOSITORY repository variable}"
 
         cloud_root="$(cd "$GITHUB_WORKSPACE/.." && pwd)"
         cloud_checkout="$RUNNER_TEMP/lobehub-cloud"

--- a/.github/workflows/manual-build-desktop.yml
+++ b/.github/workflows/manual-build-desktop.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup
         with:
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 
@@ -183,6 +184,7 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup
         with:
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 
@@ -228,6 +230,7 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup
         with:
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup
         with:
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: 24.11.1
 

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -58,11 +58,13 @@ jobs:
         id: cloud-ref
         if: steps.check.outputs.is_beta == 'true'
         env:
+          CLOUD_REPOSITORY: ${{ vars.OVERLAY_REPOSITORY }}
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
+          : "${CLOUD_REPOSITORY:?OVERLAY_REPOSITORY repository variable is not set}"
           # checkout persist-credentials extraheader would send GITHUB_TOKEN and 404 the private cloud repo
-          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
+          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/${CLOUD_REPOSITORY}.git" HEAD | cut -f1)
           if [[ ! "$cloud_ref" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve Cloud revision"
             exit 1
@@ -113,6 +115,7 @@ jobs:
         uses: ./.github/actions/desktop-build-setup
         with:
           cloud-ref: ${{ needs.check-beta.outputs.cloud_ref }}
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -127,11 +127,13 @@ jobs:
         id: cloud-ref
         if: steps.check.outputs.should_build == 'true'
         env:
+          CLOUD_REPOSITORY: ${{ vars.OVERLAY_REPOSITORY }}
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
+          : "${CLOUD_REPOSITORY:?OVERLAY_REPOSITORY repository variable is not set}"
           # checkout persist-credentials extraheader would send GITHUB_TOKEN and 404 the private cloud repo
-          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
+          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/${CLOUD_REPOSITORY}.git" HEAD | cut -f1)
           if [[ ! "$cloud_ref" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve Cloud revision"
             exit 1
@@ -249,6 +251,7 @@ jobs:
         uses: ./.github/actions/desktop-build-setup
         with:
           cloud-ref: ${{ needs.calculate-version.outputs.cloud_ref }}
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release-desktop-renderer-ota.yml
+++ b/.github/workflows/release-desktop-renderer-ota.yml
@@ -92,6 +92,7 @@ jobs:
         uses: ./.github/actions/desktop-build-setup
         with:
           cloud-ref: ${{ steps.base.outputs.cloud_ref }}
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -124,11 +124,13 @@ jobs:
         id: cloud-ref
         if: steps.check.outputs.is_stable == 'true'
         env:
+          CLOUD_REPOSITORY: ${{ vars.OVERLAY_REPOSITORY }}
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
+          : "${CLOUD_REPOSITORY:?OVERLAY_REPOSITORY repository variable is not set}"
           # checkout persist-credentials extraheader would send GITHUB_TOKEN and 404 the private cloud repo
-          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
+          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/${CLOUD_REPOSITORY}.git" HEAD | cut -f1)
           if [[ ! "$cloud_ref" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve Cloud revision"
             exit 1
@@ -206,6 +208,7 @@ jobs:
         uses: ./.github/actions/desktop-build-setup
         with:
           cloud-ref: ${{ needs.check-stable.outputs.cloud_ref }}
+          cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}
           cloud-token: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 


### PR DESCRIPTION
Every desktop CI path hardcoded the private overlay repository's owner/name (still under its pre-transfer org path, working only via GitHub's redirect). This replaces all of them with the `OVERLAY_REPOSITORY` Actions repository variable — the same one the share verify workflow (#18757) reads — so the public workflow files no longer name the private repo, and the org-transfer redirect dependency goes away.

Changes:

- `desktop-build-setup`: `cloud-repository` input loses its hardcoded default; the overlay step fails loudly (`:?` guard) when a token is supplied without a repository, instead of silently shipping an OSS-only commercial build.
- Release workflows (beta / stable / canary): the "Resolve Cloud revision" step takes the repo from `vars.OVERLAY_REPOSITORY` with an explicit unset guard; all `desktop-build-setup` call sites pass `cloud-repository: ${{ vars.OVERLAY_REPOSITORY }}` (also `manual-build-desktop`, `pr-build-desktop`, `release-desktop-renderer-ota` — 8 call sites total).

⚠️ **Merge gate**: set the `OVERLAY_REPOSITORY` repository variable (Settings → Secrets and variables → Actions → Variables) to the overlay repo's current owner/name **before** merging — after merge, any desktop build without it fails fast at the resolve/overlay step by design.

#### Test

`grep -rn "lobehub/lobehub-cloud" .github/` returns nothing; all 6 workflow files + the composite action pass yaml-lint. Behavior is exercised by the next desktop build run.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None

https://claude.ai/code/session_01TQcoZnDo12NGCxWZDJpciZ