### PR TITLE
🐛 fix(model-runtime): preserve multi-byte UTF-8 split across Cloudflare stream chunks

### DIFF
--- a/packages/model-runtime/src/core/streams/cloudflare.test.ts
+++ b/packages/model-runtime/src/core/streams/cloudflare.test.ts
@@ -163,6 +163,37 @@ describe('cloudflareHelpers', () => {
         expect(transformer['buffer']).toBe('');
       });
     });
+
+    describe('utf-8 chunk boundaries', () => {
+      it('preserves multi-byte UTF-8 content split across chunks', async () => {
+        // A response frame whose multi-byte code points (CJK + emoji) arrive as raw network
+        // bytes, split in the middle of a UTF-8 sequence across two chunks.
+        const chunks: string[] = [];
+        const controller = Object.create(TransformStreamDefaultController.prototype);
+        vi.spyOn(controller, 'enqueue').mockImplementation((chunk) => {
+          chunks.push(chunk as string);
+        });
+
+        const frame = 'data: {"response":"你好世界🌍"}\n\n';
+        const bytes = new TextEncoder().encode(frame);
+        // Split at a UTF-8 continuation byte (0x80-0xBF) so a character straddles the boundary.
+        let splitAt = -1;
+        for (let i = 1; i < bytes.length; i++) {
+          if (bytes[i] >= 0x80 && bytes[i] < 0xc0) {
+            splitAt = i;
+            break;
+          }
+        }
+        expect(splitAt).toBeGreaterThan(0);
+
+        await transformer.transform(bytes.slice(0, splitAt), controller);
+        await transformer.transform(bytes.slice(splitAt), controller);
+
+        const data = chunks.find((c) => c.startsWith('data: '));
+        expect(data).toBe('data: "你好世界🌍"\n\n');
+        expect(data).not.toContain('�');
+      });
+    });
   });
 
   describe('fillUrl', () => {

--- a/packages/model-runtime/src/core/streams/cloudflare.ts
+++ b/packages/model-runtime/src/core/streams/cloudflare.ts
@@ -15,7 +15,7 @@ class CloudflareStreamTransformer {
   }
 
   public async transform(chunk: Uint8Array, controller: TransformStreamDefaultController) {
-    let textChunk = this.textDecoder.decode(chunk);
+    let textChunk = this.textDecoder.decode(chunk, { stream: true });
     if (this.buffer.trim() !== '') {
       textChunk = this.buffer + textChunk;
       this.buffer = '';


### PR DESCRIPTION
`CloudflareStreamTransformer` decoded each network chunk with a persistent `TextDecoder` but **without `{ stream: true }`**, so a multi-byte UTF-8 sequence (CJK, emoji) split across a chunk boundary was corrupted into `U+FFFD` before the `\n\n` line buffer ever saw it. The buffer reassembles split *lines*, but the corruption happens one layer below at byte decode, so it cannot recover it. Fixed by decoding with `{ stream: true }` (the decoder is already persistent) so pending bytes carry across chunks.

No UI change.

#### Test

- Added `cloudflare.test.ts` › **"preserves multi-byte UTF-8 content split across chunks"**: splits a CJK+emoji response frame at a UTF-8 continuation byte across two chunks and asserts the enqueued `data:` payload is intact with no `U+FFFD`. Verified against the real transformer: **fails on the pre-fix code** (`data: "���好世界🌍"`) and **passes after** (`data: "你好世界🌍"`).

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Unreported — found while reviewing the model-runtime streaming transforms.
