### PR TITLE
🐛 fix(agent): scope heterogeneous default names to shared workspaces

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -673,7 +673,6 @@
   "heteroAgent.codexQuota.tooltip": "View Codex quota",
   "heteroAgent.codexQuota.totalEarned_one": "{{count}} earned in total",
   "heteroAgent.codexQuota.totalEarned_other": "{{count}} earned in total",
-  "heteroAgent.defaultName": "{{owner}}'s {{product}}",
   "heteroAgent.executionTarget.auto": "Auto",
   "heteroAgent.executionTarget.autoDesc": "Use an online device automatically, picking one when several are available",
   "heteroAgent.executionTarget.downloadDesktop": "Get Desktop App",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -673,7 +673,6 @@
   "heteroAgent.codexQuota.tooltip": "查看 Codex 额度",
   "heteroAgent.codexQuota.totalEarned_one": "累计获得 {{count}} 次",
   "heteroAgent.codexQuota.totalEarned_other": "累计获得 {{count}} 次",
-  "heteroAgent.defaultName": "{{owner}} 的 {{product}}",
   "heteroAgent.executionTarget.auto": "自动",
   "heteroAgent.executionTarget.autoDesc": "自动使用在线设备，有多台时择一使用",
   "heteroAgent.executionTarget.downloadDesktop": "下载桌面端",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -329,7 +329,6 @@ export default {
   'groupWizard.searchTemplates': 'Search templates...',
   'groupWizard.title': 'Create Group',
   'groupWizard.useTemplate': 'Use Template',
-  'heteroAgent.defaultName': "{{owner}}'s {{product}}",
   'heteroAgent.fullAccess.label': 'Full access',
   'heteroAgent.fullAccess.tooltip':
     'The local coding agent runs with full read/write access to the working directory. Switching permission modes is not available yet.',

--- a/src/features/ConnectAgent/index.tsx
+++ b/src/features/ConnectAgent/index.tsx
@@ -502,12 +502,13 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
       if (!single) return;
       const profile = isRemoteHeterogeneousType(single.type) ? profiles[single.type] : undefined;
       const productTitle = profile?.title ?? single.title;
-      // Prefill with the same "{owner}'s {product}" default that createAgent
-      // seeds, so the input shows the name the agent would actually get.
-      setName(heteroAgentDefaultName(productTitle) ?? productTitle);
+      setName(
+        heteroAgentDefaultName({ productTitle, visibility, workspaceId: activeWorkspaceId }) ??
+          productTitle,
+      );
       setDescription(profile?.description ?? '');
       setStep(2);
-    }, [profiles, single]);
+    }, [activeWorkspaceId, profiles, single, visibility]);
 
     const buildCreateParams = useCallback(
       (provider: ConnectableProvider, overrides?: { description?: string; name?: string }) => {
@@ -549,7 +550,11 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
                 // screen shows the same label the sidebar will.
                 title:
                   params.config.name?.trim() ||
-                  heteroAgentDefaultName(params.config.title) ||
+                  heteroAgentDefaultName({
+                    productTitle: params.config.title,
+                    visibility,
+                    workspaceId: activeWorkspaceId,
+                  }) ||
                   agentDisplayName(params.config, provider.title),
                 version: scanState.agents?.[provider.type]?.version,
               } satisfies CreatedAgent;
@@ -569,6 +574,7 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
         }
       },
       [
+        activeWorkspaceId,
         buildCreateParams,
         onTitleChange,
         refreshAgentList,
@@ -579,6 +585,7 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
         t,
         target,
         targetLabel,
+        visibility,
       ],
     );
 

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
@@ -268,11 +268,12 @@ describe('AgentHeader', () => {
     expect(view.container.textContent?.match(/Lobe AI/g)).toHaveLength(1);
   });
 
-  it('uses the product title once as the identity of a nameless heterogeneous agent', () => {
+  it('shows an identical heterogeneous product name and role only once', () => {
     mocks.permissionState.allowed = true;
     mocks.agentStoreState.agentMap = {
       'agent-a': {
         agencyConfig: { heterogeneousProvider: { type: 'grok-build' } },
+        name: 'Grok Build',
         slug: 'why-hard-industry',
         title: 'Grok Build',
       },
@@ -283,6 +284,34 @@ describe('AgentHeader', () => {
     expect(view.container.textContent).toContain('@why-hard-industry');
     expect(view.container.textContent).not.toContain('settingAgent.personalName.unnamed');
     expect(view.container.textContent).toContain('settingAgent.identity.edit');
+  });
+
+  it('retains the role for an owner-qualified shared heterogeneous agent', () => {
+    mocks.agentStoreState.agentMap = {
+      'agent-a': {
+        agencyConfig: { heterogeneousProvider: { type: 'grok-build' } },
+        name: 'Max’s Grok Build',
+        title: 'Grok Build',
+      },
+    };
+    const view = render(<AgentHeader />);
+
+    expect(view.container.textContent).toContain('Max’s Grok Build');
+    expect(view.container.textContent?.match(/Grok Build/g)).toHaveLength(2);
+  });
+
+  it('retains the role for a custom-named heterogeneous agent', () => {
+    mocks.agentStoreState.agentMap = {
+      'agent-a': {
+        agencyConfig: { heterogeneousProvider: { type: 'grok-build' } },
+        name: 'Release Builder',
+        title: 'Grok Build',
+      },
+    };
+    const view = render(<AgentHeader />);
+
+    expect(view.container.textContent).toContain('Release Builder');
+    expect(view.container.textContent).toContain('Grok Build');
   });
 
   // With no name there is nothing to headline, so the slot carries the prompt

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
@@ -286,18 +286,30 @@ describe('AgentHeader', () => {
     expect(view.container.textContent).toContain('settingAgent.identity.edit');
   });
 
-  it('retains the role for an owner-qualified shared heterogeneous agent', () => {
+  it('leaves an ordinary identical name and role in both slots', () => {
+    mocks.agentStoreState.agentMap = {
+      'agent-a': { name: 'Grok Build', title: 'Grok Build' },
+    };
+    const view = render(<AgentHeader />);
+
+    expect(view.container.textContent?.match(/Grok Build/g)).toHaveLength(2);
+  });
+
+  it('suppresses the role included in an owner-qualified shared heterogeneous name', () => {
     mocks.agentStoreState.agentMap = {
       'agent-a': {
         agencyConfig: { heterogeneousProvider: { type: 'grok-build' } },
         name: 'Max’s Grok Build',
+        slug: 'shared-builder',
         title: 'Grok Build',
       },
     };
     const view = render(<AgentHeader />);
 
     expect(view.container.textContent).toContain('Max’s Grok Build');
-    expect(view.container.textContent?.match(/Grok Build/g)).toHaveLength(2);
+    expect(view.container.textContent?.match(/Grok Build/g)).toHaveLength(1);
+    expect(view.container.textContent).toContain('@shared-builder');
+    expect(view.container.textContent).not.toContain('·');
   });
 
   it('retains the role for a custom-named heterogeneous agent', () => {
@@ -312,6 +324,21 @@ describe('AgentHeader', () => {
 
     expect(view.container.textContent).toContain('Release Builder');
     expect(view.container.textContent).toContain('Grok Build');
+  });
+
+  it('retains the unset role slot for a heterogeneous agent without a role', () => {
+    mocks.agentStoreState.agentMap = {
+      'agent-a': {
+        agencyConfig: { heterogeneousProvider: { type: 'grok-build' } },
+        name: 'Release Builder',
+        slug: 'release-builder',
+      },
+    };
+    const view = render(<AgentHeader />);
+
+    expect(view.container.textContent).toContain('settingAgent.role.unset');
+    expect(view.container.textContent).toContain('·');
+    expect(view.container.textContent).toContain('@release-builder');
   });
 
   // With no name there is nothing to headline, so the slot carries the prompt

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
       agentMap: {} as Record<
         string,
         {
+          agencyConfig?: { heterogeneousProvider?: { type: string } };
           avatar?: string | null;
           backgroundColor?: string;
           name?: string;
@@ -265,6 +266,23 @@ describe('AgentHeader', () => {
 
     // Exactly once: on the role line, never as the headline.
     expect(view.container.textContent?.match(/Lobe AI/g)).toHaveLength(1);
+  });
+
+  it('uses the product title once as the identity of a nameless heterogeneous agent', () => {
+    mocks.permissionState.allowed = true;
+    mocks.agentStoreState.agentMap = {
+      'agent-a': {
+        agencyConfig: { heterogeneousProvider: { type: 'grok-build' } },
+        slug: 'why-hard-industry',
+        title: 'Grok Build',
+      },
+    };
+    const view = render(<AgentHeader />);
+
+    expect(view.container.textContent?.match(/Grok Build/g)).toHaveLength(1);
+    expect(view.container.textContent).toContain('@why-hard-industry');
+    expect(view.container.textContent).not.toContain('settingAgent.personalName.unnamed');
+    expect(view.container.textContent).toContain('settingAgent.identity.edit');
   });
 
   // With no name there is nothing to headline, so the slot carries the prompt

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { agentSecondaryDisplayName } from '@lobechat/types';
 import { Flexbox, Tooltip } from '@lobehub/ui';
 import { ActionIcon, Button, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
@@ -32,7 +33,10 @@ const AgentHeader = memo(() => {
   const personalName = meta.name?.trim();
   const role = meta.title?.trim();
   const suppressDuplicateRole =
-    !!personalName && personalName === role && !!config?.agencyConfig?.heterogeneousProvider;
+    !!config?.agencyConfig?.heterogeneousProvider &&
+    !!personalName &&
+    !!role &&
+    agentSecondaryDisplayName({ name: personalName, title: role }) === undefined;
   // Without edit rights there is nothing to prompt for, so a nameless agent
   // falls back to the plain label rather than showing an action nobody can take.
   const showNamePrompt = !personalName && canEdit;
@@ -115,8 +119,8 @@ const AgentHeader = memo(() => {
               maps to the TERTIARY step — too faint for the line that carries the
               agent's role. Set the secondary colour explicitly, and leave only
               the decorative `@` and the separator at tertiary. */}
-          {/* A heterogeneous product name identical to its role is shown once.
-              Owner-qualified and custom names retain the role underneath. */}
+          {/* A heterogeneous product name that already includes its role is
+              shown once. Genuinely custom names retain the role underneath. */}
           {!suppressDuplicateRole ? (
             <Text
               ellipsis

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -29,9 +29,14 @@ const AgentHeader = memo(() => {
   const slug = useAgentStore(agentSelectors.getAgentSlugById(agentId));
   const updateMetaById = useAgentStore((s) => s.updateAgentMetaById);
   const { autoName, naming } = useAutoName(agentId);
+  const personalName = meta.name?.trim();
+  const role = meta.title?.trim();
+  const usesHeterogeneousRoleAsName =
+    !personalName && !!role && !!config?.agencyConfig?.heterogeneousProvider;
+  const displayName = personalName || (usesHeterogeneousRoleAsName ? role : undefined);
   // Without edit rights there is nothing to prompt for, so a nameless agent
   // falls back to the plain label rather than showing an action nobody can take.
-  const showNamePrompt = !meta.name?.trim() && canEdit;
+  const showNamePrompt = !displayName && canEdit;
 
   return (
     <Flexbox
@@ -68,10 +73,9 @@ const AgentHeader = memo(() => {
           form modal; inline inputs crowded the header and left no room for a
           per-field label or error. */}
       <Flexbox flex={1} gap={8} paddingInline={24} style={{ minWidth: 0 }}>
-        {/* The headline is the NAME slot. It does not borrow the role the way
-            list surfaces do — the role has its own line right below, and falling
-            back would print it twice (an agent titled "Lobe AI" read
-            "Lobe AI / Lobe AI · @inbox").
+        {/* The headline is normally the NAME slot. A heterogeneous agent is the
+            exception: without a custom name its product title is its identity,
+            so show that title once instead of prompting for a personal name.
 
             With no name there is nothing to headline, so the slot carries the
             one thing that can fix it instead of a placeholder pretending to be a
@@ -98,7 +102,7 @@ const AgentHeader = memo(() => {
         ) : (
           <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
             <Text ellipsis style={{ fontSize: 36, fontWeight: 600 }}>
-              {meta.name?.trim() || t('settingAgent.identity.untitled', { ns: 'setting' })}
+              {displayName || t('settingAgent.identity.untitled', { ns: 'setting' })}
             </Text>
             {canEdit ? (
               <ActionIcon
@@ -115,19 +119,22 @@ const AgentHeader = memo(() => {
               maps to the TERTIARY step — too faint for the line that carries the
               agent's role. Set the secondary colour explicitly, and leave only
               the decorative `@` and the separator at tertiary. */}
-          {/* The role always occupies its slot. An agent with no role gets a
-              stated placeholder rather than a gap — otherwise the line silently
-              collapses to a bare slug and the missing role is indistinguishable
-              from a role that was never meant to be there. */}
-          <Text
-            ellipsis
-            style={{
-              color: meta.title?.trim() ? cssVar.colorTextSecondary : cssVar.colorTextTertiary,
-            }}
-          >
-            {meta.title?.trim() || t('settingAgent.role.unset', { ns: 'setting' })}
-          </Text>
-          {slug ? <Text style={{ color: cssVar.colorTextTertiary }}>·</Text> : null}
+          {/* Ordinary agents keep a dedicated role slot. A heterogeneous
+              product title already promoted to the headline is omitted here to
+              avoid repeating "Grok Build" directly below "Grok Build". */}
+          {!usesHeterogeneousRoleAsName ? (
+            <Text
+              ellipsis
+              style={{
+                color: role ? cssVar.colorTextSecondary : cssVar.colorTextTertiary,
+              }}
+            >
+              {role || t('settingAgent.role.unset', { ns: 'setting' })}
+            </Text>
+          ) : null}
+          {slug && !usesHeterogeneousRoleAsName ? (
+            <Text style={{ color: cssVar.colorTextTertiary }}>·</Text>
+          ) : null}
           {/* The tooltip only renders when a slug exists, so it can always name
               the real url rather than a `<slug>` the reader has to substitute. */}
           {slug ? (

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -31,12 +31,11 @@ const AgentHeader = memo(() => {
   const { autoName, naming } = useAutoName(agentId);
   const personalName = meta.name?.trim();
   const role = meta.title?.trim();
-  const usesHeterogeneousRoleAsName =
-    !personalName && !!role && !!config?.agencyConfig?.heterogeneousProvider;
-  const displayName = personalName || (usesHeterogeneousRoleAsName ? role : undefined);
+  const suppressDuplicateRole =
+    !!personalName && personalName === role && !!config?.agencyConfig?.heterogeneousProvider;
   // Without edit rights there is nothing to prompt for, so a nameless agent
   // falls back to the plain label rather than showing an action nobody can take.
-  const showNamePrompt = !displayName && canEdit;
+  const showNamePrompt = !personalName && canEdit;
 
   return (
     <Flexbox
@@ -73,13 +72,10 @@ const AgentHeader = memo(() => {
           form modal; inline inputs crowded the header and left no room for a
           per-field label or error. */}
       <Flexbox flex={1} gap={8} paddingInline={24} style={{ minWidth: 0 }}>
-        {/* The headline is normally the NAME slot. A heterogeneous agent is the
-            exception: without a custom name its product title is its identity,
-            so show that title once instead of prompting for a personal name.
-
-            With no name there is nothing to headline, so the slot carries the
-            one thing that can fix it instead of a placeholder pretending to be a
-            name. The edit affordance stays hidden until then: naming it IS the
+        {/* The headline is the NAME slot. With no name there is nothing to
+            headline, so it carries the action that can fix this instead of a
+            placeholder pretending to be a name. The edit affordance stays hidden
+            until then: naming it IS the
             next step, and offering the full identity form alongside would split
             attention between two ways to do the same thing. */}
         {showNamePrompt ? (
@@ -102,7 +98,7 @@ const AgentHeader = memo(() => {
         ) : (
           <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
             <Text ellipsis style={{ fontSize: 36, fontWeight: 600 }}>
-              {displayName || t('settingAgent.identity.untitled', { ns: 'setting' })}
+              {personalName || t('settingAgent.identity.untitled', { ns: 'setting' })}
             </Text>
             {canEdit ? (
               <ActionIcon
@@ -119,10 +115,9 @@ const AgentHeader = memo(() => {
               maps to the TERTIARY step — too faint for the line that carries the
               agent's role. Set the secondary colour explicitly, and leave only
               the decorative `@` and the separator at tertiary. */}
-          {/* Ordinary agents keep a dedicated role slot. A heterogeneous
-              product title already promoted to the headline is omitted here to
-              avoid repeating "Grok Build" directly below "Grok Build". */}
-          {!usesHeterogeneousRoleAsName ? (
+          {/* A heterogeneous product name identical to its role is shown once.
+              Owner-qualified and custom names retain the role underneath. */}
+          {!suppressDuplicateRole ? (
             <Text
               ellipsis
               style={{
@@ -132,7 +127,7 @@ const AgentHeader = memo(() => {
               {role || t('settingAgent.role.unset', { ns: 'setting' })}
             </Text>
           ) : null}
-          {slug && !usesHeterogeneousRoleAsName ? (
+          {slug && !suppressDuplicateRole ? (
             <Text style={{ color: cssVar.colorTextTertiary }}>·</Text>
           ) : null}
           {/* The tooltip only renders when a slug exists, so it can always name

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -3,6 +3,7 @@ import { toast } from '@lobehub/ui/base-ui';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as activeWorkspaceModule from '@/business/client/hooks/useActiveWorkspaceId';
 import { setScopedMutate } from '@/libs/swr';
 import { agentConfigKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
@@ -211,7 +212,7 @@ describe('AgentSlice Actions', () => {
       }
     });
 
-    it('names a heterogeneous agent after its owner instead of a personal name', async () => {
+    it('leaves a personal heterogeneous agent unnamed so its product title is primary', async () => {
       vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
       const userState = useUserStore.getState();
       useUserStore.setState({
@@ -230,13 +231,59 @@ describe('AgentSlice Actions', () => {
           });
         });
 
-        // Test i18n serves the default (English) chat resources.
-        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBe(
-          "Max's Claude Code",
-        );
+        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBeUndefined();
       } finally {
         useUserStore.setState({ isSignedIn: userState.isSignedIn, user: userState.user });
       }
+    });
+
+    it('uses a stable English owner-qualified name for a shared workspace agent', async () => {
+      vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
+      vi.spyOn(activeWorkspaceModule, 'getActiveWorkspaceId').mockReturnValue('workspace-1');
+      const userState = useUserStore.getState();
+      const status = useGlobalStore.getState().status;
+      useUserStore.setState({
+        isSignedIn: true,
+        user: { fullName: 'Max', id: 'user-1' } as any,
+      });
+      useGlobalStore.setState({ status: { ...status, language: 'zh-CN' } });
+      const { result } = renderHook(() => useAgentStore());
+
+      try {
+        await act(async () => {
+          await result.current.createAgent({
+            config: {
+              agencyConfig: { heterogeneousProvider: { command: 'claude', type: 'claude-code' } },
+              title: 'Claude Code',
+            },
+          });
+        });
+
+        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBe(
+          'Max’s Claude Code',
+        );
+      } finally {
+        useUserStore.setState({ isSignedIn: userState.isSignedIn, user: userState.user });
+        useGlobalStore.setState({ status });
+      }
+    });
+
+    it('leaves a workspace-private heterogeneous agent unnamed', async () => {
+      vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
+      vi.spyOn(activeWorkspaceModule, 'getActiveWorkspaceId').mockReturnValue('workspace-1');
+      const { result } = renderHook(() => useAgentStore());
+
+      await act(async () => {
+        await result.current.createAgent({
+          config: {
+            agencyConfig: { heterogeneousProvider: { command: 'claude', type: 'claude-code' } },
+            title: 'Claude Code',
+          },
+          visibility: 'private',
+        });
+      });
+
+      expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBeUndefined();
     });
 
     it('leaves a heterogeneous agent unnamed for an anonymous owner', async () => {

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -212,7 +212,7 @@ describe('AgentSlice Actions', () => {
       }
     });
 
-    it('leaves a personal heterogeneous agent unnamed so its product title is primary', async () => {
+    it('uses the product title as a personal heterogeneous agent name', async () => {
       vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
       const userState = useUserStore.getState();
       useUserStore.setState({
@@ -231,7 +231,9 @@ describe('AgentSlice Actions', () => {
           });
         });
 
-        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBeUndefined();
+        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBe(
+          'Claude Code',
+        );
       } finally {
         useUserStore.setState({ isSignedIn: userState.isSignedIn, user: userState.user });
       }
@@ -268,7 +270,7 @@ describe('AgentSlice Actions', () => {
       }
     });
 
-    it('leaves a workspace-private heterogeneous agent unnamed', async () => {
+    it('uses the product title as a workspace-private heterogeneous agent name', async () => {
       vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
       vi.spyOn(activeWorkspaceModule, 'getActiveWorkspaceId').mockReturnValue('workspace-1');
       const { result } = renderHook(() => useAgentStore());
@@ -283,10 +285,10 @@ describe('AgentSlice Actions', () => {
         });
       });
 
-      expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBeUndefined();
+      expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBe('Claude Code');
     });
 
-    it('leaves a heterogeneous agent unnamed for an anonymous owner', async () => {
+    it('uses the product title as a personal heterogeneous agent name for an anonymous owner', async () => {
       vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
       const userState = useUserStore.getState();
       useUserStore.setState({ isSignedIn: false, user: undefined });
@@ -302,7 +304,9 @@ describe('AgentSlice Actions', () => {
           });
         });
 
-        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBeUndefined();
+        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBe(
+          'Claude Code',
+        );
       } finally {
         useUserStore.setState({ isSignedIn: userState.isSignedIn, user: userState.user });
       }

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -161,9 +161,9 @@ export class AgentSliceActionImpl {
     // resolves on the client (`auto` follows the browser). A caller that already
     // carries a name — e.g. a market agent — keeps it.
     //
-    // A heterogeneous agent never draws a personal name. In personal/private
-    // scope its product title is enough; a shared workspace agent adds the
-    // creator so members can distinguish otherwise identical tools.
+    // A heterogeneous agent never draws a random personal name. In personal or
+    // workspace-private scope its name is the product title; a shared workspace
+    // agent adds the creator so members can distinguish identical tools.
     const heteroProvider = params.config?.agencyConfig?.heterogeneousProvider;
     const locale = globalGeneralSelectors.currentLanguage(useGlobalStore.getState());
     const config = {

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -14,6 +14,7 @@ import { produce } from 'immer';
 import type { SWRResponse } from 'swr';
 import type { PartialDeep } from 'type-fest';
 
+import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { MESSAGE_CANCEL_FLAT } from '@/const/message';
 import { mutate, useClientDataSWR, useClientDataSWRWithSync } from '@/libs/swr';
 import { agentConfigKeys } from '@/libs/swr/keys';
@@ -160,9 +161,9 @@ export class AgentSliceActionImpl {
     // resolves on the client (`auto` follows the browser). A caller that already
     // carries a name — e.g. a market agent — keeps it.
     //
-    // A heterogeneous agent never draws a personal name: it is the user's
-    // external tool, not one of our own agents, so its default reads as whose
-    // tool it is — "{owner}'s {product}" (e.g. "Max 的 Claude Code").
+    // A heterogeneous agent never draws a personal name. In personal/private
+    // scope its product title is enough; a shared workspace agent adds the
+    // creator so members can distinguish otherwise identical tools.
     const heteroProvider = params.config?.agencyConfig?.heterogeneousProvider;
     const locale = globalGeneralSelectors.currentLanguage(useGlobalStore.getState());
     const config = {
@@ -170,9 +171,11 @@ export class AgentSliceActionImpl {
       name:
         params.config?.name ||
         (heteroProvider
-          ? heteroAgentDefaultName(
-              params.config?.title || getHeterogeneousTypeLabel(heteroProvider.type),
-            )
+          ? heteroAgentDefaultName({
+              productTitle: params.config?.title || getHeterogeneousTypeLabel(heteroProvider.type),
+              visibility: params.visibility,
+              workspaceId: getActiveWorkspaceId(),
+            })
           : randomAgentName(locale)),
     };
 

--- a/src/store/agent/utils/heteroAgentDefaultName.ts
+++ b/src/store/agent/utils/heteroAgentDefaultName.ts
@@ -1,18 +1,28 @@
-import { t } from 'i18next';
-
 import { getUserStoreState } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
+interface HeteroAgentDefaultNameOptions {
+  productTitle?: string | null;
+  visibility?: 'private' | 'public';
+  workspaceId?: string | null;
+}
+
 /**
- * Default display name for a heterogeneous (external CLI / platform) agent:
- * "{owner}'s {product}" (e.g. "Max 的 Claude Code"). Such an agent is the
- * user's external tool rather than one of our own agents, so its default label
- * says whose tool it is instead of drawing a personal name.
+ * Default display name for a shared workspace heterogeneous agent. Personal
+ * and workspace-private agents keep no separate name, so their product title
+ * remains the primary label. Shared agents include the creator to distinguish
+ * otherwise identical tools in a multilingual workspace.
  *
- * Returns undefined when the owner has no usable name (anonymous session), so
- * the product title stays the primary label.
+ * The possessive is deliberately stable English rather than creation-locale
+ * copy because the persisted name is shown to every workspace member.
  */
-export const heteroAgentDefaultName = (productTitle?: string | null): string | undefined => {
+export const heteroAgentDefaultName = ({
+  productTitle,
+  visibility,
+  workspaceId,
+}: HeteroAgentDefaultNameOptions): string | undefined => {
+  if (!workspaceId || visibility === 'private') return undefined;
+
   const userStore = getUserStoreState();
   const owner = authSelectors.isLogin(userStore)
     ? userProfileSelectors.nickName(userStore)?.trim()
@@ -21,5 +31,5 @@ export const heteroAgentDefaultName = (productTitle?: string | null): string | u
 
   if (!owner || !product) return undefined;
 
-  return t('heteroAgent.defaultName', { ns: 'chat', owner, product });
+  return `${owner}’s ${product}`;
 };

--- a/src/store/agent/utils/heteroAgentDefaultName.ts
+++ b/src/store/agent/utils/heteroAgentDefaultName.ts
@@ -8,10 +8,9 @@ interface HeteroAgentDefaultNameOptions {
 }
 
 /**
- * Default display name for a shared workspace heterogeneous agent. Personal
- * and workspace-private agents keep no separate name, so their product title
- * remains the primary label. Shared agents include the creator to distinguish
- * otherwise identical tools in a multilingual workspace.
+ * Default display name for a heterogeneous agent. Personal and
+ * workspace-private agents use their product title. Shared agents include the
+ * creator to distinguish otherwise identical tools in a multilingual workspace.
  *
  * The possessive is deliberately stable English rather than creation-locale
  * copy because the persisted name is shown to every workspace member.
@@ -21,15 +20,15 @@ export const heteroAgentDefaultName = ({
   visibility,
   workspaceId,
 }: HeteroAgentDefaultNameOptions): string | undefined => {
-  if (!workspaceId || visibility === 'private') return undefined;
+  const product = productTitle?.trim();
+  if (!product) return undefined;
+
+  if (!workspaceId || visibility === 'private') return product;
 
   const userStore = getUserStoreState();
   const owner = authSelectors.isLogin(userStore)
     ? userProfileSelectors.nickName(userStore)?.trim()
     : undefined;
-  const product = productTitle?.trim();
 
-  if (!owner || !product) return undefined;
-
-  return `${owner}’s ${product}`;
+  return owner ? `${owner}’s ${product}` : product;
 };


### PR DESCRIPTION
Heterogeneous agents currently persist an owner-qualified localized name in every scope, so a personal Grok Build can render as `AmAzing- 的 Grok Build` and repeat `Grok Build` in the profile header. The localized persisted value can also be shown unchanged to workspace members using another language.

This change keeps the heterogeneous agent fields consistent while scoping owner qualification to shared workspace agents:

- Personal and workspace-private agents persist `name = productTitle`, for example `Grok Build`.
- Shared workspace agents persist the stable English form `Owner’s Product`, for example `AmAzing-’s Grok Build`, so every member sees the same cross-language name.
- `title` remains the product title in every scope.
- Explicit caller-provided names retain precedence.
- The Connect Agent customization and completion states use the same naming rule.
- The profile hides a heterogeneous role when the displayed name already includes it, covering both exact product names and owner-qualified names; genuinely custom names retain the role.
- Obsolete localized default-name resources are removed from the authored locales.

| Scope | Name | Title |
| ----- | ---- | ----- |
| Personal | `Grok Build` | `Grok Build` |
| Workspace private | `Grok Build` | `Grok Build` |
| Workspace shared | `AmAzing-’s Grok Build` | `Grok Build` |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified with:

- `bun run check <initial changed files>` — 66 tests passed, lint clean
- `bun run check <AgentHeader source and test>` — 18 tests passed, lint clean
- `bun run check --type` — types clean

#### 🔗 Related Issue

N/A