### PR TITLE
🐛 fix(queue): encode QStash deduplication IDs

### DIFF
--- a/apps/server/src/services/queue/__tests__/QueueService.test.ts
+++ b/apps/server/src/services/queue/__tests__/QueueService.test.ts
@@ -246,25 +246,46 @@ describe('QueueService', () => {
       expect(qstashMocks.publishJSON.mock.calls[0][0]).toMatchObject({ delay: 2 });
     });
 
-    it('passes the stable intervention deduplication key to QStash', async () => {
+    it('encodes logical deduplication keys as stable QStash-safe opaque IDs', async () => {
       qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
 
       const { QStashQueueServiceImpl } = await import('../impls/qstash');
       const impl = new QStashQueueServiceImpl({ qstashToken: 'test-qstash-token' });
 
-      await impl.scheduleMessage({
-        context: { phase: 'user_input' } as any,
-        deduplicationId: 'agent-intervention:op-stable:0',
-        delay: 0,
-        endpoint: 'https://example.com/api/agent/run',
-        operationId: 'op-stable',
-        priority: 'high',
-        stepIndex: 0,
-      });
+      const publish = async (deduplicationId: string) => {
+        await impl.scheduleMessage({
+          context: { phase: 'user_input' } as any,
+          deduplicationId,
+          delay: 0,
+          endpoint: 'https://example.com/api/agent/run',
+          operationId: 'op-stable',
+          priority: 'high',
+          stepIndex: 0,
+        });
 
-      expect(qstashMocks.publishJSON).toHaveBeenCalledWith(
-        expect.objectContaining({ deduplicationId: 'agent-intervention:op-stable:0' }),
-      );
+        return qstashMocks.publishJSON.mock.calls.at(-1)![0].deduplicationId;
+      };
+
+      const logicalId = 'agent-intervention:op_intervention_9979660c87f7db5cdac6836bc90e9038:0';
+      const first = await publish(logicalId);
+      const retry = await publish(logicalId);
+      const different = await publish(`${logicalId}:retry`);
+
+      expect(first).toBe('a2d899f251f8376646eb59522e64e447805aaf2e7b97d80b2935d2e0d293ffcb');
+      expect(retry).toBe(first);
+      expect(different).not.toBe(first);
+
+      for (const unsafeOrBoundaryId of [
+        'unsafe id/with?characters=#and-non-ascii-审批',
+        'x'.repeat(63),
+        'x'.repeat(64),
+        'x'.repeat(65),
+      ]) {
+        const providerId = await publish(unsafeOrBoundaryId);
+
+        expect(providerId).toHaveLength(64);
+        expect(providerId).toMatch(/^[a-f\d]{64}$/);
+      }
     });
   });
 

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import debug from 'debug';
 
 import { OtelQstashClient } from '@/libs/qstash';
@@ -6,6 +8,14 @@ import { type HealthCheckResult, type QueueMessage, type QueueStats } from '../t
 import { type QueueServiceImpl } from './type';
 
 const log = debug('lobe-server:service:queue:qstash');
+
+/**
+ * Keep the logical execution key intact in durable state and local queues, but
+ * encode it at the provider boundary. QStash rejects characters such as `:`;
+ * a SHA-256 hex digest is deterministic, alphanumeric, and exactly 64 chars.
+ */
+const toQStashDeduplicationId = (logicalId: string): string =>
+  createHash('sha256').update(logicalId).digest('hex');
 
 /**
  * QStash's `delay` option is second-granularity — the `Duration` string form
@@ -61,7 +71,7 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
           timestamp: Date.now(),
         },
         ...(qstashDelay === undefined ? {} : { delay: qstashDelay }),
-        ...(deduplicationId ? { deduplicationId } : {}),
+        ...(deduplicationId ? { deduplicationId: toQStashDeduplicationId(deduplicationId) } : {}),
         headers: {
           'Content-Type': 'application/json',
           'X-Agent-Operation-Id': operationId,


### PR DESCRIPTION
## Summary

- encode logical queue deduplication keys as deterministic SHA-256 hex only at the QStash provider boundary
- preserve the original logical key in durable preparation and dispatch markers and in the local queue
- cover the real colon-containing approval continuation ID plus unsafe, Unicode, and length-boundary inputs

## Context

Preview Human Approval E2E reached the initial QStash callback successfully, but the approval continuation publish failed with QStash 400: DeduplicationId cannot contain colon. This keeps the durable identity unchanged while producing a provider-safe opaque ID.

## Validation

- pnpm exec vitest run --silent=passed-only apps/server/src/services/queue/__tests__/QueueService.test.ts (35/35)
- ESLint on both changed files
- Prettier check on both changed files
- git diff --check origin/canary...HEAD

## Rollout check

After merge, repin the Cloud Preview submodule to the resulting canary commit and retry the pending approval continuation against real QStash.