### PR TITLE
fix(agent-runtime): bound server retry attempts

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { ServerLLMTransport } from './ServerLLMTransport';
+
+describe('ServerLLMTransport retry budget', () => {
+  it('keeps background agent failures bounded to one retry', () => {
+    const transport = new ServerLLMTransport({} as any);
+
+    expect(transport.retryPolicy.maxAttempts('qwen')).toBe(2);
+    expect(transport.retryPolicy.maxAttempts('chatgpt')).toBe(2);
+    expect(transport.retryPolicy.maxAttempts('lobehub')).toBe(1);
+  });
+});

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
@@ -50,6 +50,11 @@ const getErrorMessage = (error: unknown): string => {
 };
 
 const SERVER_LLM_RETRY_POLICY = {
+  // Server-side sub-agents run without an interactive cancel path. Keep their
+  // retry budget bounded so provider failures cannot leave a group topic in a
+  // long-lived `running` state. The provider SDK already handles transport
+  // concerns; the runtime gets one controlled retry for transient failures.
+  maxRetries: 1,
   noRetryProviders: [BRANDING_PROVIDER],
 };
 


### PR DESCRIPTION
Server-side background agents currently inherit the default runtime retry budget of five retries. Unlike interactive client runs, these sub-agent executions have no direct cancel path, so a persistent provider failure can keep the group topic in a running state for an extended period.

This change gives server transports one controlled retry for transient failures while preserving the existing no-retry behavior for the LobeHub relay provider.

No visual UI change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.test.ts
bunx eslint apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.test.ts
```

Result: 1 test passed; ESLint passed.

#### 🔗 Related Issue

Related to #18152.