### PR TITLE
🐛 fix(chat): download chat images through the file proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.33.3",
+    "@lobehub/ui": "^5.35.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/src/features/Conversation/Messages/User/components/ImageFileListViewer.tsx
+++ b/src/features/Conversation/Messages/User/components/ImageFileListViewer.tsx
@@ -4,6 +4,8 @@ import { memo } from 'react';
 import GalleyGrid from '@/components/GalleyGrid';
 import ImageItem from '@/components/ImageItem';
 
+import { downloadPreviewImage } from '../../components/downloadPreviewImage';
+
 interface ImageFileItem {
   alt?: string;
   id: string;
@@ -18,7 +20,7 @@ interface FileListProps {
 
 const ImageFileListViewer = memo<FileListProps>(({ items }) => {
   return (
-    <PreviewGroup>
+    <PreviewGroup preview={{ onDownload: downloadPreviewImage }}>
       <GalleyGrid items={items} renderItem={ImageItem} />
     </PreviewGroup>
   );

--- a/src/features/Conversation/Messages/components/ImageFileListViewer.tsx
+++ b/src/features/Conversation/Messages/components/ImageFileListViewer.tsx
@@ -4,6 +4,8 @@ import { memo } from 'react';
 import GalleyGrid from '@/components/GalleyGrid';
 import ImageItem from '@/components/ImageItem';
 
+import { downloadPreviewImage } from './downloadPreviewImage';
+
 interface ImageFileItem {
   alt?: string;
   id: string;
@@ -18,7 +20,7 @@ interface FileListProps {
 
 const ImageFileListViewer = memo<FileListProps>(({ items }) => {
   return (
-    <PreviewGroup>
+    <PreviewGroup preview={{ onDownload: downloadPreviewImage }}>
       <GalleyGrid items={items} renderItem={ImageItem} />
     </PreviewGroup>
   );

--- a/src/features/Conversation/Messages/components/downloadPreviewImage.test.ts
+++ b/src/features/Conversation/Messages/components/downloadPreviewImage.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadPreviewImage } from './downloadPreviewImage';
+
+const downloadFile = vi.hoisted(() => vi.fn());
+
+vi.mock('@lobechat/utils/client', () => ({ downloadFile }));
+
+describe('downloadPreviewImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'open').mockReturnValue(null);
+  });
+
+  it('opens the proxy download response for a file proxy url', async () => {
+    await downloadPreviewImage('https://app.lobehub.com/f/file_abc');
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://app.lobehub.com/f/file_abc?download=1',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it('downloads other sources as a blob under the file name', async () => {
+    await downloadPreviewImage('https://cdn.lobehub.com/images/cat%20photo.png');
+
+    expect(downloadFile).toHaveBeenCalledWith(
+      'https://cdn.lobehub.com/images/cat%20photo.png',
+      'cat photo.png',
+    );
+    expect(window.open).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Conversation/Messages/components/downloadPreviewImage.ts
+++ b/src/features/Conversation/Messages/components/downloadPreviewImage.ts
@@ -1,0 +1,27 @@
+import { downloadFile } from '@lobechat/utils/client';
+
+import { getFileDownloadUrl } from '@/features/EditorCanvas/fileDownload';
+
+const fileNameFromUrl = (source: string) => {
+  try {
+    const name = new URL(source, window.location.href).pathname.split('/').pop();
+    return name ? decodeURIComponent(name) : 'image';
+  } catch {
+    return 'image';
+  }
+};
+
+export const downloadPreviewImage = async (source: string) => {
+  const downloadUrl = getFileDownloadUrl(source, { appOrigin: window.location.origin });
+
+  // The file proxy redirects to a presigned URL on an origin that sends no CORS
+  // headers — and a cross-origin redirect strips the Origin header to `null`, so
+  // no bucket rule can allow it either. Its `download=1` response carries a
+  // Content-Disposition instead, which saves the file under its stored name.
+  if (downloadUrl !== source) {
+    window.open(downloadUrl, '_blank', 'noopener,noreferrer');
+    return;
+  }
+
+  await downloadFile(source, fileNameFromUrl(source));
+};


### PR DESCRIPTION
Downloading an image from the chat preview viewer failed with a CORS error. The viewer downloads by reading the source as a blob, and `/f/:id` can never satisfy that: it redirects to a presigned URL on an origin that sends no CORS headers, and per the Fetch spec a cross-origin redirect replaces the request's origin with an opaque one — the bucket sees `Origin: null`, so no bucket CORS rule can allow it either.

Chat image previews now pass `preview.onDownload` (new in @lobehub/ui 5.35.0) and resolve the proxy's `download=1` response, which carries a `Content-Disposition` and saves the file under its stored name. Any other source keeps the existing blob path.

#### Key Decisions / Non-goals

- Reuses the existing `getFileDownloadUrl` and `downloadFile` helpers rather than adding another download implementation.
- Wired at the two `PreviewGroup` wrappers instead of every `<Image>` call site — those are where file-proxy URLs are rendered.
- The **copy** action in the same toolbar still fails on these sources. The clipboard needs a real blob, so it has no equivalent fallback; fixing it requires an `Access-Control-Allow-Origin: *` rule on the bucket, which is out of scope here.
- Bumps `@lobehub/ui` to `^5.35.0` for the `preview.onDownload` option.

#### Test

- [x] Tested locally
- [x] Added/updated tests