### PR TITLE
🐛 fix(connect-agent): prevent device loading state flash

### DIFF
--- a/src/components/CommandLine/index.tsx
+++ b/src/components/CommandLine/index.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { CopyButton } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { memo } from 'react';
+
+const styles = createStaticStyles(({ css }) => ({
+  codeBlock: css`
+    display: flex;
+    flex: none;
+    gap: 12px;
+    align-items: center;
+
+    min-width: 0;
+    padding-block: 12px;
+    padding-inline: 16px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadius};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  command: css`
+    overflow: hidden;
+    flex: 1;
+
+    min-width: 0;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: ${cssVar.fontSizeSM};
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+}));
+
+interface CommandLineProps {
+  command: string;
+}
+
+const CommandLine = memo<CommandLineProps>(({ command }) => (
+  <div className={styles.codeBlock}>
+    <code className={styles.command}>{command}</code>
+    <CopyButton content={command} size={'small'} />
+  </div>
+));
+
+CommandLine.displayName = 'CommandLine';
+
+export default CommandLine;

--- a/src/features/ConnectAgent/deviceListState.test.ts
+++ b/src/features/ConnectAgent/deviceListState.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDeviceListState } from './deviceListState';
+
+describe('getDeviceListState', () => {
+  it('keeps an empty device result in loading state while the request is in flight', () => {
+    expect(getDeviceListState({ hasDevices: false, isFetching: true })).toBe('loading');
+  });
+
+  it('reports empty only after the request settles', () => {
+    expect(getDeviceListState({ hasDevices: false, isFetching: false })).toBe('empty');
+  });
+
+  it('keeps cached devices visible during revalidation', () => {
+    expect(getDeviceListState({ hasDevices: true, isFetching: true })).toBe('ready');
+  });
+});

--- a/src/features/ConnectAgent/deviceListState.ts
+++ b/src/features/ConnectAgent/deviceListState.ts
@@ -1,0 +1,14 @@
+export type DeviceListState = 'empty' | 'loading' | 'ready';
+
+interface GetDeviceListStateOptions {
+  hasDevices: boolean;
+  isFetching: boolean;
+}
+
+export const getDeviceListState = ({
+  hasDevices,
+  isFetching,
+}: GetDeviceListStateOptions): DeviceListState => {
+  if (hasDevices) return 'ready';
+  return isFetching ? 'loading' : 'empty';
+};

--- a/src/features/ConnectAgent/index.tsx
+++ b/src/features/ConnectAgent/index.tsx
@@ -9,7 +9,7 @@ import type {
 import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
 import type { DeviceListItem } from '@lobechat/types';
 import { agentDisplayName } from '@lobechat/types';
-import { CopyButton, Flexbox, Icon, Input, TextArea, Tooltip } from '@lobehub/ui';
+import { Flexbox, Icon, Input, TextArea, Tooltip } from '@lobehub/ui';
 import {
   Alert,
   Button,
@@ -20,7 +20,6 @@ import {
   Text,
   useModalContext,
 } from '@lobehub/ui/base-ui';
-import { Typography } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { t as i18nT } from 'i18next';
 import {
@@ -36,6 +35,7 @@ import { memo, type ReactNode, useCallback, useEffect, useMemo, useState } from 
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
+import CommandLine from '@/components/CommandLine';
 import { DOWNLOAD_URL } from '@/const/url';
 import { getDeviceIcon } from '@/features/DeviceManager/getDeviceIcon';
 import { useDeviceList } from '@/features/DeviceManager/useDeviceList';
@@ -46,6 +46,7 @@ import { heteroAgentDefaultName } from '@/store/agent/utils/heteroAgentDefaultNa
 import { useElectronStore } from '@/store/electron';
 import { useHomeStore } from '@/store/home';
 
+import { getDeviceListState } from './deviceListState';
 import type { ConnectableProvider, ConnectAgentProfile } from './providers';
 import { buildConnectAgentConfig, CONNECTABLE_PROVIDERS } from './providers';
 import type { ScanTarget } from './useAgentScan';
@@ -64,17 +65,21 @@ const styles = createStaticStyles(({ css }) => ({
     overscroll-behavior: contain;
     max-height: min(50dvh, 400px);
   `,
-  cmd: css`
-    user-select: all;
+  commandHint: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
 
-    padding-block: 8px;
-    padding-inline: 12px;
-    border-radius: ${cssVar.borderRadiusSM};
+    min-width: 0;
+    padding-inline: 4px;
 
-    font-family: ${cssVar.fontFamilyCode};
-    font-size: 12px;
-
-    background: ${cssVar.colorFillTertiary};
+    > span {
+      overflow: hidden;
+      min-width: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   `,
   dot: css`
     flex: none;
@@ -126,23 +131,10 @@ const styles = createStaticStyles(({ css }) => ({
     min-height: 28px;
     margin-block-start: auto;
 
-    > a {
+    > a,
+    > div {
       width: 100%;
     }
-  `,
-  emptyOptionCode: css`
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    justify-content: space-between;
-
-    box-sizing: border-box;
-    width: 100%;
-    height: 32px;
-    padding-inline: 10px 4px;
-    border-radius: ${cssVar.borderRadius};
-
-    background: ${cssVar.colorFillTertiary};
   `,
   emptyOptions: css`
     display: grid;
@@ -261,6 +253,11 @@ const styles = createStaticStyles(({ css }) => ({
 
     animation: lobe-connect-agent-pulse 1.4s ease-in-out infinite;
   `,
+  skeletonSquare: css`
+    width: 36px;
+    height: 36px;
+    border-radius: ${cssVar.borderRadius};
+  `,
 }));
 
 interface CreatedAgent {
@@ -277,9 +274,13 @@ const SectionLabel = memo<{ children: ReactNode }>(({ children }) => (
   </Text>
 ));
 
-const SkeletonRow = memo<{ width: number }>(({ width }) => (
+const SkeletonRow = memo<{ squareIcon?: boolean; width: number }>(({ squareIcon, width }) => (
   <div className={`${styles.row} ${styles.rowStatic}`}>
-    <div className={styles.skeletonCircle} />
+    <div
+      className={
+        squareIcon ? `${styles.skeletonCircle} ${styles.skeletonSquare}` : styles.skeletonCircle
+      }
+    />
     {/* Column height matches a real row's two-line text block so the
         scanning → done swap doesn't shift the modal */}
     <Flexbox flex={1} gap={10} justify={'center'} style={{ height: 42 }}>
@@ -626,6 +627,10 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
     // ── Step 1: choose the machine ──
     if (step === 0) {
       const isRefreshing = loadingDevices || fetchingDevices;
+      const deviceListState = getDeviceListState({
+        hasDevices: listedDevices.length > 0,
+        isFetching: isRefreshing,
+      });
       const showEmpty = !isDesktop && !isRefreshing && onlineDevices.length === 0;
 
       return (
@@ -678,10 +683,7 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
                     </Text>
                   </Flexbox>
                   <div className={styles.emptyOptionAction}>
-                    <div className={styles.emptyOptionCode}>
-                      <code>{t('connectAgent.create.noDevicesCmd')}</code>
-                      <CopyButton content={t('connectAgent.create.noDevicesCmd')} size={'small'} />
-                    </div>
+                    <CommandLine command={t('connectAgent.create.noDevicesCmd')} />
                   </div>
                 </div>
               </div>
@@ -713,7 +715,7 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
                   </div>
                 </Flexbox>
               )}
-              {listedDevices.length > 0 && (
+              {deviceListState !== 'empty' && (
                 <Flexbox gap={6}>
                   <Flexbox horizontal align={'center'} justify={'space-between'}>
                     <SectionLabel>{t('connectAgent.create.connectedDevices')}</SectionLabel>
@@ -728,31 +730,33 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
                     </Button>
                   </Flexbox>
                   <div className={styles.groupList}>
-                    {listedDevices.map((device) => (
-                      <DeviceRow
-                        icon={getDeviceIcon(device.platform, 18)}
-                        key={device.deviceId}
-                        offline={!device.online}
-                        subtitle={device.hostname || device.deviceId}
-                        title={deviceLabel(device)}
-                        statusText={
-                          device.online
-                            ? t('connectAgent.create.online')
-                            : t('connectAgent.create.offline')
-                        }
-                        onClick={() => pickTarget({ device, kind: 'device' })}
-                      />
-                    ))}
+                    {deviceListState === 'loading'
+                      ? [96, 140, 112].map((width) => (
+                          <SkeletonRow squareIcon key={width} width={width} />
+                        ))
+                      : listedDevices.map((device) => (
+                          <DeviceRow
+                            icon={getDeviceIcon(device.platform, 18)}
+                            key={device.deviceId}
+                            offline={!device.online}
+                            subtitle={device.hostname || device.deviceId}
+                            title={deviceLabel(device)}
+                            statusText={
+                              device.online
+                                ? t('connectAgent.create.online')
+                                : t('connectAgent.create.offline')
+                            }
+                            onClick={() => pickTarget({ device, kind: 'device' })}
+                          />
+                        ))}
                   </div>
                 </Flexbox>
               )}
-              {isDesktop && listedDevices.length === 0 && (
-                <Flexbox gap={4}>
-                  <span>{t('connectAgent.create.noDevicesCliHint')}</span>
-                  <Typography.Text code copyable>
-                    {t('connectAgent.create.noDevicesCmd')}
-                  </Typography.Text>
-                </Flexbox>
+              {isDesktop && deviceListState === 'empty' && (
+                <div className={styles.commandHint}>
+                  <Text type={'secondary'}>{t('connectAgent.create.noDevicesCliHint')}</Text>
+                  <CommandLine command={t('connectAgent.create.noDevicesCmd')} />
+                </div>
               )}
             </Flexbox>
           )}

--- a/src/features/DeviceManager/DeviceConnectModal.tsx
+++ b/src/features/DeviceManager/DeviceConnectModal.tsx
@@ -2,7 +2,7 @@
 
 import { DOWNLOAD_URL } from '@lobechat/const';
 import type { DeviceScope, DeviceVisibility } from '@lobechat/types';
-import { CopyButton, Flexbox, Icon } from '@lobehub/ui';
+import { Flexbox, Icon } from '@lobehub/ui';
 import { Button, Tabs, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { DownloadIcon, MonitorDownIcon, ShieldCheckIcon, TerminalIcon } from 'lucide-react';
@@ -10,31 +10,10 @@ import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
+import CommandLine from '@/components/CommandLine';
 import ImperativeModal from '@/components/ImperativeModal';
 
 const styles = createStaticStyles(({ css }) => ({
-  codeBlock: css`
-    display: flex;
-    gap: 12px;
-    align-items: center;
-
-    padding-block: 12px;
-    padding-inline: 16px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadius};
-
-    background: ${cssVar.colorFillQuaternary};
-  `,
-  command: css`
-    overflow: hidden;
-    flex: 1;
-
-    font-family: ${cssVar.fontFamilyCode};
-    font-size: ${cssVar.fontSizeSM};
-    color: ${cssVar.colorText};
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `,
   footer: css`
     margin-block-start: 4px;
     padding-block-start: 16px;
@@ -88,13 +67,6 @@ const Step = memo<StepProps>(({ index, title, desc, children, last }) => (
       {children && <div style={{ marginBlockStart: 12 }}>{children}</div>}
     </Flexbox>
   </Flexbox>
-));
-
-const CommandLine = memo<{ command: string }>(({ command }) => (
-  <div className={styles.codeBlock}>
-    <code className={styles.command}>{command}</code>
-    <CopyButton content={command} size={'small'} />
-  </div>
 ));
 
 interface DeviceConnectModalProps {


### PR DESCRIPTION
<!-- Brief and heads-up -->

## Description of Change

- show a structure-matched device skeleton while the connected-device request is in flight instead of briefly rendering the empty CLI state
- keep cached devices visible during background revalidation
- render the empty-state hint and `lh connect` command on one line, with a non-wrapping command and project-token styling
- share the command-line presentation with the existing device connection wizard

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| The `lh connect` empty state briefly appears before connected devices load. | The local device remains visible while a device-list skeleton occupies the settled list structure. |
| The empty-state command uses an inconsistent inline-code treatment on a separate line. | The hint and reusable command block stay on one line, and the command never wraps. |

> A live Electron capture was unavailable in the current orb because it has no desktop dependency install or persisted Electron login snapshot.

#### Test

- `bun run check src/components/CommandLine/index.tsx src/features/ConnectAgent/deviceListState.ts src/features/ConnectAgent/deviceListState.test.ts src/features/ConnectAgent/index.tsx src/features/DeviceManager/DeviceConnectModal.tsx`
- `bun run check --type`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No directly matching issue found.
