### PR TITLE
🐛 fix(model-bank): add missing long-context pricing tier for gpt-5.5-pro

### DIFF
--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -308,14 +308,20 @@ export const openaiChatModels: AIChatModelCard[] = [
       units: [
         {
           name: 'textInput',
-          rate: 30,
-          strategy: 'fixed',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 30, upTo: 272_000 },
+            { rate: 60, upTo: 'infinity' },
+          ],
           unit: 'millionTokens',
         },
         {
           name: 'textOutput',
-          rate: 180,
-          strategy: 'fixed',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 180, upTo: 272_000 },
+            { rate: 270, upTo: 'infinity' },
+          ],
           unit: 'millionTokens',
         },
       ],

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -1155,6 +1155,64 @@ describe('computeChatPricing', () => {
     );
   });
 
+  describe('OpenAI Pro range-priced cards', () => {
+    // Scoped to OpenAI: the Pro cards have no AiHubMix counterpart.
+    const findPricing = (id: string) =>
+      (openaiChatModels as { id: string; pricing?: Pricing }[]).find((m) => m.id === id)?.pricing;
+
+    it.each([{ id: 'gpt-5.5-pro' }, { id: 'gpt-5.4-pro' }])(
+      'prices $id at 30/180 up to the 272K boundary and 60/270 above it',
+      ({ id }) => {
+        const pricing = findPricing(id);
+        expect(pricing).toBeDefined();
+
+        const usageAt272K: ModelTokensUsage = {
+          inputCacheMissTokens: 272_000,
+          inputTextTokens: 272_000,
+          outputTextTokens: 1_000,
+          totalInputTokens: 272_000,
+          totalOutputTokens: 1_000,
+          totalTokens: 273_000,
+        };
+
+        const lower = computeChatCost(pricing, usageAt272K);
+        expect(lower?.issues).toHaveLength(0);
+        expect(lower?.breakdown.find((item) => item.unit.name === 'textInput')?.segments).toEqual([
+          { credits: 272_000 * 30, quantity: 272_000, rate: 30 },
+        ]);
+        expect(lower?.breakdown.find((item) => item.unit.name === 'textOutput')?.segments).toEqual([
+          { credits: 1_000 * 180, quantity: 1_000, rate: 180 },
+        ]);
+
+        const usageAbove272K: ModelTokensUsage = {
+          ...usageAt272K,
+          inputCacheMissTokens: 272_001,
+          inputTextTokens: 272_001,
+          totalInputTokens: 272_001,
+          totalTokens: 273_001,
+        };
+
+        const higher = computeChatCost(pricing, usageAbove272K);
+        expect(higher?.issues).toHaveLength(0);
+        expect(higher?.breakdown.find((item) => item.unit.name === 'textInput')?.segments).toEqual([
+          { credits: 272_001 * 60, quantity: 272_001, rate: 60 },
+        ]);
+        expect(higher?.breakdown.find((item) => item.unit.name === 'textOutput')?.segments).toEqual(
+          [{ credits: 1_000 * 270, quantity: 1_000, rate: 270 }],
+        );
+      },
+    );
+
+    it.each([{ id: 'gpt-5.5-pro' }, { id: 'gpt-5.4-pro' }])(
+      'declares no cached-input unit for $id',
+      ({ id }) => {
+        const pricing = findPricing(id);
+        expect(pricing).toBeDefined();
+        expect(pricing?.units.map((unit) => unit.name).sort()).toEqual(['textInput', 'textOutput']);
+      },
+    );
+  });
+
   describe('MiniMax', () => {
     it('uses total input tokens to select tiered rates for MiniMax-M3', () => {
       const pricing = minimaxChatModels.find(


### PR DESCRIPTION
## Problem

`gpt-5.5-pro` carries a flat `fixed` price (input $30 / output $180 per MTok), but OpenAI bills it on two tiers - above 272K input tokens the rates are $60 / $270. The card's context window is 1,050,000 tokens, so that tier is reachable in normal use and long-context requests are reported at about half their real cost.

## Root cause

- `aiModels/openai.ts` -> `gpt-5.5-pro.pricing.units` uses `strategy: 'fixed'`, leaving `computeChatCost` no higher tier to select.
- #16991 converted the `lookup`-priced GPT cards (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-pro`) to `tiered`; `gpt-5.5-pro` was `fixed`-priced from #14142 and has not been touched since.

## Fix

Both units become `strategy: 'tiered'`, mirroring the sibling `gpt-5.4-pro` card, whose tiers are identical (30 -> 60 and 180 -> 270 at `upTo: 272_000`).

No cached-input unit is added: OpenAI lists no cached rate for the Pro models and the docs state GPT-5.5 Pro has no cached input discount. Displayed pricing is unchanged, since `getRateFromUnit` reads `tiers[0].rate` for tiered units.

#### Test

New `OpenAI Pro range-priced cards` block in `computeChatCost.test.ts`: 2 parametrized cases over `gpt-5.5-pro` and `gpt-5.4-pro` (control) = 4 tests, covering tier selection at and above the 272K boundary plus the absence of a cached-input unit. Scoped to OpenAI: `gpt-5.5-pro` has no AiHubMix counterpart (`gpt-5.4-pro` does, and that mirror is already exercised by the existing shared range-priced block).

`vitest run src/core/usageConverters/utils/computeChatCost.test.ts` -> 71 passed. Mutation run: 6 planted defects (fix reverted, each tier flattened, boundary moved, tiers reordered, phantom cache unit) all killed, comment-only negative control survived.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Acceptance: No published report (no LobeHub Cloud account). Completed verification and its limits are documented under Test.

#### 🔗 Related Issue

None - found while auditing cost reporting on a self-hosted deployment. Follows up #16991.
