### PR TITLE
fix(agent-runtime): stop retrying terminal provider errors

### DIFF
--- a/packages/agent-runtime/src/utils/llmErrorClassifier.test.ts
+++ b/packages/agent-runtime/src/utils/llmErrorClassifier.test.ts
@@ -48,6 +48,21 @@ describe('llmErrorClassifier', () => {
     ).toBe('retry');
   });
 
+  it('stops retrying a provider business error that contains a nested arrears code', () => {
+    expect(
+      classifyLLMError({
+        error: { code: 'Arrearage', message: 'Access denied because the account is in arrears' },
+        errorType: 'ProviderBizError',
+      }).kind,
+    ).toBe('stop');
+  });
+
+  it('does not retry an upstream canceled stream', () => {
+    expect(classifyLLMError({ message: 'canceled', type: 'UnknownChatFetchError' }).kind).toBe(
+      'stop',
+    );
+  });
+
   it('stops ProviderBizError invalid request shapes but retries transient ones', () => {
     expect(
       classifyWithSpecs({

--- a/packages/agent-runtime/src/utils/llmErrorClassifier.ts
+++ b/packages/agent-runtime/src/utils/llmErrorClassifier.ts
@@ -48,6 +48,7 @@ const STOP_KEYWORDS = [
   '403',
   'context window',
   'api key',
+  'arrears',
   'billing',
   'forbidden',
   'insufficient quota',
@@ -196,6 +197,9 @@ const createKindClassifier = (options: LLMErrorClassifierOptions = {}) => {
   const { retry: retryErrorTypes, stop: stopErrorTypes } = buildErrorTypeSets(options);
 
   return ({ code, errorType, message, status }: LLMErrorSignal): LLMErrorKind => {
+    if (code?.includes('ARREARAGE')) return 'stop';
+    if (message === 'canceled' || message === 'cancelled') return 'stop';
+
     if (errorType === 'ProviderBizError') {
       if (status === 400 || status === 422) return 'stop';
       if (message.includes('invalid_request_error') || message.includes('invalid request')) {


### PR DESCRIPTION
The runtime error classifier currently retries two terminal provider outcomes: account arrears responses and upstream streams that were already canceled. Retrying either outcome cannot succeed and can keep background agent runs active unnecessarily.

This change recognizes nested `Arrearage` codes, arrears messages, and both canceled spellings as terminal stop conditions.

No visual UI change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --config packages/agent-runtime/vitest.config.mts packages/agent-runtime/src/utils/llmErrorClassifier.test.ts
bunx eslint packages/agent-runtime/src/utils/llmErrorClassifier.ts packages/agent-runtime/src/utils/llmErrorClassifier.test.ts
```

Result: 9 tests passed; ESLint passed.

#### 🔗 Related Issue

No existing issue linked.