### PR TITLE
fix(fetch-sse): distinguish request aborts from upstream errors

### DIFF
--- a/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
+++ b/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
@@ -1,5 +1,5 @@
 import { MESSAGE_CANCEL_FLAT } from '@lobechat/const';
-import type { ChatMessageError } from '@lobechat/types';
+import { ChatErrorType, type ChatMessageError } from '@lobechat/types';
 import type { FetchEventSourceInit } from '@lobechat/utils/client/fetchEventSource/index';
 import { fetchEventSource } from '@lobechat/utils/client/fetchEventSource/index';
 import { sleep } from '@lobechat/utils/sleep';
@@ -479,6 +479,8 @@ describe('fetchSSE', () => {
 
   it('should call onFinish with correct parameters for different finish types', async () => {
     const mockOnFinish = vi.fn();
+    const abortController = new AbortController();
+    abortController.abort();
 
     (fetchEventSource as any).mockImplementationOnce(
       (url: string, options: FetchEventSourceInit) => {
@@ -488,7 +490,11 @@ describe('fetchSSE', () => {
       },
     );
 
-    await fetchSSE('/', { onFinish: mockOnFinish, responseAnimation: 'fadeIn' });
+    await fetchSSE('/', {
+      onFinish: mockOnFinish,
+      responseAnimation: 'fadeIn',
+      signal: abortController.signal,
+    });
 
     expect(mockOnFinish).toHaveBeenCalledWith('Hello', {
       observationId: null,
@@ -516,8 +522,10 @@ describe('fetchSSE', () => {
   });
 
   describe('onAbort', () => {
-    it('should call onAbort when AbortError is thrown', async () => {
+    it('should call onAbort when AbortError is thrown by an aborted request', async () => {
       const mockOnAbort = vi.fn();
+      const abortController = new AbortController();
+      abortController.abort();
 
       (fetchEventSource as any).mockImplementationOnce(
         (url: string, options: FetchEventSourceInit) => {
@@ -526,13 +534,19 @@ describe('fetchSSE', () => {
         },
       );
 
-      await fetchSSE('/', { onAbort: mockOnAbort, responseAnimation: 'fadeIn' });
+      await fetchSSE('/', {
+        onAbort: mockOnAbort,
+        responseAnimation: 'fadeIn',
+        signal: abortController.signal,
+      });
 
       expect(mockOnAbort).toHaveBeenCalledWith('Hello');
     });
 
-    it('should call onAbort when MESSAGE_CANCEL_FLAT is thrown', async () => {
+    it('should call onAbort when MESSAGE_CANCEL_FLAT is thrown by an aborted request', async () => {
       const mockOnAbort = vi.fn();
+      const abortController = new AbortController();
+      abortController.abort(MESSAGE_CANCEL_FLAT);
 
       (fetchEventSource as any).mockImplementationOnce(
         (url: string, options: FetchEventSourceInit) => {
@@ -541,9 +555,39 @@ describe('fetchSSE', () => {
         },
       );
 
-      await fetchSSE('/', { onAbort: mockOnAbort, responseAnimation: 'fadeIn' });
+      await fetchSSE('/', {
+        onAbort: mockOnAbort,
+        responseAnimation: 'fadeIn',
+        signal: abortController.signal,
+      });
 
       expect(mockOnAbort).toHaveBeenCalledWith('Hello');
+    });
+
+    it('surfaces an upstream canceled response as an error when the request signal is active', async () => {
+      const mockOnAbort = vi.fn();
+      const mockOnErrorHandle = vi.fn();
+
+      (fetchEventSource as any).mockImplementationOnce(
+        (url: string, options: FetchEventSourceInit) => {
+          options.onerror!(MESSAGE_CANCEL_FLAT);
+        },
+      );
+
+      await fetchSSE('/', {
+        onAbort: mockOnAbort,
+        onErrorHandle: mockOnErrorHandle,
+        responseAnimation: 'fadeIn',
+        signal: new AbortController().signal,
+      });
+
+      expect(mockOnAbort).not.toHaveBeenCalled();
+      expect(mockOnErrorHandle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: MESSAGE_CANCEL_FLAT,
+          type: ChatErrorType.UnknownChatFetchError,
+        }),
+      );
     });
   });
 

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -315,7 +315,11 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
     headers: options.headers as Record<string, string>,
     method: options.method,
     onerror: (error) => {
-      if (error === MESSAGE_CANCEL_FLAT || (error as TypeError).name === 'AbortError') {
+      const requestWasAborted = options.signal?.aborted === true;
+      if (
+        requestWasAborted &&
+        (error === MESSAGE_CANCEL_FLAT || (error as TypeError)?.name === 'AbortError')
+      ) {
         finishedType = 'abort';
         options?.onAbort?.(output);
         textController.stopAnimation();
@@ -331,16 +335,23 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
           networkStatus,
         };
 
+        const errorMessage =
+          typeof error === 'string'
+            ? error
+            : typeof error?.message === 'string'
+              ? error.message
+              : String(error);
+
         options.onErrorHandle?.(
-          error.type
+          error?.type
             ? error
             : {
                 body: {
-                  message: error.message,
-                  name: error.name,
+                  message: errorMessage,
+                  name: typeof error === 'object' ? error?.name : undefined,
                   ...contextBody,
                 },
-                message: error.message,
+                message: errorMessage,
                 type: ChatErrorType.UnknownChatFetchError,
               },
         );


### PR DESCRIPTION
The SSE error handler currently treats every `AbortError` or flat cancel message as a user-requested abort, even when the request signal is still active. Providers can emit the same values upstream, which silently suppresses the error and calls `onAbort` instead of `onErrorHandle`.

This change classifies the event as an abort only when the caller signal is actually aborted. It also normalizes string and error-object messages so upstream string failures retain useful details.

No visual UI change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --config packages/fetch-sse/vitest.config.mts packages/fetch-sse/src/__tests__/fetchSSE.test.ts
bunx eslint packages/fetch-sse/src/fetchSSE.ts packages/fetch-sse/src/__tests__/fetchSSE.test.ts --quiet
```

Result: 22 tests passed; ESLint completed with no errors.

Coverage includes:

- actual signal-driven `AbortError` cancellation;
- actual signal-driven flat cancellation;
- an upstream flat cancel response while the request remains active.

#### 🔗 Related Issue

No existing issue linked.