### PR TITLE
fix(form): commit the latest slider value on blur

### DIFF
--- a/src/components/FormInput/FormSliderWithInput.test.tsx
+++ b/src/components/FormInput/FormSliderWithInput.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import FormSliderWithInput from './FormSliderWithInput';
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  SliderWithInput: ({
+    onChange,
+    value,
+  }: {
+    onChange?: (value: number) => void;
+    value?: number;
+  }) => (
+    <>
+      <input
+        aria-label="slider-input"
+        type="number"
+        value={value}
+        onChange={(event) => onChange?.(Number(event.target.value))}
+      />
+      <button type="button">slider-thumb</button>
+    </>
+  ),
+}));
+
+describe('FormSliderWithInput', () => {
+  it('commits the latest input value when focus leaves the control', async () => {
+    const onChange = vi.fn();
+    render(
+      <>
+        <FormSliderWithInput value={2} onChange={onChange} />
+        <button type="button">outside</button>
+      </>,
+    );
+
+    const input = screen.getByRole('spinbutton', { name: 'slider-input' });
+    fireEvent.change(input, { target: { value: '3' } });
+
+    await waitFor(() => expect(input).toHaveValue(3));
+    fireEvent.blur(input, { relatedTarget: screen.getByRole('button', { name: 'outside' }) });
+
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('does not commit while focus moves within the control', () => {
+    const onChange = vi.fn();
+    render(<FormSliderWithInput value={2} onChange={onChange} />);
+
+    fireEvent.blur(screen.getByRole('spinbutton', { name: 'slider-input' }), {
+      relatedTarget: screen.getByRole('button', { name: 'slider-thumb' }),
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/FormInput/FormSliderWithInput.tsx
+++ b/src/components/FormInput/FormSliderWithInput.tsx
@@ -1,5 +1,5 @@
 import { SliderWithInput, type SliderWithInputProps } from '@lobehub/ui/base-ui';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 
 interface FormSliderWithInputProps extends Omit<SliderWithInputProps, 'onChange' | 'value'> {
   onChange?: (value: number) => void;
@@ -13,24 +13,33 @@ interface FormSliderWithInputProps extends Omit<SliderWithInputProps, 'onChange'
 const FormSliderWithInput = memo<FormSliderWithInputProps>(
   ({ onChange, value: defaultValue, ...props }) => {
     const [value, setValue] = useState(defaultValue ?? 0);
+    const valueRef = useRef(defaultValue ?? 0);
 
     useEffect(() => {
-      setValue(defaultValue ?? 0);
+      const nextValue = defaultValue ?? 0;
+      valueRef.current = nextValue;
+      setValue(nextValue);
     }, [defaultValue]);
 
     return (
-      <SliderWithInput
-        onBlur={() => {
-          onChange?.(value);
+      <div
+        style={{ width: '100%' }}
+        onBlurCapture={(event) => {
+          if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+          onChange?.(valueRef.current);
         }}
-        onChange={(newValue) => {
-          if (typeof newValue === 'number') {
-            setValue(newValue);
-          }
-        }}
-        {...props}
-        value={value}
-      />
+      >
+        <SliderWithInput
+          onChange={(newValue) => {
+            if (typeof newValue === 'number') {
+              valueRef.current = newValue;
+              setValue(newValue);
+            }
+          }}
+          {...props}
+          value={value}
+        />
+      </div>
     );
   },
 );


### PR DESCRIPTION
`FormSliderWithInput` currently commits from React state in the child blur handler. A fast input change followed by blur can therefore submit the previous value, and moving focus between the slider and its numeric input can commit prematurely.

This change keeps the latest value in a ref and commits only when focus leaves the complete slider control. Focus transitions between internal control elements are ignored.

No intended visual change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run src/components/FormInput/FormSliderWithInput.test.tsx
bunx eslint src/components/FormInput/FormSliderWithInput.tsx src/components/FormInput/FormSliderWithInput.test.tsx
```

Result: 2 tests passed; ESLint passed.

Coverage includes:

- committing the latest numeric value when focus leaves the control;
- not committing while focus moves between internal control elements.

#### 🔗 Related Issue

No existing issue linked.