### PR TITLE
✨ feat(task): let scoped task pages switch between tasks and schedules

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.test.ts
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.test.ts
@@ -105,5 +105,20 @@ describe('AgentTasksPage', () => {
         showViewOptions: true,
       });
     });
+
+    it('keeps the breadcrumb for a project scope and drops it for the global list', () => {
+      expect(
+        getTaskPageHeaderVisibility({ isEmptyHero: false, isMobile: false, projectId: 'p-1' }),
+      ).toEqual({
+        showBreadcrumb: true,
+        showTaskAgentPanelToggle: true,
+        showViewOptions: true,
+      });
+      expect(getTaskPageHeaderVisibility({ isEmptyHero: false, isMobile: false })).toEqual({
+        showBreadcrumb: false,
+        showTaskAgentPanelToggle: true,
+        showViewOptions: true,
+      });
+    });
   });
 });

--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
@@ -55,17 +55,22 @@ interface TaskPageHeaderVisibilityParams {
   agentId?: string;
   isEmptyHero: boolean;
   isMobile: boolean;
+  projectId?: string;
 }
 
 export const getTaskPageHeaderVisibility = ({
   agentId,
   isEmptyHero,
   isMobile,
+  projectId,
 }: TaskPageHeaderVisibilityParams) => {
-  const isGlobalEmpty = !agentId && isEmptyHero;
+  // The global page's own crumb is the `tasks` tab, so the breadcrumb only
+  // earns its place once the list is scoped to an agent or a project.
+  const isScoped = !!(agentId || projectId);
+  const isGlobalEmpty = !isScoped && isEmptyHero;
 
   return {
-    showBreadcrumb: !isGlobalEmpty,
+    showBreadcrumb: isScoped,
     showTaskAgentPanelToggle: !isGlobalEmpty && shouldRenderTaskAgentPanelToggle(isMobile),
     showViewOptions: !isGlobalEmpty,
   };
@@ -108,16 +113,17 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId, projectId }) => {
   const viewMode = useGlobalStore(systemStatusSelectors.taskListViewMode);
   const [searchParams, setSearchParams] = useSearchParams();
   const [scheduledPage, setScheduledPage] = useState(1);
-  const canSwitchCollection = !agentId && !projectId;
-  const collection = canSwitchCollection ? resolveTaskCollection(searchParams) : 'tasks';
-  const isScheduledCollection = canSwitchCollection && collection === 'scheduled';
+  const collection = resolveTaskCollection(searchParams);
+  const isScheduledCollection = collection === 'scheduled';
   const useFetchTaskList = useTaskStore((s) => s.useFetchTaskList);
   // Keep the SWR handle only for `error` + `mutate` (the error/Retry state).
+  // Every scope splits automated work out of the ordinary tab — it is the
+  // scheduled tab's content, and listing it twice makes the split meaningless.
   const { error, isLoading, mutate } = useFetchTaskList(
     projectId
-      ? { projectId, visibility: 'all' }
+      ? { automated: false, projectId, visibility: 'all' }
       : agentId
-        ? { agentId }
+        ? { agentId, automated: false }
         : { allAgents: true, automated: false },
   );
   // Drive the loading/empty boundary off the store's own init flag, NOT SWR's
@@ -133,9 +139,11 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId, projectId }) => {
   const isEmptyHero = useTaskStore(taskListSelectors.isListEmpty);
   const useFetchScheduledTaskList = useTaskStore((s) => s.useFetchScheduledTaskList);
   const scheduledSWR = useFetchScheduledTaskList({
+    agentId,
     enabled: isScheduledCollection,
     limit: SCHEDULED_TASK_PAGE_SIZE,
     offset: (scheduledPage - 1) * SCHEDULED_TASK_PAGE_SIZE,
+    projectId,
   });
   const scheduledTasks = scheduledSWR.data?.data ?? [];
   const scheduledTasksTotal = scheduledSWR.data?.total ?? 0;
@@ -219,24 +227,26 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId, projectId }) => {
     agentId,
     isEmptyHero: isScheduledCollection ? false : isEmptyHero,
     isMobile,
+    projectId,
   });
 
-  const collectionTabs = canSwitchCollection ? (
-    <TabsRoot size={'small'} value={collection} onValueChange={handleCollectionChange}>
-      <TabsList>
-        <TabsIndicator />
-        <TabsTab value={'tasks'}>{t('taskList.title')}</TabsTab>
-        <TabsTab value={'scheduled'}>{t('taskList.scheduled.title')}</TabsTab>
-      </TabsList>
-    </TabsRoot>
-  ) : (
-    <Breadcrumb />
+  const headerLeft = (
+    <Flexbox horizontal align={'center'} gap={8}>
+      {headerVisibility.showBreadcrumb && <Breadcrumb />}
+      <TabsRoot size={'small'} value={collection} onValueChange={handleCollectionChange}>
+        <TabsList>
+          <TabsIndicator />
+          <TabsTab value={'tasks'}>{t('taskList.title')}</TabsTab>
+          <TabsTab value={'scheduled'}>{t('taskList.scheduled.title')}</TabsTab>
+        </TabsList>
+      </TabsRoot>
+    </Flexbox>
   );
 
   return (
     <Flexbox flex={1} height={'100%'}>
       <NavHeader
-        left={headerVisibility.showBreadcrumb || canSwitchCollection ? collectionTabs : undefined}
+        left={headerLeft}
         right={
           <Flexbox horizontal align={'center'} gap={4}>
             {!isScheduledCollection && !agentId && !projectId && <TaskListVisibilityFilter />}

--- a/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
@@ -72,9 +72,9 @@ const KanbanBoard = memo<KanbanBoardProps>(({ agentId, options, projectId, route
   // Keep the SWR handle only for `error` + `mutate` (the error/Retry state).
   const { error, isLoading, isQueryScopeCurrent, mutate } = useFetchTaskGroupList(
     projectId
-      ? { excludeStatuses, groupBy, projectId }
+      ? { automated: false, excludeStatuses, groupBy, projectId }
       : agentId
-        ? { agentId, excludeStatuses, groupBy }
+        ? { agentId, automated: false, excludeStatuses, groupBy }
         : { allAgents: true, automated: false, excludeStatuses, groupBy },
   );
   // Drive the loading/empty boundary off the store's own init flag, NOT SWR's

--- a/src/store/task/slices/list/action.test.ts
+++ b/src/store/task/slices/list/action.test.ts
@@ -341,6 +341,42 @@ describe('TaskListSliceAction', () => {
       );
     });
 
+    it('scopes the scheduled roll-up to one agent, key included', async () => {
+      const { useClientDataSWR } = await import('@/libs/swr');
+      const { taskService } = await import('@/services/task');
+
+      useTaskStore.getState().useFetchScheduledTaskList({ agentId: 'agent-1', limit: 50 });
+
+      expect(useClientDataSWR).toHaveBeenCalledWith(
+        ['task:scheduledList', 'agent-1', 'all', { limit: 50, offset: undefined }],
+        expect.any(Function),
+        expect.any(Object),
+      );
+      const fetcher = vi.mocked(useClientDataSWR).mock.calls[0][1] as () => Promise<unknown>;
+      await fetcher();
+      expect(taskService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ assigneeAgentId: 'agent-1', automated: true }),
+      );
+    });
+
+    it('scopes the scheduled roll-up to one project, key included', async () => {
+      const { useClientDataSWR } = await import('@/libs/swr');
+      const { taskService } = await import('@/services/task');
+
+      useTaskStore.getState().useFetchScheduledTaskList({ limit: 50, projectId: 'project-1' });
+
+      expect(useClientDataSWR).toHaveBeenCalledWith(
+        ['task:scheduledList', '__project__:project-1', 'all', { limit: 50, offset: undefined }],
+        expect.any(Function),
+        expect.any(Object),
+      );
+      const fetcher = vi.mocked(useClientDataSWR).mock.calls[0][1] as () => Promise<unknown>;
+      await fetcher();
+      expect(taskService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ automated: true, projectId: 'project-1' }),
+      );
+    });
+
     it('keeps concurrent consumers isolated by their SWR keys', async () => {
       const { useClientDataSWR } = await import('@/libs/swr');
 

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -278,18 +278,31 @@ export class TaskListSliceActionImpl {
   };
 
   /**
-   * The automated-task roll-up behind Home's "Scheduled" section. Each caller
-   * consumes its own SWR result because Home and the paginated Tasks page can
-   * coexist in Electron with different limits and offsets.
+   * The automated-task roll-up behind Home's "Scheduled" section and the Tasks
+   * page's scheduled tab. Each caller consumes its own SWR result because Home
+   * and the paginated Tasks page can coexist in Electron with different limits
+   * and offsets. `agentId`/`projectId` narrow the roll-up to the scoped Tasks
+   * page; they are part of the key so an agent's schedules never render under
+   * another scope.
    */
   useFetchScheduledTaskList = (
-    options: { enabled?: boolean; limit?: number; offset?: number } = {},
+    options: {
+      agentId?: string;
+      enabled?: boolean;
+      limit?: number;
+      offset?: number;
+      projectId?: string;
+    } = {},
   ) => {
-    const { enabled = true, limit, offset } = options;
+    const { agentId, enabled = true, limit, offset, projectId } = options;
+    const scopeKey = projectId
+      ? `${PROJECT_LIST_KEY_PREFIX}${projectId}`
+      : (agentId ?? ALL_AGENTS_LIST_KEY);
     return useClientDataSWR(
-      enabled ? taskKeys.scheduledList(ALL_AGENTS_LIST_KEY, 'all', limit, offset) : null,
+      enabled ? taskKeys.scheduledList(scopeKey, 'all', limit, offset) : null,
       async () =>
         this.fetchTaskList({
+          ...(projectId ? { projectId } : agentId ? { assigneeAgentId: agentId } : {}),
           automated: true,
           hasGoal: false,
           limit,


### PR DESCRIPTION
The tasks / scheduled switch only existed on the global `/tasks` page. An agent's task page (`/agent/:aid/tasks`) and a project's task page had no way to reach their schedules at all, and listed automated tasks inline with ordinary work.

This renders the same switch in every scope.

| Before | After |
| ------ | ----- |
| Agent task page: breadcrumb only, schedules mixed into the list | Agent task page: breadcrumb + `Tasks` / `Scheduled` tabs, schedules on their own tab |

**What changed**

- The collection tabs render in every scope, beside the breadcrumb the scoped pages keep for navigation (the global page has no meaningful breadcrumb — its own crumb *is* the tasks tab — so `getTaskPageHeaderVisibility` now derives `showBreadcrumb` from the scope, and takes `projectId` into account).
- `useFetchScheduledTaskList` accepts `agentId` / `projectId`: they reach the request as `assigneeAgentId` / `projectId` and are part of the SWR key, so one scope never renders another's schedules. Invalidation already matched by key root (`isScheduledTaskListKey`), so the new keys are covered.
- Automated tasks are filtered out of the ordinary list *and* the kanban in every scope. They are the scheduled tab's content now; listing them on both tabs would make the split meaningless. The global page already behaved this way.

No new i18n keys — `taskList.title` / `taskList.scheduled.*` already existed.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit tests: the scheduled roll-up keys and requests per agent and per project, and the header keeps the breadcrumb for a project scope while dropping it for the global list. `bun run check` — lint clean, 31 tests passed; full type-check shows nothing in the touched files.

#### 🔗 Related Issue

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)