### PR TITLE
✨ feat(topic): add bot channel source filter to topics management page

### DIFF
--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -175,6 +175,8 @@
   "management.empty.noTopics.action": "Start new chat",
   "management.empty.noTopics.desc": "Start a conversation with this agent to create your first topic.",
   "management.empty.noTopics.title": "No topics yet",
+  "management.filters.botChannel.empty": "No bot channels",
+  "management.filters.botChannel.label": "Channel",
   "management.filters.project.empty": "No projects",
   "management.filters.project.label": "Project",
   "management.filters.status.active": "Active",

--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -175,7 +175,7 @@
   "management.empty.noTopics.action": "Start new chat",
   "management.empty.noTopics.desc": "Start a conversation with this agent to create your first topic.",
   "management.empty.noTopics.title": "No topics yet",
-  "management.filters.botChannel.empty": "No bot channels",
+  "management.filters.botChannel.empty": "No channels",
   "management.filters.botChannel.label": "Channel",
   "management.filters.project.empty": "No projects",
   "management.filters.project.label": "Project",

--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -191,6 +191,7 @@
   "management.filters.time.today": "Today",
   "management.filters.time.week": "Past week",
   "management.filters.trigger.api": "API",
+  "management.filters.trigger.bot": "Channel",
   "management.filters.trigger.chat": "Chat",
   "management.filters.trigger.eval": "Eval",
   "management.filters.trigger.label": "Trigger",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -175,6 +175,8 @@
   "management.empty.noTopics.action": "开始新对话",
   "management.empty.noTopics.desc": "和这个助手聊聊，创建第一个话题。",
   "management.empty.noTopics.title": "还没有话题",
+  "management.filters.botChannel.empty": "暂无频道",
+  "management.filters.botChannel.label": "发送来源",
   "management.filters.project.empty": "暂无项目",
   "management.filters.project.label": "项目",
   "management.filters.status.active": "活跃",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -191,6 +191,7 @@
   "management.filters.time.today": "今天",
   "management.filters.time.week": "最近一周",
   "management.filters.trigger.api": "API",
+  "management.filters.trigger.bot": "频道",
   "management.filters.trigger.chat": "对话",
   "management.filters.trigger.eval": "评测",
   "management.filters.trigger.label": "来源",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -176,7 +176,7 @@
   "management.empty.noTopics.desc": "和这个助手聊聊，创建第一个话题。",
   "management.empty.noTopics.title": "还没有话题",
   "management.filters.botChannel.empty": "暂无频道",
-  "management.filters.botChannel.label": "发送来源",
+  "management.filters.botChannel.label": "频道",
   "management.filters.project.empty": "暂无项目",
   "management.filters.project.label": "项目",
   "management.filters.status.active": "活跃",

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -233,6 +233,7 @@ export default {
   'management.filters.time.today': 'Today',
   'management.filters.time.week': 'Past week',
   'management.filters.trigger.api': 'API',
+  'management.filters.trigger.bot': 'Channel',
   'management.filters.trigger.chat': 'Chat',
   'management.filters.trigger.eval': 'Eval',
   'management.filters.trigger.label': 'Trigger',

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -217,7 +217,7 @@ export default {
   'management.empty.noTopics.desc':
     'Start a conversation with this agent to create your first topic.',
   'management.empty.noTopics.title': 'No topics yet',
-  'management.filters.botChannel.empty': 'No bot channels',
+  'management.filters.botChannel.empty': 'No channels',
   'management.filters.botChannel.label': 'Channel',
   'management.filters.project.empty': 'No projects',
   'management.filters.project.label': 'Project',

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -217,6 +217,8 @@ export default {
   'management.empty.noTopics.desc':
     'Start a conversation with this agent to create your first topic.',
   'management.empty.noTopics.title': 'No topics yet',
+  'management.filters.botChannel.empty': 'No bot channels',
+  'management.filters.botChannel.label': 'Channel',
   'management.filters.project.empty': 'No projects',
   'management.filters.project.label': 'Project',
   'management.filters.status.active': 'Active',

--- a/src/features/AgentTopicManager/Toolbar.tsx
+++ b/src/features/AgentTopicManager/Toolbar.tsx
@@ -8,6 +8,7 @@ import {
   CalendarRange,
   ChevronDown,
   FolderClosed,
+  Hash,
   LayoutGrid,
   List as ListIcon,
   ListFilter,
@@ -23,11 +24,20 @@ import {
 import { memo, type ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 
 import { useTopicsViewStore } from './store';
-import type { GroupBy, SortBy, StatusFilter, TimeRangeFilter, TriggerFilter } from './types';
+import type {
+  BotChannelFilter,
+  BotChannelGroup,
+  GroupBy,
+  SortBy,
+  StatusFilter,
+  TimeRangeFilter,
+  TriggerFilter,
+} from './types';
 
 const CONTROL_HEIGHT = 32;
 const THREE_MONTHS_MS = 90 * 24 * 60 * 60 * 1000;
@@ -160,6 +170,7 @@ const SORT_OPTIONS: SortBy[] = ['updatedAt', 'createdAt', 'title'];
 const GROUP_OPTIONS: GroupBy[] = ['byTime', 'byProject', 'none'];
 
 interface ToolbarProps {
+  botChannelGroups: BotChannelGroup[];
   projects: { label: string; value: string }[];
   statusCounts: Record<StatusFilter, number>;
 }
@@ -202,7 +213,7 @@ const FilterChip = memo<FilterChipProps>(({ icon, label, value, items, onClear }
   );
 });
 
-const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
+const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelGroups }) => {
   const { t } = useTranslation('topic');
 
   const topics = useChatStore(topicSelectors.agentTopicsViewTopics);
@@ -214,6 +225,8 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
   const setGroupIds = useTopicsViewStore((s) => s.setGroupIds);
   const triggers = useTopicsViewStore((s) => s.triggers);
   const setTriggers = useTopicsViewStore((s) => s.setTriggers);
+  const botChannels = useTopicsViewStore((s) => s.botChannels);
+  const setBotChannels = useTopicsViewStore((s) => s.setBotChannels);
   const timeRange = useTopicsViewStore((s) => s.timeRange);
   const setTimeRange = useTopicsViewStore((s) => s.setTimeRange);
   const sortBy = useTopicsViewStore((s) => s.sortBy);
@@ -253,6 +266,40 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
     }));
   }, [projects, groupIds, t, setGroupIds]);
 
+  // Two-level "send source" filter: bot (platform + application) → channels.
+  const botChannelItems: DropdownItem[] = useMemo(() => {
+    if (botChannelGroups.length === 0) {
+      return [{ disabled: true, key: 'empty', label: t('management.filters.botChannel.empty') }];
+    }
+    return botChannelGroups.map((group) => {
+      const ProviderIcon = getPlatformIcon(group.platform);
+      return {
+        children: group.channels.map((channel) => {
+          const toggle = (key: BotChannelFilter) =>
+            setBotChannels(
+              botChannels.includes(key)
+                ? botChannels.filter((x) => x !== key)
+                : [...botChannels, key],
+            );
+          return {
+            extra: <CheckMark visible={botChannels.includes(channel.key)} />,
+            key: channel.key,
+            label: channel.label,
+            onClick: () => toggle(channel.key),
+          };
+        }),
+        icon: ProviderIcon ? (
+          <Icon icon={ProviderIcon} size={14} />
+        ) : (
+          <Icon icon={Hash} size={14} />
+        ),
+        key: group.key,
+        label: group.label,
+        type: 'submenu',
+      };
+    });
+  }, [botChannelGroups, botChannels, setBotChannels, t]);
+
   const timeItems: DropdownItem[] = useMemo(
     () =>
       TIME_OPTIONS.map((r) => ({
@@ -288,8 +335,9 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
 
   const triggerApplied = triggers.length > 0;
   const projectApplied = groupIds.length > 0;
+  const botChannelApplied = botChannels.length > 0;
   const timeApplied = timeRange !== 'all';
-  const anyFilterApplied = triggerApplied || projectApplied || timeApplied;
+  const anyFilterApplied = triggerApplied || projectApplied || botChannelApplied || timeApplied;
 
   const addFilterItems: DropdownItem[] = useMemo(() => {
     const items: DropdownItem[] = [];
@@ -311,6 +359,15 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
         type: 'submenu',
       });
     }
+    if (!botChannelApplied) {
+      items.push({
+        children: botChannelItems,
+        icon: <Icon icon={Hash} size={14} />,
+        key: 'botChannel',
+        label: t('management.filters.botChannel.label'),
+        type: 'submenu',
+      });
+    }
     if (!timeApplied) {
       items.push({
         children: timeItems,
@@ -321,7 +378,17 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
       });
     }
     return items;
-  }, [triggerApplied, projectApplied, timeApplied, triggerItems, projectItems, timeItems, t]);
+  }, [
+    triggerApplied,
+    projectApplied,
+    botChannelApplied,
+    timeApplied,
+    triggerItems,
+    projectItems,
+    botChannelItems,
+    timeItems,
+    t,
+  ]);
 
   const projectChipValue = useMemo(() => {
     if (groupIds.length === 1) {
@@ -334,6 +401,17 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
     triggers.length === 1
       ? (t(`management.filters.trigger.${triggers[0]}` as any) as string)
       : `${triggers.length} selected`;
+
+  // Single selection shows "Bot · channel"; multi shows a count.
+  const botChannelChipValue = useMemo(() => {
+    if (botChannels.length !== 1) return `${botChannels.length} selected`;
+    const selected = botChannels[0];
+    for (const group of botChannelGroups) {
+      const channel = group.channels.find((c) => c.key === selected);
+      if (channel) return `${group.label} · ${channel.label}`;
+    }
+    return selected;
+  }, [botChannels, botChannelGroups]);
 
   const handleArchiveStale = useCallback(() => {
     const cutoff = Date.now() - THREE_MONTHS_MS;
@@ -381,6 +459,7 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
           onClick: () => {
             setTriggers([]);
             setGroupIds([]);
+            setBotChannels([]);
             setTimeRange('all');
           },
         },
@@ -403,6 +482,7 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
     t,
     setTriggers,
     setGroupIds,
+    setBotChannels,
     setTimeRange,
     handleArchiveStale,
   ]);
@@ -455,6 +535,15 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
           label={t('management.filters.project.label')}
           value={projectChipValue}
           onClear={() => setGroupIds([])}
+        />
+      )}
+      {botChannelApplied && (
+        <FilterChip
+          icon={Hash}
+          items={botChannelItems}
+          label={t('management.filters.botChannel.label')}
+          value={botChannelChipValue}
+          onClear={() => setBotChannels([])}
         />
       )}
       {timeApplied && (

--- a/src/features/AgentTopicManager/Toolbar.tsx
+++ b/src/features/AgentTopicManager/Toolbar.tsx
@@ -24,14 +24,12 @@ import {
 import { memo, type ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 
 import { useTopicsViewStore } from './store';
 import type {
-  BotChannelFilter,
-  BotChannelGroup,
+  BotChannelOption,
   GroupBy,
   SortBy,
   StatusFilter,
@@ -170,7 +168,7 @@ const SORT_OPTIONS: SortBy[] = ['updatedAt', 'createdAt', 'title'];
 const GROUP_OPTIONS: GroupBy[] = ['byTime', 'byProject', 'none'];
 
 interface ToolbarProps {
-  botChannelGroups: BotChannelGroup[];
+  botChannelOptions: BotChannelOption[];
   projects: { label: string; value: string }[];
   statusCounts: Record<StatusFilter, number>;
 }
@@ -213,7 +211,7 @@ const FilterChip = memo<FilterChipProps>(({ icon, label, value, items, onClear }
   );
 });
 
-const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelGroups }) => {
+const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelOptions }) => {
   const { t } = useTranslation('topic');
 
   const topics = useChatStore(topicSelectors.agentTopicsViewTopics);
@@ -266,39 +264,25 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelGroups }
     }));
   }, [projects, groupIds, t, setGroupIds]);
 
-  // Two-level "send source" filter: bot (platform + application) → channels.
+  // Flattened "send source" filter: one entry per bot platform (per review,
+  // only distinguish tg/discord level — no per-channel submenu).
   const botChannelItems: DropdownItem[] = useMemo(() => {
-    if (botChannelGroups.length === 0) {
+    if (botChannelOptions.length === 0) {
       return [{ disabled: true, key: 'empty', label: t('management.filters.botChannel.empty') }];
     }
-    return botChannelGroups.map((group) => {
-      const ProviderIcon = getPlatformIcon(group.platform);
-      return {
-        children: group.channels.map((channel) => {
-          const toggle = (key: BotChannelFilter) =>
-            setBotChannels(
-              botChannels.includes(key)
-                ? botChannels.filter((x) => x !== key)
-                : [...botChannels, key],
-            );
-          return {
-            extra: <CheckMark visible={botChannels.includes(channel.key)} />,
-            key: channel.key,
-            label: channel.label,
-            onClick: () => toggle(channel.key),
-          };
-        }),
-        icon: ProviderIcon ? (
-          <Icon icon={ProviderIcon} size={14} />
-        ) : (
-          <Icon icon={Hash} size={14} />
+    return botChannelOptions.map((option) => ({
+      extra: <CheckMark visible={botChannels.includes(option.key)} />,
+      icon: <Icon icon={Hash} size={14} />,
+      key: option.key,
+      label: option.label,
+      onClick: () =>
+        setBotChannels(
+          botChannels.includes(option.key)
+            ? botChannels.filter((x) => x !== option.key)
+            : [...botChannels, option.key],
         ),
-        key: group.key,
-        label: group.label,
-        type: 'submenu',
-      };
-    });
-  }, [botChannelGroups, botChannels, setBotChannels, t]);
+    }));
+  }, [botChannelOptions, botChannels, setBotChannels, t]);
 
   const timeItems: DropdownItem[] = useMemo(
     () =>
@@ -402,16 +386,12 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelGroups }
       ? (t(`management.filters.trigger.${triggers[0]}` as any) as string)
       : `${triggers.length} selected`;
 
-  // Single selection shows "Bot · channel"; multi shows a count.
+  // Single selection shows the channel (platform) name; multi shows a count.
   const botChannelChipValue = useMemo(() => {
     if (botChannels.length !== 1) return `${botChannels.length} selected`;
     const selected = botChannels[0];
-    for (const group of botChannelGroups) {
-      const channel = group.channels.find((c) => c.key === selected);
-      if (channel) return `${group.label} · ${channel.label}`;
-    }
-    return selected;
-  }, [botChannels, botChannelGroups]);
+    return botChannelOptions.find((o) => o.key === selected)?.label ?? selected;
+  }, [botChannels, botChannelOptions]);
 
   const handleArchiveStale = useCallback(() => {
     const cutoff = Date.now() - THREE_MONTHS_MS;

--- a/src/features/AgentTopicManager/Toolbar.tsx
+++ b/src/features/AgentTopicManager/Toolbar.tsx
@@ -24,6 +24,7 @@ import {
 import { memo, type ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 
@@ -152,10 +153,11 @@ const STATUS_OPTIONS: { key: StatusFilter; labelKey: string }[] = [
   { key: 'completed', labelKey: 'management.filters.status.completed' },
 ];
 
-const TRIGGER_OPTIONS: TriggerFilter[] = ['chat', 'api', 'task', 'eval'];
+const TRIGGER_OPTIONS: TriggerFilter[] = ['chat', 'bot', 'api', 'task', 'eval'];
 
 const TRIGGER_ICON: Record<TriggerFilter, LucideIcon> = {
   api: Webhook,
+  bot: Hash,
   chat: MessageCircle,
   eval: TestTubeIcon,
   task: ListTodoIcon,
@@ -179,18 +181,19 @@ const CheckMark = ({ visible }: { visible: boolean }) => (
 
 interface FilterChipProps {
   icon?: LucideIcon;
+  iconNode?: ReactNode;
   items: DropdownItem[];
   label: string;
   onClear: () => void;
   value: ReactNode;
 }
 
-const FilterChip = memo<FilterChipProps>(({ icon, label, value, items, onClear }) => {
+const FilterChip = memo<FilterChipProps>(({ icon, iconNode, label, value, items, onClear }) => {
   return (
     <span className={styles.chip}>
       <DropdownMenu items={items}>
         <span className={styles.chipMain}>
-          {icon && <Icon icon={icon} size={12} />}
+          {iconNode ?? (icon && <Icon icon={icon} size={12} />)}
           <Text style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>{label}:</Text>
           <span className={styles.chipValue}>{value}</span>
           <Icon icon={ChevronDown} size={10} />
@@ -223,8 +226,10 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelOptions 
   const setGroupIds = useTopicsViewStore((s) => s.setGroupIds);
   const triggers = useTopicsViewStore((s) => s.triggers);
   const setTriggers = useTopicsViewStore((s) => s.setTriggers);
+  const toggleTrigger = useTopicsViewStore((s) => s.toggleTrigger);
   const botChannels = useTopicsViewStore((s) => s.botChannels);
   const setBotChannels = useTopicsViewStore((s) => s.setBotChannels);
+  const toggleBotChannel = useTopicsViewStore((s) => s.toggleBotChannel);
   const timeRange = useTopicsViewStore((s) => s.timeRange);
   const setTimeRange = useTopicsViewStore((s) => s.setTimeRange);
   const sortBy = useTopicsViewStore((s) => s.sortBy);
@@ -241,10 +246,9 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelOptions 
         icon: <Icon icon={TRIGGER_ICON[tr]} size={14} />,
         key: tr,
         label: t(`management.filters.trigger.${tr}` as any) as string,
-        onClick: () =>
-          setTriggers(triggers.includes(tr) ? triggers.filter((x) => x !== tr) : [...triggers, tr]),
+        onClick: () => toggleTrigger(tr),
       })),
-    [triggers, t, setTriggers],
+    [triggers, t, toggleTrigger],
   );
 
   const projectItems: DropdownItem[] = useMemo(() => {
@@ -270,19 +274,17 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelOptions 
     if (botChannelOptions.length === 0) {
       return [{ disabled: true, key: 'empty', label: t('management.filters.botChannel.empty') }];
     }
-    return botChannelOptions.map((option) => ({
-      extra: <CheckMark visible={botChannels.includes(option.key)} />,
-      icon: <Icon icon={Hash} size={14} />,
-      key: option.key,
-      label: option.label,
-      onClick: () =>
-        setBotChannels(
-          botChannels.includes(option.key)
-            ? botChannels.filter((x) => x !== option.key)
-            : [...botChannels, option.key],
-        ),
-    }));
-  }, [botChannelOptions, botChannels, setBotChannels, t]);
+    return botChannelOptions.map((option) => {
+      const PlatformIcon = getPlatformIcon(option.key);
+      return {
+        extra: <CheckMark visible={botChannels.includes(option.key)} />,
+        icon: PlatformIcon ? <PlatformIcon size={14} /> : <Icon icon={Hash} size={14} />,
+        key: option.key,
+        label: option.label,
+        onClick: () => toggleBotChannel(option.key),
+      };
+    });
+  }, [botChannelOptions, botChannels, t, toggleBotChannel]);
 
   const timeItems: DropdownItem[] = useMemo(
     () =>
@@ -392,6 +394,12 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelOptions 
     const selected = botChannels[0];
     return botChannelOptions.find((o) => o.key === selected)?.label ?? selected;
   }, [botChannels, botChannelOptions]);
+
+  const botChannelChipIcon = useMemo(() => {
+    if (botChannels.length !== 1) return <Icon icon={Hash} size={12} />;
+    const PlatformIcon = getPlatformIcon(botChannels[0]);
+    return PlatformIcon ? <PlatformIcon size={12} /> : <Icon icon={Hash} size={12} />;
+  }, [botChannels]);
 
   const handleArchiveStale = useCallback(() => {
     const cutoff = Date.now() - THREE_MONTHS_MS;
@@ -519,7 +527,7 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts, botChannelOptions 
       )}
       {botChannelApplied && (
         <FilterChip
-          icon={Hash}
+          iconNode={botChannelChipIcon}
           items={botChannelItems}
           label={t('management.filters.botChannel.label')}
           value={botChannelChipValue}

--- a/src/features/AgentTopicManager/TopicCard.tsx
+++ b/src/features/AgentTopicManager/TopicCard.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useActivityTime } from '@/hooks/useActivityTime';
+import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import type { ChatTopic } from '@/types/topic';
 
 import StatusDot from './StatusDot';
@@ -117,6 +118,9 @@ const TopicCard = memo<TopicCardProps>(({ topic, agentId }) => {
 
   const projectLabel = getProjectLabel(topic);
   const status = topic.status ?? 'active';
+  // Bot source platform icon (same identity mark as the sidebar topic item).
+  const botPlatform = topic.metadata?.bot?.platform;
+  const BotPlatformIcon = botPlatform ? getPlatformIcon(botPlatform) : undefined;
   // Preview priority: user-written description → AI history summary → first user
   // message (sliced server-side when neither richer field exists).
   const preview =
@@ -147,6 +151,13 @@ const TopicCard = memo<TopicCardProps>(({ topic, agentId }) => {
       <Flexbox horizontal align={'center'} className={styles.titleRow} gap={6}>
         {topic.favorite && (
           <Icon icon={Star} size={13} style={{ color: cssVar.colorWarning, flexShrink: 0 }} />
+        )}
+        {BotPlatformIcon && (
+          <BotPlatformIcon
+            color={cssVar.colorTextDescription}
+            size={14}
+            style={{ flexShrink: 0 }}
+          />
         )}
         <Text className={styles.title} fontSize={14} weight={600}>
           {topic.title || t('defaultTitle')}

--- a/src/features/AgentTopicManager/TopicListView.tsx
+++ b/src/features/AgentTopicManager/TopicListView.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useTopicItemDropdownMenu } from '@/features/AgentSidebar/Topic/List/Item/useDropdownMenu';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useActivityTime } from '@/hooks/useActivityTime';
+import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import type { ChatTopic } from '@/types/topic';
 
 import StatusDot from './StatusDot';
@@ -178,6 +179,9 @@ const Row = memo<RowProps>(({ topic, agentId }) => {
     ? (rawTrigger as TriggerFilter)
     : 'chat';
   const triggerLabel = t(`management.filters.trigger.${triggerKey}` as any) as string;
+  // Bot source platform icon (same identity mark as the sidebar topic item).
+  const botPlatform = topic.metadata?.bot?.platform;
+  const BotPlatformIcon = botPlatform ? getPlatformIcon(botPlatform) : undefined;
 
   return (
     <div
@@ -196,6 +200,13 @@ const Row = memo<RowProps>(({ topic, agentId }) => {
         <Flexbox horizontal align={'center'} gap={6}>
           {topic.favorite && (
             <Icon icon={Star} size={12} style={{ color: cssVar.colorWarning, flexShrink: 0 }} />
+          )}
+          {BotPlatformIcon && (
+            <BotPlatformIcon
+              color={cssVar.colorTextDescription}
+              size={13}
+              style={{ flexShrink: 0 }}
+            />
           )}
           <Text className={styles.title} fontSize={13} weight={500}>
             {topic.title || t('defaultTitle')}

--- a/src/features/AgentTopicManager/index.tsx
+++ b/src/features/AgentTopicManager/index.tsx
@@ -24,7 +24,9 @@ import Toolbar from './Toolbar';
 import TopicGrid from './TopicGrid';
 import TopicListView from './TopicListView';
 import {
+  buildBotChannelGroups,
   getProjectFilterLabel,
+  matchesBotChannel,
   matchesGroup,
   matchesStatus,
   matchesTimeRange,
@@ -59,6 +61,7 @@ const AgentTopicManager = memo(() => {
   const status = useTopicsViewStore((s) => s.status);
   const groupIds = useTopicsViewStore((s) => s.groupIds);
   const triggers = useTopicsViewStore((s) => s.triggers);
+  const botChannels = useTopicsViewStore((s) => s.botChannels);
   const timeRange = useTopicsViewStore((s) => s.timeRange);
   const sortBy = useTopicsViewStore((s) => s.sortBy);
   const groupBy = useTopicsViewStore((s) => s.groupBy);
@@ -66,6 +69,7 @@ const AgentTopicManager = memo(() => {
   const setStatus = useTopicsViewStore((s) => s.setStatus);
   const setGroupIds = useTopicsViewStore((s) => s.setGroupIds);
   const setTriggers = useTopicsViewStore((s) => s.setTriggers);
+  const setBotChannels = useTopicsViewStore((s) => s.setBotChannels);
   const setTimeRange = useTopicsViewStore((s) => s.setTimeRange);
   const setSearch = useTopicsViewStore((s) => s.setSearch);
 
@@ -108,9 +112,10 @@ const AgentTopicManager = memo(() => {
         (t) =>
           matchesGroup(t, groupIds) &&
           matchesTrigger(t, triggers) &&
-          matchesTimeRange(t, timeRange),
+          matchesTimeRange(t, timeRange) &&
+          matchesBotChannel(t, botChannels),
       ),
-    [baseTopics, groupIds, triggers, timeRange],
+    [baseTopics, groupIds, triggers, timeRange, botChannels],
   );
 
   const filtered = useMemo(() => {
@@ -156,12 +161,15 @@ const AgentTopicManager = memo(() => {
     return Array.from(map, ([value, label]) => ({ label, value }));
   }, [baseTopics]);
 
+  const botChannelGroups = useMemo(() => buildBotChannelGroups(baseTopics), [baseTopics]);
+
   const totalAfterFilter = filtered.length;
   // 'active' is the default tab, so it doesn't count as a user-applied filter
   const hasActiveFilters =
     (status !== 'active' && status !== 'all') ||
     groupIds.length > 0 ||
     triggers.length > 0 ||
+    botChannels.length > 0 ||
     timeRange !== 'all' ||
     trimmedSearch.length > 0;
 
@@ -172,6 +180,7 @@ const AgentTopicManager = memo(() => {
     setStatus('all');
     setGroupIds([]);
     setTriggers([]);
+    setBotChannels([]);
     setTimeRange('all');
     setSearch('');
   };
@@ -224,7 +233,11 @@ const AgentTopicManager = memo(() => {
             width: '100%',
           }}
         >
-          <Toolbar projects={projects} statusCounts={statusCounts} />
+          <Toolbar
+            botChannelGroups={botChannelGroups}
+            projects={projects}
+            statusCounts={statusCounts}
+          />
           <BulkActionBar />
           {!isSearchMode && error && !isLoading && baseTopics.length === 0 ? (
             <AsyncError

--- a/src/features/AgentTopicManager/index.tsx
+++ b/src/features/AgentTopicManager/index.tsx
@@ -24,7 +24,7 @@ import Toolbar from './Toolbar';
 import TopicGrid from './TopicGrid';
 import TopicListView from './TopicListView';
 import {
-  buildBotChannelGroups,
+  buildBotChannelOptions,
   getProjectFilterLabel,
   matchesBotChannel,
   matchesGroup,
@@ -161,7 +161,7 @@ const AgentTopicManager = memo(() => {
     return Array.from(map, ([value, label]) => ({ label, value }));
   }, [baseTopics]);
 
-  const botChannelGroups = useMemo(() => buildBotChannelGroups(baseTopics), [baseTopics]);
+  const botChannelOptions = useMemo(() => buildBotChannelOptions(baseTopics), [baseTopics]);
 
   const totalAfterFilter = filtered.length;
   // 'active' is the default tab, so it doesn't count as a user-applied filter
@@ -234,7 +234,7 @@ const AgentTopicManager = memo(() => {
           }}
         >
           <Toolbar
-            botChannelGroups={botChannelGroups}
+            botChannelOptions={botChannelOptions}
             projects={projects}
             statusCounts={statusCounts}
           />

--- a/src/features/AgentTopicManager/store.test.ts
+++ b/src/features/AgentTopicManager/store.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useTopicsViewStore } from './store';
+
+describe('AgentTopicManager store', () => {
+  beforeEach(() => {
+    useTopicsViewStore.getState().reset();
+  });
+
+  it('switches the source to bot when selecting a channel', () => {
+    useTopicsViewStore.getState().toggleBotChannel('discord');
+
+    expect(useTopicsViewStore.getState()).toMatchObject({
+      botChannels: ['discord'],
+      triggers: ['bot'],
+    });
+  });
+
+  it('clears selected channels when removing the bot source', () => {
+    useTopicsViewStore.setState({ botChannels: ['discord'], triggers: ['bot'] });
+
+    useTopicsViewStore.getState().toggleTrigger('bot');
+
+    expect(useTopicsViewStore.getState()).toMatchObject({
+      botChannels: [],
+      triggers: [],
+    });
+  });
+});

--- a/src/features/AgentTopicManager/store.ts
+++ b/src/features/AgentTopicManager/store.ts
@@ -38,8 +38,10 @@ interface TopicsViewActions {
   setTimeRange: (range: TimeRangeFilter) => void;
   setTriggers: (triggers: TriggerFilter[]) => void;
   setViewMode: (mode: ViewMode) => void;
+  toggleBotChannel: (botChannel: BotChannelFilter) => void;
   toggleSelected: (id: string) => void;
   toggleSelectMode: () => void;
+  toggleTrigger: (trigger: TriggerFilter) => void;
 }
 
 const initialState: TopicsViewState = {
@@ -71,6 +73,24 @@ export const useTopicsViewStore = create<TopicsViewState & TopicsViewActions>((s
   setTimeRange: (timeRange) => set({ timeRange }),
   setTriggers: (triggers) => set({ triggers }),
   setViewMode: (viewMode) => set({ viewMode }),
+  toggleBotChannel: (botChannel) =>
+    set((state) => {
+      if (state.botChannels.includes(botChannel)) {
+        return { botChannels: state.botChannels.filter((item) => item !== botChannel) };
+      }
+
+      return { botChannels: [...state.botChannels, botChannel], triggers: ['bot'] };
+    }),
+  toggleTrigger: (trigger) =>
+    set((state) => {
+      const removing = state.triggers.includes(trigger);
+      return {
+        ...(removing && trigger === 'bot' ? { botChannels: [] } : {}),
+        triggers: removing
+          ? state.triggers.filter((item) => item !== trigger)
+          : [...state.triggers, trigger],
+      };
+    }),
   toggleSelectMode: () =>
     set((s) => ({ selectMode: !s.selectMode, selectedIds: s.selectMode ? [] : s.selectedIds })),
   toggleSelected: (id) =>

--- a/src/features/AgentTopicManager/store.ts
+++ b/src/features/AgentTopicManager/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 import type {
+  BotChannelFilter,
   GroupBy,
   SortBy,
   StatusFilter,
@@ -10,6 +11,7 @@ import type {
 } from './types';
 
 interface TopicsViewState {
+  botChannels: BotChannelFilter[];
   groupBy: GroupBy;
   groupIds: string[];
   search: string;
@@ -27,6 +29,7 @@ interface TopicsViewActions {
   exitSelectMode: () => void;
   reset: () => void;
   selectAll: (ids: string[]) => void;
+  setBotChannels: (botChannels: BotChannelFilter[]) => void;
   setGroupBy: (groupBy: GroupBy) => void;
   setGroupIds: (groupIds: string[]) => void;
   setSearch: (search: string) => void;
@@ -40,6 +43,7 @@ interface TopicsViewActions {
 }
 
 const initialState: TopicsViewState = {
+  botChannels: [],
   groupBy: 'byTime',
   groupIds: [],
   search: '',
@@ -58,6 +62,7 @@ export const useTopicsViewStore = create<TopicsViewState & TopicsViewActions>((s
   exitSelectMode: () => set({ selectMode: false, selectedIds: [] }),
   reset: () => set(initialState),
   selectAll: (ids) => set({ selectedIds: ids }),
+  setBotChannels: (botChannels) => set({ botChannels }),
   setGroupBy: (groupBy) => set({ groupBy }),
   setGroupIds: (groupIds) => set({ groupIds }),
   setSearch: (search) => set({ search }),

--- a/src/features/AgentTopicManager/types.ts
+++ b/src/features/AgentTopicManager/types.ts
@@ -11,31 +11,16 @@ export type SortBy = 'updatedAt' | 'createdAt' | 'title';
 export type GroupBy = 'byProject' | 'byTime' | 'none';
 
 /**
- * A bot-source channel, identified by `topic.metadata.bot.platformThreadId`
- * (e.g. `discord:guild:channel:thread`). One value selects topics that came
- * from one bot's channel on one platform.
+ * A bot source platform, identified by `topic.metadata.bot.platform`
+ * (e.g. `discord` / `telegram`). One value selects topics that arrived
+ * through any channel of that platform's bot.
  */
 export type BotChannelFilter = string;
 
-/** One selectable bot-source channel inside a bot group. */
+/** One selectable bot source platform inside the flattened channel menu. */
 export interface BotChannelOption {
-  /** bot application id, e.g. the platform app/bot id. */
-  applicationId: string;
-  /** `platformThreadId` — the filter value. */
+  /** Platform id, e.g. `discord` — the filter value. */
   key: string;
-  /** Display label for the channel (short-id fallback). */
+  /** Display label, e.g. `Discord` / `Telegram`. */
   label: string;
-  /** Platform id, e.g. `discord`. */
-  platform: string;
-}
-
-/** A bot (platform + application) owning a set of channels. */
-export interface BotChannelGroup {
-  channels: BotChannelOption[];
-  /** `${platform}:${applicationId}` — one bot install. */
-  key: string;
-  /** Display label for the bot (platform name fallback). */
-  label: string;
-  /** Platform id, e.g. `discord`. */
-  platform: string;
 }

--- a/src/features/AgentTopicManager/types.ts
+++ b/src/features/AgentTopicManager/types.ts
@@ -9,3 +9,33 @@ export type TimeRangeFilter = 'all' | 'today' | 'week' | 'month';
 export type SortBy = 'updatedAt' | 'createdAt' | 'title';
 
 export type GroupBy = 'byProject' | 'byTime' | 'none';
+
+/**
+ * A bot-source channel, identified by `topic.metadata.bot.platformThreadId`
+ * (e.g. `discord:guild:channel:thread`). One value selects topics that came
+ * from one bot's channel on one platform.
+ */
+export type BotChannelFilter = string;
+
+/** One selectable bot-source channel inside a bot group. */
+export interface BotChannelOption {
+  /** bot application id, e.g. the platform app/bot id. */
+  applicationId: string;
+  /** `platformThreadId` — the filter value. */
+  key: string;
+  /** Display label for the channel (short-id fallback). */
+  label: string;
+  /** Platform id, e.g. `discord`. */
+  platform: string;
+}
+
+/** A bot (platform + application) owning a set of channels. */
+export interface BotChannelGroup {
+  channels: BotChannelOption[];
+  /** `${platform}:${applicationId}` — one bot install. */
+  key: string;
+  /** Display label for the bot (platform name fallback). */
+  label: string;
+  /** Platform id, e.g. `discord`. */
+  platform: string;
+}

--- a/src/features/AgentTopicManager/types.ts
+++ b/src/features/AgentTopicManager/types.ts
@@ -2,7 +2,7 @@ export type ViewMode = 'card' | 'list';
 
 export type StatusFilter = 'all' | 'active' | 'running' | 'completed' | 'archived';
 
-export type TriggerFilter = 'chat' | 'api' | 'task' | 'eval';
+export type TriggerFilter = 'chat' | 'api' | 'task' | 'eval' | 'bot';
 
 export type TimeRangeFilter = 'all' | 'today' | 'week' | 'month';
 

--- a/src/features/AgentTopicManager/utils.test.ts
+++ b/src/features/AgentTopicManager/utils.test.ts
@@ -1,8 +1,7 @@
 import type { ChatTopic } from '@/types/topic';
 
 import {
-  buildBotChannelGroups,
-  getBotChannelShortLabel,
+  buildBotChannelOptions,
   getBotPlatformName,
   getProjectFilterLabel,
   getProjectLabel,
@@ -35,7 +34,7 @@ describe('AgentTopicManager utils', () => {
     expect(getProjectLabel(topic)).toBe('repo/repo-fix · fix');
   });
 
-  it('matches bot channel filters by metadata.bot.platformThreadId', () => {
+  it('matches bot channel filters by metadata.bot.platform', () => {
     const topic = createTopic({
       bot: {
         applicationId: 'app-1',
@@ -47,17 +46,17 @@ describe('AgentTopicManager utils', () => {
     });
 
     expect(matchesBotChannel(topic, [])).toBe(true);
-    expect(matchesBotChannel(topic, ['discord:guild:channel:thread'])).toBe(true);
-    expect(matchesBotChannel(topic, ['telegram:chat-456'])).toBe(false);
+    expect(matchesBotChannel(topic, ['discord'])).toBe(true);
+    expect(matchesBotChannel(topic, ['telegram'])).toBe(false);
   });
 
   it('never matches a bot channel filter when the topic has no bot metadata', () => {
     const topic = createTopic({});
-    expect(matchesBotChannel(topic, ['discord:guild:channel'])).toBe(false);
+    expect(matchesBotChannel(topic, ['discord'])).toBe(false);
   });
 
-  it('builds bot → channel groups from topics, deduped and labeled', () => {
-    const discordTopic = createTopic({
+  it('builds flattened platform options from topics, deduped and labeled', () => {
+    const discordA = createTopic({
       bot: {
         applicationId: 'app-1',
         isOwner: true,
@@ -66,63 +65,38 @@ describe('AgentTopicManager utils', () => {
         senderExternalUserId: 'user-1',
       },
     });
-    const duplicateChannelTopic = createTopic({
-      bot: {
-        applicationId: 'app-1',
-        isOwner: true,
-        platform: 'discord',
-        platformThreadId: 'discord:guild:channel-a',
-        senderExternalUserId: 'user-2',
-      },
-    });
-    const secondDiscordChannel = createTopic({
+    const discordB = createTopic({
       bot: {
         applicationId: 'app-1',
         isOwner: false,
         platform: 'discord',
         platformThreadId: 'discord:guild:channel-b',
-        senderExternalUserId: 'user-3',
+        senderExternalUserId: 'user-2',
       },
     });
-    const telegramTopic = createTopic({
+    const telegram = createTopic({
       bot: {
         applicationId: 'tg-app',
         isOwner: true,
         platform: 'telegram',
         platformThreadId: 'telegram:chat-456',
-        senderExternalUserId: 'user-4',
+        senderExternalUserId: 'user-3',
       },
     });
     const plainTopic = createTopic({});
 
-    const groups = buildBotChannelGroups([
-      plainTopic,
-      discordTopic,
-      duplicateChannelTopic,
-      secondDiscordChannel,
-      telegramTopic,
-    ]);
+    const options = buildBotChannelOptions([plainTopic, discordA, discordB, telegram]);
 
-    expect(groups).toHaveLength(2);
-    expect(groups[0]).toMatchObject({
-      key: 'discord:app-1',
-      label: 'Discord',
-      platform: 'discord',
-    });
-    expect(groups[0].channels.map((c) => c.key)).toEqual([
-      'discord:guild:channel-a',
-      'discord:guild:channel-b',
+    // Flattened to the platform level only — two discord topics collapse to one entry.
+    expect(options).toEqual([
+      { key: 'discord', label: 'Discord' },
+      { key: 'telegram', label: 'Telegram' },
     ]);
-    expect(groups[1]).toMatchObject({ key: 'telegram:tg-app', label: 'Telegram' });
-    expect(groups[1].channels[0].label).toBe('chat-456');
   });
 
-  it('exposes human-readable platform names and short channel labels', () => {
+  it('exposes human-readable platform names', () => {
     expect(getBotPlatformName('discord')).toBe('Discord');
     expect(getBotPlatformName('feishu')).toBe('Feishu');
     expect(getBotPlatformName('unknown-platform')).toBe('unknown-platform');
-    expect(getBotChannelShortLabel('discord:guild:channel:thread')).toBe('thread');
-    expect(getBotChannelShortLabel('telegram:chat-456')).toBe('chat-456');
-    expect(getBotChannelShortLabel('thread-1')).toBe('thread-1');
   });
 });

--- a/src/features/AgentTopicManager/utils.test.ts
+++ b/src/features/AgentTopicManager/utils.test.ts
@@ -7,14 +7,19 @@ import {
   getProjectLabel,
   matchesBotChannel,
   matchesGroup,
+  matchesTrigger,
 } from './utils';
 
-const createTopic = (metadata: ChatTopic['metadata']): ChatTopic => ({
+const createTopic = (
+  metadata: ChatTopic['metadata'],
+  overrides: Partial<ChatTopic> = {},
+): ChatTopic => ({
   createdAt: 1,
   id: 'topic-1',
   metadata,
   title: 'Topic',
   updatedAt: 1,
+  ...overrides,
 });
 
 describe('AgentTopicManager utils', () => {
@@ -35,19 +40,23 @@ describe('AgentTopicManager utils', () => {
   });
 
   it('matches bot channel filters by metadata.bot.platform', () => {
-    const topic = createTopic({
-      bot: {
-        applicationId: 'app-1',
-        isOwner: true,
-        platform: 'discord',
-        platformThreadId: 'discord:guild:channel:thread',
-        senderExternalUserId: 'user-1',
+    const topic = createTopic(
+      {
+        bot: {
+          applicationId: 'app-1',
+          isOwner: true,
+          platform: 'discord',
+          platformThreadId: 'discord:guild:channel:thread',
+          senderExternalUserId: 'user-1',
+        },
       },
-    });
+      { trigger: 'bot' },
+    );
 
     expect(matchesBotChannel(topic, [])).toBe(true);
     expect(matchesBotChannel(topic, ['discord'])).toBe(true);
     expect(matchesBotChannel(topic, ['telegram'])).toBe(false);
+    expect(matchesTrigger(topic, ['bot'])).toBe(true);
   });
 
   it('never matches a bot channel filter when the topic has no bot metadata', () => {

--- a/src/features/AgentTopicManager/utils.test.ts
+++ b/src/features/AgentTopicManager/utils.test.ts
@@ -1,6 +1,14 @@
 import type { ChatTopic } from '@/types/topic';
 
-import { getProjectFilterLabel, getProjectLabel, matchesGroup } from './utils';
+import {
+  buildBotChannelGroups,
+  getBotChannelShortLabel,
+  getBotPlatformName,
+  getProjectFilterLabel,
+  getProjectLabel,
+  matchesBotChannel,
+  matchesGroup,
+} from './utils';
 
 const createTopic = (metadata: ChatTopic['metadata']): ChatTopic => ({
   createdAt: 1,
@@ -25,5 +33,96 @@ describe('AgentTopicManager utils', () => {
     expect(matchesGroup(topic, ['/repo-fix'])).toBe(false);
     expect(getProjectFilterLabel(topic)).toBe('repo');
     expect(getProjectLabel(topic)).toBe('repo/repo-fix · fix');
+  });
+
+  it('matches bot channel filters by metadata.bot.platformThreadId', () => {
+    const topic = createTopic({
+      bot: {
+        applicationId: 'app-1',
+        isOwner: true,
+        platform: 'discord',
+        platformThreadId: 'discord:guild:channel:thread',
+        senderExternalUserId: 'user-1',
+      },
+    });
+
+    expect(matchesBotChannel(topic, [])).toBe(true);
+    expect(matchesBotChannel(topic, ['discord:guild:channel:thread'])).toBe(true);
+    expect(matchesBotChannel(topic, ['telegram:chat-456'])).toBe(false);
+  });
+
+  it('never matches a bot channel filter when the topic has no bot metadata', () => {
+    const topic = createTopic({});
+    expect(matchesBotChannel(topic, ['discord:guild:channel'])).toBe(false);
+  });
+
+  it('builds bot → channel groups from topics, deduped and labeled', () => {
+    const discordTopic = createTopic({
+      bot: {
+        applicationId: 'app-1',
+        isOwner: true,
+        platform: 'discord',
+        platformThreadId: 'discord:guild:channel-a',
+        senderExternalUserId: 'user-1',
+      },
+    });
+    const duplicateChannelTopic = createTopic({
+      bot: {
+        applicationId: 'app-1',
+        isOwner: true,
+        platform: 'discord',
+        platformThreadId: 'discord:guild:channel-a',
+        senderExternalUserId: 'user-2',
+      },
+    });
+    const secondDiscordChannel = createTopic({
+      bot: {
+        applicationId: 'app-1',
+        isOwner: false,
+        platform: 'discord',
+        platformThreadId: 'discord:guild:channel-b',
+        senderExternalUserId: 'user-3',
+      },
+    });
+    const telegramTopic = createTopic({
+      bot: {
+        applicationId: 'tg-app',
+        isOwner: true,
+        platform: 'telegram',
+        platformThreadId: 'telegram:chat-456',
+        senderExternalUserId: 'user-4',
+      },
+    });
+    const plainTopic = createTopic({});
+
+    const groups = buildBotChannelGroups([
+      plainTopic,
+      discordTopic,
+      duplicateChannelTopic,
+      secondDiscordChannel,
+      telegramTopic,
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({
+      key: 'discord:app-1',
+      label: 'Discord',
+      platform: 'discord',
+    });
+    expect(groups[0].channels.map((c) => c.key)).toEqual([
+      'discord:guild:channel-a',
+      'discord:guild:channel-b',
+    ]);
+    expect(groups[1]).toMatchObject({ key: 'telegram:tg-app', label: 'Telegram' });
+    expect(groups[1].channels[0].label).toBe('chat-456');
+  });
+
+  it('exposes human-readable platform names and short channel labels', () => {
+    expect(getBotPlatformName('discord')).toBe('Discord');
+    expect(getBotPlatformName('feishu')).toBe('Feishu');
+    expect(getBotPlatformName('unknown-platform')).toBe('unknown-platform');
+    expect(getBotChannelShortLabel('discord:guild:channel:thread')).toBe('thread');
+    expect(getBotChannelShortLabel('telegram:chat-456')).toBe('chat-456');
+    expect(getBotChannelShortLabel('thread-1')).toBe('thread-1');
   });
 });

--- a/src/features/AgentTopicManager/utils.ts
+++ b/src/features/AgentTopicManager/utils.ts
@@ -8,7 +8,7 @@ import type { ChatTopic } from '@/types/topic';
 
 import type {
   BotChannelFilter,
-  BotChannelGroup,
+  BotChannelOption,
   SortBy,
   StatusFilter,
   TimeRangeFilter,
@@ -57,8 +57,8 @@ export const matchesTrigger = (topic: ChatTopic, triggers: TriggerFilter[]): boo
 
 export const matchesBotChannel = (topic: ChatTopic, botChannels: BotChannelFilter[]): boolean => {
   if (botChannels.length === 0) return true;
-  const thread = topic.metadata?.bot?.platformThreadId;
-  return !!thread && botChannels.includes(thread);
+  const platform = topic.metadata?.bot?.platform;
+  return !!platform && botChannels.includes(platform);
 };
 
 export const matchesTimeRange = (topic: ChatTopic, range: TimeRangeFilter): boolean => {
@@ -148,40 +148,20 @@ export const getBotPlatformName = (platform: string): string =>
   PLATFORM_DISPLAY_NAMES[platform.toLowerCase()] ?? platform;
 
 /**
- * Last segment of a `platformThreadId` (`discord:guild:channel:thread` →
- * `thread`). Compact fallback label when a channel carries no readable title.
+ * Derive the flattened bot-source option list from a topic set — one entry
+ * per platform that actually owns topics (per review: only distinguish
+ * tg/discord level, no per-channel nesting).
  */
-export const getBotChannelShortLabel = (platformThreadId: string): string =>
-  platformThreadId.split(':').findLast(Boolean) ?? platformThreadId;
-
-/**
- * Derive the bot → channel option tree from a topic set. Only channels that
- * actually own topics appear; each bot groups its channels under
- * `${platform}:${applicationId}`.
- */
-export const buildBotChannelGroups = (topics: ChatTopic[]): BotChannelGroup[] => {
-  const groups = new Map<string, BotChannelGroup>();
+export const buildBotChannelOptions = (topics: ChatTopic[]): BotChannelOption[] => {
+  const seen = new Set<string>();
   for (const topic of topics) {
-    const bot = topic.metadata?.bot;
-    if (!bot?.platformThreadId) continue;
-    const platform = bot.platform;
-    const applicationId = bot.applicationId ?? '';
-    const groupKey = `${platform}:${applicationId}`;
-    let group = groups.get(groupKey);
-    if (!group) {
-      group = { channels: [], key: groupKey, label: getBotPlatformName(platform), platform };
-      groups.set(groupKey, group);
-    }
-    if (!group.channels.some((c) => c.key === bot.platformThreadId)) {
-      group.channels.push({
-        applicationId,
-        key: bot.platformThreadId,
-        label: getBotChannelShortLabel(bot.platformThreadId),
-        platform,
-      });
-    }
+    const platform = topic.metadata?.bot?.platform;
+    if (platform) seen.add(platform);
   }
-  return Array.from(groups.values());
+  return Array.from(seen).map((platform) => ({
+    key: platform,
+    label: getBotPlatformName(platform),
+  }));
 };
 
 /**

--- a/src/features/AgentTopicManager/utils.ts
+++ b/src/features/AgentTopicManager/utils.ts
@@ -6,7 +6,14 @@ import dayjs from 'dayjs';
 
 import type { ChatTopic } from '@/types/topic';
 
-import type { SortBy, StatusFilter, TimeRangeFilter, TriggerFilter } from './types';
+import type {
+  BotChannelFilter,
+  BotChannelGroup,
+  SortBy,
+  StatusFilter,
+  TimeRangeFilter,
+  TriggerFilter,
+} from './types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -46,6 +53,12 @@ export const matchesTrigger = (topic: ChatTopic, triggers: TriggerFilter[]): boo
   if (triggers.length === 0) return true;
   const effective: TriggerFilter = (topic.trigger as TriggerFilter | null | undefined) ?? 'chat';
   return triggers.includes(effective);
+};
+
+export const matchesBotChannel = (topic: ChatTopic, botChannels: BotChannelFilter[]): boolean => {
+  if (botChannels.length === 0) return true;
+  const thread = topic.metadata?.bot?.platformThreadId;
+  return !!thread && botChannels.includes(thread);
 };
 
 export const matchesTimeRange = (topic: ChatTopic, range: TimeRangeFilter): boolean => {
@@ -112,6 +125,63 @@ export const getProjectLabel = (topic: ChatTopic): string | undefined => {
   const branch = topic.metadata?.workingDirectoryConfig?.git?.branch;
 
   return branch ? `${pathLabel} · ${branch}` : pathLabel;
+};
+
+/** Client-side platform display names (server `PlatformDefinition.name`). */
+const PLATFORM_DISPLAY_NAMES: Record<string, string> = {
+  discord: 'Discord',
+  feishu: 'Feishu',
+  googlechat: 'Google Chat',
+  imessage: 'iMessage',
+  lark: 'Lark',
+  line: 'Line',
+  msteams: 'Microsoft Teams',
+  qq: 'QQ',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  wechat: 'WeChat',
+  whatsapp: 'WhatsApp',
+};
+
+/** Human-readable bot (platform) name, e.g. `discord` → `Discord`. */
+export const getBotPlatformName = (platform: string): string =>
+  PLATFORM_DISPLAY_NAMES[platform.toLowerCase()] ?? platform;
+
+/**
+ * Last segment of a `platformThreadId` (`discord:guild:channel:thread` →
+ * `thread`). Compact fallback label when a channel carries no readable title.
+ */
+export const getBotChannelShortLabel = (platformThreadId: string): string =>
+  platformThreadId.split(':').findLast(Boolean) ?? platformThreadId;
+
+/**
+ * Derive the bot → channel option tree from a topic set. Only channels that
+ * actually own topics appear; each bot groups its channels under
+ * `${platform}:${applicationId}`.
+ */
+export const buildBotChannelGroups = (topics: ChatTopic[]): BotChannelGroup[] => {
+  const groups = new Map<string, BotChannelGroup>();
+  for (const topic of topics) {
+    const bot = topic.metadata?.bot;
+    if (!bot?.platformThreadId) continue;
+    const platform = bot.platform;
+    const applicationId = bot.applicationId ?? '';
+    const groupKey = `${platform}:${applicationId}`;
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = { channels: [], key: groupKey, label: getBotPlatformName(platform), platform };
+      groups.set(groupKey, group);
+    }
+    if (!group.channels.some((c) => c.key === bot.platformThreadId)) {
+      group.channels.push({
+        applicationId,
+        key: bot.platformThreadId,
+        label: getBotChannelShortLabel(bot.platformThreadId),
+        platform,
+      });
+    }
+  }
+  return Array.from(groups.values());
 };
 
 /**


### PR DESCRIPTION
<!-- Brief and heads-up -->

Adds a **Channel (发送来源)** filter to the agent topics management page, so users can narrow topics by the bot channel they were sent from — e.g. only topics that arrived via a Discord channel or a Telegram chat of a specific bot.

| Before | After |
| ------ | ----- |
| Filters limited to Trigger / Project / Time | New two-level "Channel" filter: bot (platform) → its channels, multi-select with platform icons |

#### What changed

- **Filter state** (`AgentTopicManager`): new `botChannels` zustand state, matching against `topic.metadata.bot.platformThreadId` (data already carried by every bot-originated topic — no backend query changes needed).
- **Option derivation**: builds a bot → channel tree from the loaded topics, grouped by `${platform}:${applicationId}`, showing the client-side platform display name (Discord / Telegram / Slack / …) with the platform icon, and the `platformThreadId` tail segment as the channel label fallback.
- **Toolbar UI**: a `Channel` entry in `+ Add filter` rendered as a two-level submenu (bot → channels, ✓ multi-select); once applied it shows a removable `FilterChip` — single selection reads `Discord · thread`, multiple reads `2 selected`. Includes a disabled empty state when no bot-originated topics exist.
- **Integration**: wired into the status tab counts pool, `hasActiveFilters`, overflow-menu "Clear all filters", and view-store `reset()`.
- **i18n**: `management.filters.botChannel.label` / `.empty` shipped in `packages/locales/src/default/topic.ts` with hand-written en-US and zh-CN (`发送来源` / `暂无频道`).

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit tests in `utils.test.ts` cover: bot-channel matching by `metadata.bot.platformThreadId`, non-matching when bot metadata is absent, group building with dedupe + platform naming, and short-label resolution. `bun run check` passes (lint clean, 5 tests).

Manual verification: open `/agent/:aid/topics`, click `+ Add filter → Channel`, pick a bot then a channel, and confirm the topic list, tab counts, and chip display update as expected.

#### 🔗 Related Issue

None (feature request from internal discussion).