### PR TITLE
✨ feat(skill): add heterogeneous agent run diagnosis

### DIFF
--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md
@@ -101,6 +101,14 @@ python3 .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local
   --log-file /path/to/main.log
 ```
 
+For a development run that writes beside the working directory, point directly at that trace root:
+
+```bash
+python3 .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py \
+  latest \
+  --trace-root "$PWD/.heerogeneous-tracing"
+```
+
 If the script finds no trace, do not conclude that the run never happened. Check whether packaged tracing was enabled, whether the app used the dev trace root, and whether retention or cleanup removed the evidence.
 
 ### 3. Build one timeline across evidence planes

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diagnosing-heterogeneous-agent-runs
-description: Diagnose a local LobeHub Desktop heterogeneous-agent run from a topic, session, or the latest trace.
+description: Diagnoses a local LobeHub Desktop heterogeneous-agent run from a topic, session, or the latest trace.
 disable-model-invocation: true
 argument-hint: '<topic-id | session-id | latest>'
 ---
@@ -88,8 +88,10 @@ The script is read-only. It reports:
 - top-level `heteroAgent/` inventory;
 - topic status, provider, working directory, binding key, and native session IDs from the local SWR cache;
 - persisted assistant errors without message content;
-- matching trace metadata, process exit, terminal `result`, and stderr size;
+- matching trace metadata, process/transport errors, process exit, a structural stdout event index, and stderr size;
 - focused `main.log` lines for matching sessions and nearby transport/proxy activity.
+
+The stdout index deliberately reports only event types, safe structural fields, line numbers, and session IDs. It does not duplicate the TypeScript adapters by trying to normalize every provider's terminal protocol. Interpret candidate terminal lines against the run's actual adapter or transport source in step 4.
 
 Use `--storage-root` and `--log-file` when the app uses a non-default profile or another OS path:
 
@@ -140,12 +142,15 @@ Do not merge process success with protocol success. A CLI may exit 0 after corre
 For every matching trace, read in this order:
 
 1. `meta.json` — agent type, command, cwd, process/native session IDs, resume ID, safe environment key names;
-2. `exit.json` — OS process code and signal;
-3. terminal records from `stdout.jsonl` — `result`, error subtype, turn count, duration;
-4. focused raw events immediately before the terminal record;
-5. `stderr.log` only when non-empty.
+2. `process-error.json` — authoritative spawn, SDK, app-server, or ACP failure when present;
+3. `exit.json` — OS process code, signal, and transport;
+4. the collector's stdout event-type counts and structural tail — use line numbers to narrow inspection;
+5. the adapter/driver selected by `agentType` and transport, then only the candidate terminal lines and immediately preceding raw events from `stdout.jsonl`;
+6. `stderr.log` only when non-empty.
 
 Avoid dumping entire JSONL files. Select event type, tool ID, stop reason, success flag, and terminal fields with `jq`, Python, or `rg`.
+
+Do not add provider event allowlists to the collector. Local exec adapters are registered in `packages/heterogeneous-agents/src/registry.ts`; SDK, app-server, and ACP transports may have additional session-specific adapters. Source-aware interpretation keeps protocol ownership in TypeScript and prevents this skill from drifting whenever a provider changes its event schema.
 
 ### 5. Inspect native-agent history when available
 

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: diagnosing-heterogeneous-agent-runs
+description: Diagnose a local LobeHub Desktop heterogeneous-agent run from a topic, session, or the latest trace.
+disable-model-invocation: true
+argument-hint: '<topic-id | session-id | latest>'
+---
+
+# Diagnose Local Heterogeneous-Agent Runs
+
+Investigate a real LobeHub Desktop external-agent run from persisted evidence before reproducing it or changing code. Keep the investigation read-only unless the user separately asks for a fix.
+
+## Responsibility Boundary
+
+This skill owns incident triage for an installed or locally running LobeHub Desktop app:
+
+- resolve a topic, native agent session, Desktop process session, or latest run;
+- correlate Desktop state, process logs, raw CLI output, and native-agent history;
+- identify the first failed boundary and explain why LobeHub displayed the observed state;
+- hand a source-level defect to the skill that owns the implementation.
+
+Do not duplicate downstream workflows:
+
+- Use `heterogeneous-agent` after evidence points to a driver, adapter, stream protocol, resume, tool persistence, or terminal-event bug.
+- Use `agent-tracing` for the normal server-side AgentRuntime, LLM/context-engine snapshots, or `agent_operations.trace_s3_key`; `.agent-tracing/` is not the Desktop CLI trace store.
+- Use `agent-testing` only when controlled reproduction or Electron/browser verification is still needed.
+- Use `debug-package` when adding or changing debug namespaces rather than interpreting existing logs.
+
+## Safety Rules
+
+- Start read-only. Do not retry a paid agent run, change proxy settings, edit bindings, delete traces, or mutate SQLite unless the user explicitly requests that action.
+- Treat topic reports and UI labels as claims. Confirm the terminal event and persisted error before naming a root cause.
+- Do not print complete prompts, `stdin.txt`, tool output, attachment contents, binding profiles, environment values, tokens, cookies, or credentials.
+- `meta.json` contains environment key names, not values; report only the keys needed to explain behavior.
+- Query SQLite with `mode=ro` and summarize only structural fields and errors.
+- Preserve unrelated files and sessions. A shared Desktop profile may contain other users' or agents' private material.
+
+## Artifact Map
+
+On macOS, the default roots are:
+
+```text
+~/Library/Application Support/LobeHub/lobehub-storage/
+├── local-database.sqlite3
+└── heteroAgent/
+    ├── bindings/  stable provider-bound CLI profiles
+    ├── files/     downloaded attachment cache
+    ├── runs/      per-run resources, normally removed after execution
+    └── tracing/   opted-in packaged/Desktop CLI traces
+
+~/Library/Logs/LobeHub/main.log
+```
+
+Plain development runs with centralized tracing disabled write to `<cwd>/.heerogeneous-tracing/` instead. The misspelling is the real directory name.
+
+Use each `heteroAgent/` directory deliberately:
+
+| Directory  | Inspect when                                                                | Do not assume                                           |
+| ---------- | --------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `tracing`  | CLI spawn, stdout protocol, stderr, exit, model/session identity            | exit code 0 means the run succeeded                     |
+| `bindings` | provider binding, isolated CLI HOME, auth/config, resume/profile corruption | every agent has a binding; native Amp commonly does not |
+| `runs`     | a live run or abnormal cleanup may have left temporary provider files       | an empty directory means no run occurred                |
+| `files`    | image/file download, MIME, attachment handoff, cache mismatch               | attachment bytes explain an unrelated runtime failure   |
+
+## Default Workflow
+
+### 1. Ground the target
+
+Accept one of:
+
+- `tpc_...`: preferred because it can connect LobeHub state to a native session;
+- a native session such as an Amp `T-...` thread;
+- a Desktop process-session UUID from `main.log` or a trace directory;
+- `latest`: the path in the active trace root's `.last-live-trace`.
+
+Confirm whether the user means an installed packaged app or a source development run. Check the running process and listening ports rather than guessing.
+
+### 2. Collect a redacted evidence index
+
+From the repository root, run:
+
+```bash
+TARGET='tpc_...'
+python3 .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py "$TARGET"
+```
+
+The script is read-only. It reports:
+
+- top-level `heteroAgent/` inventory;
+- topic status, provider, working directory, binding key, and native session IDs from the local SWR cache;
+- persisted assistant errors without message content;
+- matching trace metadata, process exit, terminal `result`, and stderr size;
+- focused `main.log` lines for matching sessions and nearby transport/proxy activity.
+
+Use `--storage-root` and `--log-file` when the app uses a non-default profile or another OS path:
+
+```bash
+TARGET='tpc_...'
+python3 .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py \
+  "$TARGET" \
+  --storage-root /path/to/lobehub-storage \
+  --log-file /path/to/main.log
+```
+
+If the script finds no trace, do not conclude that the run never happened. Check whether packaged tracing was enabled, whether the app used the dev trace root, and whether retention or cleanup removed the evidence.
+
+### 3. Build one timeline across evidence planes
+
+Correlate stable identifiers and timestamps in this order:
+
+```diagram
+┌─────────────┐    ┌──────────────────┐    ┌────────────────┐
+│ Lobe topic  │───▶│ Desktop session  │───▶│ Native session │
+│ tpc_...     │    │ UUID / operation │    │ T-... / CLI id │
+└──────┬──────┘    └────────┬─────────┘    └───────┬────────┘
+       │                    │                      │
+       ▼                    ▼                      ▼
+ local cache          main.log + trace       native history
+```
+
+Record separately:
+
+1. user action and topic status transition;
+2. process spawn args/cwd and process exit code;
+3. raw protocol terminal event and its `is_error`/subtype/message;
+4. persisted assistant error shown by LobeHub;
+5. nearby gateway, WebSocket, TLS, proxy, updater, or device events.
+
+Do not merge process success with protocol success. A CLI may exit 0 after correctly emitting `result.is_error: true`; the adapter should still mark the topic failed.
+
+### 4. Inspect the narrowest raw evidence
+
+For every matching trace, read in this order:
+
+1. `meta.json` — agent type, command, cwd, process/native session IDs, resume ID, safe environment key names;
+2. `exit.json` — OS process code and signal;
+3. terminal records from `stdout.jsonl` — `result`, error subtype, turn count, duration;
+4. focused raw events immediately before the terminal record;
+5. `stderr.log` only when non-empty.
+
+Avoid dumping entire JSONL files. Select event type, tool ID, stop reason, success flag, and terminal fields with `jq`, Python, or `rg`.
+
+### 5. Inspect native-agent history when available
+
+- Amp: use the `T-...` value from `agentSessionId`, `resumeSessionId`, or topic metadata to read the Amp thread. Distinguish tool-level failures from the CLI's terminal `result`.
+- Claude Code/Codex: inspect their isolated binding/session data only when auth, provider configuration, resume continuity, or native history is the suspected boundary. Start from filenames, schemas, and selected structural fields; do not dump profiles or transcripts.
+- Other agents: use their trace protocol and driver source. Do not force Claude/Codex assumptions onto ACP or other runtimes.
+
+### 6. Classify the first failed boundary
+
+Use the earliest category supported by evidence:
+
+| Boundary           | Evidence examples                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| Launch/preflight   | binary missing, cwd invalid, spawn error, nonzero exit before protocol init          |
+| Provider binding   | missing endpoint/key reference, incompatible protocol, isolated profile/config error |
+| External transport | WebSocket 1006, TLS reset, DNS/proxy failure, upstream connection termination        |
+| Native agent/model | terminal provider error, quota/auth/model rejection, native thread error             |
+| Adapter/protocol   | valid raw event misclassified, missing required terminal event, wrong tool mapping   |
+| Persistence/UI     | adapted terminal is correct but message error/topic status/tool rows are wrong       |
+| Attachment handoff | cached file missing, MIME mismatch, upload/download failure                          |
+
+Treat later failures as consequences unless they independently explain the user-visible symptom. For example, a tool's bad `sed` path is not the root cause of a later inference connection reset.
+
+### 7. Explain the source path only after classification
+
+Once the first failed boundary is known, follow the exact source symbols that transform it:
+
+1. Desktop spawn and trace recorder;
+2. agent adapter terminal conversion;
+3. renderer heterogeneous executor and error persistence;
+4. topic/message state displayed by the UI.
+
+Show why an apparently contradictory state is expected or buggy—for example, process exit 0 versus `result.is_error: true`. Do not browse every driver before knowing which agent and boundary failed.
+
+### 8. Report facts, inference, and next action separately
+
+Return a compact diagnosis containing:
+
+- target topic and correlated session IDs;
+- chronological failure timeline;
+- exact terminal error and first failed boundary;
+- why LobeHub displayed the observed status;
+- root cause with confidence level;
+- secondary/non-causal errors explicitly excluded;
+- safest next action and whether it changes state or incurs model usage.
+
+If evidence is incomplete, state the missing artifact and make the conclusion conditional. Do not manufacture certainty from a UI screenshot or process exit code alone.
+
+## Handoff to Implementation
+
+When the evidence demonstrates a LobeHub source defect, load `heterogeneous-agent`, add a regression test at the earliest incorrect layer, implement the smallest fix, and verify it. Keep this skill's evidence timeline as the bug's behavioral contract; do not continue broad incident archaeology after the source boundary is proven.

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Collect a redacted, read-only evidence index for a local LobeHub hetero-agent run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from collections import Counter
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterator
+
+
+DEFAULT_STORAGE_ROOT = (
+    Path.home() / "Library" / "Application Support" / "LobeHub" / "lobehub-storage"
+)
+DEFAULT_LOG_FILE = Path.home() / "Library" / "Logs" / "LobeHub" / "main.log"
+HETERO_DIRS = ("bindings", "files", "runs", "tracing")
+LOG_TIMESTAMP = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\]")
+LOG_SIGNAL = re.compile(
+    r"HeterogeneousAgent|GatewayConnection|NetworkProxy|networkProxy|WebSocket|TLS|proxy",
+    re.IGNORECASE,
+)
+SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b(authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|secret|key)"
+    r"(\s*[:=]\s*)([^\s,}]+)"
+)
+BEARER_TOKEN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+SPAWN_ARGUMENTS = re.compile(r"(Spawning agent:)\s+.*?(\s+\(cwd:.*\))$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read local LobeHub cache, hetero-agent traces, and Desktop logs without mutating them."
+    )
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default="latest",
+        help="LobeHub topic ID, native/Desktop session ID, or 'latest'",
+    )
+    parser.add_argument(
+        "--storage-root",
+        type=Path,
+        default=Path(os.environ.get("LOBEHUB_STORAGE_ROOT", DEFAULT_STORAGE_ROOT)),
+        help="Path containing local-database.sqlite3 and heteroAgent/",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=Path(os.environ.get("LOBEHUB_MAIN_LOG", DEFAULT_LOG_FILE)),
+        help="Path to the Desktop main.log",
+    )
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+
+
+def walk_json(value: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk_json(child)
+
+
+def redact_log_line(line: str) -> str:
+    line = SPAWN_ARGUMENTS.sub(r"\1 [command arguments omitted]\2", line)
+    line = BEARER_TOKEN.sub("Bearer [REDACTED]", line)
+    return SECRET_ASSIGNMENT.sub(lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", line)
+
+
+def safe_error_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return redact_log_line(value[:2_000])
+
+
+def summarize_error(value: Any) -> dict[str, Any] | str | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return redact_log_line(str(value)[:2_000])
+
+    body = value.get("body") if isinstance(value.get("body"), dict) else {}
+    details = body.get("details") if isinstance(body.get("details"), dict) else {}
+    safe_details = {
+        key: details[key]
+        for key in ("subtype", "numTurns", "durationMs", "sessionId", "expectedEventType")
+        if key in details
+    }
+    result = {
+        "type": value.get("type"),
+        "message": safe_error_text(value.get("message")),
+        "bodyError": safe_error_text(body.get("error")),
+        "bodyCode": body.get("code"),
+        "details": safe_details or None,
+    }
+    return {key: item for key, item in result.items() if item is not None}
+
+
+def collect_native_session_ids(value: Any) -> set[str]:
+    session_ids: set[str] = set()
+    for node in walk_json(value):
+        for key, item in node.items():
+            if key in {"heteroSessionId", "agentSessionId", "resumeSessionId", "sessionId"}:
+                if isinstance(item, str) and item:
+                    session_ids.add(item)
+            elif key == "heteroSessionIdByWorkingDirectory" and isinstance(item, dict):
+                session_ids.update(entry for entry in item.values() if isinstance(entry, str) and entry)
+    return session_ids
+
+
+def sqlite_read_only(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def collect_topic_cache(database: Path, topic_id: str) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "database": str(database),
+        "errors": [],
+        "messageCount": 0,
+        "messageRoles": {},
+        "nativeSessionIds": [],
+        "topic": None,
+    }
+    if not database.is_file():
+        result["readError"] = "local database not found"
+        return result
+
+    try:
+        with sqlite_read_only(database) as connection:
+            rows = connection.execute(
+                "SELECT value FROM local_records WHERE id LIKE ? OR value LIKE ?",
+                (f"%{topic_id}%", f"%{topic_id}%"),
+            ).fetchall()
+    except sqlite3.Error as error:
+        result["readError"] = str(error)
+        return result
+
+    topics: list[dict[str, Any]] = []
+    messages: dict[str, dict[str, Any]] = {}
+    native_ids: set[str] = set()
+    for (raw_value,) in rows:
+        try:
+            value = json.loads(raw_value)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        for node in walk_json(value):
+            if (
+                node.get("id") == topic_id
+                and node.get("role") is None
+                and any(key in node for key in ("provider", "status", "metadata"))
+            ):
+                topics.append(node)
+            if node.get("topicId") == topic_id and isinstance(node.get("id"), str):
+                messages[node["id"]] = node
+
+    topic = topics[-1] if topics else None
+    if topic:
+        native_ids.update(collect_native_session_ids(topic))
+        metadata = topic.get("metadata") if isinstance(topic.get("metadata"), dict) else {}
+        working_dirs = sorted(
+            {
+                value
+                for key, value in metadata.items()
+                if key == "workingDirectory" and isinstance(value, str)
+            }
+        )
+        by_dir = metadata.get("heteroSessionBindingKeyByWorkingDirectory")
+        binding_keys = (
+            sorted(value for value in by_dir.values() if isinstance(value, str))
+            if isinstance(by_dir, dict)
+            else []
+        )
+        result["topic"] = {
+            "id": topic_id,
+            "status": topic.get("status"),
+            "provider": topic.get("provider"),
+            "createdAt": topic.get("createdAt"),
+            "updatedAt": topic.get("updatedAt"),
+            "completedAt": topic.get("completedAt"),
+            "workingDirectories": working_dirs,
+            "bindingKeys": binding_keys,
+        }
+
+    role_counts = Counter(
+        message.get("role") for message in messages.values() if isinstance(message.get("role"), str)
+    )
+    persisted_errors = []
+    for message in messages.values():
+        native_ids.update(collect_native_session_ids(message))
+        if message.get("error") is None:
+            continue
+        persisted_errors.append(
+            {
+                "messageId": message.get("id"),
+                "role": message.get("role"),
+                "createdAt": message.get("createdAt"),
+                "updatedAt": message.get("updatedAt"),
+                "error": summarize_error(message.get("error")),
+            }
+        )
+
+    result["messageCount"] = len(messages)
+    result["messageRoles"] = dict(sorted(role_counts.items()))
+    result["errors"] = sorted(persisted_errors, key=lambda item: item.get("createdAt") or "")
+    result["nativeSessionIds"] = sorted(native_ids)
+    return result
+
+
+def collect_inventory(hetero_root: Path) -> dict[str, Any]:
+    inventory: dict[str, Any] = {"root": str(hetero_root)}
+    for name in HETERO_DIRS:
+        path = hetero_root / name
+        entry: dict[str, Any] = {"exists": path.is_dir(), "path": str(path)}
+        if path.is_dir():
+            try:
+                children = list(path.iterdir())
+                entry["entryCount"] = len(children)
+                entry["modifiedAt"] = datetime.fromtimestamp(path.stat().st_mtime).astimezone().isoformat()
+                if name == "bindings":
+                    entry["agentTypes"] = sorted(child.name for child in children if child.is_dir())
+                elif name == "files":
+                    entry["metadataFiles"] = sum(child.suffix == ".meta" for child in children)
+                elif name == "tracing":
+                    agent_types = {
+                        meta.get("agentType")
+                        for meta_path in path.rglob("meta.json")
+                        if isinstance((meta := read_json(meta_path)).get("agentType"), str)
+                    }
+                    entry["agentTypes"] = sorted(agent_types)
+            except OSError as error:
+                entry["readError"] = str(error)
+        inventory[name] = entry
+    return inventory
+
+
+def terminal_results(stdout_path: Path) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    try:
+        with stdout_path.open(encoding="utf-8", errors="replace") as stream:
+            for line_number, line in enumerate(stream, 1):
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict) or event.get("type") != "result":
+                    continue
+                results.append(
+                    {
+                        "line": line_number,
+                        "subtype": event.get("subtype"),
+                        "isError": event.get("is_error"),
+                        "error": safe_error_text(event.get("error")),
+                        "durationMs": event.get("duration_ms"),
+                        "numTurns": event.get("num_turns"),
+                        "sessionId": event.get("session_id"),
+                    }
+                )
+    except OSError:
+        pass
+    return results
+
+
+def is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def discover_trace_dirs(
+    trace_root: Path, target: str, identifiers: set[str]
+) -> list[Path]:
+    if not trace_root.is_dir():
+        return []
+
+    if target == "latest":
+        pointer = trace_root / ".last-live-trace"
+        try:
+            candidate = Path(pointer.read_text(encoding="utf-8").strip())
+        except OSError:
+            return []
+        return [candidate] if candidate.is_dir() and is_under(candidate, trace_root) else []
+
+    matches: list[Path] = []
+    needles = {target, *identifiers}
+    for meta_path in trace_root.rglob("meta.json"):
+        meta = read_json(meta_path)
+        searchable = [
+            str(meta_path.parent),
+            str(meta.get("sessionId") or ""),
+            str(meta.get("agentSessionId") or ""),
+            str(meta.get("resumeSessionId") or ""),
+            *(str(value) for value in meta.get("args", []) if isinstance(value, (str, int))),
+        ]
+        metadata_matches = any(
+            needle and any(needle in value for value in searchable) for needle in needles
+        )
+        stdout_path = meta_path.parent / str(meta.get("stdoutFile") or "stdout.jsonl")
+        terminal_session_ids = {
+            result["sessionId"]
+            for result in terminal_results(stdout_path)
+            if isinstance(result.get("sessionId"), str)
+        }
+        if metadata_matches or needles.intersection(terminal_session_ids):
+            matches.append(meta_path.parent)
+    return sorted(set(matches), key=str)
+
+
+def collect_trace(trace_dir: Path) -> dict[str, Any]:
+    meta = read_json(trace_dir / "meta.json")
+    exit_data = read_json(trace_dir / "exit.json")
+    stdout_path = trace_dir / str(meta.get("stdoutFile") or "stdout.jsonl")
+    stderr_path = trace_dir / str(meta.get("stderrFile") or "stderr.log")
+    try:
+        stderr_bytes = stderr_path.stat().st_size
+    except OSError:
+        stderr_bytes = None
+    return {
+        "directory": str(trace_dir),
+        "agentType": meta.get("agentType"),
+        "command": meta.get("command"),
+        "cwd": meta.get("cwd"),
+        "createdAt": meta.get("createdAt"),
+        "processSessionId": meta.get("sessionId"),
+        "agentSessionId": meta.get("agentSessionId"),
+        "resumeSessionId": meta.get("resumeSessionId"),
+        "argumentCount": len(meta.get("args", [])) if isinstance(meta.get("args"), list) else None,
+        "envKeys": sorted(meta.get("envKeys", [])) if isinstance(meta.get("envKeys"), list) else [],
+        "attachmentCount": len(meta.get("attachments", []))
+        if isinstance(meta.get("attachments"), list)
+        else None,
+        "exit": {
+            "code": exit_data.get("code"),
+            "signal": exit_data.get("signal"),
+            "finishedAt": exit_data.get("finishedAt"),
+        },
+        "terminalResults": terminal_results(stdout_path),
+        "stderrBytes": stderr_bytes,
+    }
+
+
+def parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.astimezone().replace(tzinfo=None) if parsed.tzinfo else parsed
+    except ValueError:
+        return None
+
+
+def collect_log_evidence(
+    log_file: Path, identifiers: set[str], traces: list[dict[str, Any]]
+) -> dict[str, Any]:
+    result: dict[str, Any] = {"path": str(log_file), "exactMatches": [], "nearbySignals": []}
+    if not log_file.is_file():
+        result["readError"] = "main log not found"
+        return result
+
+    times = [
+        parsed
+        for trace in traces
+        for parsed in (parse_iso(trace.get("createdAt")), parse_iso(trace.get("exit", {}).get("finishedAt")))
+        if parsed is not None
+    ]
+    window_start = min(times) - timedelta(minutes=5) if times else None
+    window_end = max(times) + timedelta(minutes=5) if times else None
+    exact_matches: list[dict[str, Any]] = []
+    nearby_signals: list[dict[str, Any]] = []
+
+    try:
+        with log_file.open(encoding="utf-8", errors="replace") as stream:
+            for line_number, raw_line in enumerate(stream, 1):
+                line = raw_line.rstrip("\n")
+                if any(identifier and identifier in line for identifier in identifiers):
+                    exact_matches.append({"line": line_number, "text": redact_log_line(line)})
+
+                if window_start is None or window_end is None or not LOG_SIGNAL.search(line):
+                    continue
+                match = LOG_TIMESTAMP.match(line)
+                if not match:
+                    continue
+                try:
+                    timestamp = datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S.%f")
+                except ValueError:
+                    continue
+                if window_start <= timestamp <= window_end:
+                    nearby_signals.append({"line": line_number, "text": redact_log_line(line)})
+    except OSError as error:
+        result["readError"] = str(error)
+        return result
+
+    result["exactMatches"] = exact_matches[-200:]
+    result["nearbySignals"] = nearby_signals[-300:]
+    result["truncated"] = len(exact_matches) > 200 or len(nearby_signals) > 300
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    storage_root = args.storage_root.expanduser()
+    hetero_root = storage_root / "heteroAgent"
+    trace_root = hetero_root / "tracing"
+    target = args.target.strip()
+    if not target:
+        print("target must not be empty", file=sys.stderr)
+        return 2
+
+    topic_cache: dict[str, Any] | None = None
+    identifiers = set() if target == "latest" else {target}
+    if target.startswith("tpc_"):
+        topic_cache = collect_topic_cache(storage_root / "local-database.sqlite3", target)
+        identifiers.update(topic_cache.get("nativeSessionIds", []))
+
+    trace_dirs = discover_trace_dirs(trace_root, target, identifiers)
+    traces = [collect_trace(trace_dir) for trace_dir in trace_dirs]
+    for trace in traces:
+        identifiers.update(
+            value
+            for value in (
+                trace.get("processSessionId"),
+                trace.get("agentSessionId"),
+                trace.get("resumeSessionId"),
+            )
+            if isinstance(value, str) and value
+        )
+
+    report = {
+        "target": target,
+        "generatedAt": datetime.now().astimezone().isoformat(),
+        "readOnly": True,
+        "inventory": collect_inventory(hetero_root),
+        "topicCache": topic_cache,
+        "traces": traces,
+        "mainLog": collect_log_evidence(args.log_file.expanduser(), identifiers, traces),
+        "privacy": {
+            "omitted": [
+                "message content",
+                "stdin content",
+                "tool output",
+                "attachment bytes",
+                "binding profile content",
+                "environment values",
+            ]
+        },
+    }
+    json.dump(report, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py
@@ -49,6 +49,13 @@ def parse_args() -> argparse.Namespace:
         default=Path(os.environ.get("LOBEHUB_STORAGE_ROOT", DEFAULT_STORAGE_ROOT)),
         help="Path containing local-database.sqlite3 and heteroAgent/",
     )
+    trace_root = os.environ.get("LOBEHUB_HETERO_TRACE_ROOT")
+    parser.add_argument(
+        "--trace-root",
+        type=Path,
+        default=Path(trace_root) if trace_root else None,
+        help="Override the trace directory, for example <cwd>/.heerogeneous-tracing in development",
+    )
     parser.add_argument(
         "--log-file",
         type=Path,
@@ -86,6 +93,19 @@ def safe_error_text(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     return redact_log_line(value[:2_000])
+
+
+def safe_error_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        return safe_error_text(value)
+    if isinstance(value, list):
+        messages = [message for item in value if (message := safe_error_value(item))]
+        return safe_error_text("\n".join(messages)) if messages else None
+    if isinstance(value, dict):
+        for key in ("message", "error", "detail", "details", "reason"):
+            if message := safe_error_value(value.get(key)):
+                return message
+    return None
 
 
 def summarize_error(value: Any) -> dict[str, Any] | str | None:
@@ -129,6 +149,13 @@ def sqlite_read_only(path: Path) -> sqlite3.Connection:
     return connection
 
 
+def entity_freshness(value: dict[str, Any]) -> datetime:
+    for key in ("updatedAt", "completedAt", "createdAt"):
+        if timestamp := parse_iso(value.get(key)):
+            return timestamp
+    return datetime.min
+
+
 def collect_topic_cache(database: Path, topic_id: str) -> dict[str, Any]:
     result: dict[str, Any] = {
         "database": str(database),
@@ -145,14 +172,14 @@ def collect_topic_cache(database: Path, topic_id: str) -> dict[str, Any]:
     try:
         with sqlite_read_only(database) as connection:
             rows = connection.execute(
-                "SELECT value FROM local_records WHERE id LIKE ? OR value LIKE ?",
-                (f"%{topic_id}%", f"%{topic_id}%"),
+                "SELECT value FROM local_records WHERE instr(id, ?) > 0 OR instr(value, ?) > 0",
+                (topic_id, topic_id),
             ).fetchall()
     except sqlite3.Error as error:
         result["readError"] = str(error)
         return result
 
-    topics: list[dict[str, Any]] = []
+    topic: dict[str, Any] | None = None
     messages: dict[str, dict[str, Any]] = {}
     native_ids: set[str] = set()
     for (raw_value,) in rows:
@@ -166,11 +193,13 @@ def collect_topic_cache(database: Path, topic_id: str) -> dict[str, Any]:
                 and node.get("role") is None
                 and any(key in node for key in ("provider", "status", "metadata"))
             ):
-                topics.append(node)
+                if topic is None or entity_freshness(node) > entity_freshness(topic):
+                    topic = node
             if node.get("topicId") == topic_id and isinstance(node.get("id"), str):
-                messages[node["id"]] = node
+                existing = messages.get(node["id"])
+                if existing is None or entity_freshness(node) > entity_freshness(existing):
+                    messages[node["id"]] = node
 
-    topic = topics[-1] if topics else None
     if topic:
         native_ids.update(collect_native_session_ids(topic))
         metadata = topic.get("metadata") if isinstance(topic.get("metadata"), dict) else {}
@@ -223,10 +252,10 @@ def collect_topic_cache(database: Path, topic_id: str) -> dict[str, Any]:
     return result
 
 
-def collect_inventory(hetero_root: Path) -> dict[str, Any]:
+def collect_inventory(hetero_root: Path, trace_root: Path) -> dict[str, Any]:
     inventory: dict[str, Any] = {"root": str(hetero_root)}
     for name in HETERO_DIRS:
-        path = hetero_root / name
+        path = trace_root if name == "tracing" else hetero_root / name
         entry: dict[str, Any] = {"exists": path.is_dir(), "path": str(path)}
         if path.is_dir():
             try:
@@ -250,8 +279,27 @@ def collect_inventory(hetero_root: Path) -> dict[str, Any]:
     return inventory
 
 
-def terminal_results(stdout_path: Path) -> list[dict[str, Any]]:
+def event_session_ids(event: dict[str, Any]) -> list[str]:
+    session_ids: list[str] = []
+    for key in ("session_id", "thread_id", "sessionId", "sessionID"):
+        value = event.get(key)
+        if isinstance(value, str) and value and value not in session_ids:
+            session_ids.append(value)
+    return session_ids
+
+
+def terminal_error(event: dict[str, Any]) -> str | None:
+    if event.get("type") == "result":
+        candidates = (event.get("error"), event.get("result"), event.get("errors"))
+    else:
+        candidates = (event.get("message"), event.get("error"), event.get("result"))
+    return next((message for value in candidates if (message := safe_error_value(value))), None)
+
+
+def protocol_summary(stdout_path: Path) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
+    session_ids: set[str] = set()
+    current_session_id: str | None = None
     try:
         with stdout_path.open(encoding="utf-8", errors="replace") as stream:
             for line_number, line in enumerate(stream, 1):
@@ -259,22 +307,39 @@ def terminal_results(stdout_path: Path) -> list[dict[str, Any]]:
                     event = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if not isinstance(event, dict) or event.get("type") != "result":
+                if not isinstance(event, dict):
                     continue
+                event_type = event.get("type")
+                discovered_ids = event_session_ids(event)
+                session_ids.update(discovered_ids)
+                if event_type == "thread.started" and discovered_ids:
+                    current_session_id = discovered_ids[0]
+                elif current_session_id is None and discovered_ids:
+                    current_session_id = discovered_ids[0]
+
+                if event_type not in {"result", "error", "turn.failed", "turn.completed"}:
+                    continue
+                is_error = (
+                    bool(event.get("is_error"))
+                    if event_type == "result"
+                    else event_type in {"error", "turn.failed"}
+                )
+                event_session_id = discovered_ids[0] if discovered_ids else current_session_id
                 results.append(
                     {
                         "line": line_number,
-                        "subtype": event.get("subtype"),
-                        "isError": event.get("is_error"),
-                        "error": safe_error_text(event.get("error")),
+                        "eventType": event_type,
+                        "subtype": event.get("subtype") or event_type,
+                        "isError": is_error,
+                        "error": terminal_error(event) if is_error else None,
                         "durationMs": event.get("duration_ms"),
                         "numTurns": event.get("num_turns"),
-                        "sessionId": event.get("session_id"),
+                        "sessionId": event_session_id,
                     }
                 )
     except OSError:
         pass
-    return results
+    return {"streamSessionIds": sorted(session_ids), "terminalResults": results}
 
 
 def is_under(path: Path, root: Path) -> bool:
@@ -314,12 +379,8 @@ def discover_trace_dirs(
             needle and any(needle in value for value in searchable) for needle in needles
         )
         stdout_path = meta_path.parent / str(meta.get("stdoutFile") or "stdout.jsonl")
-        terminal_session_ids = {
-            result["sessionId"]
-            for result in terminal_results(stdout_path)
-            if isinstance(result.get("sessionId"), str)
-        }
-        if metadata_matches or needles.intersection(terminal_session_ids):
+        stream_session_ids = set(protocol_summary(stdout_path)["streamSessionIds"])
+        if metadata_matches or needles.intersection(stream_session_ids):
             matches.append(meta_path.parent)
     return sorted(set(matches), key=str)
 
@@ -333,6 +394,7 @@ def collect_trace(trace_dir: Path) -> dict[str, Any]:
         stderr_bytes = stderr_path.stat().st_size
     except OSError:
         stderr_bytes = None
+    protocol = protocol_summary(stdout_path)
     return {
         "directory": str(trace_dir),
         "agentType": meta.get("agentType"),
@@ -352,7 +414,8 @@ def collect_trace(trace_dir: Path) -> dict[str, Any]:
             "signal": exit_data.get("signal"),
             "finishedAt": exit_data.get("finishedAt"),
         },
-        "terminalResults": terminal_results(stdout_path),
+        "streamSessionIds": protocol["streamSessionIds"],
+        "terminalResults": protocol["terminalResults"],
         "stderrBytes": stderr_bytes,
     }
 
@@ -418,7 +481,7 @@ def main() -> int:
     args = parse_args()
     storage_root = args.storage_root.expanduser()
     hetero_root = storage_root / "heteroAgent"
-    trace_root = hetero_root / "tracing"
+    trace_root = args.trace_root.expanduser() if args.trace_root else hetero_root / "tracing"
     target = args.target.strip()
     if not target:
         print("target must not be empty", file=sys.stderr)
@@ -447,7 +510,7 @@ def main() -> int:
         "target": target,
         "generatedAt": datetime.now().astimezone().isoformat(),
         "readOnly": True,
-        "inventory": collect_inventory(hetero_root),
+        "inventory": collect_inventory(hetero_root, trace_root),
         "topicCache": topic_cache,
         "traces": traces,
         "mainLog": collect_log_evidence(args.log_file.expanduser(), identifiers, traces),

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sqlite3
 import sys
-from collections import Counter
+from collections import Counter, deque
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterator
@@ -30,7 +31,21 @@ SECRET_ASSIGNMENT = re.compile(
     r"(\s*[:=]\s*)([^\s,}]+)"
 )
 BEARER_TOKEN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+URL_USERINFO = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://)([^/@\s]+)@")
 SPAWN_ARGUMENTS = re.compile(r"(Spawning agent:)\s+.*?(\s+\(cwd:.*\))$")
+SESSION_ID_KEYS = {"session_id", "thread_id", "sessionId", "sessionID", "threadId"}
+STRUCTURAL_EVENT_KEYS = (
+    "type",
+    "subtype",
+    "method",
+    "status",
+    "sessionUpdate",
+    "stopReason",
+    "stop_reason",
+    "is_error",
+    "isError",
+)
+EVENT_TAIL_LIMIT = 100
 
 
 def parse_args() -> argparse.Namespace:
@@ -86,6 +101,7 @@ def walk_json(value: Any) -> Iterator[dict[str, Any]]:
 def redact_log_line(line: str) -> str:
     line = SPAWN_ARGUMENTS.sub(r"\1 [command arguments omitted]\2", line)
     line = BEARER_TOKEN.sub("Bearer [REDACTED]", line)
+    line = URL_USERINFO.sub(r"\1[REDACTED]@", line)
     return SECRET_ASSIGNMENT.sub(lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", line)
 
 
@@ -93,19 +109,6 @@ def safe_error_text(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     return redact_log_line(value[:2_000])
-
-
-def safe_error_value(value: Any) -> str | None:
-    if isinstance(value, str):
-        return safe_error_text(value)
-    if isinstance(value, list):
-        messages = [message for item in value if (message := safe_error_value(item))]
-        return safe_error_text("\n".join(messages)) if messages else None
-    if isinstance(value, dict):
-        for key in ("message", "error", "detail", "details", "reason"):
-            if message := safe_error_value(value.get(key)):
-                return message
-    return None
 
 
 def summarize_error(value: Any) -> dict[str, Any] | str | None:
@@ -151,7 +154,7 @@ def sqlite_read_only(path: Path) -> sqlite3.Connection:
 
 def entity_freshness(value: dict[str, Any]) -> datetime:
     for key in ("updatedAt", "completedAt", "createdAt"):
-        if timestamp := parse_iso(value.get(key)):
+        if timestamp := parse_timestamp(value.get(key)):
             return timestamp
     return datetime.min
 
@@ -247,7 +250,7 @@ def collect_topic_cache(database: Path, topic_id: str) -> dict[str, Any]:
 
     result["messageCount"] = len(messages)
     result["messageRoles"] = dict(sorted(role_counts.items()))
-    result["errors"] = sorted(persisted_errors, key=lambda item: item.get("createdAt") or "")
+    result["errors"] = sorted(persisted_errors, key=entity_freshness)
     result["nativeSessionIds"] = sorted(native_ids)
     return result
 
@@ -280,66 +283,70 @@ def collect_inventory(hetero_root: Path, trace_root: Path) -> dict[str, Any]:
 
 
 def event_session_ids(event: dict[str, Any]) -> list[str]:
-    session_ids: list[str] = []
-    for key in ("session_id", "thread_id", "sessionId", "sessionID"):
-        value = event.get(key)
-        if isinstance(value, str) and value and value not in session_ids:
-            session_ids.append(value)
-    return session_ids
-
-
-def terminal_error(event: dict[str, Any]) -> str | None:
-    if event.get("type") == "result":
-        candidates = (event.get("error"), event.get("result"), event.get("errors"))
-    else:
-        candidates = (event.get("message"), event.get("error"), event.get("result"))
-    return next((message for value in candidates if (message := safe_error_value(value))), None)
-
-
-def protocol_summary(stdout_path: Path) -> dict[str, Any]:
-    results: list[dict[str, Any]] = []
     session_ids: set[str] = set()
-    current_session_id: str | None = None
+    for node in walk_json(event):
+        session_ids.update(
+            value
+            for key, value in node.items()
+            if key in SESSION_ID_KEYS and isinstance(value, str) and value
+        )
+    return sorted(session_ids)
+
+
+def safe_structural_value(value: Any) -> bool | float | int | str | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return value
+    if isinstance(value, str) and value:
+        return redact_log_line(value[:120])
+    return None
+
+
+def stdout_summary(stdout_path: Path) -> dict[str, Any]:
+    event_tail: deque[dict[str, Any]] = deque(maxlen=EVENT_TAIL_LIMIT)
+    event_types: Counter[str] = Counter()
+    session_ids: set[str] = set()
+    json_event_count = 0
+    line_count = 0
+    non_json_line_count = 0
     try:
         with stdout_path.open(encoding="utf-8", errors="replace") as stream:
             for line_number, line in enumerate(stream, 1):
+                line_count = line_number
                 try:
                     event = json.loads(line)
                 except json.JSONDecodeError:
+                    non_json_line_count += 1
                     continue
                 if not isinstance(event, dict):
+                    non_json_line_count += 1
                     continue
-                event_type = event.get("type")
+                json_event_count += 1
                 discovered_ids = event_session_ids(event)
                 session_ids.update(discovered_ids)
-                if event_type == "thread.started" and discovered_ids:
-                    current_session_id = discovered_ids[0]
-                elif current_session_id is None and discovered_ids:
-                    current_session_id = discovered_ids[0]
 
-                if event_type not in {"result", "error", "turn.failed", "turn.completed"}:
-                    continue
-                is_error = (
-                    bool(event.get("is_error"))
-                    if event_type == "result"
-                    else event_type in {"error", "turn.failed"}
-                )
-                event_session_id = discovered_ids[0] if discovered_ids else current_session_id
-                results.append(
-                    {
-                        "line": line_number,
-                        "eventType": event_type,
-                        "subtype": event.get("subtype") or event_type,
-                        "isError": is_error,
-                        "error": terminal_error(event) if is_error else None,
-                        "durationMs": event.get("duration_ms"),
-                        "numTurns": event.get("num_turns"),
-                        "sessionId": event_session_id,
-                    }
-                )
+                event_type = safe_structural_value(event.get("type"))
+                event_method = safe_structural_value(event.get("method"))
+                event_types[str(event_type or event_method or "<untyped>")] += 1
+                signal: dict[str, Any] = {"line": line_number}
+                for key in STRUCTURAL_EVENT_KEYS:
+                    if (value := safe_structural_value(event.get(key))) is not None:
+                        signal[key] = value
+                if discovered_ids:
+                    signal["sessionIds"] = discovered_ids
+                event_tail.append(signal)
     except OSError:
         pass
-    return {"streamSessionIds": sorted(session_ids), "terminalResults": results}
+    return {
+        "eventTail": list(event_tail),
+        "eventTailTruncated": json_event_count > EVENT_TAIL_LIMIT,
+        "eventTypeCounts": dict(sorted(event_types.items())),
+        "jsonEventCount": json_event_count,
+        "lineCount": line_count,
+        "nonJsonLineCount": non_json_line_count,
+        "streamSessionIds": sorted(session_ids),
+    }
 
 
 def is_under(path: Path, root: Path) -> bool:
@@ -379,10 +386,22 @@ def discover_trace_dirs(
             needle and any(needle in value for value in searchable) for needle in needles
         )
         stdout_path = meta_path.parent / str(meta.get("stdoutFile") or "stdout.jsonl")
-        stream_session_ids = set(protocol_summary(stdout_path)["streamSessionIds"])
+        stream_session_ids = set(stdout_summary(stdout_path)["streamSessionIds"])
         if metadata_matches or needles.intersection(stream_session_ids):
             matches.append(meta_path.parent)
     return sorted(set(matches), key=str)
+
+
+def process_error_summary(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    value = read_json(path)
+    result = {
+        "message": safe_error_text(value.get("message")),
+        "name": safe_structural_value(value.get("name")),
+        "transport": safe_structural_value(value.get("transport")),
+    }
+    return {key: item for key, item in result.items() if item is not None}
 
 
 def collect_trace(trace_dir: Path) -> dict[str, Any]:
@@ -394,7 +413,7 @@ def collect_trace(trace_dir: Path) -> dict[str, Any]:
         stderr_bytes = stderr_path.stat().st_size
     except OSError:
         stderr_bytes = None
-    protocol = protocol_summary(stdout_path)
+    stdout = stdout_summary(stdout_path)
     return {
         "directory": str(trace_dir),
         "agentType": meta.get("agentType"),
@@ -413,14 +432,24 @@ def collect_trace(trace_dir: Path) -> dict[str, Any]:
             "code": exit_data.get("code"),
             "signal": exit_data.get("signal"),
             "finishedAt": exit_data.get("finishedAt"),
+            "transport": exit_data.get("transport"),
         },
-        "streamSessionIds": protocol["streamSessionIds"],
-        "terminalResults": protocol["terminalResults"],
+        "processError": process_error_summary(trace_dir / "process-error.json"),
+        "stdout": stdout,
+        "streamSessionIds": stdout["streamSessionIds"],
         "stderrBytes": stderr_bytes,
     }
 
 
-def parse_iso(value: Any) -> datetime | None:
+def parse_timestamp(value: Any) -> datetime | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        seconds = value / 1000 if abs(value) >= 100_000_000_000 else value
+        try:
+            return datetime.fromtimestamp(seconds)
+        except (OSError, OverflowError, ValueError):
+            return None
     if not isinstance(value, str) or not value:
         return None
     try:
@@ -441,7 +470,10 @@ def collect_log_evidence(
     times = [
         parsed
         for trace in traces
-        for parsed in (parse_iso(trace.get("createdAt")), parse_iso(trace.get("exit", {}).get("finishedAt")))
+        for parsed in (
+            parse_timestamp(trace.get("createdAt")),
+            parse_timestamp(trace.get("exit", {}).get("finishedAt")),
+        )
         if parsed is not None
     ]
     window_start = min(times) - timedelta(minutes=5) if times else None
@@ -498,11 +530,12 @@ def main() -> int:
     for trace in traces:
         identifiers.update(
             value
-            for value in (
+            for value in [
                 trace.get("processSessionId"),
                 trace.get("agentSessionId"),
                 trace.get("resumeSessionId"),
-            )
+                *trace.get("streamSessionIds", []),
+            ]
             if isinstance(value, str) and value
         )
 

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/test_collect_local_run.py
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/test_collect_local_run.py
@@ -28,144 +28,187 @@ def write_jsonl(path: Path, values: list[object]) -> None:
 
 
 class CollectLocalRunTest(unittest.TestCase):
-    def test_reads_claude_error_from_result(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            stdout_path = Path(directory) / 'stdout.jsonl'
-            write_jsonl(
-                stdout_path,
-                [
-                    {
-                        'is_error': True,
-                        'result': 'API Error: connection reset',
-                        'session_id': 'session-1',
-                        'subtype': 'error_during_execution',
-                        'type': 'result',
-                    },
-                ],
-            )
-
-            summary = collector.protocol_summary(stdout_path)
-
-        self.assertEqual(summary['terminalResults'][0]['error'], 'API Error: connection reset')
-
-    def test_reads_claude_error_from_errors_fallback(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            stdout_path = Path(directory) / 'stdout.jsonl'
-            write_jsonl(
-                stdout_path,
-                [
-                    {
-                        'errors': ['No conversation found with session ID: session-1'],
-                        'is_error': True,
-                        'result': '',
-                        'session_id': 'session-1',
-                        'subtype': 'error_during_execution',
-                        'type': 'result',
-                    },
-                ],
-            )
-
-            summary = collector.protocol_summary(stdout_path)
-
-        self.assertEqual(summary['streamSessionIds'], ['session-1'])
-        self.assertEqual(
-            summary['terminalResults'][0]['error'],
-            'No conversation found with session ID: session-1',
+    def test_redacts_credentials_embedded_in_urls(self) -> None:
+        value = collector.redact_log_line(
+            'Testing proxy with URL: socks5://alice:p%40ssword@127.0.0.1:7890'
         )
 
-    def test_reads_codex_sessions_and_terminal_events(self) -> None:
+        self.assertEqual(
+            value,
+            'Testing proxy with URL: socks5://[REDACTED]@127.0.0.1:7890',
+        )
+
+    def test_indexes_stdout_without_provider_terminal_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stdout_path = Path(directory) / 'stdout.jsonl'
+            write_jsonl(
+                stdout_path,
+                [
+                    {
+                        'is_error': True,
+                        'result': 'prompt and terminal content must stay omitted',
+                        'session_id': 'session-1',
+                        'subtype': 'error_during_execution',
+                        'type': 'result',
+                    },
+                    {'thread_id': 'thread-1', 'type': 'turn.failed'},
+                    {'type': 'agent_settled'},
+                    {'stopReason': 'end_turn', 'type': 'trae_prompt_completed'},
+                    {'type': 'step_finish'},
+                    {
+                        'method': 'session/update',
+                        'params': {
+                            'sessionId': 'nested-session',
+                            'update': {'sessionUpdate': 'response_completed'},
+                        },
+                    },
+                ],
+            )
+
+            summary = collector.stdout_summary(stdout_path)
+
+        self.assertEqual(
+            summary['eventTypeCounts'],
+            {
+                'agent_settled': 1,
+                'result': 1,
+                'session/update': 1,
+                'step_finish': 1,
+                'trae_prompt_completed': 1,
+                'turn.failed': 1,
+            },
+        )
+        self.assertEqual(summary['streamSessionIds'], ['nested-session', 'session-1', 'thread-1'])
+        self.assertNotIn('prompt and terminal content', json.dumps(summary))
+
+    def test_discovers_trace_from_nested_native_session(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             trace_root = Path(directory)
-            trace_dir = trace_root / 'codex' / 'trace-1'
+            trace_dir = trace_root / 'cursor' / 'trace-1'
             trace_dir.mkdir(parents=True)
             write_json(
                 trace_dir / 'meta.json',
-                {'agentType': 'codex', 'stdoutFile': 'stdout.jsonl'},
+                {'agentType': 'cursor', 'stdoutFile': 'stdout.jsonl'},
             )
             write_jsonl(
                 trace_dir / 'stdout.jsonl',
                 [
-                    {'thread_id': 'thread-1', 'type': 'thread.started'},
-                    {'message': 'Reconnecting... 1/1', 'type': 'error'},
-                    {'error': {'message': 'Service unavailable'}, 'type': 'turn.failed'},
+                    {
+                        'method': 'session/update',
+                        'params': {'session': {'sessionId': 'nested-session'}},
+                    },
                 ],
             )
 
-            matches = collector.discover_trace_dirs(trace_root, 'thread-1', {'thread-1'})
-            summary = collector.protocol_summary(trace_dir / 'stdout.jsonl')
+            matches = collector.discover_trace_dirs(
+                trace_root, 'nested-session', {'nested-session'}
+            )
 
         self.assertEqual(matches, [trace_dir])
-        self.assertEqual(summary['streamSessionIds'], ['thread-1'])
-        self.assertEqual(
-            [result['eventType'] for result in summary['terminalResults']],
-            ['error', 'turn.failed'],
-        )
-        self.assertEqual(summary['terminalResults'][-1]['error'], 'Service unavailable')
-        self.assertTrue(all(result['sessionId'] == 'thread-1' for result in summary['terminalResults']))
 
     def test_selects_newest_topic_and_message_entities(self) -> None:
         topic_id = 'tpc_test'
         message_id = 'msg_test'
+        timestamps = (
+            (
+                'ISO strings',
+                '2026-01-01T00:00:00.000Z',
+                '2026-01-02T00:00:00.000Z',
+                '2026-01-03T00:00:00.000Z',
+            ),
+            ('epoch milliseconds', 1_767_225_600_000, 1_767_312_000_000, 1_767_398_400_000),
+        )
+        for label, created_at, stale_at, newest_at in timestamps:
+            with self.subTest(timestamp_type=label), tempfile.TemporaryDirectory() as directory:
+                database = Path(directory) / 'local-database.sqlite3'
+                with sqlite3.connect(database) as connection:
+                    connection.execute(
+                        'CREATE TABLE local_records (id TEXT PRIMARY KEY, value TEXT NOT NULL)'
+                    )
+                    newest = {
+                        'json': {
+                            'data': {
+                                'createdAt': created_at,
+                                'id': topic_id,
+                                'metadata': {'heteroSessionId': 'session-new'},
+                                'provider': 'codex',
+                                'status': 'failed',
+                                'updatedAt': newest_at,
+                            },
+                            'messages': [
+                                {
+                                    'createdAt': created_at,
+                                    'error': {'message': 'new error'},
+                                    'id': message_id,
+                                    'role': 'assistant',
+                                    'topicId': topic_id,
+                                    'updatedAt': newest_at,
+                                },
+                            ],
+                        },
+                        'meta': {'v': 1},
+                    }
+                    stale = {
+                        'json': {
+                            'data': {
+                                'createdAt': created_at,
+                                'id': topic_id,
+                                'metadata': {'heteroSessionId': 'session-old'},
+                                'provider': 'codex',
+                                'status': 'processing',
+                                'updatedAt': stale_at,
+                            },
+                            'messages': [
+                                {
+                                    'createdAt': created_at,
+                                    'error': {'message': 'old error'},
+                                    'id': message_id,
+                                    'role': 'assistant',
+                                    'topicId': topic_id,
+                                    'updatedAt': stale_at,
+                                },
+                            ],
+                        },
+                        'meta': {'v': 1},
+                    }
+                    connection.executemany(
+                        'INSERT INTO local_records (id, value) VALUES (?, ?)',
+                        [('new-first', json.dumps(newest)), ('stale-last', json.dumps(stale))],
+                    )
+
+                result = collector.collect_topic_cache(database, topic_id)
+
+            self.assertEqual(result['topic']['status'], 'failed')
+            self.assertEqual(result['nativeSessionIds'], ['session-new'])
+            self.assertEqual(result['errors'][0]['error']['message'], 'new error')
+
+    def test_collects_redacted_process_error(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            database = Path(directory) / 'local-database.sqlite3'
-            with sqlite3.connect(database) as connection:
-                connection.execute('CREATE TABLE local_records (id TEXT PRIMARY KEY, value TEXT NOT NULL)')
-                newest = {
-                    'json': {
-                        'data': {
-                            'createdAt': '2026-01-01T00:00:00.000Z',
-                            'id': topic_id,
-                            'metadata': {'heteroSessionId': 'session-new'},
-                            'provider': 'codex',
-                            'status': 'failed',
-                            'updatedAt': '2026-01-03T00:00:00.000Z',
-                        },
-                        'messages': [
-                            {
-                                'createdAt': '2026-01-01T00:00:00.000Z',
-                                'error': {'message': 'new error'},
-                                'id': message_id,
-                                'role': 'assistant',
-                                'topicId': topic_id,
-                                'updatedAt': '2026-01-03T00:00:00.000Z',
-                            },
-                        ],
-                    },
-                    'meta': {'v': 1},
-                }
-                stale = {
-                    'json': {
-                        'data': {
-                            'createdAt': '2026-01-01T00:00:00.000Z',
-                            'id': topic_id,
-                            'metadata': {'heteroSessionId': 'session-old'},
-                            'provider': 'codex',
-                            'status': 'processing',
-                            'updatedAt': '2026-01-02T00:00:00.000Z',
-                        },
-                        'messages': [
-                            {
-                                'createdAt': '2026-01-01T00:00:00.000Z',
-                                'error': {'message': 'old error'},
-                                'id': message_id,
-                                'role': 'assistant',
-                                'topicId': topic_id,
-                                'updatedAt': '2026-01-02T00:00:00.000Z',
-                            },
-                        ],
-                    },
-                    'meta': {'v': 1},
-                }
-                connection.executemany(
-                    'INSERT INTO local_records (id, value) VALUES (?, ?)',
-                    [('new-first', json.dumps(newest)), ('stale-last', json.dumps(stale))],
-                )
+            trace_dir = Path(directory)
+            write_json(
+                trace_dir / 'meta.json',
+                {'agentType': 'claude-code', 'stdoutFile': 'stdout.jsonl'},
+            )
+            write_json(
+                trace_dir / 'process-error.json',
+                {
+                    'message': 'connect socks5://alice:secret@127.0.0.1:7890 failed',
+                    'name': 'Error',
+                    'transport': 'claude-sdk',
+                },
+            )
+            (trace_dir / 'stdout.jsonl').write_text('', encoding='utf-8')
 
-            result = collector.collect_topic_cache(database, topic_id)
+            result = collector.collect_trace(trace_dir)
 
-        self.assertEqual(result['topic']['status'], 'failed')
-        self.assertEqual(result['nativeSessionIds'], ['session-new'])
-        self.assertEqual(result['errors'][0]['error']['message'], 'new error')
+        self.assertEqual(
+            result['processError'],
+            {
+                'message': 'connect socks5://[REDACTED]@127.0.0.1:7890 failed',
+                'name': 'Error',
+                'transport': 'claude-sdk',
+            },
+        )
 
     def test_main_accepts_development_trace_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -196,6 +239,8 @@ class CollectLocalRunTest(unittest.TestCase):
                     },
                 ],
             )
+            log_file = root / 'main.log'
+            log_file.write_text('native session session-1 completed\n', encoding='utf-8')
 
             output = io.StringIO()
             argv = [
@@ -206,7 +251,7 @@ class CollectLocalRunTest(unittest.TestCase):
                 '--trace-root',
                 str(trace_root),
                 '--log-file',
-                str(root / 'missing.log'),
+                str(log_file),
             ]
             with mock.patch.object(sys, 'argv', argv), contextlib.redirect_stdout(output):
                 exit_code = collector.main()
@@ -216,6 +261,10 @@ class CollectLocalRunTest(unittest.TestCase):
         self.assertEqual(report['inventory']['tracing']['path'], str(trace_root))
         self.assertEqual(len(report['traces']), 1)
         self.assertEqual(report['traces'][0]['streamSessionIds'], ['session-1'])
+        self.assertEqual(
+            report['mainLog']['exactMatches'],
+            [{'line': 1, 'text': 'native session session-1 completed'}],
+        )
 
 
 if __name__ == '__main__':

--- a/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/test_collect_local_run.py
+++ b/.agents/skills/diagnosing-heterogeneous-agent-runs/scripts/test_collect_local_run.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name('collect-local-run.py')
+SPEC = importlib.util.spec_from_file_location('collect_local_run', SCRIPT_PATH)
+assert SPEC and SPEC.loader
+collector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(collector)
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value), encoding='utf-8')
+
+
+def write_jsonl(path: Path, values: list[object]) -> None:
+    path.write_text('\n'.join(json.dumps(value) for value in values) + '\n', encoding='utf-8')
+
+
+class CollectLocalRunTest(unittest.TestCase):
+    def test_reads_claude_error_from_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stdout_path = Path(directory) / 'stdout.jsonl'
+            write_jsonl(
+                stdout_path,
+                [
+                    {
+                        'is_error': True,
+                        'result': 'API Error: connection reset',
+                        'session_id': 'session-1',
+                        'subtype': 'error_during_execution',
+                        'type': 'result',
+                    },
+                ],
+            )
+
+            summary = collector.protocol_summary(stdout_path)
+
+        self.assertEqual(summary['terminalResults'][0]['error'], 'API Error: connection reset')
+
+    def test_reads_claude_error_from_errors_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stdout_path = Path(directory) / 'stdout.jsonl'
+            write_jsonl(
+                stdout_path,
+                [
+                    {
+                        'errors': ['No conversation found with session ID: session-1'],
+                        'is_error': True,
+                        'result': '',
+                        'session_id': 'session-1',
+                        'subtype': 'error_during_execution',
+                        'type': 'result',
+                    },
+                ],
+            )
+
+            summary = collector.protocol_summary(stdout_path)
+
+        self.assertEqual(summary['streamSessionIds'], ['session-1'])
+        self.assertEqual(
+            summary['terminalResults'][0]['error'],
+            'No conversation found with session ID: session-1',
+        )
+
+    def test_reads_codex_sessions_and_terminal_events(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            trace_root = Path(directory)
+            trace_dir = trace_root / 'codex' / 'trace-1'
+            trace_dir.mkdir(parents=True)
+            write_json(
+                trace_dir / 'meta.json',
+                {'agentType': 'codex', 'stdoutFile': 'stdout.jsonl'},
+            )
+            write_jsonl(
+                trace_dir / 'stdout.jsonl',
+                [
+                    {'thread_id': 'thread-1', 'type': 'thread.started'},
+                    {'message': 'Reconnecting... 1/1', 'type': 'error'},
+                    {'error': {'message': 'Service unavailable'}, 'type': 'turn.failed'},
+                ],
+            )
+
+            matches = collector.discover_trace_dirs(trace_root, 'thread-1', {'thread-1'})
+            summary = collector.protocol_summary(trace_dir / 'stdout.jsonl')
+
+        self.assertEqual(matches, [trace_dir])
+        self.assertEqual(summary['streamSessionIds'], ['thread-1'])
+        self.assertEqual(
+            [result['eventType'] for result in summary['terminalResults']],
+            ['error', 'turn.failed'],
+        )
+        self.assertEqual(summary['terminalResults'][-1]['error'], 'Service unavailable')
+        self.assertTrue(all(result['sessionId'] == 'thread-1' for result in summary['terminalResults']))
+
+    def test_selects_newest_topic_and_message_entities(self) -> None:
+        topic_id = 'tpc_test'
+        message_id = 'msg_test'
+        with tempfile.TemporaryDirectory() as directory:
+            database = Path(directory) / 'local-database.sqlite3'
+            with sqlite3.connect(database) as connection:
+                connection.execute('CREATE TABLE local_records (id TEXT PRIMARY KEY, value TEXT NOT NULL)')
+                newest = {
+                    'json': {
+                        'data': {
+                            'createdAt': '2026-01-01T00:00:00.000Z',
+                            'id': topic_id,
+                            'metadata': {'heteroSessionId': 'session-new'},
+                            'provider': 'codex',
+                            'status': 'failed',
+                            'updatedAt': '2026-01-03T00:00:00.000Z',
+                        },
+                        'messages': [
+                            {
+                                'createdAt': '2026-01-01T00:00:00.000Z',
+                                'error': {'message': 'new error'},
+                                'id': message_id,
+                                'role': 'assistant',
+                                'topicId': topic_id,
+                                'updatedAt': '2026-01-03T00:00:00.000Z',
+                            },
+                        ],
+                    },
+                    'meta': {'v': 1},
+                }
+                stale = {
+                    'json': {
+                        'data': {
+                            'createdAt': '2026-01-01T00:00:00.000Z',
+                            'id': topic_id,
+                            'metadata': {'heteroSessionId': 'session-old'},
+                            'provider': 'codex',
+                            'status': 'processing',
+                            'updatedAt': '2026-01-02T00:00:00.000Z',
+                        },
+                        'messages': [
+                            {
+                                'createdAt': '2026-01-01T00:00:00.000Z',
+                                'error': {'message': 'old error'},
+                                'id': message_id,
+                                'role': 'assistant',
+                                'topicId': topic_id,
+                                'updatedAt': '2026-01-02T00:00:00.000Z',
+                            },
+                        ],
+                    },
+                    'meta': {'v': 1},
+                }
+                connection.executemany(
+                    'INSERT INTO local_records (id, value) VALUES (?, ?)',
+                    [('new-first', json.dumps(newest)), ('stale-last', json.dumps(stale))],
+                )
+
+            result = collector.collect_topic_cache(database, topic_id)
+
+        self.assertEqual(result['topic']['status'], 'failed')
+        self.assertEqual(result['nativeSessionIds'], ['session-new'])
+        self.assertEqual(result['errors'][0]['error']['message'], 'new error')
+
+    def test_main_accepts_development_trace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            storage_root = root / 'storage'
+            trace_root = root / '.heerogeneous-tracing'
+            trace_dir = trace_root / 'amp' / 'trace-1'
+            trace_dir.mkdir(parents=True)
+            (trace_root / '.last-live-trace').write_text(str(trace_dir), encoding='utf-8')
+            write_json(
+                trace_dir / 'meta.json',
+                {
+                    'agentType': 'amp',
+                    'createdAt': '2026-01-01T00:00:00.000Z',
+                    'sessionId': 'process-1',
+                    'stdoutFile': 'stdout.jsonl',
+                },
+            )
+            write_json(trace_dir / 'exit.json', {'code': 0})
+            write_jsonl(
+                trace_dir / 'stdout.jsonl',
+                [
+                    {
+                        'is_error': False,
+                        'session_id': 'session-1',
+                        'subtype': 'success',
+                        'type': 'result',
+                    },
+                ],
+            )
+
+            output = io.StringIO()
+            argv = [
+                str(SCRIPT_PATH),
+                'latest',
+                '--storage-root',
+                str(storage_root),
+                '--trace-root',
+                str(trace_root),
+                '--log-file',
+                str(root / 'missing.log'),
+            ]
+            with mock.patch.object(sys, 'argv', argv), contextlib.redirect_stdout(output):
+                exit_code = collector.main()
+            report = json.loads(output.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(report['inventory']['tracing']['path'], str(trace_root))
+        self.assertEqual(len(report['traces']), 1)
+        self.assertEqual(report['traces'][0]['streamSessionIds'], ['session-1'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description of Change

- Add an explicitly user-invoked skill for diagnosing local LobeHub Desktop heterogeneous-agent runs from topic IDs, native session IDs, process session IDs, or the latest trace.
- Correlate the local SWR cache, Desktop logs, all four `heteroAgent` artifact directories, CLI trace evidence, native-agent history, and source ownership boundaries.
- Keep provider protocol semantics in the existing TypeScript adapters: the Python collector now emits a provider-agnostic structural stdout index with event types, safe fields, line numbers, and recursively discovered session IDs instead of maintaining a second terminal-event allowlist.
- Include redacted `process-error.json` evidence for spawn, SDK, app-server, and ACP failures, plus transport metadata from `exit.json`.
- Select the newest duplicate topic/message entities from either ISO or numeric epoch timestamps, support development traces through `--trace-root`, and correlate discovered stream session IDs back to `main.log`.
- Redact credentials embedded in proxy URLs and omit prompts, stdin, tool output, attachments, binding contents, and environment values.
- Set `disable-model-invocation: true` so the workflow is loaded only when a user explicitly invokes it and does not add automatic context overhead.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation performed:

- `bun run check .agents/skills/diagnosing-heterogeneous-agent-runs/SKILL.md .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/collect-local-run.py .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/test_collect_local_run.py`
- `python3 .agents/skills/diagnosing-heterogeneous-agent-runs/scripts/test_collect_local_run.py -v` (6 tests)
- Ran the collector against the motivating Amp topic and verified the expected successful trace plus two failed traces and terminal structure.
- Verified the generic index against real local Amp, Claude Code, Codex, Grok Build ACP, and OpenCode traces.
- Verified nested native-session discovery, `process-error.json`, proxy URL redaction, mixed ISO/numeric timestamps, custom development trace roots, and native-session log correlation.

#### 🔗 Related Issue

No matching issue found.
