### PR TITLE
✨ feat(portal): support direct site uploads

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -2126,6 +2126,7 @@
   "workingPanel.localFile.publish.unresolvedLocals": "This page still points at local files that were not packed, so those assets would break after publish.",
   "workingPanel.localFile.publish.upload_one": "1 larger file will be uploaded with the page.",
   "workingPanel.localFile.publish.upload_other": "{{count}} larger files will be uploaded with the page.",
+  "workingPanel.localFile.publish.uploadingProgress": "Uploading {{completed}} / {{total}} · {{percent}}%",
   "workingPanel.localFile.publish.version": "Publish this version",
   "workingPanel.localFile.sandboxUnavailable": "This file is no longer available — its sandbox environment has been recycled",
   "workingPanel.localFile.truncated": "File preview truncated to {{limit}} characters",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -2126,6 +2126,7 @@
   "workingPanel.localFile.publish.unresolvedLocals": "此页面仍引用未打包的本地文件，发布后这些资源会失效。",
   "workingPanel.localFile.publish.upload_one": "1 个较大的文件会与页面一起上传。",
   "workingPanel.localFile.publish.upload_other": "{{count}} 个较大的文件会与页面一起上传。",
+  "workingPanel.localFile.publish.uploadingProgress": "正在上传 {{completed}} / {{total}} · {{percent}}%",
   "workingPanel.localFile.publish.version": "发布此版本",
   "workingPanel.localFile.sandboxUnavailable": "此文件已不可用——所在的沙盒环境已被回收",
   "workingPanel.localFile.truncated": "文件预览被截断至 {{limit}} 个字符",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -2377,6 +2377,8 @@ export default {
   'workingPanel.localFile.publish.upload_one': '1 larger file will be uploaded with the page.',
   'workingPanel.localFile.publish.upload_other':
     '{{count}} larger files will be uploaded with the page.',
+  'workingPanel.localFile.publish.uploadingProgress':
+    'Uploading {{completed}} / {{total}} · {{percent}}%',
   'workingPanel.localFile.publish.missing': 'Missing files will not be included: {{list}}',
   'workingPanel.localFile.publish.noLocalFiles': 'This page has no local files besides the HTML.',
   'workingPanel.localFile.publish.noTopic': 'Open a topic to publish this page',

--- a/src/features/Portal/LocalFile/prepareWorkspaceHtmlPublish.ts
+++ b/src/features/Portal/LocalFile/prepareWorkspaceHtmlPublish.ts
@@ -140,14 +140,20 @@ const workspaceHtmlPublishErrorMessage = (error: unknown): string => {
 export const publishPreparedWorkspaceHtml = async ({
   agentId,
   onError,
+  onUploadPhase,
+  onUploadProgress,
   plan,
   publish,
+  signal,
   topicId,
 }: {
   agentId?: string | null;
   onError?: (error: unknown) => boolean;
+  onUploadPhase?: Parameters<WorkspaceHtmlArtifactPublisher['publish']>[0]['onUploadPhase'];
+  onUploadProgress?: Parameters<WorkspaceHtmlArtifactPublisher['publish']>[0]['onUploadProgress'];
   plan: ReadyWorkspaceHtmlPublishPlan;
   publish: WorkspaceHtmlArtifactPublisher['publish'];
+  signal?: AbortSignal;
   topicId: string;
 }): Promise<WorkspaceHtmlArtifactPublishResult | undefined> => {
   try {
@@ -156,7 +162,10 @@ export const publishPreparedWorkspaceHtml = async ({
       entryPath: plan.gathered.entryPath,
       files: plan.gathered.files,
       identifier: plan.gathered.identifier,
+      onUploadPhase,
+      onUploadProgress,
       packed: { html: plan.packed.html, sidecars: plan.packed.sidecars },
+      signal,
       title: plan.gathered.title,
       topicId,
     });

--- a/src/features/Portal/LocalFile/publishWorkspaceHtmlArtifact.test.ts
+++ b/src/features/Portal/LocalFile/publishWorkspaceHtmlArtifact.test.ts
@@ -116,17 +116,20 @@ describe('publishWorkspaceHtmlArtifact', () => {
     );
 
     expect(result.publicUrl).toBe('https://example.lobehub.com/page');
-    expect(publishSite).toHaveBeenCalledWith({
-      artifactIdentifier: 'workspace-html-index-html',
-      files: [
-        expect.objectContaining({
-          path: '/hero.png',
-        }),
-      ],
-      html: expect.stringContaining('src="/hero.png"'),
-      requestedSlug: 'Demo',
-      topicId: 'tpc_1',
-    });
+    expect(publishSite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifactIdentifier: 'workspace-html-index-html',
+        files: [
+          expect.objectContaining({
+            path: '/hero.png',
+          }),
+        ],
+        html: expect.stringContaining('src="/hero.png"'),
+        requestedSlug: 'Demo',
+        title: 'Demo',
+        topicId: 'tpc_1',
+      }),
+    );
   });
 
   it('publishes a prepacked plan without re-packing the file set', async () => {
@@ -198,6 +201,7 @@ describe('publishWorkspaceHtmlArtifact', () => {
           entryPath: 'index.html',
           files: [],
           identifier: 'workspace-html-index-html',
+          packed: { html: '<main>small</main>', sidecars: [] },
           title: 'Demo',
           topicId: 'tpc_1',
         },

--- a/src/features/Portal/LocalFile/publishWorkspaceHtmlArtifact.ts
+++ b/src/features/Portal/LocalFile/publishWorkspaceHtmlArtifact.ts
@@ -2,6 +2,7 @@ import { ARTIFACT_TAG } from '@lobechat/const';
 import { escapeXmlAttr } from '@lobechat/prompts';
 
 import { hostedPath, packWorkspaceHtmlDocument } from './packWorkspaceHtmlDocument';
+import { WORKSPACE_HTML_ARTIFACT_INLINE_MAX_BYTES } from './readWorkspaceAsset';
 import type {
   WorkspaceHtmlArtifactFile,
   WorkspaceHtmlArtifactPublishInput,
@@ -23,7 +24,11 @@ export interface PublishWorkspaceHtmlSiteParams {
   artifactIdentifier: string;
   files: WorkspaceHtmlArtifactFile[];
   html: string;
+  onPhase?: WorkspaceHtmlArtifactPublishInput['onUploadPhase'];
+  onProgress?: WorkspaceHtmlArtifactPublishInput['onUploadProgress'];
   requestedSlug?: string;
+  signal?: AbortSignal;
+  title?: string;
   topicId: string;
 }
 
@@ -47,10 +52,6 @@ export const publishWorkspaceHtmlArtifact = async (
     ) => Promise<{ id?: string; latestRevisionNumber?: number; publicUrl?: string }>;
   },
 ): Promise<WorkspaceHtmlArtifactPublishResult> => {
-  if (!input.agentId) {
-    throw new Error('unavailable');
-  }
-
   const packed =
     input.packed ??
     (() => {
@@ -64,7 +65,10 @@ export const publishWorkspaceHtmlArtifact = async (
       return fresh;
     })();
 
-  if (packed.sidecars.length > 0) {
+  if (
+    packed.sidecars.length > 0 ||
+    new TextEncoder().encode(packed.html).byteLength > WORKSPACE_HTML_ARTIFACT_INLINE_MAX_BYTES
+  ) {
     if (!deps.publishSite) {
       throw new Error('unavailable');
     }
@@ -76,7 +80,11 @@ export const publishWorkspaceHtmlArtifact = async (
         path: hostedPath(file.path),
       })),
       html: packed.html,
+      onPhase: input.onUploadPhase,
+      onProgress: input.onUploadProgress,
       requestedSlug: input.title,
+      signal: input.signal,
+      title: input.title,
       topicId: input.topicId,
     });
 
@@ -85,6 +93,10 @@ export const publishWorkspaceHtmlArtifact = async (
       publicUrl: deployment.publicUrl,
       revision: deployment.latestRevisionNumber,
     };
+  }
+
+  if (!input.agentId) {
+    throw new Error('unavailable');
   }
 
   const message = await deps.createMessage({

--- a/src/features/Portal/LocalFile/workspaceHtmlArtifact.ts
+++ b/src/features/Portal/LocalFile/workspaceHtmlArtifact.ts
@@ -10,7 +10,15 @@ export interface WorkspaceHtmlArtifactPublishInput {
   entryPath: string;
   files: WorkspaceHtmlArtifactFile[];
   identifier: string;
+  onUploadPhase?: (phase: 'finalizing' | 'preparing' | 'uploading') => void;
+  onUploadProgress?: (progress: {
+    completedFiles: number;
+    loadedBytes: number;
+    totalBytes: number;
+    totalFiles: number;
+  }) => void;
   packed?: { html: string; sidecars: WorkspaceHtmlArtifactFile[] };
+  signal?: AbortSignal;
   title: string;
   topicId: string;
 }


### PR DESCRIPTION
## 📝 Additional Information

Adds generic upload lifecycle signals to the workspace HTML publisher contract and routes pages with sidecars or larger standalone HTML through the optional site publisher. Small standalone HTML keeps the existing inline message flow.

Intentional non-goals: no resume, multipart upload, client-side hashing, or provider-specific API details in the open-source layer.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- `vitest run src/features/Portal/LocalFile/publishWorkspaceHtmlArtifact.test.ts` — 5 passed
- targeted ESLint for the changed TypeScript files

#### 🔗 Related Issue

- https://linear.app/lobehub/issue/LOBE-13571
