### PR TITLE
fix(message): normalize errors before persistence

### DIFF
--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -32,6 +32,27 @@ export interface MessageQueryContext {
   topicShareId?: string;
 }
 
+const normalizeMessageError = (value: ChatMessageError): ChatMessageError => {
+  const record =
+    value && typeof value === 'object' ? (value as unknown as Record<string, unknown>) : {};
+  const candidateType = record.type;
+  const type =
+    typeof candidateType === 'string' ||
+    (typeof candidateType === 'number' && Number.isFinite(candidateType))
+      ? candidateType
+      : 'ApplicationRuntimeError';
+
+  return {
+    ...record,
+    body: record.body ?? value,
+    message:
+      typeof record.message === 'string'
+        ? record.message
+        : 'The model request failed before returning a response',
+    type,
+  } as ChatMessageError;
+};
+
 interface MessageReadQueryContext {
   agentId?: string | null;
   groupId?: string | null;
@@ -195,9 +216,7 @@ export class MessageService {
   };
 
   updateMessageError = async (id: string, value: ChatMessageError, ctx?: MessageQueryContext) => {
-    const error = value.type
-      ? value
-      : { body: value, message: value.message, type: 'ApplicationRuntimeError' };
+    const error = normalizeMessageError(value);
 
     return lambdaClient.message.update.mutate({
       ...ctx,
@@ -232,10 +251,14 @@ export class MessageService {
     value: Partial<UpdateMessageParams>,
     ctx?: MessageQueryContext,
   ): Promise<UpdateMessageResult> => {
+    const normalizedValue = value.error
+      ? { ...value, error: normalizeMessageError(value.error) }
+      : value;
+
     return lambdaClient.message.update.mutate({
       ...ctx,
       id,
-      value,
+      value: normalizedValue,
     });
   };
 

--- a/src/services/message/server.test.ts
+++ b/src/services/message/server.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/libs/trpc/client', () => ({
       createMessage: { mutate: vi.fn() },
       getMessages: { query: vi.fn() },
       removeMessagesByAssistant: { mutate: vi.fn() },
+      update: { mutate: vi.fn() },
     },
   },
 }));
@@ -71,6 +72,96 @@ describe('MessageService', () => {
         content: 'test',
         role: 'user',
         agentId: 'agent-123',
+      });
+    });
+  });
+
+  describe('updateMessage', () => {
+    const service = new MessageService();
+
+    it('normalizes provider errors without a valid type before persistence', async () => {
+      vi.mocked(lambdaClient.message.update.mutate).mockResolvedValue({ success: true } as any);
+
+      await service.updateMessage(
+        'msg-1',
+        {
+          error: {
+            body: { code: 'Arrearage' },
+            message: 'Access denied because the account is in arrears',
+            type: undefined,
+          } as any,
+        },
+        { agentId: 'agent-1', topicId: 'topic-1' },
+      );
+
+      expect(lambdaClient.message.update.mutate).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        id: 'msg-1',
+        topicId: 'topic-1',
+        value: {
+          error: {
+            body: { code: 'Arrearage' },
+            message: 'Access denied because the account is in arrears',
+            type: 'ApplicationRuntimeError',
+          },
+        },
+      });
+    });
+
+    it.each([undefined, null, {}, Number.NaN, Number.POSITIVE_INFINITY])(
+      'falls back when the persisted error type is invalid: %s',
+      async (type) => {
+        vi.mocked(lambdaClient.message.update.mutate).mockResolvedValue({ success: true } as any);
+
+        await service.updateMessage('msg-1', {
+          error: { message: 'provider failed', type } as any,
+        });
+
+        expect(lambdaClient.message.update.mutate).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            value: {
+              error: expect.objectContaining({ type: 'ApplicationRuntimeError' }),
+            },
+          }),
+        );
+      },
+    );
+
+    it('preserves a valid type even when errorType is also present', async () => {
+      vi.mocked(lambdaClient.message.update.mutate).mockResolvedValue({ success: true } as any);
+
+      await service.updateMessage('msg-1', {
+        error: {
+          errorType: 'ProviderBizError',
+          message: 'rate limited',
+          type: 'RateLimitExceeded',
+        } as any,
+      });
+
+      expect(lambdaClient.message.update.mutate).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          value: {
+            error: expect.objectContaining({ type: 'RateLimitExceeded' }),
+          },
+        }),
+      );
+    });
+  });
+
+  describe('updateMessageError', () => {
+    it('normalizes an invalid error type through the dedicated error update path', async () => {
+      vi.mocked(lambdaClient.message.update.mutate).mockResolvedValue({ success: true } as any);
+
+      await new MessageService().updateMessageError('msg-1', {
+        message: 'provider failed',
+        type: Number.NaN,
+      } as any);
+
+      expect(lambdaClient.message.update.mutate).toHaveBeenLastCalledWith({
+        id: 'msg-1',
+        value: {
+          error: expect.objectContaining({ type: 'ApplicationRuntimeError' }),
+        },
       });
     });
   });


### PR DESCRIPTION
### What this PR does

- normalizes malformed provider errors before `message.update` persists them
- falls back to `ApplicationRuntimeError` for missing, non-finite, or non-string/number error types
- preserves valid provider error types and supplies safe body/message fallbacks
- applies the same normalization to both generic and dedicated error update paths

### Why

Some provider failures can reach the message service without a valid `type`. Persisting those values makes downstream rendering and terminal-error classification unreliable.

### Tests

- `bunx vitest run src/services/message/server.test.ts` (13 passed)
- `bunx eslint src/services/message/index.ts src/services/message/server.test.ts`
- `git diff --check`