### PR TITLE
fix(model-runtime): preserve builtin provider sdk type

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -31,6 +31,7 @@ import {
   getServerDefaultHeterogeneousModels,
   initModelRuntimeFromServerConfig,
   initModelRuntimeWithUserPayload,
+  resolveProviderSdkType,
   resolveServerDefaultHeterogeneousModel,
   resolveServerModel,
 } from './index';
@@ -986,6 +987,20 @@ describe('buildPayloadFromKeyVaults', () => {
       });
     });
 
+    it('DeepSeek: preserves the configured SDK type for router selection', () => {
+      const keyVaults = {
+        apiKey: 'test-api-key',
+      };
+      const payload = buildPayloadFromKeyVaults(keyVaults, ModelProvider.DeepSeek, 'openai');
+
+      expect(payload).toEqual({
+        apiKey: 'test-api-key',
+        baseURL: undefined,
+        runtimeProvider: ModelProvider.DeepSeek,
+        sdkType: 'openai',
+      });
+    });
+
     it('ChatGPT: returns the OAuth access token and account id', () => {
       const keyVaults = {
         oauthAccessToken: 'oauth-access-token',
@@ -1206,5 +1221,15 @@ describe('buildPayloadFromKeyVaults', () => {
       expect(payload.vertexAIRegion).toBe('asia-northeast1');
       expect(payload.runtimeProvider).toBe(ModelProvider.VertexAI);
     });
+  });
+});
+
+describe('resolveProviderSdkType', () => {
+  it('uses the model-bank default when a builtin provider has no persisted sdkType', () => {
+    expect(resolveProviderSdkType(ModelProvider.DeepSeek)).toBe('openai');
+  });
+
+  it('keeps an explicit provider override', () => {
+    expect(resolveProviderSdkType(ModelProvider.DeepSeek, 'anthropic')).toBe('anthropic');
   });
 });

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -80,6 +80,19 @@ const resolveRuntimeProvider = (provider: string, sdkType?: string): string => {
 };
 
 /**
+ * Provider rows only persist user overrides. Builtin protocol defaults live in
+ * model-bank, so an empty persisted settings object must fall back to that card
+ * instead of silently selecting the runtime router's own default protocol.
+ */
+export const resolveProviderSdkType = (
+  provider: string,
+  configuredSdkType?: string,
+): string | undefined =>
+  configuredSdkType ??
+  DEFAULT_MODEL_PROVIDER_LIST.find((providerCard) => providerCard.id === provider)?.settings
+    ?.sdkType;
+
+/**
  * Build ClientSecretPayload from keyVaults stored in database
  *
  * This is the server-side equivalent of the frontend's getProviderAuthPayload function.
@@ -97,6 +110,7 @@ const resolveRuntimeProvider = (provider: string, sdkType?: string): string => {
 export const buildPayloadFromKeyVaults = (
   keyVaults: ProviderKeyVaults,
   runtimeProvider: string,
+  sdkType?: string,
 ): ClientSecretPayload => {
   // Use runtimeProvider to determine which fields to include
   // This handles both builtin providers and custom providers with sdkType
@@ -191,6 +205,7 @@ export const buildPayloadFromKeyVaults = (
         apiKey: keyVaults.apiKey,
         baseURL: keyVaults.baseURL,
         runtimeProvider,
+        ...(sdkType && { sdkType }),
       };
     }
   }
@@ -226,7 +241,11 @@ const getParamsFromPayload = (provider: string, payload: ClientSecretPayload) =>
       const apiKey = apiKeyManager.pick(payload?.apiKey || llmConfig[`${upperProvider}_API_KEY`]);
       const baseURL = payload?.baseURL || process.env[`${upperProvider}_PROXY_URL`];
 
-      return baseURL ? { apiKey, baseURL } : { apiKey };
+      return {
+        apiKey,
+        ...(baseURL && { baseURL }),
+        ...(payload.sdkType && { sdkType: payload.sdkType }),
+      };
     }
 
     case ModelProvider.Ollama: {
@@ -487,9 +506,9 @@ export const initModelRuntimeFromDB = async (
     KeyVaultsGateKeeper.getUserKeyVaults,
   );
 
-  // 2. Resolve the runtime provider for custom providers
-  // For custom providers, use sdkType from settings (defaults to 'openai')
-  const sdkType = providerConfig?.settings?.sdkType;
+  // 2. Resolve the protocol wrapper from a persisted override or the builtin
+  // provider card, then map custom providers to their runtime implementation.
+  const sdkType = resolveProviderSdkType(provider, providerConfig?.settings?.sdkType);
   const runtimeProvider = resolveRuntimeProvider(provider, sdkType);
 
   // 3. Build ClientSecretPayload from keyVaults based on runtimeProvider
@@ -515,7 +534,7 @@ export const initModelRuntimeFromDB = async (
     keyVaults = { ...keyVaults, ...freshKeyVaults } as ProviderKeyVaults;
   }
 
-  const payload = buildPayloadFromKeyVaults(keyVaults, runtimeProvider);
+  const payload = buildPayloadFromKeyVaults(keyVaults, runtimeProvider, sdkType);
 
   // 4. Get business hooks (billing in cloud, undefined in OSS)
   const businessHooks = getBusinessModelRuntimeHooks(userId, provider, workspaceId);

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -38,6 +38,11 @@ export interface ClientSecretPayload {
 
   runtimeProvider?: string;
   /**
+   * Selects the protocol wrapper for providers that expose more than one
+   * compatible API, for example DeepSeek's OpenAI and Anthropic endpoints.
+   */
+  sdkType?: string;
+  /**
    * user id
    * in client db mode it's a uuid
    * in server db mode it's a user id


### PR DESCRIPTION
Builtin provider rows persist user overrides, while their default protocol wrapper lives in model-bank. When a database row has no explicit `settings.sdkType`, the server runtime currently drops that builtin default before initializing protocol-aware providers such as DeepSeek.

This change resolves `sdkType` from the persisted override first and the builtin provider card second, carries it through `ClientSecretPayload`, and forwards it to the provider runtime options. Explicit overrides still win.

No visual UI change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run apps/server/src/modules/ModelRuntime/index.test.ts
bunx eslint apps/server/src/modules/ModelRuntime/index.ts apps/server/src/modules/ModelRuntime/index.test.ts packages/types/src/auth.ts
```

Result: 79 tests passed; ESLint passed.

Coverage includes:

- falling back to the builtin model-bank `sdkType`;
- preserving an explicit provider override;
- carrying the protocol wrapper through the DeepSeek payload.

#### 🔗 Related Issue

No existing issue linked.