### PR TITLE
✨ feat(heterogeneous-agent): expand LobeHub provider support

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -23,6 +23,7 @@ import {
   formatHeterogeneousProviderBindingError,
   getHeterogeneousAgentConfigOrThrow,
   isHeterogeneousAgentAuthRequired,
+  isServerDefaultHeterogeneousAgentType,
   resolveHeterogeneousAgentCommand,
   resolveHeterogeneousProviderBinding,
 } from '@lobechat/heterogeneous-agents';
@@ -805,10 +806,9 @@ export default class HeterogeneousAgentCtr {
         : {}),
       ...session.env,
     };
-    if (session.serverOperationToken) {
-      if (session.agentType === 'claude-code')
-        env.ANTHROPIC_AUTH_TOKEN = session.serverOperationToken;
-      if (session.agentType === 'codex') env.LOBEHUB_HETERO_TOKEN = session.serverOperationToken;
+    const operationTokenEnvKey = session.hostedProviderBinding?.operationTokenEnvKey;
+    if (session.serverOperationToken && operationTokenEnvKey) {
+      env[operationTokenEnvKey] = session.serverOperationToken;
     }
     if (
       session.agentType === 'kimi-code' &&
@@ -1335,7 +1335,7 @@ export default class HeterogeneousAgentCtr {
     const serverDefaultApiConfig = session?.serverDefaultApiConfig;
     if (!session || !serverDefaultApiConfig) return this.sendPromptImpl(params);
     if (!params.topicId) throw new Error('Server-default execution requires a topic');
-    if (session.agentType !== 'claude-code' && session.agentType !== 'codex') {
+    if (!isServerDefaultHeterogeneousAgentType(session.agentType)) {
       throw new Error(`Server-default execution does not support ${session.agentType}`);
     }
 

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1973,9 +1973,102 @@ describe('HeterogeneousAgentCtr', () => {
         topicId: 'topic-1',
       });
       expect(spawnCalls[0].args).toEqual(expect.arrayContaining(['--model', 'lobehub/gpt-5.4']));
+      expect(spawnCalls[0].options.env.LOBEHUB_HETERO_TOKEN).toBe('operation-token');
       expect(settleServerDefaultOperationMock).toHaveBeenCalledWith(expect.any(Object), {
         cancelled: false,
         operationId: 'op-server-default',
+        result: 'done',
+      });
+    });
+
+    it('injects a Kimi operation token into its Anthropic credential env', async () => {
+      nextFakeProc = createFakeProc().proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const { sessionId } = await ctr.startSession({
+        agentType: 'kimi-code',
+        command: 'kimi',
+        providerBinding: {
+          apiConfig: { model: 'kimi-k2.6', source: 'server-default' },
+          kind: 'server-default',
+        },
+      });
+
+      await ctr.sendPrompt({
+        operationId: 'op-server-default-kimi',
+        prompt: 'hello',
+        sessionId,
+        topicId: 'topic-1',
+      });
+
+      expect(beginServerDefaultOperationMock).toHaveBeenCalledWith(expect.any(Object), {
+        agentId: undefined,
+        agentType: 'kimi-code',
+        model: 'kimi-k2.6',
+        operationId: 'op-server-default-kimi',
+        topicId: 'topic-1',
+      });
+      expect(spawnCalls[0]).toMatchObject({
+        command: 'kimi',
+        options: {
+          env: {
+            KIMI_MODEL_API_KEY: 'operation-token',
+            KIMI_MODEL_BASE_URL: 'https://app.example.com/api/v1/anthropic',
+            KIMI_MODEL_NAME: 'lobehub/kimi-k2.6',
+            KIMI_MODEL_PROVIDER_TYPE: 'anthropic',
+          },
+        },
+      });
+      expect(settleServerDefaultOperationMock).toHaveBeenCalledWith(expect.any(Object), {
+        cancelled: false,
+        operationId: 'op-server-default-kimi',
+        result: 'done',
+      });
+    });
+
+    it('injects a Pi operation token into its Responses credential env', async () => {
+      nextFakeProc = createFakeProc().proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const { sessionId } = await ctr.startSession({
+        agentType: 'pi',
+        command: 'pi',
+        providerBinding: {
+          apiConfig: { model: 'kimi-k2.6', source: 'server-default' },
+          kind: 'server-default',
+        },
+      });
+
+      await ctr.sendPrompt({
+        operationId: 'op-server-default-pi',
+        prompt: 'hello',
+        sessionId,
+        topicId: 'topic-1',
+      });
+
+      expect(beginServerDefaultOperationMock).toHaveBeenCalledWith(expect.any(Object), {
+        agentId: undefined,
+        agentType: 'pi',
+        model: 'kimi-k2.6',
+        operationId: 'op-server-default-pi',
+        topicId: 'topic-1',
+      });
+      expect(spawnCalls[0].args).toEqual(
+        expect.arrayContaining([
+          '--provider',
+          'lobehub-server-default',
+          '--model',
+          'lobehub/kimi-k2.6',
+        ]),
+      );
+      expect(spawnCalls[0].options.env.LOBEHUB_PI_API_KEY).toBe('operation-token');
+      expect(settleServerDefaultOperationMock).toHaveBeenCalledWith(expect.any(Object), {
+        cancelled: false,
+        operationId: 'op-server-default-pi',
         result: 'done',
       });
     });

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
@@ -36,6 +36,7 @@ describe('claudeCodeDriver', () => {
       ANTHROPIC_SMALL_FAST_MODEL: 'lobehub/claude-sonnet-4-6',
       CLAUDE_CODE_SUBAGENT_MODEL: 'lobehub/claude-sonnet-4-6',
     });
+    expect(plan.operationTokenEnvKey).toBe('ANTHROPIC_AUTH_TOKEN');
     expect(plan.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
   });
   it('omits --mcp-config when mcpConfigPath is undefined', async () => {

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
@@ -76,6 +76,7 @@ export const claudeCodeDriver: HeterogeneousAgentDriver = {
         CLAUDE_CODE_SUBAGENT_MODEL: requestModel,
         CLAUDE_CONFIG_DIR: profileDir,
       },
+      operationTokenEnvKey: 'ANTHROPIC_AUTH_TOKEN',
     };
   },
 };

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.test.ts
@@ -46,6 +46,7 @@ describe('codexDriver provider binding', () => {
     expect(config).not.toContain('model_catalog_json');
     expect(plan.profileFiles).toHaveLength(1);
     expect(config).not.toContain('stale');
+    expect(plan.operationTokenEnvKey).toBe('LOBEHUB_HETERO_TOKEN');
     expect(plan.env.LOBEHUB_HETERO_TOKEN).toBeUndefined();
   });
 

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.ts
@@ -259,6 +259,7 @@ export const codexDriver: HeterogeneousAgentDriver = {
     return {
       args: [...sanitizeCodexProviderBindingArgs(args), '--model', requestModel],
       env: { ...sanitizeCodexProviderBindingEnv(env), CODEX_HOME: profileDir },
+      operationTokenEnvKey: SERVER_TOKEN_ENV,
       profileFiles: [
         { content: config, path: 'config.toml' },
         ...(customModel

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/grokBuild.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/grokBuild.test.ts
@@ -50,6 +50,29 @@ const bindingContext = (
 });
 
 describe('grokBuildDriver provider binding', () => {
+  it('writes a secret-free server-default Responses profile', async () => {
+    const plan = await grokBuildDriver.prepareServerDefaultBinding!({
+      args: ['--model', 'stale-model', '--effort', 'high'],
+      endpoint: 'https://app.example.com/',
+      env: { LOBEHUB_GROK_API_KEY: 'stale-token' },
+      model: 'kimi-k2.6',
+      profileDir: '/managed/grok',
+    });
+    const config = plan.profileFiles?.[0]?.content ?? '';
+    const alias = plan.args.at(-1);
+
+    expect(plan.args).toEqual(['--effort', 'high', '--model', alias]);
+    expect(alias).toMatch(/^lobehub-provider-[\da-f]{16}$/);
+    expect(plan.env).toMatchObject({ GROK_HOME: '/managed/grok' });
+    expect(plan.env.LOBEHUB_GROK_API_KEY).toBeUndefined();
+    expect(plan.operationTokenEnvKey).toBe('LOBEHUB_GROK_API_KEY');
+    expect(config).toContain('model = "lobehub/kimi-k2.6"');
+    expect(config).toContain('base_url = "https://app.example.com/api/v1/openai/v1"');
+    expect(config).toContain('api_backend = "responses"');
+    expect(config).toContain('auth_scheme = "bearer"');
+    expect(config).not.toContain('stale-token');
+  });
+
   it.each([
     [
       'openai-chat-completions',

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/grokBuild.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/grokBuild.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import type { HeterogeneousProviderBindingProtocol } from '@lobechat/heterogeneous-agents';
 import { buildGrokAcpArgs } from '@lobechat/heterogeneous-agents/spawn';
+import { formatServerDefaultHeterogeneousModel } from '@lobechat/types';
 
 import type { HeterogeneousAgentDriver } from '../types';
 
@@ -170,6 +171,33 @@ export const grokBuildDriver: HeterogeneousAgentDriver = {
         GROK_HOME: profileDir,
         [HOST_API_KEY_ENV]: apiKey,
       },
+      profileFiles: [{ content: config, path: 'config.toml' }],
+    };
+  },
+  prepareServerDefaultBinding({ args, endpoint, env, model, profileDir }) {
+    const requestModel = formatServerDefaultHeterogeneousModel(model);
+    const alias = buildModelAlias(['server-default', endpoint, model].join('\0'));
+    const config = [
+      `[model.${alias}]`,
+      `name = ${tomlString('LobeHub Server Default')}`,
+      `model = ${tomlString(requestModel)}`,
+      `base_url = ${tomlString(`${stripTrailingSlashes(endpoint)}/api/v1/openai/v1`)}`,
+      `env_key = ${tomlString(HOST_API_KEY_ENV)}`,
+      'api_backend = "responses"',
+      'auth_scheme = "bearer"',
+      '',
+      '[models]',
+      `default = ${tomlString(alias)}`,
+      '',
+    ].join('\n');
+
+    return {
+      args: [...sanitizeGrokProviderBindingArgs(args), '--model', alias],
+      env: {
+        ...sanitizeGrokProviderBindingEnv(env),
+        GROK_HOME: profileDir,
+      },
+      operationTokenEnvKey: HOST_API_KEY_ENV,
       profileFiles: [{ content: config, path: 'config.toml' }],
     };
   },

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/kimiCode.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/kimiCode.test.ts
@@ -77,6 +77,29 @@ describe('kimiCodeDriver', () => {
     }));
   });
 
+  it('prepares the server-default Anthropic binding without persisting its operation token', async () => {
+    const plan = await kimiCodeDriver.prepareServerDefaultBinding!({
+      args: ['--model', 'stale-model', '--verbose'],
+      endpoint: 'https://app.example.com',
+      env: { KEEP_ME: 'yes', KIMI_MODEL_API_KEY: 'stale-token' },
+      model: 'kimi-k2.6',
+      profileDir: '/managed/kimi',
+    });
+
+    expect(plan).toMatchObject({
+      args: ['--verbose'],
+      env: {
+        KEEP_ME: 'yes',
+        KIMI_CODE_HOME: '/managed/kimi',
+        KIMI_MODEL_BASE_URL: 'https://app.example.com/api/v1/anthropic',
+        KIMI_MODEL_NAME: 'lobehub/kimi-k2.6',
+        KIMI_MODEL_PROVIDER_TYPE: 'anthropic',
+      },
+      operationTokenEnvKey: 'KIMI_MODEL_API_KEY',
+    });
+    expect(plan.env.KIMI_MODEL_API_KEY).toBeUndefined();
+  });
+
   it('builds exact fresh and resumed one-shot plans', async () => {
     const buildAgentInput = vi.fn().mockResolvedValue({ args: ['--prompt', 'secret'], stdin: '' });
     const base = {

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/kimiCode.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/kimiCode.ts
@@ -1,4 +1,5 @@
 import { KIMI_CODE_BASE_ARGS } from '@lobechat/heterogeneous-agents/spawn';
+import { formatServerDefaultHeterogeneousModel } from '@lobechat/types';
 
 import { startProviderBindingProxy } from '../providerBindingProxy';
 import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
@@ -93,6 +94,20 @@ export const kimiCodeDriver: HeterogeneousAgentDriver = {
         KIMI_MODEL_NAME: resolution.apiConfig.model,
         KIMI_MODEL_PROVIDER_TYPE: providerType,
       },
+    };
+  },
+  prepareServerDefaultBinding({ args, endpoint, env, model, profileDir }) {
+    const requestModel = formatServerDefaultHeterogeneousModel(model);
+    return {
+      args: sanitizeKimiCodeProviderBindingArgs(args),
+      env: {
+        ...sanitizeKimiCodeProviderBindingEnv(env),
+        KIMI_CODE_HOME: profileDir,
+        KIMI_MODEL_BASE_URL: `${endpoint}/api/v1/anthropic`,
+        KIMI_MODEL_NAME: requestModel,
+        KIMI_MODEL_PROVIDER_TYPE: 'anthropic',
+      },
+      operationTokenEnvKey: 'KIMI_MODEL_API_KEY',
     };
   },
 };

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.test.ts
@@ -75,6 +75,43 @@ const bindingContext = (
 });
 
 describe('piDriver', () => {
+  it('writes a secret-free server-default Responses profile', async () => {
+    const plan = await piDriver.prepareServerDefaultBinding!({
+      args: ['--provider', 'stale', '--thinking', 'high'],
+      endpoint: 'https://app.example.com',
+      env: { LOBEHUB_PI_API_KEY: 'stale-token' },
+      model: 'kimi-k2.6',
+      profileDir: '/managed/pi',
+    });
+    const content = plan.profileFiles?.[0]?.content ?? '';
+    const config = JSON.parse(content);
+    const provider = config.providers['lobehub-server-default'];
+
+    expect(plan.args).toEqual([
+      '--provider',
+      'lobehub-server-default',
+      '--model',
+      'lobehub/kimi-k2.6',
+      '--thinking',
+      'high',
+    ]);
+    expect(plan.env).toEqual({ PI_CODING_AGENT_DIR: '/managed/pi' });
+    expect(plan.operationTokenEnvKey).toBe('LOBEHUB_PI_API_KEY');
+    expect(provider).toMatchObject({
+      api: 'openai-responses',
+      apiKey: '$LOBEHUB_PI_API_KEY',
+      baseUrl: 'https://app.example.com/api/v1/openai/v1',
+      models: [
+        {
+          contextWindow: 128_000,
+          id: 'lobehub/kimi-k2.6',
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(content).not.toContain('stale-token');
+  });
+
   it('is registered and composes base, resume, configured, and input args in order', async () => {
     expect(getHeterogeneousAgentDriver('pi')).toBe(piDriver);
 

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import type { HeterogeneousProviderBindingProtocol } from '@lobechat/heterogeneous-agents';
 import { PI_BASE_ARGS } from '@lobechat/heterogeneous-agents/spawn';
+import { formatServerDefaultHeterogeneousModel } from '@lobechat/types';
 
 import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
 
@@ -123,6 +124,47 @@ export const piDriver: HeterogeneousAgentDriver = {
         [HOST_API_KEY_ENV]: apiKey,
         PI_CODING_AGENT_DIR: profileDir,
       },
+      profileFiles: [{ content: `${JSON.stringify(modelsConfig, null, 2)}\n`, path: MODELS_FILE }],
+    };
+  },
+  prepareServerDefaultBinding({ args, endpoint, env, model, profileDir }) {
+    const providerId = 'lobehub-server-default';
+    const requestModel = formatServerDefaultHeterogeneousModel(model);
+    const modelsConfig = {
+      providers: {
+        [providerId]: {
+          api: 'openai-responses',
+          apiKey: `$${HOST_API_KEY_ENV}`,
+          baseUrl: `${endpoint}/api/v1/openai/v1`,
+          models: [
+            {
+              contextWindow: DEFAULT_CONTEXT_WINDOW,
+              cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
+              id: requestModel,
+              input: ['text'],
+              maxTokens: DEFAULT_MAX_TOKENS,
+              name: model,
+              reasoning: false,
+            },
+          ],
+          name: 'LobeHub Server Default',
+        },
+      },
+    };
+
+    return {
+      args: [
+        '--provider',
+        providerId,
+        '--model',
+        requestModel,
+        ...sanitizePiProviderBindingArgs(args),
+      ],
+      env: {
+        ...sanitizePiProviderBindingEnv(env),
+        PI_CODING_AGENT_DIR: profileDir,
+      },
+      operationTokenEnvKey: HOST_API_KEY_ENV,
       profileFiles: [{ content: `${JSON.stringify(modelsConfig, null, 2)}\n`, path: MODELS_FILE }],
     };
   },

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.test.ts
@@ -207,6 +207,7 @@ describe('prepareHostedServerDefaultBinding', () => {
     prepareServerDefaultBinding: ({ profileDir }) => ({
       args: [],
       env: { CLAUDE_CONFIG_DIR: profileDir },
+      operationTokenEnvKey: 'ANTHROPIC_AUTH_TOKEN',
     }),
   };
 
@@ -229,6 +230,7 @@ describe('prepareHostedServerDefaultBinding', () => {
 
     expect((await stat(binding.profileDir)).mode & 0o777).toBe(0o700);
     expect((await stat(binding.runDir)).mode & 0o777).toBe(0o700);
+    expect(binding.operationTokenEnvKey).toBe('ANTHROPIC_AUTH_TOKEN');
 
     await binding.cleanup();
     await expect(stat(binding.runDir)).rejects.toThrow();

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.ts
@@ -84,6 +84,7 @@ export interface HostedProviderBinding {
   cleanup: () => Promise<void>;
   cleanupSync: () => void;
   env: Record<string, string>;
+  operationTokenEnvKey?: string;
   profileDir: string;
   runDir: string;
 }
@@ -155,6 +156,7 @@ export const prepareHostedProviderBinding = async (params: {
       cleanup: () => cleanupBindingRun(runDir, plan),
       cleanupSync: () => cleanupBindingRunSync(runDir, plan),
       env: plan.env,
+      operationTokenEnvKey: plan.operationTokenEnvKey,
       profileDir,
       runDir,
     };
@@ -216,6 +218,7 @@ export const prepareHostedServerDefaultBinding = async (params: {
       cleanup: () => cleanupBindingRun(runDir, plan),
       cleanupSync: () => cleanupBindingRunSync(runDir, plan),
       env: plan.env,
+      operationTokenEnvKey: plan.operationTokenEnvKey,
       profileDir,
       runDir,
     };

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingPort.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingPort.ts
@@ -1,6 +1,7 @@
 import type {
   HeterogeneousProviderBindingReference,
   HeterogeneousProviderBindingRuntime,
+  ServerDefaultHeterogeneousAgentType,
 } from '@lobechat/heterogeneous-agents';
 
 import {
@@ -43,7 +44,7 @@ const getAuthenticatedServer = async (auth: RemoteServerAuth) => {
 export const beginServerDefaultOperation = async (
   auth: RemoteServerAuth,
   input: {
-    agentType: 'claude-code' | 'codex';
+    agentType: ServerDefaultHeterogeneousAgentType;
     agentId?: string;
     model: string;
     operationId: string;

--- a/apps/desktop/src/main/modules/heterogeneousAgent/types.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/types.ts
@@ -67,6 +67,8 @@ export interface ProviderBindingPlan {
   /** Best-effort synchronous release for app shutdown. */
   cleanupSync?: () => void;
   env: Record<string, string>;
+  /** Environment variable that receives the per-prompt server operation token. */
+  operationTokenEnvKey?: string;
   profileFiles?: ProviderBindingFilePlan[];
   runFiles?: ProviderBindingFilePlan[];
 }

--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -166,6 +166,9 @@ describe('getServerDefaultHeterogeneousModels', () => {
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
       'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [{ model: 'gpt-5.4' }],
+      'grok-build': [{ model: 'claude-sonnet-4-6' }],
+      'kimi-code': [{ model: 'claude-sonnet-4-6' }],
+      'pi': [{ model: 'claude-sonnet-4-6' }],
     });
   });
 
@@ -202,10 +205,13 @@ describe('getServerDefaultHeterogeneousModels', () => {
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
       'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [{ model: 'gpt-5.4' }],
+      'grok-build': [{ model: 'claude-sonnet-4-6' }],
+      'kimi-code': [{ model: 'claude-sonnet-4-6' }],
+      'pi': [{ model: 'claude-sonnet-4-6' }],
     });
   });
 
-  it('offers tool-capable relay models to Claude Code and only explicit custom models to Codex', async () => {
+  it('offers tool-capable relay models to compatible agents and keeps Codex narrow', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         lobehub: {
@@ -253,6 +259,27 @@ describe('getServerDefaultHeterogeneousModels', () => {
         { model: 'gemini-3.1-pro-preview' },
       ],
       'codex': [{ model: 'deepseek-v4-flash' }, { model: 'deepseek-v4-pro' }, { model: 'glm-5.2' }],
+      'grok-build': [
+        { model: 'kimi-k2.6' },
+        { model: 'deepseek-v4-flash' },
+        { model: 'deepseek-v4-pro' },
+        { model: 'glm-5.2' },
+        { model: 'gemini-3.1-pro-preview' },
+      ],
+      'kimi-code': [
+        { model: 'kimi-k2.6' },
+        { model: 'deepseek-v4-flash' },
+        { model: 'deepseek-v4-pro' },
+        { model: 'glm-5.2' },
+        { model: 'gemini-3.1-pro-preview' },
+      ],
+      'pi': [
+        { model: 'kimi-k2.6' },
+        { model: 'deepseek-v4-flash' },
+        { model: 'deepseek-v4-pro' },
+        { model: 'glm-5.2' },
+        { model: 'gemini-3.1-pro-preview' },
+      ],
     });
   });
 
@@ -272,6 +299,9 @@ describe('getServerDefaultHeterogeneousModels', () => {
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
       'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [],
+      'grok-build': [{ model: 'claude-sonnet-4-6' }],
+      'kimi-code': [{ model: 'claude-sonnet-4-6' }],
+      'pi': [{ model: 'claude-sonnet-4-6' }],
     });
   });
 });
@@ -343,7 +373,7 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     });
   });
 
-  it('accepts a tool-capable third-party relay model for Claude Code only', async () => {
+  it('accepts a tool-capable third-party relay model for all non-Codex agents', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         lobehub: {
@@ -363,6 +393,16 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
       provider: 'lobehub',
       supportsAdaptiveThinking: false,
     });
+    await expect(
+      resolveServerDefaultHeterogeneousModel('kimi-code', 'kimi-k2.6'),
+    ).resolves.toMatchObject({ model: 'kimi-k2.6', provider: 'lobehub' });
+    await expect(resolveServerDefaultHeterogeneousModel('pi', 'kimi-k2.6')).resolves.toMatchObject({
+      model: 'kimi-k2.6',
+      provider: 'lobehub',
+    });
+    await expect(
+      resolveServerDefaultHeterogeneousModel('grok-build', 'kimi-k2.6'),
+    ).resolves.toMatchObject({ model: 'kimi-k2.6', provider: 'lobehub' });
 
     await expect(resolveServerDefaultHeterogeneousModel('codex', 'kimi-k2.6')).rejects.toThrow(
       'not compatible with this heterogeneous agent',

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -1,4 +1,9 @@
 import { type GoogleGenAIOptions } from '@google/genai';
+import type { ServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
+import {
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
+} from '@lobechat/heterogeneous-agents';
 import {
   AgentRuntimeError,
   mergeModelRuntimeHooks,
@@ -40,6 +45,8 @@ import { KeyVaultsGateKeeper } from '../KeyVaultsEncrypt';
 import apiKeyManager from './apiKeyManager';
 
 export * from './trace';
+export type { ServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
+export { SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES } from '@lobechat/heterogeneous-agents';
 
 /**
  * Combined KeyVaults type for all providers
@@ -522,10 +529,6 @@ export const initModelRuntimeFromDB = async (
   return initModelRuntimeWithUserPayload(provider, payload, { userId, workspaceId }, hooks);
 };
 
-export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES = ['claude-code', 'codex'] as const;
-export type ServerDefaultHeterogeneousAgentType =
-  (typeof SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES)[number];
-
 export interface ServerDefaultHeterogeneousModelReference {
   model: string;
 }
@@ -536,32 +539,38 @@ export type ServerDefaultHeterogeneousModels = Record<
 >;
 
 /**
- * Both CLIs use the single LobeHub relay provider. `lobehub` is a deployment-
- * owned router slot, not a hosted-only upstream: official and private
- * distributions provide their own model catalog and RouterRuntime behind it.
+ * Every supported CLI uses the single LobeHub relay provider. `lobehub` is a
+ * deployment-owned router slot, not a hosted-only upstream: official and
+ * private distributions provide their own model catalog and RouterRuntime
+ * behind it.
  *
- * Claude Code reaches the relay through the Anthropic Messages ingress, which
- * translates the wire protocol in both directions rather than proxying it
- * (`normalizeAnthropicRequest` / `encodeAnthropicStream`). Both CLIs address
- * the relay as `lobehub/${catalogId}`; the operation token is still the source
- * of truth and the request must match that selection. The upstream only has to
- * be able to call tools. Any tool-capable chat model in the relay catalog
- * qualifies; the `parseClaudeModelId` arm keeps Claude ids eligible in
- * deployments whose catalog omits `abilities`.
+ * The shared agent matrix selects either the Anthropic Messages or OpenAI
+ * Responses ingress. Both translate the wire protocol in both directions
+ * rather than proxying it, and every CLI addresses the relay as
+ * `lobehub/${catalogId}`. The operation token remains the source of truth and
+ * the request must match that selection.
  *
- * Codex accepts native Responses models plus an explicit set of tool-capable
- * relay models configured through its custom model-catalog path. Keep that set
- * narrow: the CLI branches reasoning and continuation behaviour on model
- * metadata, so function calling alone is not enough to establish compatibility.
+ * Most agents can use any tool-capable chat model in the relay catalog; the
+ * `parseClaudeModelId` arm keeps Claude ids eligible in deployments whose
+ * catalog omits `abilities`. Codex retains a narrower policy: it accepts native
+ * Responses models plus an explicit set of tool-capable relay models configured
+ * through its custom model-catalog path because its reasoning and continuation
+ * behavior also depends on model metadata.
  */
 const supportsServerDefaultHeterogeneousAgent = (
   agentType: ServerDefaultHeterogeneousAgentType,
   model: Pick<AiFullModelCard, 'abilities' | 'id'>,
-) =>
-  agentType === 'claude-code'
-    ? parseClaudeModelId(model.id) !== undefined || model.abilities?.functionCall === true
-    : isResponsesAPIModel(model.id) ||
-      (isCodexServerDefaultCustomModel(model.id) && model.abilities?.functionCall === true);
+) => {
+  const { modelPolicy } = SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG[agentType];
+  if (modelPolicy === 'tool-capable') {
+    return parseClaudeModelId(model.id) !== undefined || model.abilities?.functionCall === true;
+  }
+
+  return (
+    isResponsesAPIModel(model.id) ||
+    (isCodexServerDefaultCustomModel(model.id) && model.abilities?.functionCall === true)
+  );
+};
 
 const getEnabledServerChatModels = async (provider: ModelProvider) => {
   const providerConfig = (await getServerGlobalConfig()).aiProvider[provider];
@@ -598,7 +607,10 @@ const toServerModelSelection = (provider: string, modelConfig: AiFullModelCard) 
 
 /** Return compatible models from the single deployment-owned relay provider. */
 export const getServerDefaultHeterogeneousModels = async () => {
-  const models: ServerDefaultHeterogeneousModels = { 'claude-code': [], 'codex': [] };
+  const models = {} as ServerDefaultHeterogeneousModels;
+  for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
+    models[agentType] = [];
+  }
 
   for (const model of await getEnabledServerChatModels(ModelProvider.LobeHub)) {
     for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
@@ -615,7 +627,7 @@ export const getServerDefaultHeterogeneousModels = async () => {
 export const resolveServerModel = async (provider: string, model: string) =>
   toServerModelSelection(provider, await findEnabledServerChatModel(provider, model));
 
-/** Resolve a model only when it belongs to the selected CLI's V1 runtime path. */
+/** Resolve a model only when it belongs to the selected CLI's relay runtime path. */
 export const resolveServerDefaultHeterogeneousModel = async (
   agentType: ServerDefaultHeterogeneousAgentType,
   model: string,

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
@@ -7,7 +7,13 @@ const getSupportedModels = vi.hoisted(() => vi.fn());
 
 vi.mock('@/server/modules/ModelRuntime', () => ({
   getServerDefaultHeterogeneousModels: getSupportedModels,
-  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES: ['claude-code', 'codex'],
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES: [
+    'claude-code',
+    'codex',
+    'grok-build',
+    'kimi-code',
+    'pi',
+  ],
 }));
 
 describe('resolveServerDefaultHeterogeneousCapability', () => {
@@ -16,6 +22,9 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
     getSupportedModels.mockResolvedValue({
       'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [{ model: 'gpt-5.4' }],
+      'grok-build': [{ model: 'kimi-k2.6' }],
+      'kimi-code': [{ model: 'kimi-k2.6' }],
+      'pi': [{ model: 'kimi-k2.6' }],
     });
   });
 
@@ -26,12 +35,15 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
 
   it('reports the shared deployment model alias when the server catalog has a model', async () => {
     await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toEqual({
-      agents: ['claude-code', 'codex'],
+      agents: ['claude-code', 'codex', 'grok-build', 'kimi-code', 'pi'],
       enabled: true,
       model: 'lobehub-default',
       models: {
         'claude-code': [{ model: 'claude-sonnet-4-6' }],
         'codex': [{ model: 'gpt-5.4' }],
+        'grok-build': [{ model: 'kimi-k2.6' }],
+        'kimi-code': [{ model: 'kimi-k2.6' }],
+        'pi': [{ model: 'kimi-k2.6' }],
       },
     });
 
@@ -42,6 +54,9 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
     getSupportedModels.mockResolvedValue({
       'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [],
+      'grok-build': [],
+      'kimi-code': [],
+      'pi': [],
     });
 
     await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
@@ -61,7 +76,13 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
   });
 
   it('reports an invalid configuration when the server catalog has no models', async () => {
-    getSupportedModels.mockResolvedValue({ 'claude-code': [], 'codex': [] });
+    getSupportedModels.mockResolvedValue({
+      'claude-code': [],
+      'codex': [],
+      'grok-build': [],
+      'kimi-code': [],
+      'pi': [],
+    });
 
     await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
       enabled: false,

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
@@ -27,7 +27,13 @@ vi.mock('@/server/modules/ModelRuntime', () => ({
   getServerDefaultHeterogeneousModels: getSupportedModels,
   initModelRuntimeFromServerConfig: initRuntime,
   resolveServerDefaultHeterogeneousModel: resolveModel,
-  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES: ['claude-code', 'codex'],
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES: [
+    'claude-code',
+    'codex',
+    'grok-build',
+    'kimi-code',
+    'pi',
+  ],
 }));
 
 vi.mock('@/libs/trpc/utils/internalJwt', async (importOriginal) => ({
@@ -60,6 +66,9 @@ describe('server-default heterogeneous operation control', () => {
     getSupportedModels.mockResolvedValue({
       'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [{ model: 'gpt-5.4' }],
+      'grok-build': [{ model: 'kimi-k2.6' }],
+      'kimi-code': [{ model: 'kimi-k2.6' }],
+      'pi': [{ model: 'kimi-k2.6' }],
     });
     resolveModel.mockResolvedValue({ model: 'gpt-5.4', provider: 'lobehub' });
     initRuntime.mockResolvedValue({});
@@ -105,6 +114,31 @@ describe('server-default heterogeneous operation control', () => {
     });
   });
 
+  it('accepts and persists a newly supported Kimi Code operation', async () => {
+    resolveModel.mockResolvedValueOnce({ model: 'kimi-k2.6', provider: 'lobehub' });
+
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation({
+        agentType: 'kimi-code',
+        model: 'kimi-k2.6',
+        operationId: 'desktop-operation-kimi',
+        topicId,
+      }),
+    ).resolves.toMatchObject({ model: 'lobehub-default', token: 'operation-token' });
+
+    const [operation] = await testDB
+      .select()
+      .from(agentOperations)
+      .where(eq(agentOperations.id, 'desktop-operation-kimi'));
+    expect(operation).toMatchObject({
+      metadata: { agentType: 'kimi-code', serverDefaultHeterogeneous: true },
+      model: 'kimi-k2.6',
+      provider: 'lobehub',
+      status: 'running',
+    });
+    expect(resolveModel).toHaveBeenCalledWith('kimi-code', 'kimi-k2.6');
+  });
+
   it('requires a normal user OIDC token for the control plane', async () => {
     await expect(
       caller('hetero-operation').beginServerDefaultHeterogeneousOperation(
@@ -146,7 +180,7 @@ describe('server-default heterogeneous operation control', () => {
     expect(signOperationToken).not.toHaveBeenCalled();
   });
 
-  it('does not persist or mint for an agent/runtime pair outside the V1 support matrix', async () => {
+  it('does not persist or mint for an agent/runtime pair outside the support matrix', async () => {
     resolveModel.mockRejectedValueOnce(new Error('unsupported agent/runtime pair'));
 
     await expect(

--- a/apps/server/src/services/heterogeneousAgent/operationPrincipal.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/operationPrincipal.test.ts
@@ -32,10 +32,23 @@ const claims: HeteroOperationJwtClaims = {
   iat: 1,
   iss: 'urn:lobehub:internal',
   jti: 'jti-1',
+  model: 'model-a',
   operation_id: 'op-1',
+  provider_id: 'lobehub',
   purpose: 'hetero-operation',
   sub: 'user-1',
 };
+
+const activeOperation = (overrides: Record<string, unknown> = {}) => ({
+  id: 'op-1',
+  metadata: { agentType: 'kimi-code', serverDefaultHeterogeneous: true },
+  model: 'model-a',
+  provider: 'lobehub',
+  status: 'running',
+  userId: 'user-1',
+  workspaceId: null,
+  ...overrides,
+});
 
 const dbWithOperation = (operation: unknown) => {
   const query = {
@@ -58,11 +71,16 @@ describe('resolveActiveHeteroOperationPrincipal', () => {
     const principal = await resolveActiveHeteroOperationPrincipal({
       capability: 'model:invoke',
       claims,
-      db: dbWithOperation({ id: 'op-1', status: 'running', userId: 'user-1', workspaceId: null }),
+      db: dbWithOperation(activeOperation()),
       operationId: 'op-1',
     });
 
-    expect(principal).toEqual({ operationId: 'op-1', userId: 'user-1', workspaceId: undefined });
+    expect(principal).toEqual({
+      agentType: 'kimi-code',
+      operationId: 'op-1',
+      userId: 'user-1',
+      workspaceId: undefined,
+    });
     expect(activeUser).toHaveBeenCalledWith(expect.anything(), 'user-1');
     expect(hasPermission).toHaveBeenCalledOnce();
   });
@@ -84,7 +102,7 @@ describe('resolveActiveHeteroOperationPrincipal', () => {
       resolveActiveHeteroOperationPrincipal({
         capability: 'model:invoke',
         claims,
-        db: dbWithOperation({ id: 'op-1', status: 'done', userId: 'user-1', workspaceId: null }),
+        db: dbWithOperation(activeOperation({ status: 'done' })),
         operationId: 'op-1',
       }),
     ).rejects.toEqual(new HeteroOperationPrincipalError('Operation has already ended', 409));
@@ -94,15 +112,38 @@ describe('resolveActiveHeteroOperationPrincipal', () => {
     await expect(
       resolveActiveHeteroOperationPrincipal({
         capability: 'model:invoke',
-        claims: { ...claims, model: 'model-a', provider_id: 'openai' },
-        db: dbWithOperation({
-          id: 'op-1',
-          model: 'model-b',
-          provider: 'openai',
-          status: 'running',
-          userId: 'user-1',
-          workspaceId: null,
-        }),
+        claims,
+        db: dbWithOperation(activeOperation({ model: 'model-b' })),
+        operationId: 'op-1',
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it.each([
+    ['missing server-default marker', { agentType: 'kimi-code' }],
+    ['missing agent type', { serverDefaultHeterogeneous: true }],
+    ['unsupported agent type', { agentType: 'opencode', serverDefaultHeterogeneous: true }],
+  ])('rejects model invocation with %s in durable metadata', async (_label, metadata) => {
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims,
+        db: dbWithOperation(activeOperation({ metadata })),
+        operationId: 'op-1',
+      }),
+    ).rejects.toEqual(
+      new HeteroOperationPrincipalError('Operation token has no valid server model selection', 403),
+    );
+  });
+
+  it('rejects a model-invocation token without model and provider claims', async () => {
+    const { model: _model, provider_id: _providerId, ...unscopedClaims } = claims;
+
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims: unscopedClaims,
+        db: dbWithOperation(activeOperation()),
         operationId: 'op-1',
       }),
     ).rejects.toMatchObject({ status: 403 });
@@ -111,12 +152,7 @@ describe('resolveActiveHeteroOperationPrincipal', () => {
   it('rechecks workspace membership and RBAC', async () => {
     hasMembership.mockResolvedValue(false);
     const workspaceClaims = { ...claims, workspace_id: 'workspace-1' };
-    const db = dbWithOperation({
-      id: 'op-1',
-      status: 'running',
-      userId: 'user-1',
-      workspaceId: 'workspace-1',
-    });
+    const db = dbWithOperation(activeOperation({ workspaceId: 'workspace-1' }));
 
     await expect(
       resolveActiveHeteroOperationPrincipal({

--- a/apps/server/src/services/heterogeneousAgent/operationPrincipal.ts
+++ b/apps/server/src/services/heterogeneousAgent/operationPrincipal.ts
@@ -1,3 +1,5 @@
+import type { ServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
+import { isServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
 import { eq } from 'drizzle-orm';
 
 import { RbacModel } from '@/database/models/rbac';
@@ -22,6 +24,7 @@ export class HeteroOperationPrincipalError extends Error {
 }
 
 export interface ActiveHeteroOperationPrincipal {
+  agentType?: ServerDefaultHeterogeneousAgentType;
   operationId: string;
   userId: string;
   workspaceId?: string;
@@ -46,6 +49,7 @@ export const resolveActiveHeteroOperationPrincipal = async (params: {
   const [operation] = await db
     .select({
       id: agentOperations.id,
+      metadata: agentOperations.metadata,
       model: agentOperations.model,
       provider: agentOperations.provider,
       status: agentOperations.status,
@@ -69,6 +73,20 @@ export const resolveActiveHeteroOperationPrincipal = async (params: {
     throw new HeteroOperationPrincipalError('Operation has already ended', 409);
   }
 
+  const metadataAgentType = operation.metadata?.agentType;
+  const agentType =
+    operation.metadata?.serverDefaultHeterogeneous === true &&
+    typeof metadataAgentType === 'string' &&
+    isServerDefaultHeterogeneousAgentType(metadataAgentType)
+      ? metadataAgentType
+      : undefined;
+  if (capability === 'model:invoke' && (!claims.model || !claims.provider_id || !agentType)) {
+    throw new HeteroOperationPrincipalError(
+      'Operation token has no valid server model selection',
+      403,
+    );
+  }
+
   const workspaceId = operation.workspaceId ?? undefined;
   if (
     workspaceId &&
@@ -85,5 +103,5 @@ export const resolveActiveHeteroOperationPrincipal = async (params: {
     throw new HeteroOperationPrincipalError('Model invocation is no longer permitted', 403);
   }
 
-  return { operationId, userId: claims.sub, workspaceId };
+  return { agentType, operationId, userId: claims.sub, workspaceId };
 };

--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -2,7 +2,7 @@
   "description": "These features are experimental. We might remove them, and they might have bugs. We'd love your feedback while using them.",
   "features.agentGraphConfig.desc": "Show graph runtime configuration in an agent profile advanced settings.",
   "features.agentGraphConfig.title": "Agent Graph Runtime Configuration",
-  "features.agentProviderBinding.desc": "Let supported local agents run on API instead of their subscription — through the LobeHub default provider or a configured API provider and model. Initially available for Claude Code and Codex on Desktop local execution.",
+  "features.agentProviderBinding.desc": "Let supported local agents run on API instead of their subscription — through the LobeHub default provider or a configured API provider and model. Available for select agents on Desktop local execution.",
   "features.agentProviderBinding.title": "Agent Provider Binding",
   "features.agentSelfIteration.desc": "Allow the agent to reflect, build self-awareness, and continuously iterate through ongoing attempts and interactions.",
   "features.agentSelfIteration.title": "Agent Self-iteration",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -2,7 +2,7 @@
   "description": "这些功能仍处于实验阶段，可能会被移除，也可能存在问题。欢迎在使用过程中向我们提供反馈。",
   "features.agentGraphConfig.desc": "在助理档案的进阶设置中显示 Graph 运行时配置。",
   "features.agentGraphConfig.title": "Agent Graph 运行时配置",
-  "features.agentProviderBinding.desc": "让支持的本地 Agent 使用 API 而非订阅运行——可选用 LobeHub 默认服务商，或已配置的 API 服务商和模型。首批支持 Claude Code 和 Codex，仅限桌面端本地执行。",
+  "features.agentProviderBinding.desc": "让支持的本地 Agent 使用 API 而非订阅运行——可选用 LobeHub 默认服务商，或已配置的 API 服务商和模型。目前仅支持部分 Agent，且仅限桌面端本地执行。",
   "features.agentProviderBinding.title": "Agent 服务商绑定",
   "features.agentSelfIteration.desc": "允许助理自我反思、自我感知，并在持续的尝试与交互中不断自我迭代。",
   "features.agentSelfIteration.title": "Agent 自我迭代",

--- a/packages/heterogeneous-agents/src/index.ts
+++ b/packages/heterogeneous-agents/src/index.ts
@@ -102,15 +102,23 @@ export type {
   HeterogeneousProviderBindingRuntime,
   ResolveHeterogeneousProviderBindingInput,
   ResolveHeterogeneousProviderBindingResult,
+  ServerDefaultHeterogeneousAgentType,
+  ServerDefaultHeterogeneousIngress,
+  ServerDefaultHeterogeneousModelPolicy,
+  ServerDefaultHeterogeneousTokenHeader,
 } from './providerBinding';
 export {
   formatHeterogeneousProviderBindingError,
   getHeterogeneousProviderBindingCapability,
   getProviderInferenceProtocols,
+  getServerDefaultHeterogeneousAgentConfig,
   HETEROGENEOUS_PROVIDER_BINDING_AGENT_TYPES,
   isHeterogeneousProviderBindingSupported,
+  isServerDefaultHeterogeneousAgentType,
   resolveHeterogeneousProviderBinding,
   resolveProviderBindingProtocol,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
 } from './providerBinding';
 export { createAdapter, listAgentTypes, listLocalAgentTypes } from './registry';
 export type { HeterogeneousAgentScanMap, HeterogeneousAgentScanStatus } from './scan/types';

--- a/packages/heterogeneous-agents/src/providerBinding/index.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/index.ts
@@ -8,6 +8,18 @@ export {
   resolveProviderBindingProtocol,
 } from './resolveBinding';
 export type {
+  ServerDefaultHeterogeneousAgentType,
+  ServerDefaultHeterogeneousIngress,
+  ServerDefaultHeterogeneousModelPolicy,
+  ServerDefaultHeterogeneousTokenHeader,
+} from './serverDefault';
+export {
+  getServerDefaultHeterogeneousAgentConfig,
+  isServerDefaultHeterogeneousAgentType,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
+} from './serverDefault';
+export type {
   EnabledProviderBindingModelRef,
   HeterogeneousProviderBindingCapability,
   HeterogeneousProviderBindingError,

--- a/packages/heterogeneous-agents/src/providerBinding/serverDefault.test.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/serverDefault.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getServerDefaultHeterogeneousAgentConfig,
+  isServerDefaultHeterogeneousAgentType,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
+} from './serverDefault';
+
+describe('server-default heterogeneous agent matrix', () => {
+  it('declares the native relay ingress and credential contract for every supported agent', () => {
+    expect(SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES).toEqual([
+      'claude-code',
+      'codex',
+      'grok-build',
+      'kimi-code',
+      'pi',
+    ]);
+    expect(SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG).toEqual({
+      'claude-code': {
+        ingress: 'anthropic-messages',
+        modelPolicy: 'tool-capable',
+        tokenHeader: 'bearer',
+      },
+      'codex': {
+        ingress: 'openai-responses',
+        modelPolicy: 'codex',
+        tokenHeader: 'bearer',
+      },
+      'grok-build': {
+        ingress: 'openai-responses',
+        modelPolicy: 'tool-capable',
+        tokenHeader: 'bearer',
+      },
+      'kimi-code': {
+        ingress: 'anthropic-messages',
+        modelPolicy: 'tool-capable',
+        tokenHeader: 'x-api-key',
+      },
+      'pi': {
+        ingress: 'openai-responses',
+        modelPolicy: 'tool-capable',
+        tokenHeader: 'bearer',
+      },
+    });
+  });
+
+  it('looks up and narrows only supported agent types', () => {
+    expect(getServerDefaultHeterogeneousAgentConfig('kimi-code')).toEqual({
+      ingress: 'anthropic-messages',
+      modelPolicy: 'tool-capable',
+      tokenHeader: 'x-api-key',
+    });
+    expect(isServerDefaultHeterogeneousAgentType('pi')).toBe(true);
+    expect(isServerDefaultHeterogeneousAgentType('opencode')).toBe(false);
+    expect(isServerDefaultHeterogeneousAgentType('toString')).toBe(false);
+    expect(getServerDefaultHeterogeneousAgentConfig(undefined)).toBeUndefined();
+  });
+});

--- a/packages/heterogeneous-agents/src/providerBinding/serverDefault.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/serverDefault.ts
@@ -1,0 +1,64 @@
+import type { LocalHeterogeneousAgentType } from '../config';
+
+export type ServerDefaultHeterogeneousIngress = 'anthropic-messages' | 'openai-responses';
+
+export type ServerDefaultHeterogeneousModelPolicy = 'codex' | 'tool-capable';
+
+export type ServerDefaultHeterogeneousTokenHeader = 'bearer' | 'x-api-key';
+
+interface ServerDefaultHeterogeneousAgentConfig {
+  ingress: ServerDefaultHeterogeneousIngress;
+  modelPolicy: ServerDefaultHeterogeneousModelPolicy;
+  tokenHeader: ServerDefaultHeterogeneousTokenHeader;
+}
+
+export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG = {
+  'claude-code': {
+    ingress: 'anthropic-messages',
+    modelPolicy: 'tool-capable',
+    tokenHeader: 'bearer',
+  },
+  'codex': {
+    ingress: 'openai-responses',
+    modelPolicy: 'codex',
+    tokenHeader: 'bearer',
+  },
+  'grok-build': {
+    ingress: 'openai-responses',
+    modelPolicy: 'tool-capable',
+    tokenHeader: 'bearer',
+  },
+  'kimi-code': {
+    ingress: 'anthropic-messages',
+    modelPolicy: 'tool-capable',
+    tokenHeader: 'x-api-key',
+  },
+  'pi': {
+    ingress: 'openai-responses',
+    modelPolicy: 'tool-capable',
+    tokenHeader: 'bearer',
+  },
+} as const satisfies Partial<
+  Record<LocalHeterogeneousAgentType, ServerDefaultHeterogeneousAgentConfig>
+>;
+
+export type ServerDefaultHeterogeneousAgentType =
+  keyof typeof SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG;
+
+export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES = Object.keys(
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
+) as ServerDefaultHeterogeneousAgentType[];
+
+export const getServerDefaultHeterogeneousAgentConfig = (
+  agentType: string | undefined,
+): ServerDefaultHeterogeneousAgentConfig | undefined => {
+  if (!agentType || !Object.hasOwn(SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG, agentType)) return;
+  return SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG[
+    agentType as ServerDefaultHeterogeneousAgentType
+  ];
+};
+
+export const isServerDefaultHeterogeneousAgentType = (
+  agentType: string | undefined,
+): agentType is ServerDefaultHeterogeneousAgentType =>
+  !!getServerDefaultHeterogeneousAgentConfig(agentType);

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -5,7 +5,7 @@ export default {
     'Show graph runtime configuration in an agent profile advanced settings.',
   'features.agentGraphConfig.title': 'Agent Graph Runtime Configuration',
   'features.agentProviderBinding.desc':
-    'Let supported local agents run on API instead of their subscription — through the LobeHub default provider or a configured API provider and model. Initially available for Claude Code and Codex on Desktop local execution.',
+    'Let supported local agents run on API instead of their subscription — through the LobeHub default provider or a configured API provider and model. Available for select agents on Desktop local execution.',
   'features.agentProviderBinding.title': 'Agent Provider Binding',
   'features.agentSelfIteration.desc':
     'Allow the agent to reflect, build self-awareness, and continuously iterate through ongoing attempts and interactions.',

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@hono/standard-validator": "^0.3.0",
     "@hono/zod-validator": "^0.7.6",
+    "@lobechat/heterogeneous-agents": "workspace:*",
     "@lobechat/model-runtime": "workspace:*",
     "@lobechat/types": "workspace:*",
     "@scalar/hono-api-reference": "^0.11.12",

--- a/packages/openapi/src/middleware/hetero-operation-auth.test.ts
+++ b/packages/openapi/src/middleware/hetero-operation-auth.test.ts
@@ -1,3 +1,4 @@
+import type { ServerDefaultHeterogeneousIngress } from '@lobechat/heterogeneous-agents';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -26,14 +27,18 @@ vi.mock('@/server/services/heterogeneousAgent/operationPrincipal', () => ({
 }));
 vi.mock('@/utils/server/auth', () => ({ extractBearerToken: mockExtractBearerToken }));
 
-const createApp = () => {
+const createApp = (ingress: ServerDefaultHeterogeneousIngress = 'anthropic-messages') => {
   const app = new Hono();
   app.onError((error) =>
     error instanceof HTTPException ? error.getResponse() : new Response(null, { status: 500 }),
   );
-  app.use('*', requireHeteroModelInvocation);
+  app.use('*', requireHeteroModelInvocation(ingress));
   app.get('/invoke', (c) =>
-    c.json({ userId: c.get('userId' as never), workspaceId: c.get('workspaceId' as never) }),
+    c.json({
+      agentType: c.get('heteroAgentType' as never),
+      userId: c.get('userId' as never),
+      workspaceId: c.get('workspaceId' as never),
+    }),
   );
   return app;
 };
@@ -42,7 +47,9 @@ describe('heterogeneous operation auth middleware', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
-    mockExtractBearerToken.mockReturnValue('operation-token');
+    mockExtractBearerToken.mockImplementation((authorization?: string) =>
+      authorization?.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : undefined,
+    );
     mockValidateHeteroOperationJWT.mockResolvedValue({
       capabilities: ['model:invoke'],
       operation_id: 'operation-1',
@@ -50,6 +57,7 @@ describe('heterogeneous operation auth middleware', () => {
     });
     mockGetServerDB.mockResolvedValue({});
     mockResolveActiveHeteroOperationPrincipal.mockResolvedValue({
+      agentType: 'claude-code',
       userId: 'user-1',
       workspaceId: 'workspace-1',
     });
@@ -59,19 +67,88 @@ describe('heterogeneous operation auth middleware', () => {
     vi.unstubAllEnvs();
   });
 
-  it('authorizes an active operation while server-default agents are enabled', async () => {
+  it('authorizes a Claude Code Bearer token on the Anthropic ingress', async () => {
     const response = await createApp().request('/invoke', {
       headers: { Authorization: 'Bearer operation-token' },
     });
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
+      agentType: 'claude-code',
       userId: 'user-1',
       workspaceId: 'workspace-1',
     });
     expect(mockResolveActiveHeteroOperationPrincipal).toHaveBeenCalledWith(
       expect.objectContaining({ capability: 'model:invoke', operationId: 'operation-1' }),
     );
+  });
+
+  it('authorizes a Kimi Code x-api-key token on the Anthropic ingress', async () => {
+    mockResolveActiveHeteroOperationPrincipal.mockResolvedValueOnce({
+      agentType: 'kimi-code',
+      userId: 'user-1',
+    });
+
+    const response = await createApp().request('/invoke', {
+      headers: { 'x-api-key': 'kimi-operation-token' },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      agentType: 'kimi-code',
+      userId: 'user-1',
+    });
+    expect(mockValidateHeteroOperationJWT).toHaveBeenCalledWith('kimi-operation-token');
+  });
+
+  it('rejects requests that provide both operation credential headers', async () => {
+    const response = await createApp().request('/invoke', {
+      headers: {
+        'Authorization': 'Bearer operation-token',
+        'x-api-key': 'other-operation-token',
+      },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toContain(
+      'Multiple operation credentials are not allowed',
+    );
+    expect(mockValidateHeteroOperationJWT).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['kimi-code', 'anthropic-messages', 'Bearer operation-token'],
+    ['pi', 'anthropic-messages', 'Bearer operation-token'],
+    ['pi', 'openai-responses', undefined],
+  ] as const)(
+    'rejects %s when its ingress or credential header does not match the matrix',
+    async (agentType, ingress, authorization) => {
+      mockResolveActiveHeteroOperationPrincipal.mockResolvedValueOnce({
+        agentType,
+        userId: 'user-1',
+      });
+      const response = await createApp(ingress).request('/invoke', {
+        headers: authorization
+          ? { Authorization: authorization }
+          : { 'x-api-key': 'operation-token' },
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.text()).resolves.toContain(
+        'Operation token cannot invoke this server model ingress',
+      );
+    },
+  );
+
+  it('does not accept an ordinary API key that is not an operation JWT', async () => {
+    mockValidateHeteroOperationJWT.mockResolvedValueOnce(null);
+
+    const response = await createApp().request('/invoke', {
+      headers: { 'x-api-key': 'ordinary-provider-key' },
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockResolveActiveHeteroOperationPrincipal).not.toHaveBeenCalled();
   });
 
   it('rejects previously issued tokens when server-default agents are disabled', async () => {

--- a/packages/openapi/src/middleware/hetero-operation-auth.ts
+++ b/packages/openapi/src/middleware/hetero-operation-auth.ts
@@ -1,4 +1,6 @@
-import type { Context, Next } from 'hono';
+import type { ServerDefaultHeterogeneousIngress } from '@lobechat/heterogeneous-agents';
+import { getServerDefaultHeterogeneousAgentConfig } from '@lobechat/heterogeneous-agents';
+import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
 import { getServerDB } from '@/database/core/db-adaptor';
@@ -10,30 +12,47 @@ import {
 } from '@/server/services/heterogeneousAgent/operationPrincipal';
 import { extractBearerToken } from '@/utils/server/auth';
 
-export const requireHeteroModelInvocation = async (c: Context, next: Next) => {
-  if (process.env.ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT === '0') {
-    throw new HTTPException(403, { message: 'Server-default agents are disabled' });
-  }
-
-  const token = extractBearerToken(c.req.header('Authorization'));
-  const claims = token ? await validateHeteroOperationJWT(token) : null;
-  if (!claims) throw new HTTPException(401, { message: 'Invalid operation token' });
-
-  try {
-    const principal = await resolveActiveHeteroOperationPrincipal({
-      capability: 'model:invoke',
-      claims,
-      db: await getServerDB(),
-      operationId: claims.operation_id,
-    });
-    c.set('heteroOperationClaims', claims satisfies HeteroOperationJwtClaims);
-    c.set('userId', principal.userId);
-    c.set('workspaceId', principal.workspaceId);
-  } catch (error) {
-    if (error instanceof HeteroOperationPrincipalError) {
-      throw new HTTPException(error.status, { message: error.message });
+export const requireHeteroModelInvocation =
+  (ingress: ServerDefaultHeterogeneousIngress): MiddlewareHandler =>
+  async (c, next) => {
+    if (process.env.ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT === '0') {
+      throw new HTTPException(403, { message: 'Server-default agents are disabled' });
     }
-    throw error;
-  }
-  return next();
-};
+
+    const bearerToken = extractBearerToken(c.req.header('Authorization'));
+    const apiKeyToken = c.req.header('x-api-key')?.trim() || undefined;
+    if (bearerToken && apiKeyToken) {
+      throw new HTTPException(401, { message: 'Multiple operation credentials are not allowed' });
+    }
+    const token = bearerToken ?? apiKeyToken;
+    const tokenHeader = bearerToken ? 'bearer' : apiKeyToken ? 'x-api-key' : undefined;
+    const claims = token ? await validateHeteroOperationJWT(token) : null;
+    if (!claims || !tokenHeader) {
+      throw new HTTPException(401, { message: 'Invalid operation token' });
+    }
+
+    try {
+      const principal = await resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims,
+        db: await getServerDB(),
+        operationId: claims.operation_id,
+      });
+      const config = getServerDefaultHeterogeneousAgentConfig(principal.agentType);
+      if (!config || config.ingress !== ingress || config.tokenHeader !== tokenHeader) {
+        throw new HTTPException(403, {
+          message: 'Operation token cannot invoke this server model ingress',
+        });
+      }
+      c.set('heteroAgentType', principal.agentType);
+      c.set('heteroOperationClaims', claims satisfies HeteroOperationJwtClaims);
+      c.set('userId', principal.userId);
+      c.set('workspaceId', principal.workspaceId);
+    } catch (error) {
+      if (error instanceof HeteroOperationPrincipalError) {
+        throw new HTTPException(error.status, { message: error.message });
+      }
+      throw error;
+    }
+    return next();
+  };

--- a/packages/openapi/src/routes/anthropic.route.ts
+++ b/packages/openapi/src/routes/anthropic.route.ts
@@ -20,7 +20,7 @@ import {
 
 const app = new Hono();
 
-app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
+app.post('/v1/messages', requireHeteroModelInvocation('anthropic-messages'), async (c) => {
   const request = await c.req.json().catch(() => null);
   if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
   const context = c as Context;
@@ -35,6 +35,7 @@ app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
     throw new HTTPException(400, { message: 'server-default Anthropic requests must stream' });
   }
   const workspaceId = context.get('workspaceId');
+  const agentType = context.get('heteroAgentType');
   const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
 
   // Anything the model runtime throws has to be turned into an Anthropic error
@@ -43,7 +44,7 @@ app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
   let body: ReadableStream<Uint8Array> | null;
   try {
     const { response } = await invokeServerDefaultModel({
-      agentType: 'claude-code',
+      agentType,
       model: claims.model,
       payload: normalizeAnthropicRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
       signal: c.req.raw.signal,

--- a/packages/openapi/src/routes/heterogeneous-relay.route.test.ts
+++ b/packages/openapi/src/routes/heterogeneous-relay.route.test.ts
@@ -11,14 +11,20 @@ vi.mock('@/server/modules/ModelRuntime', () => ({
   resolveServerDefaultHeterogeneousModel: vi.fn(),
 }));
 vi.mock('../middleware/hetero-operation-auth', () => {
-  const requireHeteroModelInvocation: MiddlewareHandler = async (c, next) => {
-    c.set(
-      'heteroOperationClaims' as never,
-      { model: 'deepseek-v4-pro', provider_id: 'lobehub' } as never,
-    );
-    c.set('userId' as never, 'user-1' as never);
-    await next();
-  };
+  const requireHeteroModelInvocation =
+    (ingress: 'anthropic-messages' | 'openai-responses'): MiddlewareHandler =>
+    async (c, next) => {
+      c.set(
+        'heteroOperationClaims' as never,
+        { model: 'deepseek-v4-pro', provider_id: 'lobehub' } as never,
+      );
+      c.set(
+        'heteroAgentType' as never,
+        (ingress === 'anthropic-messages' ? 'kimi-code' : 'grok-build') as never,
+      );
+      c.set('userId' as never, 'user-1' as never);
+      await next();
+    };
 
   return { requireHeteroModelInvocation };
 });
@@ -65,6 +71,9 @@ describe('heterogeneous relay route failures', () => {
       error: { message: failureMessage, type: 'api_error' },
       type: 'error',
     });
+    expect(invokeServerDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({ agentType: 'kimi-code' }),
+    );
   });
 
   it('returns an OpenAI error envelope when model invocation rejects', async () => {
@@ -82,5 +91,8 @@ describe('heterogeneous relay route failures', () => {
     await expect(response.json()).resolves.toEqual({
       error: { message: failureMessage, type: 'api_error' },
     });
+    expect(invokeServerDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({ agentType: 'grok-build' }),
+    );
   });
 });

--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -20,7 +20,7 @@ import {
 
 const app = new Hono();
 
-app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
+app.post('/v1/responses', requireHeteroModelInvocation('openai-responses'), async (c) => {
   const request = await c.req.json().catch(() => null);
   if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
   const context = c as Context;
@@ -35,6 +35,7 @@ app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
     throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
   }
   const workspaceId = context.get('workspaceId');
+  const agentType = context.get('heteroAgentType');
   const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
 
   // Same reasoning as the Anthropic relay: an escaping runtime rejection reaches
@@ -42,7 +43,7 @@ app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
   let body: ReadableStream<Uint8Array> | null;
   try {
     const { response } = await invokeServerDefaultModel({
-      agentType: 'codex',
+      agentType,
       model: claims.model,
       payload: normalizeResponsesRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
       signal: c.req.raw.signal,

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -111,7 +111,7 @@ export const isServerDefaultHeterogeneousModel = (
 /**
  * Map a CLI-reported server-default model back to the catalog id.
  *
- * Both CLIs request `lobehub/${catalogId}`. Older Claude Code sessions used
+ * Supported CLIs request `lobehub/${catalogId}`. Older Claude Code sessions used
  * {@link SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS}. Neither is the catalog id
  * the user picked.
  */

--- a/src/features/HeterogeneousAgent/modelPicker.test.ts
+++ b/src/features/HeterogeneousAgent/modelPicker.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildServerDefaultModelOptions,
   compactModelTriggerText,
+  resolveServerDefaultAgentModels,
   resolveServerDefaultModelMeta,
 } from './modelPicker';
 
@@ -16,6 +17,20 @@ const catalogItem = (partial: {
     abilities: {},
     ...partial,
   }) as LobeDefaultAiModelListItem;
+
+describe('resolveServerDefaultAgentModels', () => {
+  it('returns an empty list when an older server omits the requested agent entry', () => {
+    const legacyModels = {
+      'claude-code': [{ model: 'claude-sonnet-4-6' }],
+      'codex': [{ model: 'gpt-5.6' }],
+    };
+
+    expect(resolveServerDefaultAgentModels(legacyModels, 'kimi-code')).toEqual([]);
+    expect(resolveServerDefaultAgentModels(legacyModels, 'claude-code')).toEqual([
+      { model: 'claude-sonnet-4-6' },
+    ]);
+  });
+});
 
 describe('resolveServerDefaultModelMeta', () => {
   it('prefers the LobeHub catalog entry over another provider with the same id', () => {

--- a/src/features/HeterogeneousAgent/modelPicker.tsx
+++ b/src/features/HeterogeneousAgent/modelPicker.tsx
@@ -1,3 +1,4 @@
+import type { ServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
 import { createStaticStyles } from 'antd-style';
 import type { LobeDefaultAiModelListItem } from 'model-bank';
 
@@ -7,6 +8,16 @@ export const MODEL_PICKER_STYLE = { minWidth: 200, width: 'initial' } as const;
 
 /** Closed trigger next to the composer send button — hug the label, cap growth. */
 export const COMPACT_MODEL_PICKER_STYLE = { maxWidth: 160, minWidth: 0, width: 'auto' } as const;
+
+interface ServerDefaultModel {
+  model: string;
+}
+
+/** A server deployed before an agent was added can omit that agent's model entry. */
+export const resolveServerDefaultAgentModels = (
+  models: Partial<Record<ServerDefaultHeterogeneousAgentType, ServerDefaultModel[]>> | undefined,
+  agentType: ServerDefaultHeterogeneousAgentType | undefined,
+): ServerDefaultModel[] => (agentType ? (models?.[agentType] ?? []) : []);
 
 export const modelPickerStyles = createStaticStyles(({ css }) => ({
   compactLabel: css`
@@ -40,7 +51,7 @@ export const compactModelTriggerText = (option: { title?: string; value?: unknow
 };
 
 export const buildServerDefaultModelOptions = (
-  models: Array<{ model: string }>,
+  models: ServerDefaultModel[],
   builtinAiModelList: LobeDefaultAiModelListItem[],
 ) =>
   models.map(({ model }) => {

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -13,6 +13,7 @@ import {
   COMPACT_MODEL_PICKER_STYLE,
   compactModelTriggerText,
   modelPickerStyles,
+  resolveServerDefaultAgentModels,
 } from '@/features/HeterogeneousAgent/modelPicker';
 import ModelSelect from '@/features/ModelSelect';
 import { useAgentStore } from '@/store/agent';
@@ -56,7 +57,7 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
   const serverDefaultModelOptions = useMemo(() => {
     const models =
       serverCapability.data?.enabled === true && serverDefaultAgentType
-        ? serverCapability.data.models[serverDefaultAgentType]
+        ? resolveServerDefaultAgentModels(serverCapability.data.models, serverDefaultAgentType)
         : [];
     return buildServerDefaultModelOptions(models, builtinAiModelList);
   }, [builtinAiModelList, serverCapability.data, serverDefaultAgentType]);

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { isServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
 import type { HeterogeneousApiConfig } from '@lobechat/types';
 import { applyTopicModelToHeterogeneousProvider } from '@lobechat/types';
 import { TooltipGroup } from '@lobehub/ui';
@@ -38,7 +39,7 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
   const { providers } = useProviderBindingCompatibleProviders(heterogeneousProvider?.type);
   const providerIds = useMemo(() => providers.map(({ id }) => id), [providers]);
   const serverDefaultAgentType =
-    heterogeneousProvider?.type === 'claude-code' || heterogeneousProvider?.type === 'codex'
+    heterogeneousProvider && isServerDefaultHeterogeneousAgentType(heterogeneousProvider.type)
       ? heterogeneousProvider.type
       : undefined;
   const apiConfig = heterogeneousProvider?.apiConfig;

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -4,6 +4,7 @@ import { isDesktop } from '@lobechat/const';
 import {
   isHeterogeneousProviderBindingSupported,
   isRemoteHeterogeneousType,
+  isServerDefaultHeterogeneousAgentType,
 } from '@lobechat/heterogeneous-agents';
 import type { HeterogeneousApiConfig, HeterogeneousAuthMode } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
@@ -140,10 +141,10 @@ const ProfileEditor = memo(() => {
   const useFetchServerDefaultCapability = useAgentStore(
     (s) => s.useFetchServerDefaultHeterogeneousCapability,
   );
-  // V1 wires only these two native protocol paths. Future client drivers may widen this gate,
-  // while model/runtime compatibility must continue to come from the server capability below.
+  // The shared matrix owns which native drivers can reach the deployment relay;
+  // model/runtime compatibility continues to come from the server capability below.
   const serverDefaultAgentType =
-    heterogeneousProvider?.type === 'claude-code' || heterogeneousProvider?.type === 'codex'
+    heterogeneousProvider && isServerDefaultHeterogeneousAgentType(heterogeneousProvider.type)
       ? heterogeneousProvider.type
       : undefined;
   // Labs-gated with the rest of API mode: with the flag off we never fetch the

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -16,6 +16,7 @@ import { Wrench } from 'lucide-react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { resolveServerDefaultAgentModels } from '@/features/HeterogeneousAgent/modelPicker';
 import ModelSelect from '@/features/ModelSelect';
 import RunPriorityHint from '@/features/ProfileEditor/AgentUserTools/RunPriorityHint';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
@@ -154,7 +155,7 @@ const ProfileEditor = memo(() => {
   const serverCapability = useFetchServerDefaultCapability(serverCapabilityEnabled);
   const serverDefaultModels =
     serverCapability.data?.enabled === true && serverDefaultAgentType
-      ? serverCapability.data.models[serverDefaultAgentType]
+      ? resolveServerDefaultAgentModels(serverCapability.data.models, serverDefaultAgentType)
       : [];
   const serverDefaultAvailable = serverCapabilityEnabled && serverDefaultModels.length > 0;
   const serverDefaultUnavailableReason = !apiModeLabEnabled

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -765,6 +765,30 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       expect(mockGetClaudeCodeIdentity).not.toHaveBeenCalled();
     });
 
+    it('passes a Kimi Code deployment-provider reference to Desktop main', async () => {
+      const kimiServerDefaultProvider = {
+        apiConfig: { model: 'kimi-k2.6', source: 'server-default' as const },
+        authMode: 'api' as const,
+        command: 'kimi',
+        type: 'kimi-code' as const,
+      } satisfies HeterogeneousProviderConfig;
+
+      await runWithEvents([], {
+        params: { heterogeneousProvider: kimiServerDefaultProvider },
+      });
+
+      expect(mockStartSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentType: 'kimi-code',
+          providerBinding: {
+            apiConfig: { model: 'kimi-k2.6', source: 'server-default' },
+            kind: 'server-default',
+            resumeBindingKey: undefined,
+          },
+        }),
+      );
+    });
+
     it.each(['lobehub/claude-server', 'lobehub-default'])(
       'persists the catalog model instead of the CLI report %s',
       async (reportedModel) => {

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -11,6 +11,7 @@ import {
   isHeterogeneousAgentAuthRequired,
   isHeterogeneousProviderBindingSupported,
   isLocalHeterogeneousType,
+  isServerDefaultHeterogeneousAgentType,
   type MainAgentIntent,
   type MainAgentReduceCtx,
   type MainAgentRunState,
@@ -1892,8 +1893,7 @@ export const executeHeterogeneousAgent = async (
 
   if (
     serverDefaultBindingActive &&
-    (!serverDefaultApiConfig.model.trim() ||
-      (adapterType !== 'claude-code' && adapterType !== 'codex'))
+    (!serverDefaultApiConfig.model.trim() || !isServerDefaultHeterogeneousAgentType(adapterType))
   ) {
     await persistTerminalError(
       toHeterogeneousAgentMessageError(


### PR DESCRIPTION
Expand Desktop local heterogeneous-agent support for the deployment-provided LobeHub model connection.

- add a shared server-default capability matrix for Claude Code, Codex, Grok Build, Kimi Code, and Pi
- enable Kimi Code through Anthropic Messages and Pi/Grok Build through OpenAI Responses
- let each driver declare the environment variable that receives the short-lived operation token
- bind operation JWTs to the durable agent type and reject protocol, header, and cross-agent replay mismatches
- use the shared capability in the renderer and replace agent-specific Labs copy with select-agent wording

| Before | After |
| ------ | ----- |
| The LobeHub deployment provider was only selectable for a subset of local agents; Kimi Code, Pi, and Grok Build were disabled. | Kimi Code, Pi, and Grok Build can use the LobeHub deployment provider with agent-specific protocol and authentication handling. |

#### Test

- `bun run check <40 changed files>` — lint clean, 479 tests passed
- focused ModelRuntime checks — 76 tests passed
- server-default matrix hardening checks — 2 tests passed
- full workspace typecheck remains blocked by pre-existing `@lobehub/ui/base-ui` and duplicate Drizzle type errors; filtering the output found no remaining errors involving the new symbols

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A — no matching issue found.
