### PR TITLE
♻️ refactor: remove obsolete subscription mismatch error

### DIFF
--- a/packages/locales/src/default/error.ts
+++ b/packages/locales/src/default/error.ts
@@ -186,8 +186,6 @@ export default {
     'The server could not be reached. This usually indicates a local network problem — please check your internet connection, proxy, or VPN settings and try again.',
   'response.ServerAgentRuntimeError':
     'Sorry, the Agent service is currently unavailable. Please try again later or contact us via email for support.',
-  'response.SubscriptionKeyMismatch':
-    'We apologize for the inconvenience. Due to a temporary system malfunction, your current subscription usage is inactive. Please click the button below to restore your subscription, or contact us via email for support.',
   'response.SubscriptionPlanLimit':
     'Your subscription points have been exhausted, and you cannot use this feature. Please upgrade to a higher plan or configure a custom model API to continue using it.',
   'response.SubscriptionPlanLimitUltimate':

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -274,10 +274,6 @@ export default {
   'credits.topUp.validityInfo': '{{months}} months validity',
   'header.desc': 'Usage and subscription management',
   'header.title': 'Billing',
-  'keyMissMatch.button': 'Restore usage and continue conversation',
-  'keyMissMatch.description':
-    'Due to an occasional system failure, your current subscription usage is temporarily inactive. Please click the button below to restore usage and continue the conversation. If this happens repeatedly, please contact us via email (support@lobehub.com)',
-  'keyMissMatch.title': 'Restore Subscription Usage Now',
   'limitation.chat.budgetReady.action': 'Continue Chatting',
   'limitation.chat.budgetReady.desc': 'Your available credits now cover this request.',
   'limitation.chat.budgetReady.title': 'Credits Ready',

--- a/packages/types/src/fetch.ts
+++ b/packages/types/src/fetch.ts
@@ -10,8 +10,6 @@ export const ChatErrorType = {
   WorkspaceFrozenByAdmin: 'WorkspaceFrozenByAdmin', // Workspace manually frozen by admin (reason is operator-written, safe to surface)
   WorkspaceFrozenByRiskControl: 'WorkspaceFrozenByRiskControl', // Workspace auto-frozen by risk control (reason is engineer debug text, hide from user)
   WorkspaceSubscriptionInactive: 'WorkspaceSubscriptionInactive', // Workspace's paid subscription has lapsed — view-only for non-primary members; spend blocked until renewed
-  SubscriptionKeyMismatch: 'SubscriptionKeyMismatch', // Subscription key mismatch
-
   SupervisorDecisionFailed: 'SupervisorDecisionFailed', // Supervisor decision failed
 
   InvalidUserKey: 'InvalidUserKey', // is not valid User key

--- a/src/utils/errorResponse.test.ts
+++ b/src/utils/errorResponse.test.ts
@@ -77,12 +77,6 @@ describe('createErrorResponse', () => {
     expect(response.status).toBe(400);
   });
 
-  it('returns a 400 status for SubscriptionKeyMismatch error type', () => {
-    const errorType = ChatErrorType.SubscriptionKeyMismatch;
-    const response = createErrorResponse(errorType);
-    expect(response.status).toBe(400);
-  });
-
   describe('Provider Biz Error', () => {
     it('returns a 471 status for ProviderBizError error type', () => {
       const errorType = AgentRuntimeErrorType.ProviderBizError;

--- a/src/utils/errorResponse.ts
+++ b/src/utils/errorResponse.ts
@@ -34,7 +34,6 @@ const getStatus = (errorType: ILobeAgentRuntimeErrorType | ErrorType) => {
       return 403;
     }
 
-    case ChatErrorType.SubscriptionKeyMismatch:
     case ChatErrorType.SystemTimeNotMatchError: {
       return 400;
     }


### PR DESCRIPTION
Remove an obsolete subscription mismatch error from the shared error contract, HTTP status mapping, default locale sources, and the corresponding mapping test.

No runtime producer remains for this error, so keeping it only preserves an unreachable compatibility branch.

#### Test

- [x] Tested locally
- [x] Added/updated tests

- `bun run check` (146 tests passed)

Generated locale JSON is intentionally left to the normal localization workflow; this PR updates the authoritative default locale sources only.

#### 🔗 Related Issue

N/A