### PR TITLE
✅ test(server): pin seeded message timestamps in execAgent topic-reuse case

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
@@ -173,6 +173,7 @@ describe('execAgent', () => {
         .values({
           agentId: testAgentId,
           content: 'Initial question',
+          createdAt: new Date('2024-01-01T00:00:00Z'),
           role: 'user',
           topicId: existingTopic.id,
           userId,
@@ -183,6 +184,7 @@ describe('execAgent', () => {
         .values({
           agentId: testAgentId,
           content: 'Initial answer',
+          createdAt: new Date('2024-01-01T00:00:01Z'),
           parentId: seedUserMessage.id,
           role: 'assistant',
           topicId: existingTopic.id,


### PR DESCRIPTION
## 问题

`execAgent.integration.test.ts` 的 `should reuse existing topic when topicId is provided` 偶发失败(本地约 1/3):

```
expected 'msg_T1yVkM220W84' to be 'msg_SKTJLGAaQIHV'
```

## 根因

用例先后 seed 一条 user 消息和一条 assistant 消息,两次 insert 落在同一毫秒时 `createdAt` 相同。`MessageModel.getLatestSpineMessageId` 只按 `createdAt desc` 排序、没有次序键,平局时可能把 user 消息当成最新 spine,follow-up 消息的 `parentId` 就指错了。

## 修复

给两条 seed 消息显式指定相差 1s 的 `createdAt`,让"最新"没有歧义。不改生产 SQL:真实流量里两条 spine 消息同毫秒写入几乎不会发生,且 `messages` 表没有单调列可做稳定的次序键。

## 验证

该文件连跑 3 次 15/15 通过;lint 干净。

https://claude.ai/code/session_01EjmRHEnEMf5mEDRFCDAjy1