### PR TITLE
⚡️ perf(test): cut root suite from 397s to 287s, dedupe logger mocks, fix blind stream tests

### DIFF
--- a/apps/cli/src/api/client.test.ts
+++ b/apps/cli/src/api/client.test.ts
@@ -16,10 +16,6 @@ vi.mock('../settings', () => ({
   resolveServerUrl: () => 'https://app.lobehub.com',
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: { error: vi.fn() },
-}));
-
 const headersOfLastLink = () => (mockHttpLink.mock.calls.at(-1)![0] as any).headers;
 
 describe('api/client workspace scoping', () => {

--- a/apps/cli/src/api/http.test.ts
+++ b/apps/cli/src/api/http.test.ts
@@ -11,10 +11,6 @@ vi.mock('../settings', () => ({
   resolveServerUrl: mockResolveServerUrl,
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: { error: vi.fn() },
-}));
-
 describe('api/http auth helpers', () => {
   const originalJwt = process.env.LOBEHUB_JWT;
   const originalWorkspaceId = process.env.LOBEHUB_WORKSPACE_ID;

--- a/apps/cli/src/auth/resolveToken.test.ts
+++ b/apps/cli/src/auth/resolveToken.test.ts
@@ -16,15 +16,6 @@ vi.mock('../settings', () => ({
     (process.env.LOBEHUB_SERVER || 'https://app.lobehub.com').replace(/\/$/, ''),
   ),
 }));
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
 // Helper to create a valid JWT with sub claim
 function makeJwt(sub: string): string {
   const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');

--- a/apps/cli/src/commands/agent-group.test.ts
+++ b/apps/cli/src/commands/agent-group.test.ts
@@ -23,11 +23,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('agent-group command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/agent.test.ts
+++ b/apps/cli/src/commands/agent.test.ts
@@ -90,11 +90,6 @@ vi.mock('../utils/agentStream', () => ({
   streamAgentEventsViaWebSocket: mockStreamAgentEventsViaWebSocket,
 }));
 vi.mock('../utils/device', () => ({ resolveLocalDeviceId: mockResolveLocalDeviceId }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), heartbeat: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('agent command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/bot.test.ts
+++ b/apps/cli/src/commands/bot.test.ts
@@ -22,11 +22,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('bot command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/botMessage.test.ts
+++ b/apps/cli/src/commands/botMessage.test.ts
@@ -22,11 +22,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('bot message send --attachment', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/botMessengers.test.ts
+++ b/apps/cli/src/commands/botMessengers.test.ts
@@ -23,11 +23,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 // `confirm` always answers yes — we test uninstall/unlink under the explicit
 // `--yes` flag too, but for the prompt path we want a deterministic answer.
 vi.mock('../utils/format', async () => {

--- a/apps/cli/src/commands/config.test.ts
+++ b/apps/cli/src/commands/config.test.ts
@@ -21,11 +21,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('config command', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
   const originalWorkspaceId = process.env.LOBEHUB_WORKSPACE_ID;

--- a/apps/cli/src/commands/connect.test.ts
+++ b/apps/cli/src/commands/connect.test.ts
@@ -42,18 +42,6 @@ vi.mock('../settings', () => ({
   saveSettings: vi.fn(),
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    toolCall: vi.fn(),
-    toolResult: vi.fn(),
-    warn: vi.fn(),
-  },
-  setVerbose: vi.fn(),
-}));
-
 vi.mock('../tools/shell', () => ({
   cleanupAllProcesses: vi.fn(),
 }));

--- a/apps/cli/src/commands/device.test.ts
+++ b/apps/cli/src/commands/device.test.ts
@@ -26,10 +26,6 @@ const { mockConfirm } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), heartbeat: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
 vi.mock('../utils/format', async (importOriginal) => {
   const actual = await importOriginal<typeof FormatUtils>();
   return { ...actual, confirm: mockConfirm };

--- a/apps/cli/src/commands/doc.test.ts
+++ b/apps/cli/src/commands/doc.test.ts
@@ -35,16 +35,6 @@ vi.mock('../api/client', () => ({
   getTrpcClient: mockGetTrpcClient,
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-  setVerbose: vi.fn(),
-}));
-
 describe('doc command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/eval.test.ts
+++ b/apps/cli/src/commands/eval.test.ts
@@ -74,16 +74,6 @@ vi.mock('../api/client', () => ({
   getTrpcClient: getTrpcClientMock,
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-  setVerbose: vi.fn(),
-}));
-
 describe('eval command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let logSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/file.test.ts
+++ b/apps/cli/src/commands/file.test.ts
@@ -32,11 +32,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('file command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/generate.test.ts
+++ b/apps/cli/src/commands/generate.test.ts
@@ -57,11 +57,6 @@ vi.mock('node:fs', async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal();
   return { ...actual, writeFileSync: mockWriteFileSync };
 });
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('generate command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/goal.test.ts
+++ b/apps/cli/src/commands/goal.test.ts
@@ -12,10 +12,6 @@ const { mockClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: vi.fn().mockResolvedValue(mockClient) }));
-vi.mock('../utils/logger', () => ({
-  log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-}));
-
 const createProgram = () => {
   const program = new Command();
   program.exitOverride();

--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -36,11 +36,6 @@ vi.mock('../api/client', () => ({
   getTrpcClient: mockGetTrpcClient,
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 /**
  * Build a Promise resolving to a fake `SpawnAgentHandle`. `spawnAgent` itself
  * is async, so test mocks return the handle wrapped — same iterable contract,

--- a/apps/cli/src/commands/kb.test.ts
+++ b/apps/cli/src/commands/kb.test.ts
@@ -27,11 +27,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('kb command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/login.test.ts
+++ b/apps/cli/src/commands/login.test.ts
@@ -20,15 +20,6 @@ vi.mock('../settings', () => ({
   saveSettings: vi.fn(),
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
 // Mock child_process to prevent browser opening
 vi.mock('node:child_process', () => ({
   default: {

--- a/apps/cli/src/commands/logout.test.ts
+++ b/apps/cli/src/commands/logout.test.ts
@@ -14,15 +14,6 @@ vi.mock('../daemon/manager', () => ({
   stopDaemon: vi.fn(),
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
 describe('logout command', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/cli/src/commands/memory.test.ts
+++ b/apps/cli/src/commands/memory.test.ts
@@ -27,11 +27,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('memory command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/message.test.ts
+++ b/apps/cli/src/commands/message.test.ts
@@ -24,11 +24,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('message command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/model.test.ts
+++ b/apps/cli/src/commands/model.test.ts
@@ -27,11 +27,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('model command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -21,11 +21,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('plugin command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/project.test.ts
+++ b/apps/cli/src/commands/project.test.ts
@@ -27,10 +27,6 @@ const { mockClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: vi.fn().mockResolvedValue(mockClient) }));
-vi.mock('../utils/logger', () => ({
-  log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-}));
-
 function createProgram() {
   const program = new Command();
   program.exitOverride();

--- a/apps/cli/src/commands/provider.test.ts
+++ b/apps/cli/src/commands/provider.test.ts
@@ -24,11 +24,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('provider command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/search.test.ts
+++ b/apps/cli/src/commands/search.test.ts
@@ -28,11 +28,6 @@ vi.mock('../api/client', () => ({
   getToolsTrpcClient: mockGetToolsTrpcClient,
   getTrpcClient: mockGetTrpcClient,
 }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('search command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/session-group.test.ts
+++ b/apps/cli/src/commands/session-group.test.ts
@@ -20,11 +20,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('session-group command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/skill.test.ts
+++ b/apps/cli/src/commands/skill.test.ts
@@ -27,11 +27,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('skill command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/status.test.ts
+++ b/apps/cli/src/commands/status.test.ts
@@ -20,16 +20,6 @@ vi.mock('../settings', () => ({
   saveSettings: vi.fn(),
 }));
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-  setVerbose: vi.fn(),
-}));
-
 // Track event handlers registered on GatewayClient instances
 let clientEventHandlers: Record<string, (...args: any[]) => any> = {};
 let connectCalled = false;

--- a/apps/cli/src/commands/thread.test.ts
+++ b/apps/cli/src/commands/thread.test.ts
@@ -18,11 +18,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('thread command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/topic.test.ts
+++ b/apps/cli/src/commands/topic.test.ts
@@ -24,11 +24,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('topic command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/user.test.ts
+++ b/apps/cli/src/commands/user.test.ts
@@ -22,11 +22,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('user command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -44,11 +44,6 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
 vi.mock('../settings', () => ({ resolveServerUrl: () => 'https://app.lobehub.com' }));
-vi.mock('../utils/logger', () => ({
-  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-  setVerbose: vi.fn(),
-}));
-
 describe('verify rubric config commands', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
 

--- a/apps/cli/src/settings/index.test.ts
+++ b/apps/cli/src/settings/index.test.ts
@@ -29,12 +29,6 @@ vi.mock('node:os', async (importOriginal) => {
   };
 });
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    warn: vi.fn(),
-  },
-}));
-
 describe('settings', () => {
   beforeEach(() => {
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/apps/cli/src/tools/file.test.ts
+++ b/apps/cli/src/tools/file.test.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   editLocalFile,
@@ -14,15 +14,6 @@ import {
   searchLocalFiles,
   writeLocalFile,
 } from './file';
-
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
 
 describe('file tools (integration wrapper)', () => {
   const tmpDir = path.join(os.tmpdir(), 'cli-file-test-' + process.pid);

--- a/apps/cli/src/tools/index.test.ts
+++ b/apps/cli/src/tools/index.test.ts
@@ -9,15 +9,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { executeToolCall } from './index';
 import * as isolatedWorker from './isolatedWorker';
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
 describe('executeToolCall', () => {
   const tmpDir = path.join(os.tmpdir(), 'cli-tool-dispatch-test-' + process.pid);
 

--- a/apps/cli/src/tools/shell.test.ts
+++ b/apps/cli/src/tools/shell.test.ts
@@ -1,15 +1,6 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { cleanupAllProcesses, getCommandOutput, killCommand, runCommand } from './shell';
-
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
 
 describe('shell tools (integration wrapper)', () => {
   afterEach(() => {

--- a/apps/cli/src/utils/logger.test.ts
+++ b/apps/cli/src/utils/logger.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { log, setVerbose } from './logger';
 
+// This suite exercises the real logger, so opt out of the global stub in
+// `tests/setup.ts`.
+vi.unmock('./logger');
+
 describe('logger', () => {
   const consoleSpy = {
     error: vi.spyOn(console, 'error').mockImplementation(() => {}),

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+import type * as loggerModule from '../src/utils/logger';
+
+// The real logger writes straight to stdout/stderr, so every suite stubbed it by
+// hand. Suites asserting on log calls import `log` and read the spies below; a
+// suite needing different behavior overrides this with its own `vi.mock`.
+vi.mock('../src/utils/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof loggerModule>();
+
+  return {
+    ...actual,
+    log: Object.fromEntries(Object.keys(actual.log).map((key) => [key, vi.fn()])),
+    setVerbose: vi.fn(),
+  };
+});

--- a/apps/cli/vitest.config.mts
+++ b/apps/cli/vitest.config.mts
@@ -29,6 +29,7 @@ export default defineConfig({
       reporter: ['text', 'json', 'lcov', 'text-summary'],
     },
     environment: 'node',
+    setupFiles: ['./tests/setup.ts'],
     // Suppress unhandled rejection warnings from Commander async actions with mocked process.exit
     onConsoleLog: () => true,
   },

--- a/apps/desktop/src/main/__mocks__/setup.ts
+++ b/apps/desktop/src/main/__mocks__/setup.ts
@@ -11,3 +11,16 @@ vi.mock('node-mac-permissions', () => import('./node-mac-permissions'));
 // without per-suite stubbing. A test's own `vi.mock('electron', …)` overrides
 // this per-file.
 vi.mock('electron', () => import('./electron'));
+
+// The real logger pulls in electron-log + `@/env` at module scope and prints to
+// the terminal. Every suite silenced it by hand; a suite asserting on log calls
+// overrides this with its own `vi.mock('@/utils/logger', …)`.
+vi.mock('@/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    verbose: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));

--- a/apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts
@@ -7,16 +7,6 @@ import type { App } from '@/core/App';
 import AuthCtr from '../AuthCtr';
 import RemoteServerConfigCtr from '../RemoteServerConfigCtr';
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 const { ipcMainHandleMock } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
 }));

--- a/apps/desktop/src/main/controllers/__tests__/BrowserSidebarCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/BrowserSidebarCtr.test.ts
@@ -33,10 +33,6 @@ const { fromIdMock, ipcHandlers, ipcMainHandleMock, sessionFromPartitionMock } =
   };
 });
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-}));
-
 vi.mock('electron', () => ({
   ipcMain: { handle: ipcMainHandleMock },
   session: { fromPartition: sessionFromPartitionMock },

--- a/apps/desktop/src/main/controllers/__tests__/HeteroSessionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeteroSessionCtr.test.ts
@@ -17,15 +17,6 @@ vi.mock('electron', () => ({
   ipcMain: { handle: ipcMainHandleMock },
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('node:os', async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal();
   return { ...actual, homedir: homedirMock };

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.readFile.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.readFile.test.ts
@@ -20,15 +20,6 @@ vi.mock('electron', () => ({
 
 vi.mock('execa', () => ({ execa: vi.fn() }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('@/utils/net-fetch', () => ({ netFetch: vi.fn() }));
 
 vi.mock('@/utils/file-system', () => ({ makeSureDirExist: vi.fn() }));

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
@@ -21,16 +21,6 @@ vi.mock('execa', () => ({
   execa: execaMock,
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock file-loaders
 vi.mock('@lobechat/file-loaders', () => ({
   loadFile: vi.fn(),

--- a/apps/desktop/src/main/controllers/__tests__/McpInstallCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/McpInstallCtr.test.ts
@@ -4,16 +4,6 @@ import type { App } from '@/core/App';
 
 import McpInstallController from '../McpInstallCtr';
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock browserManager
 const mockBrowserManager = {
   broadcastToWindow: vi.fn(),

--- a/apps/desktop/src/main/controllers/__tests__/NetworkProxyCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/NetworkProxyCtr.test.ts
@@ -9,16 +9,6 @@ const { ipcMainHandleMock } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock undici - create mocks directly using vi.fn()
 vi.mock('undici', () => ({
   fetch: vi.fn(),

--- a/apps/desktop/src/main/controllers/__tests__/OpenInAppCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/OpenInAppCtr.test.ts
@@ -41,15 +41,6 @@ const invokeIpc = async <T = any>(
   return handler(fakeEvent, payload);
 };
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('electron', () => ({
   ipcMain: {
     handle: ipcMainHandleMock,

--- a/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
@@ -14,16 +14,6 @@ vi.mock('@/utils/net-fetch', () => ({
   netFetch: mockFetch,
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock electron
 vi.mock('electron', () => ({
   app: {

--- a/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
@@ -19,15 +19,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock child_process for the shared package
 vi.mock('node:child_process', () => ({
   execFile: vi.fn(),

--- a/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
@@ -50,16 +50,6 @@ const invokeIpc = async <T = any>(
   return handler(fakeEvent, payload);
 };
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock electron
 vi.mock('electron', () => ({
   app: {

--- a/apps/desktop/src/main/controllers/__tests__/TrayMenuCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/TrayMenuCtr.test.ts
@@ -20,14 +20,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Save the original platform to restore after all tests complete
 const originalPlatform = process.platform;
 

--- a/apps/desktop/src/main/controllers/__tests__/UpdaterCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/UpdaterCtr.test.ts
@@ -4,14 +4,6 @@ import type { App } from '@/core/App';
 
 import UpdaterCtr from '../UpdaterCtr';
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('@/modules/updater/configs', () => ({
   UPDATE_CHANNEL: 'stable',
 }));

--- a/apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
@@ -8,15 +8,6 @@ const { ipcMainHandleMock } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('electron', () => ({
   ipcMain: {
     handle: ipcMainHandleMock,

--- a/apps/desktop/src/main/core/__tests__/App.test.ts
+++ b/apps/desktop/src/main/core/__tests__/App.test.ts
@@ -51,16 +51,6 @@ vi.mock('fs-extra', () => ({
   pathExistsSync: (...args: any[]) => mockPathExistsSync(...args),
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock common/routes
 vi.mock('~common/routes', () => ({
   findMatchingRoute: vi.fn(),

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -113,16 +113,6 @@ vi.mock('electron', () => ({
   shell: mockShell,
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock constants
 vi.mock('@/const/dir', () => ({
   buildDir: '/mock/build',

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -73,16 +73,6 @@ vi.mock('../../../appBrowsers', () => ({
   windowTemplates: mockWindowTemplates,
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock RemoteServerConfigCtr
 vi.mock('@/controllers/RemoteServerConfigCtr', () => ({
   default: class MockRemoteServerConfigCtr {

--- a/apps/desktop/src/main/core/browser/__tests__/WindowStateManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/WindowStateManager.test.ts
@@ -19,15 +19,6 @@ vi.mock('electron', () => ({
   screen: mockScreen,
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 describe('WindowStateManager', () => {
   let manager: WindowStateManager;
   let mockApp: AppCore;

--- a/apps/desktop/src/main/core/browser/__tests__/WindowThemeManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/WindowThemeManager.test.ts
@@ -21,15 +21,6 @@ vi.mock('electron', () => ({
   nativeTheme: mockNativeTheme,
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('@/const/dir', () => ({
   buildDir: '/mock/build',
 }));

--- a/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
@@ -17,15 +17,6 @@ vi.mock('@/utils/platform', () => ({
   linux: vi.fn(() => true),
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('electron', () => ({
   app: {
     getVersion: vi.fn(() => '1.2.3'),

--- a/apps/desktop/src/main/core/infrastructure/__tests__/BinaryManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/BinaryManager.test.ts
@@ -26,15 +26,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Import AFTER the mocks so the singleton logger and electron stub are wired.
 const { BinaryManager, defineCommandBinary } = await import('../BinaryManager');
 

--- a/apps/desktop/src/main/core/infrastructure/__tests__/I18nManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/I18nManager.test.ts
@@ -39,16 +39,6 @@ vi.mock('i18next', () => ({
   },
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock loadResources
 vi.mock('@/locales/resources', () => ({
   loadResources: mockLoadResources,

--- a/apps/desktop/src/main/core/infrastructure/__tests__/LocalFileProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/LocalFileProtocolManager.test.ts
@@ -39,15 +39,6 @@ vi.mock('node:os', async (importOriginal) => {
   return { ...actual, default: actual, homedir: () => '/Users/alice' };
 });
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 describe('LocalFileProtocolManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/desktop/src/main/core/infrastructure/__tests__/ProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/ProtocolManager.test.ts
@@ -25,16 +25,6 @@ vi.mock('electron', () => ({
   app: mockApp,
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock protocol utils
 vi.mock('@/utils/protocol', () => ({
   getProtocolScheme: mockGetProtocolScheme,

--- a/apps/desktop/src/main/core/infrastructure/__tests__/RendererProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/RendererProtocolManager.test.ts
@@ -51,15 +51,6 @@ vi.mock('node:fs/promises', () => ({
   stat: mockStat,
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 describe('RendererProtocolManager + StaticRendererFallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/desktop/src/main/core/infrastructure/__tests__/RendererUrlManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/RendererUrlManager.test.ts
@@ -36,15 +36,6 @@ vi.mock('@/env', () => ({
   getDesktopEnv: vi.fn(() => ({ DESKTOP_RENDERER_STATIC: false })),
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 describe('RendererUrlManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/desktop/src/main/core/infrastructure/__tests__/StaticFileServerManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/StaticFileServerManager.test.ts
@@ -27,16 +27,6 @@ vi.mock('node:http', () => ({
   }),
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock LOCAL_STORAGE_URL_PREFIX
 vi.mock('@/const/dir', () => ({
   LOCAL_STORAGE_URL_PREFIX: '/lobe-desktop-file',

--- a/apps/desktop/src/main/core/infrastructure/__tests__/StoreManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/StoreManager.test.ts
@@ -32,16 +32,6 @@ vi.mock('electron-store', () => ({
   default: MockStore,
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock file-system utils
 vi.mock('@/utils/file-system', () => ({
   makeSureDirExist: mockMakeSureDirExist,

--- a/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
@@ -62,16 +62,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock updater configs
 vi.mock('@/modules/updater/configs', () => ({
   UPDATE_CHANNEL: 'stable',

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
@@ -46,10 +46,6 @@ vi.mock('@/modules/updater/configs', () => ({
   UPDATE_SERVER_URL: 'https://updates.test/stable',
   coerceStoredUpdateChannel: (channel?: string) => (channel === 'canary' ? 'canary' : 'stable'),
 }));
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-}));
-
 const makeApp = () => ({
   browserManager: { broadcastToAllWindows: vi.fn(), browsers: new Map() },
   rendererUrlManager: { setActiveRendererDir: vi.fn() },

--- a/apps/desktop/src/main/core/ui/__tests__/MenuManager.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/MenuManager.test.ts
@@ -11,16 +11,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock menu platform implementation
 const mockBuildAndSetAppMenu = vi.fn();
 const mockBuildContextMenu = vi.fn();

--- a/apps/desktop/src/main/core/ui/__tests__/ShortcutManager.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/ShortcutManager.test.ts
@@ -15,16 +15,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-// Mock Logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock desktop global shortcut defaults
 vi.mock('@lobechat/const/desktopGlobalShortcuts', () => ({
   DEFAULT_ELECTRON_DESKTOP_SHORTCUTS: {

--- a/apps/desktop/src/main/core/ui/__tests__/Tray.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/Tray.test.ts
@@ -20,16 +20,6 @@ vi.mock('electron', () => ({
   },
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock dir constants
 vi.mock('@/const/dir', () => ({
   resourcesDir: '/mock/resources',

--- a/apps/desktop/src/main/core/ui/__tests__/TrayManager.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/TrayManager.test.ts
@@ -7,16 +7,6 @@ import { TrayManager } from '../TrayManager';
 // Mock electron modules (empty shim — TrayManager no longer reads nativeTheme)
 vi.mock('electron', () => ({}));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock environment constants
 vi.mock('@/const/env', () => ({
   isMac: true,

--- a/apps/desktop/src/main/menus/impls/macOS.locale.test.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.locale.test.ts
@@ -30,10 +30,6 @@ vi.mock('electron-is', () => ({ macOS: vi.fn(() => true) }));
 
 vi.mock('@/const/env', () => ({ isDev: false }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-}));
-
 const createAppCore = () => {
   const appCore = {
     browserManager: {

--- a/apps/desktop/src/main/menus/impls/macOS.test.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.test.ts
@@ -35,15 +35,6 @@ vi.mock('@/utils/platform', () => ({
   macOS: vi.fn(() => true),
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock isDev
 vi.mock('@/const/env', () => ({
   isDev: false,

--- a/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.test.ts
@@ -3,10 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createLambdaFileStorePort } from './fileStorePort';
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-}));
-
 const auth = {
   getAccessToken: async () => 'token-123',
   getServerUrl: async () => 'https://cloud.lobehub.com',

--- a/apps/desktop/src/main/modules/heterogeneousAgent/registryConsistency.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/registryConsistency.test.ts
@@ -1,18 +1,8 @@
 import { HETEROGENEOUS_AGENT_CONFIGS, listLocalAgentTypes } from '@lobechat/heterogeneous-agents';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { listHeterogeneousCliBinaryTypes } from '../binaries/cliAgentBinaries';
 import { listHeterogeneousAgentDriverTypes } from '.';
-
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    verbose: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
 
 describe('heterogeneous agent registry consistency', () => {
   it('keeps every executable registry aligned with the descriptor catalog', () => {

--- a/apps/desktop/src/main/modules/networkProxy/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/modules/networkProxy/__tests__/dispatcher.test.ts
@@ -3,16 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProxyDispatcherManager } from '../dispatcher';
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock undici
 vi.mock('undici', () => ({
   Agent: vi.fn(),

--- a/apps/desktop/src/main/modules/networkProxy/__tests__/tester.test.ts
+++ b/apps/desktop/src/main/modules/networkProxy/__tests__/tester.test.ts
@@ -3,16 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProxyConnectionTester } from '../tester';
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock undici
 vi.mock('undici', () => ({
   fetch: vi.fn(),

--- a/apps/desktop/src/main/modules/openInApp/__tests__/cache.test.ts
+++ b/apps/desktop/src/main/modules/openInApp/__tests__/cache.test.ts
@@ -3,15 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearDetectionCache, getCachedDetection } from '../cache';
 import { detectAllApps } from '../detectors';
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('../detectors', () => ({
   detectAllApps: vi.fn(),
 }));

--- a/apps/desktop/src/main/modules/openInApp/__tests__/detectors.test.ts
+++ b/apps/desktop/src/main/modules/openInApp/__tests__/detectors.test.ts
@@ -6,16 +6,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { detectAllApps, detectApp } from '../detectors';
 import { extractAllIcons } from '../iconExtractor';
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 // Mock node:fs/promises
 vi.mock('node:fs/promises', () => ({
   access: vi.fn(),

--- a/apps/desktop/src/main/modules/openInApp/__tests__/iconExtractor.test.ts
+++ b/apps/desktop/src/main/modules/openInApp/__tests__/iconExtractor.test.ts
@@ -5,15 +5,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { __resetForTest, extractAllIcons, extractAppIcon } from '../iconExtractor';
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('node:fs/promises', () => ({
   access: vi.fn(),
   mkdtemp: vi.fn(),

--- a/apps/desktop/src/main/modules/openInApp/__tests__/launchers.test.ts
+++ b/apps/desktop/src/main/modules/openInApp/__tests__/launchers.test.ts
@@ -6,15 +6,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { launchApp } from '../launchers';
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('node:fs/promises', () => ({
   access: vi.fn(),
 }));

--- a/apps/desktop/src/main/modules/screenCapture/ScreenCaptureManager.test.ts
+++ b/apps/desktop/src/main/modules/screenCapture/ScreenCaptureManager.test.ts
@@ -74,15 +74,6 @@ vi.mock('@/const/env', () => ({
   },
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 vi.mock('@/utils/permissions', () => ({
   getScreenCaptureStatus: mockGetScreenCaptureStatus,
   requestScreenCaptureAccess: mockRequestScreenCaptureAccess,

--- a/apps/desktop/src/main/services/__tests__/LocalDatabaseSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/LocalDatabaseSrv.test.ts
@@ -2,15 +2,11 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { App } from '@/core/App';
 
 import LocalDatabaseService from '../LocalDatabaseSrv';
-
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({ info: vi.fn() }),
-}));
 
 describe('LocalDatabaseService', () => {
   let storagePath: string;

--- a/apps/desktop/src/main/services/__tests__/fileSearchSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/fileSearchSrv.test.ts
@@ -19,16 +19,6 @@ vi.mock('@lobechat/local-file-shell/file-search', () => {
   };
 });
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 describe('FileSearchService', () => {
   let fileSearchService: FileSearchService;
   let mockApp: App;

--- a/apps/desktop/src/main/services/__tests__/fileSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/fileSrv.test.ts
@@ -18,16 +18,6 @@ vi.mock('@/const/dir', () => ({
   LOCAL_STORAGE_URL_PREFIX: '/lobe-desktop-file',
 }));
 
-// Mock logger
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 // Mock file-system utilities
 vi.mock('@/utils/file-system', () => ({
   makeSureDirExist: vi.fn(),

--- a/apps/desktop/src/main/services/__tests__/imessageBridgeSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/imessageBridgeSrv.test.ts
@@ -39,15 +39,6 @@ vi.mock('get-port-please', () => ({
   getPort: getPortMock,
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 const config = {
   applicationId: 'home-mac-mini',
   blueBubblesPassword: 'local-password',

--- a/apps/desktop/src/main/services/__tests__/remoteFileUploadSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/remoteFileUploadSrv.test.ts
@@ -22,15 +22,6 @@ vi.mock('@/modules/cliEmbedding', () => ({
   resolveCliScript: () => '/app/resources/bin/lobe-cli.js',
 }));
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 const mockRemoteServerConfigCtr = {
   getAccessToken: vi.fn(),
   getRemoteServerUrl: vi.fn(),

--- a/apps/desktop/src/main/services/__tests__/zoomSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/zoomSrv.test.ts
@@ -5,15 +5,6 @@ import type { App } from '@/core/App';
 
 import ZoomService, { ZOOM_FACTOR_MAX, ZOOM_FACTOR_MIN } from '../zoomSrv';
 
-vi.mock('@/utils/logger', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}));
-
 interface MockWebContents {
   destroyed: boolean;
   factor: number;

--- a/apps/desktop/src/main/utils/__tests__/logger.test.ts
+++ b/apps/desktop/src/main/utils/__tests__/logger.test.ts
@@ -6,6 +6,10 @@ import { getDesktopEnv } from '@/env';
 
 import { createLogger } from '../logger';
 
+// This suite exercises the real logger, so opt out of the global stub in
+// `__mocks__/setup.ts`.
+vi.unmock('@/utils/logger');
+
 vi.mock('debug');
 
 vi.mock('electron-log', () => ({

--- a/packages/model-runtime/src/providers/azureOpenai/index.test.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.test.ts
@@ -341,9 +341,14 @@ describe('LobeAzureOpenAI', () => {
         temperature: 0.6,
         model: 'o1-preview',
         messages: [{ role: 'user', content: '你好' }],
+        stream: true,
       });
 
       // Assert
+      expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'o1-preview', stream: false }),
+        expect.anything(),
+      );
       expect(nonStreamToStreamModule.transformResponseToStream).toHaveBeenCalled();
     });
 

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -292,10 +292,14 @@ describe('LobeGoogleAI', () => {
     });
 
     it('should handle text messages correctly', async () => {
-      // Mock Google AI SDK's generateContentStream method to return a successful response stream
       const mockStream = new ReadableStream({
         start(controller) {
-          controller.enqueue('Hello, world!');
+          controller.enqueue({
+            candidates: [
+              { content: { parts: [{ text: 'Hello, world!' }], role: 'model' }, index: 0 },
+            ],
+            text: 'Hello, world!',
+          });
           controller.close();
         },
       });
@@ -310,7 +314,17 @@ describe('LobeGoogleAI', () => {
       });
 
       expect(result).toBeInstanceOf(Response);
-      // Additional assertions can be added, such as verifying the returned stream content
+
+      const reader = result.body!.getReader();
+      let sse = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        sse += new TextDecoder().decode(value as Uint8Array);
+      }
+
+      expect(sse).toContain('event: text');
+      expect(sse).toContain('"Hello, world!"');
     });
 
     it.each([

--- a/packages/model-runtime/src/providers/zhipu/index.test.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.test.ts
@@ -698,368 +698,156 @@ describe('LobeZhipuAI - custom features', () => {
 
   describe('handleStream', () => {
     describe('Tool calls index fixing for GLM-4.5', () => {
-      it('should fix negative tool_calls index to positive', async () => {
-        const mockStream = new ReadableStream({
+      const chunk = (delta: unknown, model = 'glm-4.5') => ({
+        choices: delta === undefined ? undefined : [{ delta, finish_reason: null, index: 0 }],
+        created: 1234567890,
+        id: 'chatcmpl-123',
+        model,
+        object: 'chat.completion.chunk',
+      });
+
+      const runStream = async (chunks: unknown[]) => {
+        const source = new ReadableStream({
           start(controller) {
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [
-                      { index: -1, id: 'call_1', function: { name: 'tool1', arguments: '{}' } },
-                      { index: -1, id: 'call_2', function: { name: 'tool2', arguments: '{}' } },
-                    ],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4.5',
-              object: 'chat.completion.chunk',
-            });
+            for (const c of chunks) controller.enqueue(c);
             controller.close();
           },
         });
 
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
+        const out = params.chatCompletion.handleStream!(
+          source as any,
+          {
+            callbacks: {},
+            inputStartAt: Date.now(),
+            payload: { model: 'glm-4.5' },
+          } as any,
+        );
 
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4.5',
-          temperature: 0.5,
-        });
-
-        // Read the stream to trigger the transform
-        const reader = result.body?.getReader();
-        const chunks = [];
-        if (reader) {
-          let done = false;
-          while (!done) {
-            const { value, done: isDone } = await reader.read();
-            done = isDone;
-            if (value) {
-              chunks.push(new TextDecoder().decode(value));
-            }
-          }
+        const reader = (out as ReadableStream).getReader();
+        let text = '';
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          text += typeof value === 'string' ? value : new TextDecoder().decode(value as any);
         }
+        return text;
+      };
 
-        // The transform should have fixed the negative indices
-        expect(chunks).toBeDefined();
+      const toolCallEvents = (sse: string) =>
+        sse
+          .split('\n')
+          .filter((line) => line.startsWith('data: [{'))
+          .map((line) => JSON.parse(line.slice('data: '.length)));
+
+      it('should fix negative tool_calls index to positive', async () => {
+        const sse = await runStream([
+          chunk({
+            tool_calls: [
+              { index: -1, id: 'call_1', function: { name: 'tool1', arguments: '{}' } },
+              { index: -1, id: 'call_2', function: { name: 'tool2', arguments: '{}' } },
+            ],
+          }),
+        ]);
+
+        expect(sse).toContain('event: tool_calls');
+        expect(toolCallEvents(sse)[0].map((c: any) => c.index)).toEqual([0, 1]);
       });
 
       it('should preserve positive tool_calls index', async () => {
-        const mockStream = new ReadableStream({
-          start(controller) {
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [
-                      { index: 0, id: 'call_1', function: { name: 'tool1', arguments: '{}' } },
-                      { index: 1, id: 'call_2', function: { name: 'tool2', arguments: '{}' } },
-                    ],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
+        const sse = await runStream([
+          chunk(
+            {
+              tool_calls: [
+                { index: 0, id: 'call_1', function: { name: 'tool1', arguments: '{}' } },
+                { index: 1, id: 'call_2', function: { name: 'tool2', arguments: '{}' } },
               ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
+            },
+            'glm-4',
+          ),
+        ]);
 
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
-
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4',
-          temperature: 0.5,
-        });
-
-        // Read the stream
-        const reader = result.body?.getReader();
-        if (reader) {
-          let done = false;
-          while (!done) {
-            const { value, done: isDone } = await reader.read();
-            done = isDone;
-          }
-        }
-
-        expect(result).toBeDefined();
+        expect(toolCallEvents(sse)[0].map((c: any) => c.index)).toEqual([0, 1]);
       });
 
-      it('should handle chunks without tool_calls', async () => {
-        const mockStream = new ReadableStream({
-          start(controller) {
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    content: 'Hello',
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
+      it('should fix only the negative entry among mixed indices', async () => {
+        const sse = await runStream([
+          chunk({
+            tool_calls: [
+              { index: 0, id: 'call_1', function: { name: 'tool1', arguments: '{}' } },
+              { index: -1, id: 'call_2', function: { name: 'tool2', arguments: '{}' } },
+              { index: 2, id: 'call_3', function: { name: 'tool3', arguments: '{}' } },
+            ],
+          }),
+        ]);
 
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
-
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4',
-          temperature: 0.5,
-        });
-
-        expect(result).toBeInstanceOf(Response);
+        expect(toolCallEvents(sse)[0].map((c: any) => c.index)).toEqual([0, 1, 2]);
       });
 
-      it('should handle chunks without choices', async () => {
-        const mockStream = new ReadableStream({
-          start(controller) {
-            controller.enqueue({
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
+      it('should reindex negative tool_calls across separate chunks', async () => {
+        const sse = await runStream([
+          chunk({ tool_calls: [{ index: -1, id: 'call_1', function: { name: 'tool1' } }] }),
+          chunk({ tool_calls: [{ index: -1, function: { arguments: '{"a":1}' } }] }),
+        ]);
 
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
-
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4',
-          temperature: 0.5,
-        });
-
-        expect(result).toBeInstanceOf(Response);
-      });
-
-      it('should handle empty tool_calls array', async () => {
-        const mockStream = new ReadableStream({
-          start(controller) {
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
-
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
-
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4',
-          temperature: 0.5,
-        });
-
-        expect(result).toBeInstanceOf(Response);
-      });
-
-      it('should handle mixed tool_calls indices', async () => {
-        const mockStream = new ReadableStream({
-          start(controller) {
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [
-                      { index: 0, id: 'call_1', function: { name: 'tool1', arguments: '{}' } },
-                      { index: -1, id: 'call_2', function: { name: 'tool2', arguments: '{}' } },
-                      { index: 2, id: 'call_3', function: { name: 'tool3', arguments: '{}' } },
-                    ],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4.5',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
-
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
-
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4.5',
-          temperature: 0.5,
-        });
-
-        // Read the stream to trigger the transform
-        const reader = result.body?.getReader();
-        if (reader) {
-          let done = false;
-          while (!done) {
-            const { value, done: isDone } = await reader.read();
-            done = isDone;
-          }
-        }
-
-        expect(result).toBeDefined();
+        const events = toolCallEvents(sse);
+        expect(events.at(-1)[0]).toMatchObject({ index: 0 });
+        expect(sse).toContain('{\\"a\\":1}');
       });
 
       it('should filter out incomplete placeholder tool_call chunks from proxies', async () => {
-        // Some proxies (e.g., aihubmix) send empty placeholder chunks without
-        // id/function.name when tool_stream is enabled. These must be filtered
-        // out to prevent ZodError in parseToolCalls.
-        const mockStream = new ReadableStream({
-          start(controller) {
-            // Placeholder chunks (no id, no name, empty arguments)
-            controller.enqueue({
-              choices: [
+        // Some proxies (e.g. aihubmix) send an empty placeholder before the real
+        // chunk when tool_stream is on; letting it through throws ZodError in
+        // parseToolCalls.
+        const sse = await runStream([
+          chunk(
+            { tool_calls: [{ function: { arguments: '' }, index: 0, type: 'function' }] },
+            'glm-5',
+          ),
+          chunk(
+            {
+              tool_calls: [
                 {
-                  delta: {
-                    tool_calls: [{ type: 'function', function: { arguments: '' }, index: 0 }],
-                  },
-                  finish_reason: null,
+                  function: { arguments: '{"expression":"1+1"}', name: 'calculator' },
+                  id: 'tool-abc123',
                   index: 0,
+                  type: 'function',
                 },
               ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-5',
-              object: 'chat.completion.chunk',
-            });
-            // Real chunk with id and name
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [
-                      {
-                        id: 'tool-abc123',
-                        type: 'function',
-                        function: { name: 'calculator', arguments: '{"expression":"1+1"}' },
-                        index: 0,
-                      },
-                    ],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-5',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
+            },
+            'glm-5',
+          ),
+        ]);
 
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
-
-        // Should not throw ZodError from incomplete placeholder chunks
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-5',
-          temperature: 0.5,
-        });
-
-        const reader = result.body?.getReader();
-        if (reader) {
-          let done = false;
-          while (!done) {
-            const { value, done: isDone } = await reader.read();
-            done = isDone;
-          }
-        }
-
-        expect(result).toBeDefined();
+        const events = toolCallEvents(sse);
+        expect(events).toHaveLength(1);
+        expect(events[0][0]).toMatchObject({ id: 'tool-abc123', index: 0 });
       });
 
-      it('should handle multiple chunks with tool_calls', async () => {
-        const mockStream = new ReadableStream({
-          start(controller) {
-            // First chunk with tool_call
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [{ index: -1, id: 'call_1', function: { name: 'tool1' } }],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4.5',
-              object: 'chat.completion.chunk',
-            });
-            // Second chunk with arguments
-            controller.enqueue({
-              choices: [
-                {
-                  delta: {
-                    tool_calls: [{ index: -1, function: { arguments: '{"a":1}' } }],
-                  },
-                  finish_reason: null,
-                  index: 0,
-                },
-              ],
-              created: 1234567890,
-              id: 'chatcmpl-123',
-              model: 'glm-4.5',
-              object: 'chat.completion.chunk',
-            });
-            controller.close();
-          },
-        });
+      it('should drop the delta when every tool_call is a placeholder', async () => {
+        const sse = await runStream([
+          chunk({ tool_calls: [{ function: { arguments: '' }, index: 0, type: 'function' }] }),
+        ]);
 
-        (instance['client'].chat.completions.create as any).mockResolvedValue(mockStream);
+        expect(toolCallEvents(sse)).toHaveLength(0);
+      });
 
-        const result = await instance.chat({
-          messages: [{ content: 'Hello', role: 'user' }],
-          model: 'glm-4.5',
-          temperature: 0.5,
-        });
+      it('should pass through chunks without tool_calls', async () => {
+        const sse = await runStream([chunk({ content: 'Hello' }, 'glm-4')]);
 
-        // Read the stream
-        const reader = result.body?.getReader();
-        if (reader) {
-          let done = false;
-          while (!done) {
-            const { value, done: isDone } = await reader.read();
-            done = isDone;
-          }
-        }
+        expect(sse).toContain('event: text');
+        expect(sse).toContain('"Hello"');
+      });
 
-        expect(result).toBeDefined();
+      it('should pass through chunks without choices', async () => {
+        const sse = await runStream([chunk(undefined, 'glm-4')]);
+
+        expect(toolCallEvents(sse)).toHaveLength(0);
+      });
+
+      it('should emit no tool_calls for an empty tool_calls array', async () => {
+        const sse = await runStream([chunk({ tool_calls: [] }, 'glm-4')]);
+
+        expect(toolCallEvents(sse)).toHaveLength(0);
       });
     });
   });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom';
 // refs: https://github.com/dumbmatter/fakeIndexedDB#dexie-and-other-indexeddb-api-wrappers
 import 'fake-indexeddb/auto';
 
-import { theme } from 'antd';
 import i18n from 'i18next';
 import { enableMapSet, enablePatches } from 'immer';
 import type { ButtonHTMLAttributes, ComponentType, ElementType, ReactNode } from 'react';
@@ -259,9 +258,6 @@ if (typeof globalThis.window === 'undefined') {
 
 installTestStorage();
 beforeEach(installTestStorage);
-
-// remove antd hash on test
-theme.defaultConfig.hashed = false;
 
 // init i18n for non-React modules (stores/utils) using i18next.t(...)
 // Use in-memory resources to avoid interfering with Vitest module mocking.


### PR DESCRIPTION
Follow-up to #18761. Three independent changes, one theme: the test suite was paying for work nobody asked for, and hiding a few tests that asserted nothing.

### 1. `tests/setup.ts` no longer imports antd — the whole timing win

`setupFiles` re-evaluate **per test file**, so `import { theme } from 'antd'` cost every one of the 1836 root-suite files ~596ms of module evaluation. It existed only to set `theme.defaultConfig.hashed = false`, and nothing asserts on unhashed antd class names.

| | before | after |
| --- | --- | --- |
| wall | 396.95s | **283.88s** |
| setup | 2027s | **256s** |

(Re-measured on the current canary base: **286.84s**, setup 272s.)

`collect` is now ~90% of the remaining CPU — per-file module-graph evaluation. Heaviest single imports measured: `@lobechat/const` 733ms, `antd-style` 526ms, `model-bank` 484ms. Attacking that means getting workspace source packages out of `server.deps.inline`, which is a build-system change and out of scope here.

**Rejected alternative, worth recording:** prebundling `antd` / `antd-style` via `deps.optimizer.include` (the trick #18761 used for `@lobehub/ui`) is faster on paper — 305s — but **breaks `vi.mock` for the prebundled module**. The component resolves to the optimizer chunk while `vi.mock('<bare-specifier>')` registers on the bare id, so the mock silently stops applying: 23 suites started reading the real `useTheme`. Not fixable from the mock side. `@lobehub/ui` is only safe because nothing partially mocks it outside `tests/setup.ts`.

### 2. Logger mocks lifted into the desktop/CLI setup files

52 desktop suites and 38 CLI suites each carried an identical `vi.mock('…/utils/logger')` whose only job was silencing output (the desktop one also pulls electron-log and `@/env` in at module scope).

- desktop `__mocks__/setup.ts` stubs `createLogger`
- new `apps/cli/tests/setup.ts` spreads the real module and replaces every `log` method with a spy, so the 23 suites that assert on log calls keep working unchanged

Suites needing different behavior still override with their own `vi.mock`; each app's `logger.test.ts` opts out via `vi.unmock`.

### 3. Three stream tests that were green against broken code

- **zhipu `handleStream`** — 8 cases built tool_call chunks, read the entire stream into `chunks`, then asserted `expect(chunks).toBeDefined()`. Driving `instance.chat()` with a mocked `create` actually yields `choices: []`, so the transform under test never ran. **Proof: all 79 original tests passed with the negative-index fix deleted from the implementation.** Rewritten to call `params.chatCompletion.handleStream` directly and assert the emitted SSE `event: tool_calls` indices — 365 → 147 lines, plus the previously-uncovered all-placeholders branch.
- **google `should handle text messages correctly`** — the mock enqueued a bare string; reading the body actually throws `Cannot use 'in' operator to search for 'promptFeedback' in Hello, world!`. Green only because the test never read `result.body`. Now enqueues a real candidates chunk and asserts the SSE text payload.
- **azureOpenai `should handle o1 series models without streaming`** — asserted only that `transformResponseToStream` ran, never that o1 forces `stream: false`.

Each fix is **mutation-verified**: deleting the negative-index fix, the placeholder filter, the google thought filter, or the o1 stream override now fails these tests and previously did not.

### What was measured and deliberately not done

| lever | recoverable | verdict |
| --- | --- | --- |
| `it.each` table-ification, repo-wide | ~5,300 lines (0.56%) | not worth the churn |
| provider-test preamble dedupe | 3.3%, 103/113 shapes distinct | no lever |
| cross-provider duplicated case titles | 145 instances | no lever |
| weak-assertion-only cases | 684 repo-wide | mostly false positives — `expect(spy).toHaveBeenCalled()` is usually the assertion the title claims |

The 113 provider test files are not copy-paste; each tests its own `handlePayload` / `models` logic. Cutting them means cutting coverage, not duplication.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified on the current canary base:

| suite | result |
| --- | --- |
| root (`vitest run`) | 1834 passed, 3 skipped — 286.84s |
| `apps/desktop` | 122/122 passed |
| `packages/model-runtime` | 186 files / 4650 tests passed |
| `apps/cli` unit | 8 pre-existing failures, unchanged from base (`src/settings/index.test.ts` now passes) |

Plus mutation testing on all three stream fixes, as described above.

#### 🔗 Related Issue

Follow-up to #18761.

https://claude.ai/code/session_01K9fwqjBqMYMsYDddo9b4JN