### PR TITLE
🐛 fix(desktop): hash renderer OTA main bundles

### DIFF
--- a/.github/actions/desktop-upload-artifacts/action.yml
+++ b/.github/actions/desktop-upload-artifacts/action.yml
@@ -24,11 +24,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Export renderer OTA base hash
+    - name: Validate renderer OTA base hash
       shell: bash
-      env:
-        RENDERER_OTA_PUBLIC_KEY: ${{ inputs.renderer-ota-public-key }}
-      run: node apps/desktop/scripts/mainHash.mjs > apps/desktop/release/renderer-mainhash.txt
+      run: |
+        set -euo pipefail
+        MAIN_HASH=$(cat apps/desktop/release/renderer-mainhash.txt)
+        if [[ ! "$MAIN_HASH" =~ ^[0-9a-f]{64}$ ]]; then
+          echo "Invalid renderer OTA main bundle hash"
+          exit 1
+        fi
 
     - name: Sign renderer OTA r0 baseline
       if: runner.os == 'Linux' && inputs.renderer-ota-private-key != '' && inputs.update-channel != ''

--- a/.github/workflows/release-desktop-renderer-ota.yml
+++ b/.github/workflows/release-desktop-renderer-ota.yml
@@ -106,6 +106,8 @@ jobs:
         env:
           BASE_MAIN_HASH: ${{ steps.base.outputs.main_hash }}
           RENDERER_OTA_PUBLIC_KEY: ${{ secrets.RENDERER_OTA_PUBLIC_KEY }}
+          UPDATE_CHANNEL: ${{ inputs.channel }}
+          UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}
         run: |
           MAIN_HASH=$(node apps/desktop/scripts/mainHash.mjs)
           echo "main_hash=$MAIN_HASH" >> "$GITHUB_OUTPUT"

--- a/apps/desktop/native-deps.config.mjs
+++ b/apps/desktop/native-deps.config.mjs
@@ -35,7 +35,9 @@ const isDarwin = getTargetPlatform() === 'darwin';
 // The packaged macOS runtime invokes get-windows' native helper directly.
 // Its optional dependencies are build/install tooling and the Windows loader
 // chain, neither of which is required in a macOS application artifact.
-const dependencyOptions = isDarwin ? { skipOptionalDependenciesFor: new Set(['get-windows']) } : {};
+export const dependencyOptions = isDarwin
+  ? { skipOptionalDependenciesFor: new Set(['get-windows']) }
+  : {};
 
 /**
  * First-party native addon packages are discovered instead of being listed by

--- a/apps/desktop/scripts/__tests__/mainHash.test.mjs
+++ b/apps/desktop/scripts/__tests__/mainHash.test.mjs
@@ -1,11 +1,12 @@
 import { randomUUID } from 'node:crypto';
-import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { computeMainHash, createMainHash } from '../mainHash.mjs';
+import { discoverFirstPartyNativeAddons } from '../../native-deps.config.mjs';
+import { computeExternalModulesHash, computeMainHash, createMainHash } from '../mainHash.mjs';
 
 const desktopRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
 const repoRoot = path.dirname(path.dirname(desktopRoot));
@@ -36,6 +37,24 @@ describe('mainHash', () => {
       writeFileSync(bundledFile, originalBundledFile);
     }
   }, 30_000);
+
+  it('tracks externalized first-party native addon sources', async () => {
+    process.env.npm_config_platform = 'darwin';
+    const [addon] = discoverFirstPartyNativeAddons();
+    delete process.env.npm_config_platform;
+
+    const addonDir = realpathSync(path.join(desktopRoot, 'node_modules', addon.name));
+    const probe = path.join(addonDir, `__mainhash-probe-${randomUUID()}.js`);
+    const before = await computeExternalModulesHash('darwin');
+
+    writeFileSync(probe, 'module.exports = {};\n');
+    try {
+      expect(await computeExternalModulesHash('darwin')).not.toBe(before);
+    } finally {
+      rmSync(probe, { force: true });
+    }
+    expect(await computeExternalModulesHash('darwin')).toBe(before);
+  });
 
   it('starts a new lineage when bundle metadata changes', () => {
     const base = {

--- a/apps/desktop/scripts/__tests__/mainHash.test.mjs
+++ b/apps/desktop/scripts/__tests__/mainHash.test.mjs
@@ -1,42 +1,58 @@
-import { randomUUID } from 'node:crypto';
-import { readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 import { discoverFirstPartyNativeAddons } from '../../native-deps.config.mjs';
-import { computeExternalModulesHash, computeMainHash, createMainHash } from '../mainHash.mjs';
+import {
+  computeExternalModulesHash,
+  createMainHash,
+  createMainHashFromProbes,
+} from '../mainHash.mjs';
 
 const desktopRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
-const repoRoot = path.dirname(path.dirname(desktopRoot));
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
 
 describe('mainHash', () => {
-  it('hashes emitted main/preload code, not unrelated workspace files', () => {
-    const ignoredProbe = path.join(
-      repoRoot,
-      'packages',
-      'types',
-      'src',
-      `__mainhash-probe-${randomUUID()}.ts`,
-    );
-    const bundledFile = path.join(desktopRoot, 'src', 'common', 'routes.ts');
-    const originalBundledFile = readFileSync(bundledFile, 'utf8');
-    const before = computeMainHash();
-    writeFileSync(ignoredProbe, 'export type MainHashProbe = string;\n');
-    try {
-      expect(computeMainHash()).toBe(before);
+  it('creates the lineage hash from all platform probes without running builds', () => {
+    const calls = [];
+    const runProbe = (flag, platform, target) => {
+      calls.push([flag, platform, target]);
+      return sha256(`${platform}/${target}/bundle-v1`);
+    };
+    const before = createMainHashFromProbes({
+      cloudRef: 'a'.repeat(40),
+      publicKey: 'key-a',
+      runProbe,
+      version: '1.0.0',
+    });
 
-      writeFileSync(
-        bundledFile,
-        originalBundledFile.replace('Developer Tools', `Developer Tools ${randomUUID()}`),
-      );
-      expect(computeMainHash()).not.toBe(before);
-    } finally {
-      rmSync(ignoredProbe, { force: true });
-      writeFileSync(bundledFile, originalBundledFile);
-    }
-  }, 30_000);
+    expect(calls).toEqual([
+      ['--bundle-probe', 'darwin', 'main'],
+      ['--bundle-probe', 'darwin', 'preload'],
+      ['--externals-probe', 'darwin', 'externals'],
+      ['--bundle-probe', 'linux', 'main'],
+      ['--bundle-probe', 'linux', 'preload'],
+      ['--externals-probe', 'linux', 'externals'],
+      ['--bundle-probe', 'win32', 'main'],
+      ['--bundle-probe', 'win32', 'preload'],
+      ['--externals-probe', 'win32', 'externals'],
+    ]);
+    expect(before).toMatch(/^[0-9a-f]{64}$/);
+    expect(
+      createMainHashFromProbes({
+        cloudRef: 'a'.repeat(40),
+        publicKey: 'key-a',
+        runProbe: (flag, platform, target) =>
+          flag === '--bundle-probe' && platform === 'darwin' && target === 'main'
+            ? sha256(`${platform}/${target}/bundle-v2`)
+            : sha256(`${platform}/${target}/bundle-v1`),
+        version: '1.0.0',
+      }),
+    ).not.toBe(before);
+  });
 
   it('tracks externalized first-party native addon sources', async () => {
     process.env.npm_config_platform = 'darwin';
@@ -54,6 +70,43 @@ describe('mainHash', () => {
       rmSync(probe, { force: true });
     }
     expect(await computeExternalModulesHash('darwin')).toBe(before);
+  });
+
+  it('tracks nested external dependency instances by resolved path', async () => {
+    const id = randomUUID();
+    const addonName = `@lobechat/mainhash-probe-${id}`;
+    const dependencyName = `mainhash-probe-dep-${id}`;
+    const addonDir = path.join(desktopRoot, 'node_modules', ...addonName.split('/'));
+    const nestedDependencyDir = path.join(addonDir, 'node_modules', dependencyName);
+    const rootDependencyDir = path.join(desktopRoot, 'node_modules', dependencyName);
+
+    const writePackageJson = (dir, packageJson) => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, 'package.json'), `${JSON.stringify(packageJson)}\n`);
+    };
+
+    writePackageJson(addonDir, {
+      dependencies: { [dependencyName]: '^2.0.0' },
+      name: addonName,
+      version: '1.0.0',
+    });
+    writeFileSync(path.join(addonDir, 'binding.gyp'), '{}\n');
+    writePackageJson(rootDependencyDir, { name: dependencyName, version: '1.0.0' });
+    writePackageJson(nestedDependencyDir, { name: dependencyName, version: '2.0.0' });
+
+    try {
+      const before = await computeExternalModulesHash('linux');
+
+      writePackageJson(nestedDependencyDir, { name: dependencyName, version: '2.0.1' });
+      expect(await computeExternalModulesHash('linux')).not.toBe(before);
+
+      writePackageJson(nestedDependencyDir, { name: dependencyName, version: '2.0.0' });
+      writePackageJson(rootDependencyDir, { name: dependencyName, version: '1.0.1' });
+      expect(await computeExternalModulesHash('linux')).toBe(before);
+    } finally {
+      rmSync(addonDir, { force: true, recursive: true });
+      rmSync(rootDependencyDir, { force: true, recursive: true });
+    }
   });
 
   it('starts a new lineage when bundle metadata changes', () => {

--- a/apps/desktop/scripts/__tests__/mainHash.test.mjs
+++ b/apps/desktop/scripts/__tests__/mainHash.test.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
@@ -6,81 +5,55 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { computeMainHash, STANDALONE_FILES } from '../mainHash.mjs';
+import { computeMainHash, createMainHash } from '../mainHash.mjs';
 
 const desktopRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
 const repoRoot = path.dirname(path.dirname(desktopRoot));
 
 describe('mainHash', () => {
-  it('only hashes git-tracked standalone files so CI fresh checkouts reproduce the hash', () => {
-    for (const file of STANDALONE_FILES) {
-      const abs = path.join(desktopRoot, file);
-      expect(
-        () => execFileSync('git', ['ls-files', '--error-unmatch', abs], { cwd: repoRoot }),
-        `${file} must be committed — untracked inputs are silently skipped on fresh checkouts`,
-      ).not.toThrow();
-    }
-  });
-
-  it('changes when a file under src/common changes', () => {
-    const probe = path.join(desktopRoot, 'src', 'common', `__mainhash-probe-${randomUUID()}.ts`);
-    const before = computeMainHash();
-    writeFileSync(probe, 'export const probe = 1;\n');
-    try {
-      expect(computeMainHash()).not.toBe(before);
-    } finally {
-      rmSync(probe, { force: true });
-    }
-  });
-
-  it('changes when a main-process locale resource changes', () => {
-    const probe = path.join(
-      desktopRoot,
-      'resources',
-      'locales',
-      `__mainhash-probe-${randomUUID()}.json`,
+  it('hashes emitted main/preload code, not unrelated workspace files', () => {
+    const ignoredProbe = path.join(
+      repoRoot,
+      'packages',
+      'types',
+      'src',
+      `__mainhash-probe-${randomUUID()}.ts`,
     );
+    const bundledFile = path.join(desktopRoot, 'src', 'common', 'routes.ts');
+    const originalBundledFile = readFileSync(bundledFile, 'utf8');
     const before = computeMainHash();
-    writeFileSync(probe, '{}\n');
+    writeFileSync(ignoredProbe, 'export type MainHashProbe = string;\n');
     try {
+      expect(computeMainHash()).toBe(before);
+
+      writeFileSync(
+        bundledFile,
+        originalBundledFile.replace('Developer Tools', `Developer Tools ${randomUUID()}`),
+      );
       expect(computeMainHash()).not.toBe(before);
     } finally {
-      rmSync(probe, { force: true });
+      rmSync(ignoredProbe, { force: true });
+      writeFileSync(bundledFile, originalBundledFile);
     }
-  });
+  }, 30_000);
 
-  it('changes when the Cloud build revision changes', () => {
-    const originalCloudRef = process.env.CLOUD_REF;
-    try {
-      process.env.CLOUD_REF = 'a'.repeat(40);
-      const before = computeMainHash();
-      process.env.CLOUD_REF = 'b'.repeat(40);
-      expect(computeMainHash()).not.toBe(before);
-    } finally {
-      if (originalCloudRef === undefined) delete process.env.CLOUD_REF;
-      else process.env.CLOUD_REF = originalCloudRef;
-    }
-  });
+  it('starts a new lineage when bundle metadata changes', () => {
+    const base = {
+      bundleHashes: [{ hash: 'a'.repeat(64), platform: 'darwin', target: 'main' }],
+      cloudRef: 'a'.repeat(40),
+      publicKey: 'key-a',
+      version: '1.0.0',
+    };
+    const before = createMainHash(base);
 
-  it('starts a new lineage for each release version and verification key', () => {
-    const packagePath = path.join(desktopRoot, 'package.json');
-    const originalPackage = readFileSync(packagePath, 'utf8');
-    const originalPublicKey = process.env.RENDERER_OTA_PUBLIC_KEY;
-    try {
-      process.env.RENDERER_OTA_PUBLIC_KEY = 'key-a';
-      const before = computeMainHash();
-      const packageJson = JSON.parse(originalPackage);
-      packageJson.version = '99.0.0-beta.1';
-      writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
-      const nextRelease = computeMainHash();
-      expect(nextRelease).not.toBe(before);
-
-      process.env.RENDERER_OTA_PUBLIC_KEY = 'key-b';
-      expect(computeMainHash()).not.toBe(nextRelease);
-    } finally {
-      writeFileSync(packagePath, originalPackage);
-      if (originalPublicKey === undefined) delete process.env.RENDERER_OTA_PUBLIC_KEY;
-      else process.env.RENDERER_OTA_PUBLIC_KEY = originalPublicKey;
-    }
+    expect(createMainHash({ ...base, cloudRef: 'b'.repeat(40) })).not.toBe(before);
+    expect(createMainHash({ ...base, publicKey: 'key-b' })).not.toBe(before);
+    expect(createMainHash({ ...base, version: '1.0.1' })).not.toBe(before);
+    expect(
+      createMainHash({
+        ...base,
+        bundleHashes: [{ ...base.bundleHashes[0], hash: 'b'.repeat(64) }],
+      }),
+    ).not.toBe(before);
   });
 });

--- a/apps/desktop/scripts/mainHash.mjs
+++ b/apps/desktop/scripts/mainHash.mjs
@@ -1,6 +1,13 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -88,22 +95,41 @@ function walkModuleFiles(dir, files = []) {
   return files;
 }
 
-function updateExternalModuleHash(hash, name) {
-  const moduleDir = path.join(desktopRoot, 'node_modules', name);
-  let realDir;
+function readModulePackageJson(moduleDir) {
   try {
-    realDir = realpathSync(moduleDir);
+    return JSON.parse(readFileSync(path.join(moduleDir, 'package.json'), 'utf8'));
   } catch {
+    return {};
+  }
+}
+
+function resolveInstalledModuleDir(name, fromDirs) {
+  for (const fromDir of fromDirs) {
+    let current = fromDir;
+    while (true) {
+      const candidate = path.join(current, 'node_modules', name);
+      if (existsSync(path.join(candidate, 'package.json'))) return candidate;
+
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+}
+
+function updateExternalModuleHash(hash, name, fromDirs, options = {}, visited = new Set()) {
+  const moduleDir = resolveInstalledModuleDir(name, fromDirs);
+  if (!moduleDir) {
     hash.update(`${name}\0(absent)\0`);
     return;
   }
 
-  let version = '';
-  try {
-    version = JSON.parse(readFileSync(path.join(realDir, 'package.json'), 'utf8')).version ?? '';
-  } catch {
-    // A dependency without a readable manifest still needs a stable identity.
-  }
+  const realDir = realpathSync(moduleDir);
+  if (visited.has(realDir)) return;
+  visited.add(realDir);
+
+  const packageJson = readModulePackageJson(realDir);
+  const version = packageJson.version ?? '';
   hash.update(`${name}\0${version}\0`);
 
   // Workspace packages keep the same version across every source change, so a
@@ -112,13 +138,23 @@ function updateExternalModuleHash(hash, name) {
   const isWorkspacePackage =
     realDir.startsWith(`${repoRoot}${path.sep}`) &&
     !realDir.includes(`${path.sep}node_modules${path.sep}`);
-  if (!isWorkspacePackage) return;
+  if (isWorkspacePackage) {
+    for (const file of walkModuleFiles(realDir).sort()) {
+      hash.update(path.relative(realDir, file).replaceAll('\\', '/'));
+      hash.update('\0');
+      hash.update(readFileSync(file));
+      hash.update('\0');
+    }
+  }
 
-  for (const file of walkModuleFiles(realDir).sort()) {
-    hash.update(path.relative(realDir, file).replaceAll('\\', '/'));
-    hash.update('\0');
-    hash.update(readFileSync(file));
-    hash.update('\0');
+  const dependencies = {
+    ...(packageJson.dependencies || {}),
+    ...(options.skipOptionalDependenciesFor?.has(packageJson.name)
+      ? {}
+      : packageJson.optionalDependencies || {}),
+  };
+  for (const dependency of Object.keys(dependencies).sort()) {
+    updateExternalModuleHash(hash, dependency, [realDir, moduleDir, desktopRoot], options, visited);
   }
 }
 
@@ -134,13 +170,12 @@ export async function computeExternalModulesHash(platform) {
           import(`${pathToFileURL(path.join(desktopRoot, file)).href}?platform=${platform}`),
       ),
     );
-    const modules = new Set([
-      ...runtimeDeps.getAllExternalRuntimeDependencies(),
-      ...nativeDeps.getNativeExternalDependencies(),
-    ]);
+    const modules = new Set([...runtimeDeps.externalRuntimeModules, ...nativeDeps.nativeModules]);
 
     const hash = createHash('sha256');
-    for (const name of [...modules].sort()) updateExternalModuleHash(hash, name);
+    for (const name of [...modules].sort()) {
+      updateExternalModuleHash(hash, name, [desktopRoot], nativeDeps.dependencyOptions);
+    }
     return hash.digest('hex');
   } finally {
     if (originalPlatform === undefined) delete process.env.npm_config_platform;
@@ -159,10 +194,31 @@ export function createMainHash({ bundleHashes, cloudRef = '', publicKey = '', ve
   return hash.digest('hex');
 }
 
+export function createMainHashFromProbes({ cloudRef, publicKey, runProbe, version }) {
+  const bundleHashes = [];
+
+  for (const platform of PLATFORMS) {
+    for (const target of TARGETS) {
+      bundleHashes.push({ hash: runProbe('--bundle-probe', platform, target), platform, target });
+    }
+    bundleHashes.push({
+      hash: runProbe('--externals-probe', platform, EXTERNALS_TARGET),
+      platform,
+      target: EXTERNALS_TARGET,
+    });
+  }
+
+  return createMainHash({
+    bundleHashes,
+    cloudRef,
+    publicKey,
+    version,
+  });
+}
+
 export function computeMainHash() {
   const packageJson = JSON.parse(readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'));
   const childEnv = { ...process.env, [probeEnv]: '1' };
-  const bundleHashes = [];
   delete childEnv.MAIN_HASH;
 
   const runProbe = (flag, platform, target) => {
@@ -182,21 +238,10 @@ export function computeMainHash() {
     return output;
   };
 
-  for (const platform of PLATFORMS) {
-    for (const target of TARGETS) {
-      bundleHashes.push({ hash: runProbe('--bundle-probe', platform, target), platform, target });
-    }
-    bundleHashes.push({
-      hash: runProbe('--externals-probe', platform, EXTERNALS_TARGET),
-      platform,
-      target: EXTERNALS_TARGET,
-    });
-  }
-
-  return createMainHash({
-    bundleHashes,
+  return createMainHashFromProbes({
     cloudRef: process.env.CLOUD_REF,
     publicKey: process.env.RENDERER_OTA_PUBLIC_KEY,
+    runProbe,
     version: packageJson.version,
   });
 }

--- a/apps/desktop/scripts/mainHash.mjs
+++ b/apps/desktop/scripts/mainHash.mjs
@@ -1,129 +1,142 @@
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const desktopRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const scriptPath = fileURLToPath(import.meta.url);
+const desktopRoot = path.dirname(path.dirname(scriptPath));
 const repoRoot = path.dirname(path.dirname(desktopRoot));
+const probeEnv = 'RENDERER_OTA_MAIN_HASH_PROBE';
+const runningEnv = 'RENDERER_OTA_MAIN_HASH_RUNNING';
 
-// Only committed files: this hash must be reproducible from a fresh checkout
-// (CI gate/marker jobs) — never include generated files like pnpm-lock.yaml,
-// which only exists after install-isolated and would silently be skipped.
-export const STANDALONE_FILES = [
-  'vite.main.config.ts',
-  'vite.preload.config.ts',
-  'vite.shared.ts',
-  'native-deps.config.mjs',
-  'external-runtime-deps.config.mjs',
-  'module-deps.config.mjs',
-  'electron-builder.mjs',
-  'package.json',
-];
+export const MAIN_HASH_PLACEHOLDER = '__LOBEMAINHASH_BUNDLE_PROBE__';
 
-const IGNORED_DIRS = new Set(['__tests__', '__mocks__', 'node_modules', 'dist']);
-const IGNORED_FILE_RE = /\.(?:test|spec)\.[cm]?tsx?$|\.md$|\.snap$/;
+const TARGETS = ['main', 'preload'];
+const PLATFORMS = ['darwin', 'linux', 'win32'];
 
-function walk(dir, files = []) {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return files;
-  }
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      if (!IGNORED_DIRS.has(entry.name)) walk(path.join(dir, entry.name), files);
-    } else if (!IGNORED_FILE_RE.test(entry.name)) {
-      files.push(path.join(dir, entry.name));
-    }
-  }
-  return files;
-}
+const bundleOutputs = (result) =>
+  (Array.isArray(result) ? result : [result]).flatMap((item) => item.output ?? []);
 
-function collectWorkspaceImports(files) {
-  const packages = new Set();
-  const importRe = /(?:from\s+|import\s*\(\s*|^\s*import\s+)['"]@lobechat\/([\w-]+)/gm;
-  for (const file of files) {
-    if (!/\.[cm]?tsx?$/.test(file)) continue;
-    const content = readFileSync(file, 'utf8');
-    for (const match of content.matchAll(importRe)) packages.add(match[1]);
-  }
-  return packages;
-}
-
-function resolveWorkspaceClosure(seedFiles) {
-  const resolved = new Set();
-  let pending = collectWorkspaceImports(seedFiles);
-  while (pending.size > 0) {
-    const next = new Set();
-    for (const pkg of pending) {
-      if (resolved.has(pkg)) continue;
-      resolved.add(pkg);
-      const srcDir = path.join(repoRoot, 'packages', pkg, 'src');
-      try {
-        statSync(srcDir);
-      } catch {
-        continue;
-      }
-      for (const dep of collectWorkspaceImports(walk(srcDir))) {
-        if (!resolved.has(dep)) next.add(dep);
-      }
-    }
-    pending = next;
-  }
-  return [...resolved].sort();
-}
-
-export function computeMainHash() {
-  const seedFiles = [
-    ...walk(path.join(desktopRoot, 'src', 'main')),
-    ...walk(path.join(desktopRoot, 'src', 'preload')),
-    ...walk(path.join(desktopRoot, 'src', 'common')),
-    ...walk(path.join(desktopRoot, 'resources', 'locales')),
-  ];
-
-  const files = [...seedFiles, ...STANDALONE_FILES.map((f) => path.join(desktopRoot, f))];
-
-  for (const pkg of resolveWorkspaceClosure(seedFiles)) {
-    files.push(
-      ...walk(path.join(repoRoot, 'packages', pkg, 'src')),
-      path.join(repoRoot, 'packages', pkg, 'package.json'),
-    );
-  }
-
+export async function computeBundleHash(platform, target) {
+  const { build } = await import('vite');
   const hash = createHash('sha256');
-  for (const file of [...new Set(files)].sort()) {
-    let content;
-    try {
-      content = readFileSync(file);
-    } catch {
-      continue;
+  const originalPlatform = process.env.npm_config_platform;
+  const originalProbe = process.env[probeEnv];
+  const originalRunning = process.env[runningEnv];
+  const originalInfo = console.info;
+
+  process.env[probeEnv] = '1';
+  process.env[runningEnv] = '1';
+  process.env.npm_config_platform = platform;
+  console.info = () => {};
+  try {
+    const result = await build({
+      build: { sourcemap: false, write: false },
+      configFile: path.join(desktopRoot, `vite.${target}.config.ts`),
+      logLevel: 'silent',
+      mode: 'production',
+    });
+
+    for (const output of bundleOutputs(result).sort((a, b) =>
+      a.fileName.localeCompare(b.fileName),
+    )) {
+      hash.update(`${output.fileName}\0`);
+      hash.update(output.type === 'chunk' ? output.code : output.source);
+      hash.update('\0');
     }
-    if (file === path.join(desktopRoot, 'package.json')) {
-      const packageJson = JSON.parse(content.toString());
-      delete packageJson.name;
-      delete packageJson.productName;
-      // Keep version: every full release must start a fresh renderer OTA lineage.
-      content = Buffer.from(JSON.stringify(packageJson));
-    }
-    hash.update(path.relative(repoRoot, file).replaceAll('\\', '/'));
-    hash.update('\0');
-    hash.update(content);
-    hash.update('\0');
+  } finally {
+    console.info = originalInfo;
+    if (originalPlatform === undefined) delete process.env.npm_config_platform;
+    else process.env.npm_config_platform = originalPlatform;
+    if (originalProbe === undefined) delete process.env[probeEnv];
+    else process.env[probeEnv] = originalProbe;
+    if (originalRunning === undefined) delete process.env[runningEnv];
+    else process.env[runningEnv] = originalRunning;
   }
-  if (process.env.CLOUD_REF) {
-    hash.update('cloud-ref\0');
-    hash.update(process.env.CLOUD_REF);
-    hash.update('\0');
-  }
-  if (process.env.RENDERER_OTA_PUBLIC_KEY) {
-    hash.update('renderer-ota-public-key\0');
-    hash.update(process.env.RENDERER_OTA_PUBLIC_KEY);
-    hash.update('\0');
+
+  return hash.digest('hex');
+}
+
+export function createMainHash({ bundleHashes, cloudRef = '', publicKey = '', version }) {
+  const hash = createHash('sha256');
+  hash.update(`version\0${version}\0`);
+  hash.update(`cloud-ref\0${cloudRef}\0`);
+  hash.update(`renderer-ota-public-key\0${publicKey}\0`);
+  for (const { hash: bundleHash, platform, target } of bundleHashes) {
+    hash.update(`${platform}/${target}\0${bundleHash}\0`);
   }
   return hash.digest('hex');
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  console.log(computeMainHash());
+export function computeMainHash() {
+  const packageJson = JSON.parse(readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'));
+  const childEnv = { ...process.env, [probeEnv]: '1' };
+  const bundleHashes = [];
+  delete childEnv.MAIN_HASH;
+
+  for (const platform of PLATFORMS) {
+    for (const target of TARGETS) {
+      const output = execFileSync(
+        process.execPath,
+        [scriptPath, '--bundle-probe', platform, target],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: childEnv,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      )
+        .trim()
+        .split(/\r?\n/)
+        .at(-1);
+
+      if (!output || !/^[0-9a-f]{64}$/.test(output)) {
+        throw new Error(`Invalid ${platform}/${target} bundle hash: ${output ?? '(empty)'}`);
+      }
+      bundleHashes.push({ hash: output, platform, target });
+    }
+  }
+
+  return createMainHash({
+    bundleHashes,
+    cloudRef: process.env.CLOUD_REF,
+    publicKey: process.env.RENDERER_OTA_PUBLIC_KEY,
+    version: packageJson.version,
+  });
+}
+
+export function resolveMainHash() {
+  if (process.env[probeEnv] === '1') return MAIN_HASH_PLACEHOLDER;
+  if (!process.env.MAIN_HASH) return computeMainHash();
+  if (!/^[0-9a-f]{64}$/.test(process.env.MAIN_HASH)) {
+    throw new Error('MAIN_HASH must be a 64-character lowercase SHA-256');
+  }
+  return process.env.MAIN_HASH;
+}
+
+export const rendererMainHashArtifact = (mainHash) => ({
+  name: 'renderer-main-hash-artifact',
+  writeBundle() {
+    const releaseDir = path.join(desktopRoot, 'release');
+    mkdirSync(releaseDir, { recursive: true });
+    writeFileSync(path.join(releaseDir, 'renderer-mainhash.txt'), `${mainHash}\n`);
+  },
+});
+
+if (process.argv[1] === scriptPath && process.env[runningEnv] !== '1') {
+  if (process.argv.includes('--bundle-probe')) {
+    const probeIndex = process.argv.indexOf('--bundle-probe');
+    const platform = process.argv[probeIndex + 1];
+    const target = process.argv[probeIndex + 2];
+    if (!PLATFORMS.includes(platform) || !TARGETS.includes(target)) {
+      throw new Error('Bundle probe requires a valid platform and target');
+    }
+    computeBundleHash(platform, target).then(console.log, (error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  } else {
+    console.log(computeMainHash());
+  }
 }

--- a/apps/desktop/scripts/mainHash.mjs
+++ b/apps/desktop/scripts/mainHash.mjs
@@ -1,8 +1,8 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const desktopRoot = path.dirname(path.dirname(scriptPath));
@@ -14,6 +14,17 @@ export const MAIN_HASH_PLACEHOLDER = '__LOBEMAINHASH_BUNDLE_PROBE__';
 
 const TARGETS = ['main', 'preload'];
 const PLATFORMS = ['darwin', 'linux', 'win32'];
+
+const EXTERNALS_TARGET = 'externals';
+const EXTERNAL_SOURCE_IGNORED_DIRS = new Set([
+  '__mocks__',
+  '__tests__',
+  'build',
+  'dist',
+  'node_modules',
+  'prebuilds',
+]);
+const EXTERNAL_SOURCE_IGNORED_FILE_RE = /\.(?:test|spec)\.[cm]?[jt]sx?$|\.md$|\.map$/;
 
 const bundleOutputs = (result) =>
   (Array.isArray(result) ? result : [result]).flatMap((item) => item.output ?? []);
@@ -58,6 +69,85 @@ export async function computeBundleHash(platform, target) {
   return hash.digest('hex');
 }
 
+function walkModuleFiles(dir, files = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!EXTERNAL_SOURCE_IGNORED_DIRS.has(entry.name)) {
+        walkModuleFiles(path.join(dir, entry.name), files);
+      }
+    } else if (!EXTERNAL_SOURCE_IGNORED_FILE_RE.test(entry.name)) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function updateExternalModuleHash(hash, name) {
+  const moduleDir = path.join(desktopRoot, 'node_modules', name);
+  let realDir;
+  try {
+    realDir = realpathSync(moduleDir);
+  } catch {
+    hash.update(`${name}\0(absent)\0`);
+    return;
+  }
+
+  let version = '';
+  try {
+    version = JSON.parse(readFileSync(path.join(realDir, 'package.json'), 'utf8')).version ?? '';
+  } catch {
+    // A dependency without a readable manifest still needs a stable identity.
+  }
+  hash.update(`${name}\0${version}\0`);
+
+  // Workspace packages keep the same version across every source change, so a
+  // first-party native addon would otherwise ship new main-process code under an
+  // unchanged mainHash. Registry packages are immutable per version.
+  const isWorkspacePackage =
+    realDir.startsWith(`${repoRoot}${path.sep}`) &&
+    !realDir.includes(`${path.sep}node_modules${path.sep}`);
+  if (!isWorkspacePackage) return;
+
+  for (const file of walkModuleFiles(realDir).sort()) {
+    hash.update(path.relative(realDir, file).replaceAll('\\', '/'));
+    hash.update('\0');
+    hash.update(readFileSync(file));
+    hash.update('\0');
+  }
+}
+
+export async function computeExternalModulesHash(platform) {
+  const originalPlatform = process.env.npm_config_platform;
+  process.env.npm_config_platform = platform;
+  try {
+    // Both configs read the target platform at module scope, so each platform
+    // needs its own module instance rather than the cached one.
+    const [runtimeDeps, nativeDeps] = await Promise.all(
+      ['external-runtime-deps.config.mjs', 'native-deps.config.mjs'].map(
+        (file) =>
+          import(`${pathToFileURL(path.join(desktopRoot, file)).href}?platform=${platform}`),
+      ),
+    );
+    const modules = new Set([
+      ...runtimeDeps.getAllExternalRuntimeDependencies(),
+      ...nativeDeps.getNativeExternalDependencies(),
+    ]);
+
+    const hash = createHash('sha256');
+    for (const name of [...modules].sort()) updateExternalModuleHash(hash, name);
+    return hash.digest('hex');
+  } finally {
+    if (originalPlatform === undefined) delete process.env.npm_config_platform;
+    else process.env.npm_config_platform = originalPlatform;
+  }
+}
+
 export function createMainHash({ bundleHashes, cloudRef = '', publicKey = '', version }) {
   const hash = createHash('sha256');
   hash.update(`version\0${version}\0`);
@@ -75,27 +165,32 @@ export function computeMainHash() {
   const bundleHashes = [];
   delete childEnv.MAIN_HASH;
 
+  const runProbe = (flag, platform, target) => {
+    const output = execFileSync(process.execPath, [scriptPath, flag, platform, target], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: childEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+      .trim()
+      .split(/\r?\n/)
+      .at(-1);
+
+    if (!output || !/^[0-9a-f]{64}$/.test(output)) {
+      throw new Error(`Invalid ${platform}/${target} hash: ${output ?? '(empty)'}`);
+    }
+    return output;
+  };
+
   for (const platform of PLATFORMS) {
     for (const target of TARGETS) {
-      const output = execFileSync(
-        process.execPath,
-        [scriptPath, '--bundle-probe', platform, target],
-        {
-          cwd: repoRoot,
-          encoding: 'utf8',
-          env: childEnv,
-          stdio: ['ignore', 'pipe', 'pipe'],
-        },
-      )
-        .trim()
-        .split(/\r?\n/)
-        .at(-1);
-
-      if (!output || !/^[0-9a-f]{64}$/.test(output)) {
-        throw new Error(`Invalid ${platform}/${target} bundle hash: ${output ?? '(empty)'}`);
-      }
-      bundleHashes.push({ hash: output, platform, target });
+      bundleHashes.push({ hash: runProbe('--bundle-probe', platform, target), platform, target });
     }
+    bundleHashes.push({
+      hash: runProbe('--externals-probe', platform, EXTERNALS_TARGET),
+      platform,
+      target: EXTERNALS_TARGET,
+    });
   }
 
   return createMainHash({
@@ -125,14 +220,24 @@ export const rendererMainHashArtifact = (mainHash) => ({
 });
 
 if (process.argv[1] === scriptPath && process.env[runningEnv] !== '1') {
-  if (process.argv.includes('--bundle-probe')) {
-    const probeIndex = process.argv.indexOf('--bundle-probe');
+  const probeFlag = ['--bundle-probe', '--externals-probe'].find((flag) =>
+    process.argv.includes(flag),
+  );
+
+  if (probeFlag) {
+    const probeIndex = process.argv.indexOf(probeFlag);
     const platform = process.argv[probeIndex + 1];
     const target = process.argv[probeIndex + 2];
-    if (!PLATFORMS.includes(platform) || !TARGETS.includes(target)) {
-      throw new Error('Bundle probe requires a valid platform and target');
+    const validTarget =
+      probeFlag === '--bundle-probe' ? TARGETS.includes(target) : target === EXTERNALS_TARGET;
+    if (!PLATFORMS.includes(platform) || !validTarget) {
+      throw new Error('Probe requires a valid platform and target');
     }
-    computeBundleHash(platform, target).then(console.log, (error) => {
+    const probe =
+      probeFlag === '--bundle-probe'
+        ? computeBundleHash(platform, target)
+        : computeExternalModulesHash(platform);
+    probe.then(console.log, (error) => {
       console.error(error);
       process.exitCode = 1;
     });

--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -321,6 +321,7 @@ export class UpdaterManager {
     logger.info('Simulating update available...');
 
     const mockUpdateInfo: UpdateInfo = {
+      kind: 'app',
       releaseDate: new Date().toISOString(),
       releaseNotes: ` #### Version 1.0.0 Release Notes
 - Added some great new features
@@ -349,6 +350,7 @@ export class UpdaterManager {
     logger.info('Simulating update downloaded...');
 
     const mockUpdateInfo: UpdateInfo = {
+      kind: 'app',
       releaseDate: new Date().toISOString(),
       releaseNotes: ` #### Version 1.0.0 Release Notes
 - Added some great new features
@@ -361,7 +363,7 @@ export class UpdaterManager {
 
     this.downloading = false;
     this.setStage('downloaded', { updateInfo: mockUpdateInfo });
-    this.mainWindow.broadcast('updateDownloaded', mockUpdateInfo);
+    this.mainWindow.broadcast('updateReady', mockUpdateInfo);
   };
 
   /**
@@ -472,7 +474,7 @@ export class UpdaterManager {
 
       // Always auto-download
       logger.info('Update found, starting download automatically...');
-      this.setStage('downloading', { updateInfo: info });
+      this.setStage('downloading', { updateInfo: { ...info, kind: 'app' } });
       this.downloadUpdate();
     });
 
@@ -526,16 +528,17 @@ export class UpdaterManager {
 
       this.maybeClearInstallLaterGuard(info.version);
 
-      this.setStage('downloaded', { updateInfo: info });
+      const updateInfo = { ...info, kind: 'app' } satisfies UpdateInfo;
+      this.setStage('downloaded', { updateInfo });
 
       if (this.installLaterVersion) {
         logger.info(
-          `Not re-broadcasting updateDownloaded — install-later acknowledged for v${this.installLaterVersion}, incoming v${info.version}`,
+          `Not broadcasting updateReady — install-later acknowledged for v${this.installLaterVersion}, incoming v${info.version}`,
         );
         return;
       }
 
-      this.mainWindow.broadcast('updateDownloaded', info);
+      this.mainWindow.broadcast('updateReady', updateInfo);
     });
 
     logger.debug('Updater events registered');
@@ -584,6 +587,7 @@ export class UpdaterManager {
   private getCurrentUpdateInfo(): UpdateInfo {
     const version = autoUpdater.currentVersion?.version || electronApp.getVersion();
     return {
+      kind: 'app',
       releaseDate: new Date().toISOString(),
       version,
     };

--- a/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
@@ -466,10 +466,10 @@ describe('UpdaterManager', () => {
       registeredEvents.get('update-available')?.({ version });
     };
 
-    it('suppresses re-broadcast of updateDownloaded for the install-later version', () => {
+    it('suppresses re-broadcast of updateReady for the install-later version', () => {
       fireDownloaded('2.2.6');
       expect(mockBroadcast).toHaveBeenCalledWith(
-        'updateDownloaded',
+        'updateReady',
         expect.objectContaining({ version: '2.2.6' }),
       );
 
@@ -478,7 +478,7 @@ describe('UpdaterManager', () => {
       mockBroadcast.mockClear();
       fireDownloaded('2.2.6');
 
-      expect(mockBroadcast).not.toHaveBeenCalledWith('updateDownloaded', expect.anything());
+      expect(mockBroadcast).not.toHaveBeenCalledWith('updateReady', expect.anything());
       expect(mockBroadcast).toHaveBeenCalledWith(
         'updaterStateChanged',
         expect.objectContaining({ stage: 'downloaded' }),
@@ -505,7 +505,7 @@ describe('UpdaterManager', () => {
       fireDownloaded('2.2.7');
 
       expect(mockBroadcast).toHaveBeenCalledWith(
-        'updateDownloaded',
+        'updateReady',
         expect.objectContaining({ version: '2.2.7' }),
       );
     });
@@ -518,7 +518,7 @@ describe('UpdaterManager', () => {
       fireDownloaded('2.2.5');
 
       expect(mockBroadcast).not.toHaveBeenCalledWith(
-        'updateDownloaded',
+        'updateReady',
         expect.objectContaining({ version: '2.2.5' }),
       );
     });
@@ -533,7 +533,7 @@ describe('UpdaterManager', () => {
       fireDownloaded('2.2.6');
 
       expect(mockBroadcast).toHaveBeenCalledWith(
-        'updateDownloaded',
+        'updateReady',
         expect.objectContaining({ version: '2.2.6' }),
       );
     });
@@ -627,14 +627,14 @@ describe('UpdaterManager', () => {
     });
 
     describe('update-downloaded', () => {
-      it('should broadcast updateDownloaded', async () => {
+      it('should broadcast updateReady with the app update info', async () => {
         await updaterManager.initialize();
 
         const info = { version: '2.0.0' };
         const handler = registeredEvents.get('update-downloaded');
         handler?.(info);
 
-        expect(mockBroadcast).toHaveBeenCalledWith('updateDownloaded', info);
+        expect(mockBroadcast).toHaveBeenCalledWith('updateReady', { ...info, kind: 'app' });
       });
     });
 
@@ -698,7 +698,7 @@ describe('UpdaterManager', () => {
       updaterManager.simulateUpdateDownloaded();
 
       expect(mockBroadcast).not.toHaveBeenCalledWith(
-        'updateDownloaded',
+        'updateReady',
         expect.objectContaining({ version: '1.0.0' }),
       );
     });

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
@@ -227,9 +227,9 @@ export class RendererUpdateManager {
       this.state = 'staged';
 
       logger.info(`Renderer ${manifest.version} staged (app ${manifest.appVersion})`);
-      this.app.browserManager.broadcastToAllWindows('rendererUpdateReady', {
-        appVersion: manifest.appVersion,
-        version: manifest.version,
+      this.app.browserManager.broadcastToAllWindows('updateReady', {
+        kind: 'renderer',
+        version: manifest.appVersion,
       });
       return;
     } catch (error) {

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
@@ -199,9 +199,9 @@ describe('RendererUpdateManager V2 lifecycle', () => {
 
     const otaDir = channelDir();
     expect(readPointer(otaDir, MAIN_HASH).staged).toBe('r1');
-    expect(app.browserManager.broadcastToAllWindows).toHaveBeenCalledWith('rendererUpdateReady', {
-      appVersion: APP_VERSION,
-      version: 'r1',
+    expect(app.browserManager.broadcastToAllWindows).toHaveBeenCalledWith('updateReady', {
+      kind: 'renderer',
+      version: APP_VERSION,
     });
     const fetchedUrls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]);
     expect(fetchedUrls).toEqual([

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -6,7 +6,7 @@ import zodCompiler from 'zod-compiler/vite';
 import { viteOsPlatformResolve } from '../../plugins/vite/osPlatformResolve';
 import { externalRuntimeModules } from './external-runtime-deps.config.mjs';
 import { getNativeExternalDependencies } from './native-deps.config.mjs';
-import { computeMainHash } from './scripts/mainHash.mjs';
+import { rendererMainHashArtifact, resolveMainHash } from './scripts/mainHash.mjs';
 import {
   applyDesktopViteConfigExtension,
   isCloudDesktopBuild,
@@ -24,6 +24,7 @@ export default defineConfig(async (env) => {
   const isDev = mode === 'development';
   const updateChannel = process.env.UPDATE_CHANNEL;
   const isCloudDesktop = isCloudDesktopBuild();
+  const mainHash = resolveMainHash();
   const externalNavigationHosts =
     process.env.DESKTOP_EXTERNAL_NAVIGATION_HOSTS ?? (isCloudDesktop ? 'stripe.com' : '');
 
@@ -112,12 +113,12 @@ export default defineConfig(async (env) => {
     define: {
       ...processEnvDefine,
       'process.env.DESKTOP_EXTERNAL_NAVIGATION_HOSTS': JSON.stringify(externalNavigationHosts),
-      'process.env.MAIN_HASH': JSON.stringify(computeMainHash()),
+      'process.env.MAIN_HASH': JSON.stringify(mainHash),
       'process.env.RENDERER_OTA_PUBLIC_KEY': JSON.stringify(process.env.RENDERER_OTA_PUBLIC_KEY),
       'process.env.UPDATE_CHANNEL': JSON.stringify(process.env.UPDATE_CHANNEL),
       'process.env.UPDATE_SERVER_URL': JSON.stringify(process.env.UPDATE_SERVER_URL),
     },
-    plugins: [viteOsPlatformResolve(), zodCompiler()],
+    plugins: [viteOsPlatformResolve(), zodCompiler(), rendererMainHashArtifact(mainHash)],
     publicDir: false,
     resolve: {
       alias: mainProcessAlias,

--- a/packages/electron-client-ipc/src/events/index.ts
+++ b/packages/electron-client-ipc/src/events/index.ts
@@ -5,12 +5,11 @@ import type { HeterogeneousAgentBroadcastEvents } from './heterogeneousAgent';
 import type { NavigationBroadcastEvents } from './navigation';
 import type { ProtocolBroadcastEvents } from './protocol';
 import type { RemoteServerBroadcastEvents } from './remoteServer';
-import type { RendererOtaBroadcastEvents } from './rendererOta';
 import type { ScreenCaptureBroadcastEvents } from './screenCapture';
 import type { SystemBroadcastEvents } from './system';
 import type { TerminalBroadcastEvents } from './terminal';
 import type { TopicPopupBroadcastEvents } from './topicPopup';
-import type { AutoUpdateBroadcastEvents } from './update';
+import type { UpdateBroadcastEvents } from './update';
 import type { ZoomBroadcastEvents } from './zoom';
 
 /**
@@ -20,13 +19,12 @@ import type { ZoomBroadcastEvents } from './zoom';
 export interface MainBroadcastEvents
   extends
     ACPBroadcastEvents,
-    AutoUpdateBroadcastEvents,
+    UpdateBroadcastEvents,
     BrowserSidebarBroadcastEvents,
     GatewayConnectionBroadcastEvents,
     HeterogeneousAgentBroadcastEvents,
     NavigationBroadcastEvents,
     RemoteServerBroadcastEvents,
-    RendererOtaBroadcastEvents,
     ScreenCaptureBroadcastEvents,
     SystemBroadcastEvents,
     TerminalBroadcastEvents,
@@ -53,6 +51,5 @@ export type {
   AuthorizationProgress,
   MarketAuthorizationParams,
 } from './remoteServer';
-export type { RendererOtaUpdateInfo } from './rendererOta';
 export type { OverlayDispatchMessagePayload } from './screenCapture';
 export type { OpenSettingsWindowOptions } from './windows';

--- a/packages/electron-client-ipc/src/events/rendererOta.ts
+++ b/packages/electron-client-ipc/src/events/rendererOta.ts
@@ -1,8 +1,0 @@
-export interface RendererOtaUpdateInfo {
-  appVersion: string;
-  version: string;
-}
-
-export interface RendererOtaBroadcastEvents {
-  rendererUpdateReady: (info: RendererOtaUpdateInfo) => void;
-}

--- a/packages/electron-client-ipc/src/events/update.ts
+++ b/packages/electron-client-ipc/src/events/update.ts
@@ -1,10 +1,10 @@
 import type { ProgressInfo, UpdateChannel, UpdateInfo, UpdaterState } from '../types';
 
-export interface AutoUpdateBroadcastEvents {
+export interface UpdateBroadcastEvents {
   updateChannelChanged: (channel: UpdateChannel) => void;
-  updateDownloaded: (info: UpdateInfo) => void;
   updateDownloadProgress: (progress: ProgressInfo) => void;
   updateError: (message: string) => void;
+  updateReady: (info: UpdateInfo) => void;
   updaterStateChanged: (state: UpdaterState) => void;
   updateWillInstallLater: () => void;
 }

--- a/packages/electron-client-ipc/src/types/update.ts
+++ b/packages/electron-client-ipc/src/types/update.ts
@@ -1,4 +1,5 @@
 export type UpdateChannel = 'stable' | 'canary';
+export type UpdateKind = 'app' | 'renderer';
 
 export interface ReleaseNoteInfo {
   /**
@@ -19,7 +20,8 @@ export interface ProgressInfo {
 }
 
 export interface UpdateInfo {
-  releaseDate: string;
+  kind: UpdateKind;
+  releaseDate?: string;
   releaseNotes?: string | ReleaseNoteInfo[];
   version: string;
 }

--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -1,4 +1,4 @@
-import { type RendererOtaUpdateInfo, type UpdateInfo } from '@lobechat/electron-client-ipc';
+import type { UpdateInfo } from '@lobechat/electron-client-ipc';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Button as BaseButton, createModal, useModalContext } from '@lobehub/ui/base-ui';
@@ -12,6 +12,8 @@ import { autoUpdateService } from '@/services/electron/autoUpdate';
 import { rendererOtaService } from '@/services/electron/rendererOta';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
+
+import { selectUpdateInfo } from './selectUpdateInfo';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   installLaterCloseButton: css`
@@ -135,22 +137,16 @@ const openUpdateDetailModal = (updateInfo: UpdateInfo) =>
 
 export const UpdateNotification: React.FC = () => {
   const { t: tElectron } = useTranslation('electron');
-  const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [updateDownloaded, setUpdateDownloaded] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
   const [installConfirmMode, setInstallConfirmMode] = useState<
     'unconfirm' | 'installLater' | 'installNow' | null
   >('unconfirm');
   const [isInstalling, setIsInstalling] = useState(false);
-  const [rendererUpdateReady, setRendererUpdateReady] = useState(false);
-  const [rendererUpdateInfo, setRendererUpdateInfo] = useState<RendererOtaUpdateInfo | null>(null);
   const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
 
-  useWatchBroadcast('updateDownloaded', (info: UpdateInfo) => {
-    setUpdateInfo(info);
-    setUpdateDownloaded(true);
-    setUpdateAvailable(false);
-    setInstallConfirmMode('unconfirm');
+  useWatchBroadcast('updateReady', (info) => {
+    setUpdateInfo((current) => selectUpdateInfo(current, info));
+    if (info.kind === 'app') setInstallConfirmMode('unconfirm');
   });
 
   useWatchBroadcast('updateWillInstallLater', () => {
@@ -159,19 +155,14 @@ export const UpdateNotification: React.FC = () => {
     setTimeout(() => setInstallConfirmMode(null), 5000);
   });
 
-  useWatchBroadcast('rendererUpdateReady', (info: RendererOtaUpdateInfo) => {
-    setRendererUpdateInfo(info);
-    setRendererUpdateReady(true);
-  });
-
-  if (rendererUpdateReady && !updateDownloaded && !updateAvailable) {
+  if (updateInfo?.kind === 'renderer') {
     return (
       <div className={styles.installLaterToast}>
         <span>
           {tElectron('updater.updateReady')}
-          {isDevMode && rendererUpdateInfo?.version ? ` · ${rendererUpdateInfo.version}` : ''}
+          {isDevMode && updateInfo.version ? ` · ${updateInfo.version}` : ''}
         </span>
-        <BaseButton size={'small'} type={'text'} onClick={() => setRendererUpdateReady(false)}>
+        <BaseButton size={'small'} type={'text'} onClick={() => setUpdateInfo(null)}>
           {tElectron('updater.ignore')}
         </BaseButton>
         <BaseButton
@@ -187,7 +178,7 @@ export const UpdateNotification: React.FC = () => {
     );
   }
 
-  if (!updateDownloaded && !updateAvailable) return null;
+  if (!updateInfo) return null;
 
   if (installConfirmMode === 'installLater') {
     return (

--- a/src/features/Electron/updater/selectUpdateInfo.test.ts
+++ b/src/features/Electron/updater/selectUpdateInfo.test.ts
@@ -1,0 +1,15 @@
+import type { UpdateInfo } from '@lobechat/electron-client-ipc';
+import { describe, expect, it } from 'vitest';
+
+import { selectUpdateInfo } from './selectUpdateInfo';
+
+const appUpdate = { kind: 'app', version: '2.2.16' } satisfies UpdateInfo;
+const rendererUpdate = { kind: 'renderer', version: '2.2.15' } satisfies UpdateInfo;
+
+describe('selectUpdateInfo', () => {
+  it('keeps an app update ahead of renderer updates', () => {
+    expect(selectUpdateInfo(null, rendererUpdate)).toBe(rendererUpdate);
+    expect(selectUpdateInfo(rendererUpdate, appUpdate)).toBe(appUpdate);
+    expect(selectUpdateInfo(appUpdate, rendererUpdate)).toBe(appUpdate);
+  });
+});

--- a/src/features/Electron/updater/selectUpdateInfo.ts
+++ b/src/features/Electron/updater/selectUpdateInfo.ts
@@ -1,0 +1,4 @@
+import type { UpdateInfo } from '@lobechat/electron-client-ipc';
+
+export const selectUpdateInfo = (current: UpdateInfo | null, incoming: UpdateInfo): UpdateInfo =>
+  current?.kind === 'app' && incoming.kind === 'renderer' ? current : incoming;


### PR DESCRIPTION
## Summary

- derive renderer OTA mainHash from production Vite main/preload bundle outputs for Darwin, Linux, and Windows
- export the exact injected hash from the real Desktop build artifact
- align the renderer-only OTA gate environment and cover bundled vs unbundled changes

## Why

The previous source-closure hash walked every file in imported workspace packages, so type-only, comment-only, and otherwise unbundled changes incorrectly started a new OTA lineage.

## Validation

- `bun run check` on all 5 changed files: 2 tests passed
- production Vite main and preload builds passed
- generated renderer-mainhash matched the CLI value and the value embedded in the main bundle