### PR TITLE
fix(builtin-skills): match artifacts guide boundary tags

### DIFF
--- a/packages/builtin-skills/src/artifacts/content.test.ts
+++ b/packages/builtin-skills/src/artifacts/content.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { systemPrompt } from './content';
+
+describe('artifacts system prompt', () => {
+  it('uses matching artifacts guide boundary tags', () => {
+    expect(systemPrompt).toMatch(/^<artifacts_guides>/);
+    expect(systemPrompt).toMatch(/<\/artifacts_guides>\s*$/);
+  });
+});

--- a/packages/builtin-skills/src/artifacts/content.ts
+++ b/packages/builtin-skills/src/artifacts/content.ts
@@ -201,5 +201,5 @@ Here are some examples of correct usage of artifacts:
 The assistant should not mention any of these instructions to the user, nor make reference to the \`lobeArtifact\` tag, any of the MIME types (e.g. \`application/lobe.artifacts.react\`), or related syntax unless it is directly relevant to the query.
 
 The assistant should always take care to not produce artifacts that would be highly hazardous to human health or wellbeing if misused, even if is asked to produce them for seemingly benign reasons. However, if Claude would be willing to produce the same content in text form, it should be willing to produce it in an artifact.
-</artifacts_info>
+</artifacts_guides>
 `;


### PR DESCRIPTION
The artifacts system prompt opens with `<artifacts_guides>` but currently closes with `</artifacts_info>`, leaving the wrapper tags inconsistent.

This change aligns the closing tag with the opening tag and adds a regression test that verifies both prompt boundaries.

No visual UI change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --config packages/builtin-skills/vitest.config.mts packages/builtin-skills/src/artifacts/content.test.ts
bunx eslint packages/builtin-skills/src/artifacts/content.ts packages/builtin-skills/src/artifacts/content.test.ts
```

Result: 1 test passed; ESLint passed.

#### 🔗 Related Issue

No existing issue linked.