### PR TITLE
🐛 fix(local-file-shell): resolve the Windows cmd.exe fallback to an absolute path

### DIFF
--- a/packages/local-file-shell/src/shell/__tests__/utils.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/utils.test.ts
@@ -135,6 +135,37 @@ describe('getShellConfig', () => {
   it('should fall back to cmd.exe /c when neither PowerShell edition exists', async () => {
     setPlatform('win32');
     process.env.PATH = 'C:\\Tools';
+    // %ComSpec% takes priority over the System32 default, which may live on
+    // another drive.
+    process.env.ComSpec = 'D:\\Windows\\System32\\cmd.exe';
+    process.env.SystemRoot = 'C:\\Windows';
+    mockExisting(process.env.ComSpec, path.join('C:\\Windows', 'System32', 'cmd.exe'));
+
+    const config = await getShellConfig('dir');
+
+    expect(config.cmd).toBe('D:\\Windows\\System32\\cmd.exe');
+    expect(config.args).toEqual(['/c', 'dir']);
+  });
+
+  it('should resolve cmd.exe under %SystemRoot% when %ComSpec% is unset', async () => {
+    setPlatform('win32');
+    process.env.PATH = 'C:\\Tools';
+    process.env.SystemRoot = 'C:\\Windows';
+    delete process.env.ComSpec;
+    const systemCmd = path.join('C:\\Windows', 'System32', 'cmd.exe');
+    mockExisting(systemCmd);
+
+    const config = await getShellConfig('dir');
+
+    expect(config.cmd).toBe(systemCmd);
+    expect(config.args).toEqual(['/c', 'dir']);
+  });
+
+  it('should keep the bare cmd.exe when no cmd.exe candidate exists on disk', async () => {
+    setPlatform('win32');
+    process.env.PATH = 'C:\\Tools';
+    delete process.env.ComSpec;
+    delete process.env.SystemRoot;
     mockExisting();
 
     const config = await getShellConfig('dir');

--- a/packages/local-file-shell/src/shell/utils.ts
+++ b/packages/local-file-shell/src/shell/utils.ts
@@ -198,6 +198,21 @@ export const findGitBash = async (): Promise<string | undefined> => {
   );
 };
 
+/**
+ * Locate `cmd.exe`, preferring `%ComSpec%` over the System32 default.
+ * Commands are spawned with `shell: false`, so a bare `cmd.exe` would be
+ * resolved against `PATH` — which fails on hosts whose inherited `PATH`
+ * lacks `System32`.
+ */
+const findCmd = async (): Promise<string | undefined> => {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+
+  return firstExisting([
+    ...(process.env.ComSpec ? [process.env.ComSpec] : []),
+    path.join(systemRoot, 'System32', 'cmd.exe'),
+  ]);
+};
+
 /** Locate the built-in Windows PowerShell 5.1 (`powershell.exe`). */
 const findWindowsPowerShell = async (): Promise<string | undefined> => {
   const systemRoot = process.env.SystemRoot || 'C:\\Windows';
@@ -283,7 +298,7 @@ const resolveWindowsShell = async (): Promise<WindowsShellInfo> => {
   }
 
   // Extremely unlikely: neither PowerShell edition is present. Fall back to cmd.
-  return { displayName: 'cmd.exe', path: 'cmd.exe', type: 'cmd' };
+  return { displayName: 'cmd.exe', path: (await findCmd()) ?? 'cmd.exe', type: 'cmd' };
 };
 
 /**


### PR DESCRIPTION
On Windows the local-system `runCommand` tool always fails with `spawn cmd.exe ENOENT`, while `readFile` / `writeFile` / `searchFiles` keep working.

`resolveWindowsShell()` in `packages/local-file-shell/src/shell/utils.ts` runs a `pwsh` → Windows PowerShell 5.1 → `cmd` detection chain. Both PowerShell locators return **absolute** paths, but the final `cmd` fallback returned the bare name `'cmd.exe'`. That value becomes `config.cmd` and is handed to `spawn(launchCommand.cmd, ..., { shell: false })` in `shell/runner.ts`, so Windows resolves the bare name against the spawn env's `PATH` — which fails on any host whose inherited `PATH` lacks `System32`. Pure-Node file operations never spawn a process, which is exactly why they are unaffected.

The new `findCmd()` locator follows the shape of the neighbouring locators and mirrors the `%ComSpec%` handling already used by `buildWindowsShellProbe` in `packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts`. It also restores this file's own documented contract — `ShellInfo.path` is declared as *"Absolute path to the shell executable used to spawn commands"*. The bare `'cmd.exe'` is kept as the very last resort so nothing regresses when neither candidate exists, and `displayName` / `type` are unchanged (`shellSyntaxGuidance.ts` keys off the display name).

| Before | After |
| ------ | ----- |
| The cmd fallback returns the bare name `cmd.exe`. Spawned with `shell: false`, it fails with `spawn cmd.exe ENOENT` whenever `System32` is missing from the inherited `PATH`. | The cmd fallback resolves to `%ComSpec%`, falling back to the `System32` copy under `%SystemRoot%`, so the spawn succeeds regardless of `PATH`. |

No UI change, so no screenshots.

#### Test

Reproduced on Windows 11 with a minimal script: `spawn('cmd.exe', ['/c', 'echo hi'], { shell: false, env: { ...process.env, PATH: 'C:/Tools' } })` errors with `spawn cmd.exe ENOENT`, while the identical call using the absolute `%ComSpec%` path exits 0 and prints `hi`.

Unit tests in `packages/local-file-shell/src/shell/__tests__/utils.test.ts`:

- the existing cmd-fallback case now asserts the **absolute** path and pins `%ComSpec%` precedence over the `System32` default;
- a new case covers `%ComSpec%` unset, resolving the copy under `%SystemRoot%`;
- a new case covers neither candidate existing on disk, which must still degrade to the bare `cmd.exe`.

The first two fail on `canary` and pass with this change; the third is the no-regression guard and passes either way. `bun run check` on both files reports lint clean. Note that the two `findGitBash package-manager installs` cases in this file already fail when the suite is run on a real Windows host — they build their expectations with `path.resolve` over POSIX-style fixture paths, so they only match on a POSIX host. That is pre-existing on `canary` and untouched here.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Closes #16893
