### PR TITLE
🐛 fix(context-engine): stop reporting image tool results as failed calls

### DIFF
--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -22,6 +22,29 @@ const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
 });
 
 /**
+ * Whether a tool result still carries something the model can read.
+ *
+ * `MessageContentProcessor` rewrites a tool result that produced images (e.g.
+ * `readFile` on a screenshot, which uploads the file and carries the URL on
+ * `pluginState.images`) into multimodal parts — `[{ type: 'text' }, { type:
+ * 'image_url' }]` — whenever the model supports vision. A bare
+ * `typeof content === 'string'` guard therefore rejects exactly the results
+ * that carry an image: this pass would drop the parts and hand the model
+ * {@link DEFAULT_TOOL_FAILURE_CONTENT} instead, so a successful screenshot read
+ * arrived as "Tool call failed" and the image never reached the request at all.
+ */
+const hasUsableToolContent = (content: unknown, pluginErrorMessage?: string): boolean => {
+  // Multimodal parts (text + image_url / video_url / audio_url).
+  if (Array.isArray(content)) return content.length > 0;
+  if (typeof content !== 'string') return false;
+
+  // An empty string is a legitimate result for a tool that produced no output —
+  // unless the row also recorded an error, in which case the error text is the
+  // more useful thing to show the model.
+  return content.length > 0 || !pluginErrorMessage;
+};
+
+/**
  * Reorder tool messages to ensure that tool messages are displayed in the correct order.
  * see https://github.com/lobehub/lobe-chat/pull/3155
  */
@@ -151,11 +174,9 @@ export class ToolMessageReorder extends BaseProcessor {
 
           reorderedMessages.push({
             ...matchedToolMessage,
-            content:
-              typeof matchedToolMessage.content === 'string' &&
-              (matchedToolMessage.content.length > 0 || !pluginErrorMessage)
-                ? matchedToolMessage.content
-                : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
+            content: hasUsableToolContent(matchedToolMessage.content, pluginErrorMessage)
+              ? matchedToolMessage.content
+              : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
           });
           toolMessages.delete(toolCall.id);
           continue;

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -306,4 +306,63 @@ describe('ToolMessageReorder', () => {
       },
     ]);
   });
+
+  // Regression: MessageContentProcessor turns a tool result that produced an
+  // image into multimodal parts for vision models. The old string-only guard
+  // here replaced those parts with the synthetic "Tool call failed" payload, so
+  // a successful `readFile` on a screenshot reached the model as a failure and
+  // the image was dropped from the request.
+  it('should keep multimodal tool result parts produced for vision models', async () => {
+    const proc = new ToolMessageReorder();
+    const multimodalContent = [
+      { text: '[Image: screenshot.png]', type: 'text' },
+      {
+        image_url: { detail: 'auto', url: 'https://app.lobehub.com/f/file_abc' },
+        type: 'image_url',
+      },
+    ];
+    const ctx = createContext([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'readFile' }, id: 'call_1', type: 'function' },
+        ],
+      },
+      {
+        id: 't1',
+        role: 'tool',
+        content: multimodalContent,
+        tool_call_id: 'call_1',
+      },
+    ]);
+
+    const result = await proc.process(ctx);
+
+    expect(result.messages[1].content).toEqual(multimodalContent);
+  });
+
+  it('should fall back to the synthetic failure when tool content is empty or unusable', async () => {
+    const proc = new ToolMessageReorder();
+    const ctx = createContext([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'readFile' }, id: 'call_1', type: 'function' },
+          { function: { arguments: '{}', name: 'readFile' }, id: 'call_2', type: 'function' },
+        ],
+      },
+      { id: 't1', role: 'tool', content: [], tool_call_id: 'call_1' },
+      { id: 't2', role: 'tool', content: undefined, tool_call_id: 'call_2' },
+    ]);
+
+    const result = await proc.process(ctx);
+
+    const failure = JSON.stringify({ error: 'Tool call failed', success: false, synthetic: true });
+    expect(result.messages[1].content).toBe(failure);
+    expect(result.messages[2].content).toBe(failure);
+  });
 });


### PR DESCRIPTION
A tool result that produces an image never reaches a vision-capable model — it arrives as a **failed tool call**.

`MessageContentProcessor` rewrites a tool result carrying images (e.g. `readFile` on a screenshot, whose uploaded URL rides on `pluginState.images`) into multimodal parts — `[{ type: 'text' }, { type: 'image_url' }]` — whenever the target model supports vision. `ToolMessageReorder`, the **last** processor in the pipeline, then guarded its content-preservation branch with `typeof content === 'string'`:

```ts
content:
  typeof matchedToolMessage.content === 'string' &&
  (matchedToolMessage.content.length > 0 || !pluginErrorMessage)
    ? matchedToolMessage.content
    : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
```

That guard rejects exactly the results carrying an image. The parts were dropped and the model received the synthetic failure payload instead:

```json
{"error":"Tool call failed","success":false,"synthetic":true}
```

So a successful screenshot read was reported to the model as a failure, and the image never entered the request at all.

Observed on a real run (`lobehub/glm-5.3-flash`, vision enabled): the tool message was persisted correctly — `content: "[Image: smoke-after-reset.png]"`, `pluginState.images[0].url: "https://app.lobehub.com/f/file_…"` — but `steps[].contextEngine.output` in the execution trace shows the payload actually sent to the model was the synthetic failure. The agent then reasoned, correctly given what it was told, that "readFile errored on this PNG", and fell back to re-analyzing a stale image for the rest of the session.

The non-vision path is untouched: `MessageContentProcessor` still downgrades to a text placeholder carrying a media ref, which steers the model to a visual-analysis tool.

#### Change

Extract `hasUsableToolContent()` and preserve non-empty multimodal parts. The string branch keeps its existing semantics — an empty string stays valid unless the row also recorded a `pluginError`, in which case the error text still wins.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Two regression tests in `ToolMessageReorder.test.ts`:

- multimodal parts survive the reorder pass — fails without the fix, with the exact `Tool call failed` payload;
- empty-array / `undefined` content still falls back to the synthetic failure.

`bun run check` on the touched files: lint clean (one pre-existing unrelated warning), 8 tests pass. Full `packages/context-engine` processor + engine suites: 581 pass.

#### 🔗 Related Issue

Related to #13348 — this restores the multimodal tool-result forwarding that issue introduced.