### PR TITLE
🐛 fix(heterogeneous-agent): hide misleading message delete

### DIFF
--- a/src/features/Conversation/Error/heterogeneous.ts
+++ b/src/features/Conversation/Error/heterogeneous.ts
@@ -2,13 +2,12 @@ import {
   type HeterogeneousAgentSessionError,
   HeterogeneousAgentSessionErrorCode,
 } from '@lobechat/electron-client-ipc';
-import type { UIChatMessage } from '@lobechat/types';
 
 /**
  * Heterogeneous CLI-agent session errors that render the
  * dedicated status-guide card (auth required, CLI missing, overload, rate
  * limit). Kept in this dependency-free module so non-React callers (e.g. the
- * message action bar) can branch on them without pulling the whole Error UI
+ * conversation store's retry logic) can branch on them without pulling the whole Error UI
  * barrel.
  */
 export const HETEROGENEOUS_AGENT_STATUS_GUIDE_ERROR_CODES = new Set<string>([
@@ -41,28 +40,4 @@ export const isHeterogeneousAgentStatusGuideError = (
     typeof code === 'string' &&
     HETEROGENEOUS_AGENT_STATUS_GUIDE_ERROR_CODES.has(code)
   );
-};
-
-/**
- * Id of the single failed step at the tail of a heterogeneous run, when that
- * step can be dropped on its own without taking the rest of the run with it.
- *
- * A hetero (CC/Codex) turn renders as ONE `assistantGroup` bubble whose
- * `children` are the run's real steps, so acting on the group id acts on the
- * whole run. Returns undefined — meaning "operate on the whole group" — when:
- * - the message isn't a hetero run's group bubble;
- * - its tail step died on something other than a hetero status error (a generic
- *   tool/provider failure isn't a resumable run);
- * - the tail step IS the group head, i.e. the run died on its first step. Its id
- *   doubles as the group id, and no earlier work exists to preserve.
- */
-export const resolveHeteroErroredStepId = (
-  message: UIChatMessage | undefined,
-): string | undefined => {
-  if (message?.role !== 'assistantGroup') return;
-
-  const tail = message.children?.at(-1);
-  if (!tail || tail.id === message.id) return;
-
-  return tail.error && isHeterogeneousAgentStatusGuideError(tail.error.body) ? tail.id : undefined;
 };

--- a/src/features/Conversation/MessageForward/SelectionFooterBar.tsx
+++ b/src/features/Conversation/MessageForward/SelectionFooterBar.tsx
@@ -7,6 +7,9 @@ import { Forward, Trash2, X } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+
 import { messageStateSelectors, useConversationStore, useConversationStoreApi } from '../store';
 import { openForwardModal } from './ForwardModal';
 
@@ -35,13 +38,16 @@ const styles = createStaticStyles(({ css }) => ({
 
 /**
  * Bottom action bar shown while multi-selecting: selection count on the leading
- * edge, Cancel / Delete / Forward on the trailing edge. Replaces the chat
- * composer (hidden by MessageForwardFooter).
+ * edge, Cancel / optional Delete / Forward on the trailing edge. Delete is
+ * omitted for heterogeneous agents because removing LobeHub rows cannot
+ * reliably remove those turns from the resumed native CLI session. Replaces
+ * the chat composer (hidden by MessageForwardFooter).
  */
 const SelectionFooterBar = memo(() => {
   const { t } = useTranslation('chat');
 
   const [forwardOpen, setForwardOpen] = useState(false);
+  const isHeterogeneousAgent = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
   const storeApi = useConversationStoreApi();
   const selectedCount = useConversationStore(messageStateSelectors.selectedMessageCount);
   const selectedMessageIds = useConversationStore((s) => s.selectedMessageIds);
@@ -93,15 +99,17 @@ const SelectionFooterBar = memo(() => {
         <Button icon={<Icon icon={X} />} type={'text'} onClick={exitSelectionMode}>
           {t('messageForward.bar.cancel')}
         </Button>
-        <Button
-          danger
-          disabled={disabled}
-          icon={<Icon icon={Trash2} />}
-          type={'text'}
-          onClick={handleDelete}
-        >
-          {t('messageForward.bar.delete')}
-        </Button>
+        {!isHeterogeneousAgent && (
+          <Button
+            danger
+            disabled={disabled}
+            icon={<Icon icon={Trash2} />}
+            type={'text'}
+            onClick={handleDelete}
+          >
+            {t('messageForward.bar.delete')}
+          </Button>
+        )}
         <Button
           disabled={disabled}
           icon={<Icon icon={Forward} />}

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/del.test.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/del.test.ts
@@ -9,108 +9,48 @@ import type { MessageActionContext } from '../types';
 import { delAction } from './del';
 
 const deleteMessage = vi.fn();
-const deleteAssistantMessage = vi.fn();
+const agentState = vi.hoisted(() => ({ isHeterogeneous: false }));
 
 vi.mock('../../../../store', () => ({
-  useConversationStore: (selector: (s: any) => any) =>
-    selector({ deleteAssistantMessage, deleteMessage }),
+  useConversationStore: (selector: (s: { deleteMessage: typeof deleteMessage }) => unknown) =>
+    selector({ deleteMessage }),
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (s: typeof agentState) => unknown) => selector(agentState),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    isCurrentAgentHeterogeneous: (s: typeof agentState) => s.isHeterogeneous,
+  },
 }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// A group's id IS its head child's id — the assistantGroup bubble is a virtual
-// message built from the run's first assistant row. Fixtures mirror that.
 const build = (
   data: Partial<UIChatMessage>,
-  role: MessageActionContext['role'] = 'group',
-  id = 'step-1',
-) =>
-  renderHook(() => delAction.useBuild({ data: data as UIChatMessage, id, role })).result.current!;
-
-const heteroError = { body: { agentType: 'claude-code', code: 'overloaded' } };
+  role: MessageActionContext['role'] = 'assistant',
+  id = 'message-1',
+) => renderHook(() => delAction.useBuild({ data: data as UIChatMessage, id, role })).result.current;
 
 describe('delAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    agentState.isHeterogeneous = false;
   });
 
-  it('deletes only the errored tail step of a heterogeneous (CC/Codex) run', () => {
-    const data = {
-      id: 'step-1',
-      role: 'assistantGroup',
-      children: [
-        { id: 'step-1', content: 'done' },
-        { id: 'step-2', error: heteroError },
-      ],
-    } as unknown as UIChatMessage;
+  it('hides delete for heterogeneous-agent messages', () => {
+    agentState.isHeterogeneous = true;
 
-    build(data).handleClick!();
-
-    // Must target the failed step's DB id (a child block), not the group id, and
-    // go through the tool-aware delete so the step's tool rows don't orphan.
-    expect(deleteAssistantMessage).toHaveBeenCalledWith('step-2');
-    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(build({ content: 'CLI-owned turn' })).toBeNull();
   });
 
-  it('deletes the whole group when the errored step IS the group head', () => {
-    // The run died on its first step: nothing succeeded before it, and the head's
-    // id doubles as the group id — deleting it alone would strand the chain.
-    const data = {
-      id: 'step-1',
-      role: 'assistantGroup',
-      children: [{ id: 'step-1', error: heteroError }],
-    } as unknown as UIChatMessage;
+  it('keeps delete available for ordinary-agent messages', () => {
+    build({ content: 'regular turn' })!.handleClick!();
 
-    build(data).handleClick!();
-
-    expect(deleteMessage).toHaveBeenCalledWith('step-1');
-    expect(deleteAssistantMessage).not.toHaveBeenCalled();
-  });
-
-  it('deletes the whole group when the tail error is NOT a heterogeneous-agent error', () => {
-    // A normal grouped reply that merely ends in a generic tool/provider error
-    // keeps the whole-group delete.
-    const data = {
-      id: 'step-1',
-      role: 'assistantGroup',
-      children: [
-        { id: 'step-1', content: 'done' },
-        { id: 'step-2', error: { type: 'PluginError', body: { message: 'boom' } } },
-      ],
-    } as unknown as UIChatMessage;
-
-    build(data).handleClick!();
-
-    expect(deleteMessage).toHaveBeenCalledWith('step-1');
-    expect(deleteAssistantMessage).not.toHaveBeenCalled();
-  });
-
-  it('deletes the whole group when no step errored', () => {
-    const data = {
-      id: 'step-1',
-      role: 'assistantGroup',
-      children: [
-        { id: 'step-1', content: 'done' },
-        { id: 'step-2', content: 'done' },
-      ],
-    } as unknown as UIChatMessage;
-
-    build(data).handleClick!();
-
-    expect(deleteMessage).toHaveBeenCalledWith('step-1');
-    expect(deleteAssistantMessage).not.toHaveBeenCalled();
-  });
-
-  it('deletes by message id for a non-group message', () => {
-    build(
-      { id: 'msg-1', role: 'assistant', content: 'hi' } as unknown as UIChatMessage,
-      'assistant',
-      'msg-1',
-    ).handleClick!();
-
-    expect(deleteMessage).toHaveBeenCalledWith('msg-1');
-    expect(deleteAssistantMessage).not.toHaveBeenCalled();
+    expect(deleteMessage).toHaveBeenCalledWith('message-1');
   });
 });

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/del.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/del.ts
@@ -2,7 +2,8 @@ import { Trash } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { resolveHeteroErroredStepId } from '@/features/Conversation/Error/heterogeneous';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 
 import { useConversationStore } from '../../../../store';
 import { defineAction } from '../defineAction';
@@ -12,33 +13,22 @@ export const delAction = defineAction({
   useBuild: (ctx) => {
     const { t } = useTranslation('common');
     const deleteMessage = useConversationStore((s) => s.deleteMessage);
-    const deleteAssistantMessage = useConversationStore((s) => s.deleteAssistantMessage);
-
-    // Deleting a heterogeneous (CC/Codex) run's group id removes the ENTIRE run,
-    // including every step that succeeded before the tail failed. When only the
-    // tail step died on a hetero status error, drop just that step.
-    //
-    // `deleteAssistantMessage` (not `deleteMessage`) resolves the child block
-    // against `dbMessages` — `getDisplayMessageById` only sees top-level bubbles
-    // and would no-op on a child id — and takes the step's tool result rows down
-    // with it, which a bare single-id delete would leave orphaned.
-    const erroredBlockId = resolveHeteroErroredStepId(ctx.data);
+    const isHeterogeneousAgent = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
 
     return useMemo(
-      () => ({
-        danger: true,
-        handleClick: () => {
-          if (erroredBlockId) {
-            void deleteAssistantMessage(erroredBlockId);
-            return;
-          }
-          deleteMessage(ctx.id);
-        },
-        icon: Trash,
-        key: 'del',
-        label: t('delete'),
-      }),
-      [t, ctx.id, deleteMessage, deleteAssistantMessage, erroredBlockId],
+      () =>
+        isHeterogeneousAgent
+          ? null
+          : {
+              danger: true,
+              handleClick: () => {
+                deleteMessage(ctx.id);
+              },
+              icon: Trash,
+              key: 'del',
+              label: t('delete'),
+            },
+      [t, ctx.id, deleteMessage, isHeterogeneousAgent],
     );
   },
 });

--- a/src/features/Conversation/hooks/useChatItemContextMenu.test.ts
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from '@testing-library/react';
+import type { MouseEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useChatItemContextMenu } from './useChatItemContextMenu';
+
+const mocks = vi.hoisted(() => ({
+  copyMessage: vi.fn(),
+  delAndRegenerateMessage: vi.fn(),
+  delAndResendThreadMessage: vi.fn(),
+  deleteMessage: vi.fn(),
+  isHeterogeneous: false,
+  message: { content: 'hello', id: 'message-1', role: 'user' },
+  openThreadCreator: vi.fn(),
+  regenerateAssistantMessage: vi.fn(),
+  regenerateUserMessage: vi.fn(),
+  resendThreadMessage: vi.fn(),
+  showContextMenu: vi.fn(),
+  startMessageTTS: vi.fn(),
+  toggleMessageCollapsed: vi.fn(),
+  toggleMessageEditing: vi.fn(),
+  translateMessage: vi.fn(),
+}));
+
+vi.mock('@/features/Conversation/ChatItem/components/MessageContent', () => ({
+  MSG_CONTENT_CLASSNAME: 'message-content',
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/libs/contextMenu', () => ({
+  showContextMenu: mocks.showContextMenu,
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (state: typeof mocks) => unknown) => selector(mocks),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    isCurrentAgentHeterogeneous: (state: typeof mocks) => state.isHeterogeneous,
+  },
+}));
+
+vi.mock('@/store/session', () => ({
+  useSessionStore: (selector: (state: { isGroup: boolean }) => unknown) =>
+    selector({ isGroup: false }),
+}));
+
+vi.mock('@/store/session/selectors', () => ({
+  sessionSelectors: {
+    isCurrentSessionGroupSession: (state: { isGroup: boolean }) => state.isGroup,
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: { contextMenuMode: string; isDevMode: boolean }) => unknown) =>
+    selector({ contextMenuMode: 'system', isDevMode: false }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  userGeneralSettingsSelectors: {
+    config: (state: { isDevMode: boolean }) => ({ isDevMode: state.isDevMode }),
+    contextMenuMode: (state: { contextMenuMode: string }) => state.contextMenuMode,
+  },
+}));
+
+vi.mock('../components/ShareMessageModal', () => ({
+  openShareMessageModal: vi.fn(),
+}));
+
+vi.mock('../store', () => {
+  const state = {
+    ...mocks,
+    context: {},
+    hooks: {},
+    skipFetch: false,
+  };
+
+  return {
+    createStore: vi.fn(),
+    dataSelectors: {
+      getDisplayMessageById: () => () => mocks.message,
+    },
+    messageStateSelectors: {
+      hasThreadBySourceMsgId: () => () => false,
+      isMessageCollapsed: () => () => false,
+      isMessageRegenerating: () => () => false,
+      isThreadMode: () => false,
+    },
+    useConversationStore: (selector: (value: typeof state) => unknown) => selector(state),
+    useConversationStoreApi: () => ({ getState: () => state }),
+  };
+});
+
+vi.mock('./useChatListActionsBar', () => ({
+  useChatListActionsBar: () => ({
+    branching: { key: 'branching', label: 'Branch' },
+    collapse: { key: 'collapse', label: 'Collapse' },
+    copy: { key: 'copy', label: 'Copy' },
+    del: { danger: true, key: 'del', label: 'Delete' },
+    delAndRegenerate: { key: 'delAndRegenerate', label: 'Delete and regenerate' },
+    divider: { type: 'divider' },
+    edit: { key: 'edit', label: 'Edit' },
+    expand: { key: 'expand', label: 'Expand' },
+    regenerate: { key: 'regenerate', label: 'Regenerate' },
+    share: { key: 'share', label: 'Share' },
+    translate: { key: 'translate', label: 'Translate' },
+    tts: { key: 'tts', label: 'TTS' },
+  }),
+}));
+
+vi.mock('./useConversationResourceAccess', () => ({
+  useConversationResourceAccess: () => ({ canUseResource: true }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const openContextMenu = () => {
+  const { result } = renderHook(() =>
+    useChatItemContextMenu({ id: 'message-1', inPortalThread: false }),
+  );
+  const target = document.createElement('div');
+  target.className = 'message-content';
+  document.body.append(target);
+
+  act(() => {
+    result.current.handleContextMenu({
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      target,
+    } as unknown as MouseEvent<HTMLDivElement>);
+  });
+
+  target.remove();
+  return mocks.showContextMenu.mock.calls.at(-1)?.[0] as Array<{ key?: string }>;
+};
+
+describe('useChatItemContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isHeterogeneous = false;
+  });
+
+  it('omits delete for heterogeneous-agent messages', () => {
+    mocks.isHeterogeneous = true;
+
+    expect(openContextMenu().map((item) => item.key)).not.toContain('del');
+  });
+
+  it('keeps delete for ordinary-agent messages', () => {
+    expect(openContextMenu().map((item) => item.key)).toContain('del');
+  });
+});

--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -11,10 +11,11 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { MSG_CONTENT_CLASSNAME } from '@/features/Conversation/ChatItem/components/MessageContent';
-import { resolveHeteroErroredStepId } from '@/features/Conversation/Error/heterogeneous';
 import { usePermission } from '@/hooks/usePermission';
 import { showContextMenu } from '@/libs/contextMenu';
 import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useSessionStore } from '@/store/session';
 import { sessionSelectors } from '@/store/session/selectors';
 import { useUserStore } from '@/store/user';
@@ -81,6 +82,7 @@ export const useChatItemContextMenu = ({
   }, isEqual);
 
   const isThreadMode = useConversationStore(messageStateSelectors.isThreadMode);
+  const isHeterogeneousAgent = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
   const isGroupSession = useSessionStore(sessionSelectors.isCurrentSessionGroupSession);
   const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
   const actionsBar = useChatListActionsBar({ hasThread, isRegenerating });
@@ -99,7 +101,6 @@ export const useChatItemContextMenu = ({
     resendThreadMessage,
     delAndResendThreadMessage,
     toggleMessageCollapsed,
-    deleteAssistantMessage,
   ] = useConversationStore((s) => [
     s.toggleMessageEditing,
     s.deleteMessage,
@@ -113,7 +114,6 @@ export const useChatItemContextMenu = ({
     s.resendThreadMessage,
     s.delAndResendThreadMessage,
     s.toggleMessageCollapsed,
-    s.deleteAssistantMessage,
   ]);
 
   const getMessage = useCallback(
@@ -158,7 +158,10 @@ export const useChatItemContextMenu = ({
     if (role === 'assistant') {
       if (error) {
         return withPermission(
-          [edit, copy, divider, del, divider, regenerate].filter(Boolean) as MenuItem[],
+          (isHeterogeneousAgent
+            ? [edit, copy, divider, regenerate]
+            : [edit, copy, divider, del, divider, regenerate]
+          ).filter(Boolean) as MenuItem[],
         );
       }
 
@@ -167,17 +170,8 @@ export const useChatItemContextMenu = ({
 
       if (!inThread && !isGroupSession && isDevMode) list.push(branching);
 
-      list.push(
-        divider,
-        tts,
-        translate,
-        divider,
-        share,
-        divider,
-        regenerate,
-        delAndRegenerate,
-        del,
-      );
+      list.push(divider, tts, translate, divider, share, divider, regenerate, delAndRegenerate);
+      if (!isHeterogeneousAgent) list.push(del);
 
       return withPermission(list.filter(Boolean) as MenuItem[]);
     }
@@ -185,21 +179,16 @@ export const useChatItemContextMenu = ({
     if (role === 'assistantGroup') {
       if (error) {
         return withPermission(
-          [edit, copy, divider, del, divider, regenerate].filter(Boolean) as MenuItem[],
+          (isHeterogeneousAgent
+            ? [edit, copy, divider, regenerate]
+            : [edit, copy, divider, del, divider, regenerate]
+          ).filter(Boolean) as MenuItem[],
         );
       }
 
       const collapseAction = isCollapsed ? expand : collapse;
-      const list: MenuItem[] = [
-        edit,
-        copy,
-        collapseAction,
-        divider,
-        share,
-        divider,
-        regenerate,
-        del,
-      ];
+      const list: MenuItem[] = [edit, copy, collapseAction, divider, share, divider, regenerate];
+      if (!isHeterogeneousAgent) list.push(del);
 
       return withPermission(list.filter(Boolean) as MenuItem[]);
     }
@@ -209,7 +198,8 @@ export const useChatItemContextMenu = ({
 
       if (!inThread && isDevMode) list.push(branching);
 
-      list.push(divider, tts, translate, divider, regenerate, del);
+      list.push(divider, tts, translate, divider, regenerate);
+      if (!isHeterogeneousAgent) list.push(del);
 
       return withPermission(list.filter(Boolean) as MenuItem[]);
     }
@@ -224,6 +214,7 @@ export const useChatItemContextMenu = ({
     isCollapsed,
     isDevMode,
     isGroupSession,
+    isHeterogeneousAgent,
     role,
   ]);
 
@@ -274,11 +265,7 @@ export const useChatItemContextMenu = ({
         }
         case 'del': {
           if (!canEdit) break;
-          // Mirrors the action bar's `del`: on a heterogeneous run that only
-          // failed on its tail step, drop that step instead of the whole run.
-          const erroredStepId = resolveHeteroErroredStepId(item);
-          if (erroredStepId) deleteAssistantMessage(erroredStepId);
-          else deleteMessage(id);
+          deleteMessage(id);
           break;
         }
         case 'regenerate': {
@@ -325,7 +312,6 @@ export const useChatItemContextMenu = ({
       copyMessage,
       canCreate,
       canEdit,
-      deleteAssistantMessage,
       deleteMessage,
       delAndRegenerateMessage,
       delAndResendThreadMessage,

--- a/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.test.ts
+++ b/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.test.ts
@@ -1,12 +1,33 @@
 /**
  * @vitest-environment happy-dom
  */
-import { renderHook } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SelectionFooterBar from '@/features/Conversation/MessageForward/SelectionFooterBar';
 
 import { useActionsBarConfig } from './useActionsBarConfig';
 
 const agentState = vi.hoisted(() => ({ isHeterogeneous: false }));
+const conversationState = vi.hoisted(() => ({
+  deleteMessages: vi.fn(),
+  exitSelectionMode: vi.fn(),
+  selectedMessageIds: ['message-1'],
+}));
+
+vi.mock('@/features/Conversation/MessageForward/ForwardModal', () => ({
+  openForwardModal: vi.fn(),
+}));
+
+vi.mock('@/features/Conversation/store', () => ({
+  messageStateSelectors: {
+    selectedMessageCount: (state: typeof conversationState) => state.selectedMessageIds.length,
+  },
+  useConversationStore: (selector: (state: typeof conversationState) => unknown) =>
+    selector(conversationState),
+  useConversationStoreApi: () => ({}),
+}));
 
 vi.mock('@/store/agent', () => ({
   useAgentStore: (selector: (state: typeof agentState) => unknown) => selector(agentState),
@@ -18,8 +39,13 @@ vi.mock('@/store/agent/selectors', () => ({
   },
 }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 describe('useActionsBarConfig', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     agentState.isHeterogeneous = false;
   });
 
@@ -36,5 +62,22 @@ describe('useActionsBarConfig', () => {
     expect(result.current.user?.menu).not.toContain('del');
     expect(result.current.assistant?.menu).not.toContain('del');
     expect(result.current.assistantGroup?.menu).not.toContain('del');
+  });
+
+  it('keeps selection-mode actions available for ordinary agents', () => {
+    render(createElement(SelectionFooterBar));
+
+    expect(screen.getByRole('button', { name: 'messageForward.bar.cancel' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'messageForward.bar.delete' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'messageForward.bar.forward' })).toBeEnabled();
+  });
+
+  it('omits selection-mode delete while keeping forwarding for heterogeneous agents', () => {
+    agentState.isHeterogeneous = true;
+    render(createElement(SelectionFooterBar));
+
+    expect(screen.getByRole('button', { name: 'messageForward.bar.cancel' })).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'messageForward.bar.delete' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'messageForward.bar.forward' })).toBeEnabled();
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.test.ts
+++ b/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useActionsBarConfig } from './useActionsBarConfig';
+
+const agentState = vi.hoisted(() => ({ isHeterogeneous: false }));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (state: typeof agentState) => unknown) => selector(agentState),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    isCurrentAgentHeterogeneous: (state: typeof agentState) => state.isHeterogeneous,
+  },
+}));
+
+describe('useActionsBarConfig', () => {
+  beforeEach(() => {
+    agentState.isHeterogeneous = false;
+  });
+
+  it('keeps the ordinary-agent defaults', () => {
+    const { result } = renderHook(() => useActionsBarConfig());
+
+    expect(result.current).toEqual({});
+  });
+
+  it('omits delete from every heterogeneous-agent message menu', () => {
+    agentState.isHeterogeneous = true;
+    const { result } = renderHook(() => useActionsBarConfig());
+
+    expect(result.current.user?.menu).not.toContain('del');
+    expect(result.current.assistant?.menu).not.toContain('del');
+    expect(result.current.assistantGroup?.menu).not.toContain('del');
+  });
+});

--- a/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.ts
+++ b/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.ts
@@ -7,11 +7,12 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 /**
- * Hetero-agent (Claude Code / Codex) sessions keep the menu minimal — copy +
- * delete — because the external runtime owns the assistant message lifecycle
- * (edit / regenerate / branching / translate / tts / share don't apply).
- * `select` remains available because forwarding / batch deletion is handled by
- * the local conversation UI and does not depend on the external runtime.
+ * Hetero-agent (Claude Code / Codex) sessions keep the menu minimal because the
+ * external runtime owns the assistant message lifecycle (edit / regenerate /
+ * branching / translate / tts / share don't apply). Delete is omitted too:
+ * removing LobeHub's message row does not remove that turn from the resumed
+ * native CLI session, so exposing it would promise a context change it cannot
+ * reliably deliver. `select` remains available for forwarding.
  *
  * The one user-message action that DOES belong here is `restoreToInput`: a long
  * CLI run that errors out or loses context is exactly when you want to pull the
@@ -20,12 +21,12 @@ import { agentSelectors } from '@/store/agent/selectors';
  */
 const HETERO_USER: { bar: MessageActionSlot[]; menu: MessageActionSlot[] } = {
   bar: ['copy'],
-  menu: ['restoreToInput', 'copy', 'divider', 'select', 'divider', 'del'],
+  menu: ['restoreToInput', 'copy', 'divider', 'select'],
 };
 
 const HETERO_ASSISTANT: { bar: MessageActionSlot[]; menu: MessageActionSlot[] } = {
   bar: ['copy'],
-  menu: ['copy', 'divider', 'select', 'divider', 'del'],
+  menu: ['copy', 'divider', 'select'],
 };
 
 export const useActionsBarConfig = (): ActionsBarConfig => {


### PR DESCRIPTION
Hide per-message deletion for heterogeneous-agent conversations because deleting LobeHub's persisted message does not reliably remove the turn from the resumed native CLI session.

This change:

- removes Delete from heterogeneous user, assistant, and assistant-group overflow menus;
- suppresses Delete in special error/no-text action bars;
- removes Delete from heterogeneous message context menus;
- keeps ordinary-agent message deletion unchanged;
- removes the obsolete heterogeneous failed-step deletion branch.

| Before | After |
| ------ | ----- |
| Heterogeneous messages expose a Delete action whose effect differs from the CLI session context | Heterogeneous messages omit Delete while ordinary-agent messages retain it |

#### Test

- `bun run check <changed files>` — lint clean, 6 tests passed
- `bun run check --type` — types clean

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
