### PR TITLE
🐛 fix(chat-adapter): adapt to chat@4.39.0 fetchData Buffer | ArrayBuffer contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "better-auth": "1.6.15",
     "brotli-wasm": "^3.0.1",
     "buffer.js": "npm:buffer@^6.0.3",
-    "chat": "^4.37.0",
+    "chat": "^4.39.0",
     "chroma-js": "^3.2.0",
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",

--- a/packages/chat-adapter-feishu/package.json
+++ b/packages/chat-adapter-feishu/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chat": "^4.31.0"
+    "chat": "^4.39.0"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/packages/chat-adapter-imessage/package.json
+++ b/packages/chat-adapter-imessage/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chat": "^4.31.0"
+    "chat": "^4.39.0"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/packages/chat-adapter-line/package.json
+++ b/packages/chat-adapter-line/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chat": "^4.31.0",
+    "chat": "^4.39.0",
     "mime": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/chat-adapter-qq/package.json
+++ b/packages/chat-adapter-qq/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chat": "^4.31.0",
+    "chat": "^4.39.0",
     "mime": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/chat-adapter-qq/src/adapter.test.ts
+++ b/packages/chat-adapter-qq/src/adapter.test.ts
@@ -423,7 +423,7 @@ describe('QQAdapter', () => {
       const data = await message.attachments[0].fetchData!();
 
       expect(data).toBeInstanceOf(Buffer);
-      expect(data.length).toBe(4);
+      expect(data.byteLength).toBe(4);
 
       vi.unstubAllGlobals();
     });

--- a/packages/chat-adapter-wechat/package.json
+++ b/packages/chat-adapter-wechat/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chat": "^4.31.0",
+    "chat": "^4.39.0",
     "mime": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/chat-adapter-wechat/src/adapter.test.ts
+++ b/packages/chat-adapter-wechat/src/adapter.test.ts
@@ -653,6 +653,29 @@ describe('WechatAdapter', () => {
       expect(Buffer.from(uploadedBytes).equals(remoteBytes)).toBe(true);
     });
 
+    it('normalizes a fetchData() result that resolves to an ArrayBuffer', async () => {
+      const bytes = Buffer.from([9, 8, 7, 6]);
+      const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+
+      await adapter.postMessage(threadId, {
+        attachments: [
+          {
+            fetchData: async () => arrayBuffer,
+            mimeType: 'image/png',
+            name: 'lazy.png',
+            type: 'image',
+            url: '',
+          },
+        ],
+        raw: '',
+      });
+
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const uploadedBytes = uploadSpy.mock.calls[0][2];
+      expect(Buffer.isBuffer(uploadedBytes)).toBe(true);
+      expect(Buffer.from(uploadedBytes).equals(bytes)).toBe(true);
+    });
+
     it('promotes a FileUpload (no type field) to FILE based on mimeType', async () => {
       const bytes = Buffer.from('arbitrary bytes');
 

--- a/packages/chat-adapter-wechat/src/adapter.ts
+++ b/packages/chat-adapter-wechat/src/adapter.ts
@@ -332,7 +332,8 @@ async function loadAttachmentBuffer(
   }
   if (typeof attachment.fetchData === 'function') {
     try {
-      return await attachment.fetchData();
+      // chat@4.39.0 widened fetchData to Promise<Buffer | ArrayBuffer>
+      return await blobOrBufferToBuffer(await attachment.fetchData());
     } catch (error) {
       logger?.warn?.('Attachment fetchData failed: %s', error);
     }


### PR DESCRIPTION
chat@4.39.0 (published 2026-08-28) widened `Attachment.fetchData` from `() => Promise<Buffer>` to `() => Promise<Buffer | ArrayBuffer>`. Since this repo installs without a lockfile, every fresh CI install now resolves the new version and `tsgo --noEmit` fails in `Test CI / Test Database`, blocking all PRs:

```text
packages/chat-adapter-qq/src/adapter.test.ts(426,19): error TS2339:
Property 'length' does not exist on type 'ArrayBuffer | Buffer<ArrayBufferLike>'.

packages/chat-adapter-wechat/src/adapter.ts(335,7): error TS2322:
Type 'ArrayBuffer | Buffer<ArrayBufferLike>' is not assignable to type 'Buffer<ArrayBufferLike> | undefined'.
```

Failing run: https://github.com/lobehub/lobehub/actions/runs/33163476569/job/98824407578

#### Changes

- **wechat adapter**: `loadAttachmentBuffer` now normalizes the `fetchData()` result through the existing `blobOrBufferToBuffer` helper, so an `ArrayBuffer` result is converted to `Buffer` before upload.
- **qq adapter test**: assert `byteLength` (valid on both `Buffer` and `ArrayBuffer`) after the existing `toBeInstanceOf(Buffer)` check.
- **regression test**: new wechat `postMessage` case where `fetchData()` resolves to an `ArrayBuffer`, asserting the CDN upload still receives an equivalent `Buffer`.
- **manifests**: raise the `chat` range floor to `^4.39.0` — the widened `fetchData` type is now required for the adapters to type-check.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Reproduced both errors locally with `chat@4.39.0` installed (`tsgo --noEmit`), then verified they are gone after the fix. `bun run check` on the touched files: lint clean, 92 tests passed.

#### 🔗 Related Issue

Fixes LOBE-13593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01523f6A6kqKpJQSM6HmgzyE