### PR TITLE
🐛 fix(chat-input): apply parsing tag styles without ant-tag

### DIFF
--- a/src/features/ChatInput/Desktop/FilePreview/FileItem/index.tsx
+++ b/src/features/ChatInput/Desktop/FilePreview/FileItem/index.tsx
@@ -38,12 +38,6 @@ const styles = createStaticStyles(({ css }) => ({
   image: css`
     margin-block: 0 !important;
   `,
-  status: css`
-    &.ant-tag {
-      padding-inline: 0;
-      background: none;
-    }
-  `,
 }));
 
 type FileItemProps = UploadFileItem;

--- a/src/features/ChatInput/components/UploadDetail/index.tsx
+++ b/src/features/ChatInput/components/UploadDetail/index.tsx
@@ -12,10 +12,8 @@ import UploadStatus from './UploadStatus';
 
 const styles = createStaticStyles(({ css }) => ({
   status: css`
-    &.ant-tag {
-      padding-inline: 0;
-      background: none;
-    }
+    padding-inline: 0;
+    background: none;
   `,
 }));
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

After the Tag migration to `@lobehub/ui/base-ui`, upload parsing status chips no longer receive their local style overrides. base-ui Tag is a native `span` and does not render `.ant-tag`.

| Before | After |
| ------ | ----- |
| `&.ant-tag` never matches, so the chip keeps default padding/background | Overrides apply on the Tag class itself |

#### Test

<!-- How you tested your changes -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Selector-only CSS fix; a source-string assertion would not be a useful regression test.

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

Related: `@lobehub/ui` `fix/tag-middle-size-padding` (default middle Tag padding). This PR only fixes leftover `.ant-tag` selectors in chat input.