### PR TITLE
👷 ci: upgrade pnpm setup action to v6

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         run_install: false
 

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         run_install: false
 

--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 24.16.0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install
@@ -55,7 +55,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -32,7 +32,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Upgrade every remaining `pnpm/action-setup` reference from v4 to v6 so GitHub Actions uses the Node 24 runtime and no longer emits the Node 20 deprecation warning.

This keeps the shared setup actions and the ModelBank/SDK release workflows aligned with `actions/setup-node@v6`.

#### Test

- [x] Tested locally: `bun run check --lint` (4 files, lint clean)
- [x] `git diff --check`
- [x] No tests needed

#### 🔗 Related Issue

N/A