### PR TITLE
✅ test: stub base-ui ActionIcon in input banner queue case

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -83,6 +83,32 @@ vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
 vi.mock('@/services/chat'); // Too broad
 ```
 
+## UI Library Mocks (@lobehub/ui/base-ui)
+
+**Default: do NOT mock `@lobehub/ui/base-ui` — render the real components.**
+`vitest.config.mts` redirects the library's internal MotionProvider to a static
+stub (`tests/mocks/lobehubUiMotionProvider.tsx`), so base-ui components render in
+tests without the app-level ConfigProvider. `Please wrap your app with <ConfigProvider> (or <MotionProvider>)` in a test means that redirect is not in
+effect (e.g. a package-local vitest config) — do not fix it by hand-mocking every
+component.
+
+When a test genuinely wants simplified DOM, compose the canonical stubs over the
+real module instead of writing a closed factory (closed factories break whenever
+the library migrates a component's import path):
+
+```typescript
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  ...(await import('~base-ui-stubs')).baseUiStubs,
+}));
+```
+
+`~base-ui-stubs` (`tests/mocks/baseUiStubs.tsx`) covers ActionIcon / Button /
+Text / Tag / Avatar / Alert / toast / confirmModal / createModal with standard
+aria semantics. A per-file factory is still fine when assertions need bespoke
+testid conventions — but keep it composed over `importOriginal` so unknown
+exports never go missing.
+
 ## Detailed Guides
 
 See `references/` for specific testing scenarios:

--- a/src/features/AgentSidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
@@ -18,6 +18,11 @@ vi.mock('react-router', () => ({
   useParams: () => routeParamsMock,
 }));
 
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  ...(await import('~base-ui-stubs')).baseUiStubs,
+}));
+
 vi.mock('@lobehub/ui', () => ({
   AccordionItem: ({
     action,
@@ -56,7 +61,8 @@ vi.mock('@lobehub/ui', () => ({
   Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   createStaticStyles: () => ({
     addTopicAction: 'addTopicAction',
     statusBadge: 'statusBadge',

--- a/src/features/AgentTasks/AgentTaskList/TaskListVisibilityFilter.test.tsx
+++ b/src/features/AgentTasks/AgentTaskList/TaskListVisibilityFilter.test.tsx
@@ -33,7 +33,8 @@ vi.mock('@lobehub/ui', () => ({
   Icon: () => <span data-testid="menu-extra-icon" />,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   cssVar: { colorTextSecondary: '#666' },
 }));
 

--- a/src/features/AgentTasks/features/TaskVisibilityChipLabel.test.tsx
+++ b/src/features/AgentTasks/features/TaskVisibilityChipLabel.test.tsx
@@ -13,7 +13,8 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   cssVar: {
     colorTextDescription: '#999',
     colorTextSecondary: '#666',

--- a/src/features/Electron/titlebar/NavigationBar.test.tsx
+++ b/src/features/Electron/titlebar/NavigationBar.test.tsx
@@ -34,7 +34,8 @@ vi.mock('@lobehub/ui', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => children,
 }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   createStaticStyles: () => ({ clock: 'clock' }),
 }));
 

--- a/src/features/Home/__tests__/portraitVisibility.test.tsx
+++ b/src/features/Home/__tests__/portraitVisibility.test.tsx
@@ -214,6 +214,15 @@ describe('Home portrait visibility', () => {
 describe('Home input banner queue', () => {
   it('reveals the next available segment after dismissing the current one', async () => {
     vi.resetModules();
+    vi.doMock('@lobehub/ui/base-ui', () => ({
+      ActionIcon: ({
+        onClick,
+        title,
+      }: {
+        onClick?: (e: React.MouseEvent) => void;
+        title?: string;
+      }) => <button aria-label={title} type={'button'} onClick={onClick} />,
+    }));
     const { useGlobalStore } = await import('@/store/global');
     const originalDismissedIds = useGlobalStore.getState().status.dismissedBannerIds;
     const originalStatusInit = useGlobalStore.getState().isStatusInit;
@@ -247,6 +256,7 @@ describe('Home input banner queue', () => {
       expect(container.querySelector('[data-home-input-banner]')).toHaveTextContent('Second');
       expect(screen.getByTestId('second')).toBeVisible();
     } finally {
+      vi.doUnmock('@lobehub/ui/base-ui');
       useGlobalStore.setState((state) => ({
         isStatusInit: originalStatusInit,
         status: { ...state.status, dismissedBannerIds: originalDismissedIds },

--- a/src/features/ModelSwitchPanel/components/ModelDetailPanel.test.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelDetailPanel.test.tsx
@@ -10,7 +10,8 @@ import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
 import ModelDetailPanel from './ModelDetailPanel';
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   createStaticStyles: () => ({
     actionText: 'actionText',
     container: 'container',

--- a/src/features/Portal/AcceptanceCheck/Body.test.tsx
+++ b/src/features/Portal/AcceptanceCheck/Body.test.tsx
@@ -33,14 +33,9 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
-  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
-    <button type="button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-  Tag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
-  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  ...(await import('~base-ui-stubs')).baseUiStubs,
 }));
 
 vi.mock('antd', () => ({

--- a/src/features/ProfileEditor/PluginTag.test.tsx
+++ b/src/features/ProfileEditor/PluginTag.test.tsx
@@ -32,13 +32,18 @@ vi.mock('react-i18next', () => ({
 }));
 vi.mock('@/hooks/useIsDark', () => ({ useIsDark: () => false }));
 
-vi.mock('antd-style', () => ({
+vi.mock('antd-style', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   createStaticStyles: () => ({}),
   cssVar: new Proxy({}, { get: () => 'var(--x)' }),
 }));
 vi.mock('@lobehub/const', () => ({ COMPOSIO_APP_TYPES: [], LOBEHUB_SKILL_PROVIDERS: [] }));
 vi.mock('@lobehub/ui/icons', () => ({ McpIcon: () => null }));
 vi.mock('@/components/Plugins/PluginAvatar', () => ({ default: () => null }));
+vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  Avatar: ({ title }: { title?: string }) => <span data-testid="author-avatar">{title}</span>,
+}));
 vi.mock('@lobehub/ui', () => ({
   Avatar: ({ title }: { title?: string }) => <span data-testid="author-avatar">{title}</span>,
   Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,

--- a/tests/mocks/baseUiStubs.tsx
+++ b/tests/mocks/baseUiStubs.tsx
@@ -1,0 +1,91 @@
+/**
+ * Canonical simplified-DOM stubs for `@lobehub/ui/base-ui` atoms. Prefer the
+ * real components — the vitest config already stubs their MotionProvider so
+ * they render without app-level providers. Use this only when a test wants
+ * simplified DOM, composed over the real module so no export ever goes missing:
+ *
+ * ```ts
+ * vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
+ *   ...(await importOriginal<object>()),
+ *   ...(await import('~base-ui-stubs')).baseUiStubs,
+ * }));
+ * ```
+ *
+ * Per-file factories still win for bespoke testid conventions.
+ */
+import type { MouseEventHandler, ReactNode } from 'react';
+import { vi } from 'vitest';
+
+const ActionIcon = ({
+  disabled,
+  onClick,
+  title,
+}: {
+  disabled?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  title?: string;
+}) => (
+  <button aria-label={title} disabled={disabled} type={'button'} onClick={onClick}>
+    {title}
+  </button>
+);
+
+const Button = ({
+  children,
+  disabled,
+  loading,
+  onClick,
+  type,
+}: {
+  children?: ReactNode;
+  disabled?: boolean;
+  loading?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  type?: string;
+}) => (
+  <button
+    data-button-loading={loading ? 'true' : undefined}
+    data-button-type={type}
+    disabled={disabled || loading}
+    type={'button'}
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+
+const Text = ({ children }: { children?: ReactNode }) => <span>{children}</span>;
+
+const Tag = ({ children }: { children?: ReactNode }) => <span>{children}</span>;
+
+const Avatar = ({ alt, avatar }: { alt?: string; avatar?: ReactNode }) => (
+  <span role={'img'}>{alt ?? (typeof avatar === 'string' ? avatar : null)}</span>
+);
+
+const Alert = ({ message, title }: { message?: ReactNode; title?: ReactNode }) => (
+  <div role={'alert'}>
+    <div>{title}</div>
+    <div>{message}</div>
+  </div>
+);
+
+export const createBaseUiStubs = () => ({
+  ActionIcon,
+  Alert,
+  Avatar,
+  Button,
+  Tag,
+  Text,
+  confirmModal: vi.fn(),
+  createModal: vi.fn(() => ({ close: vi.fn(), open: vi.fn() })),
+  toast: Object.assign(vi.fn(), {
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  }),
+});
+
+export const baseUiStubs = createBaseUiStubs();

--- a/tests/mocks/lobehubUiMotionProvider.tsx
+++ b/tests/mocks/lobehubUiMotionProvider.tsx
@@ -1,0 +1,68 @@
+/**
+ * Test replacement for @lobehub/ui's internal MotionProvider module (wired in
+ * vitest.config.mts). The real `useMotionComponent` throws unless the app-level
+ * ConfigProvider supplies a motion implementation, which unit tests don't mount —
+ * this stub defaults the context to static passthrough elements so real base-ui
+ * components render without per-file mocks. Motion-only props are stripped so
+ * they don't leak onto DOM nodes as unknown attributes.
+ */
+import type { FC, ReactNode, RefObject } from 'react';
+import { createContext, createElement, use } from 'react';
+
+const MOTION_ONLY_PROPS = [
+  'animate',
+  'custom',
+  'drag',
+  'dragConstraints',
+  'dragElastic',
+  'dragMomentum',
+  'exit',
+  'initial',
+  'layout',
+  'layoutDependency',
+  'layoutId',
+  'onAnimationComplete',
+  'onAnimationStart',
+  'onDrag',
+  'onDragEnd',
+  'onDragStart',
+  'onUpdate',
+  'transition',
+  'variants',
+  'viewport',
+  'whileDrag',
+  'whileFocus',
+  'whileHover',
+  'whileInView',
+  'whileTap',
+];
+
+type StubProps = Record<string, unknown> & { ref?: RefObject<HTMLElement | null> };
+
+const componentCache = new Map<string, FC<StubProps>>();
+
+const stubFor = (tag: string) => {
+  let cached = componentCache.get(tag);
+  if (!cached) {
+    cached = ({ ref, ...props }: StubProps) => {
+      const { children, ...rest } = props;
+      for (const key of MOTION_ONLY_PROPS) delete rest[key];
+      return createElement(tag, { ...rest, ref }, children as ReactNode);
+    };
+    (cached as { displayName?: string }).displayName = `motion.${tag}`;
+    componentCache.set(tag, cached);
+  }
+  return cached;
+};
+
+const motionStub = new Proxy(
+  {},
+  { get: (_target, prop) => (typeof prop === 'string' ? stubFor(prop) : undefined) },
+);
+
+export const MotionComponent = createContext<unknown>(motionStub);
+
+export const MotionProvider = ({ children, motion }: { children?: ReactNode; motion?: unknown }) =>
+  createElement(MotionComponent, { value: motion ?? motionStub }, children);
+
+export const useMotionComponent = () => use(MotionComponent) ?? motionStub;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
       "@/business/server/*": ["./packages/business-server/src/*", "./src/business/server/*"],
       "@/server/*": ["./apps/server/src/*"],
       "@/*": ["./src/*"],
+      "~base-ui-stubs": ["./tests/mocks/baseUiStubs.tsx"],
       "~test-utils": ["./tests/utils.tsx"]
     },
     "plugins": [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -40,17 +40,18 @@ const alias = {
   // that reports no active workspace so workspace-aware nav helpers behave
   // like plain react-router.
   '@/store/workspace': resolve(__dirname, './tests/mocks/storeWorkspace.ts'),
+  '~base-ui-stubs': resolve(__dirname, './tests/mocks/baseUiStubs.tsx'),
   '~test-utils': resolve(__dirname, './tests/utils.tsx'),
   'lru_map': resolve(__dirname, './tests/mocks/lru_map'),
 };
 
 export default defineConfig({
   define: {
-    '__CI__': process.env.CI === 'true' ? 'true' : 'false',
-    '__DEV__': process.env.NODE_ENV !== 'production' ? 'true' : 'false',
-    '__ELECTRON__': 'false',
-    '__MOBILE__': 'false',
-    '__TEST__': 'true',
+    __CI__: process.env.CI === 'true' ? 'true' : 'false',
+    __DEV__: process.env.NODE_ENV !== 'production' ? 'true' : 'false',
+    __ELECTRON__: 'false',
+    __MOBILE__: 'false',
+    __TEST__: 'true',
   },
   optimizeDeps: {
     exclude: ['crypto', 'util', 'tty'],
@@ -63,8 +64,7 @@ export default defineConfig({
     {
       name: 'raw-md',
       transform(_, id) {
-        if (id.endsWith('.md'))
-          return { code: 'export default ""', map: null };
+        if (id.endsWith('.md')) return { code: 'export default ""', map: null };
       },
     },
     /**
@@ -74,6 +74,24 @@ export default defineConfig({
      * In app bundlers this can be tolerated/rewritten, but Vite/Vitest resolves it strictly and
      * fails the whole test run. Redirect it to the real file.
      */
+    /**
+     * base-ui components resolve their motion implementation through
+     * `@lobehub/ui`'s internal MotionProvider module via relative imports, and
+     * its hook throws without the app-level ConfigProvider. Redirect that one
+     * module to a static stub so real base-ui components render in tests
+     * without per-file mocks. The module has no package subpath export, so an
+     * alias/vi.mock on a specifier cannot intercept it — only resolveId can.
+     */
+    {
+      enforce: 'pre',
+      name: 'stub-lobehub-ui-motion-provider',
+      resolveId(id, importer) {
+        if (!importer || !importer.includes('/@lobehub/ui/')) return null;
+        if (id.endsWith('/MotionProvider/index.mjs') || id.endsWith('/MotionProvider/index.js'))
+          return resolve(__dirname, './tests/mocks/lobehubUiMotionProvider.tsx');
+        return null;
+      },
+    },
     {
       enforce: 'pre',
       name: 'fix-lobehub-fluent-emoji-style-import',


### PR DESCRIPTION
## 背景

#18752 合入后 canary 的 Test App 有 7 处失败(合入前 shard 2 被 fail-fast 取消,漏跑了其中 6 个文件):1 个 MotionProvider 缺失(portraitVisibility),6 个封闭 antd-style mock 缺 createStaticStyles/keyframes/createGlobalStyle(base-ui 样式模块在 import 期需要)。

## 修复(三层)

1. **全局 MotionProvider stub**(cherry-pick 自 #18761 的 L1 基建):vitest config 把 @lobehub/ui 内部 MotionProvider 模块重定向到静态透传 stub,真实 base-ui 组件从此在单测可渲染 —— 一次性消灭该类失败
2. **6 个 antd-style 封闭工厂**改为 importOriginal spread 打底,保留各自覆盖项
3. **PluginTag / GroupItem** 把 UI stub 重定向到组件已迁移到的 base-ui 路径(GroupItem 用 ~base-ui-stubs 规范 stub)

含 tests/mocks/baseUiStubs.tsx(组合式规范 stub)与 testing skill 文档,详见 #18761(该 PR 剩余部分为存量 mock 清扫,可后续合)。

## 验证

7 个受影响文件 37/37 通过;lint、type-check 干净。

https://claude.ai/code/session_01UTDivfaszDuBjpPn7PV7gQ