### PR TITLE
fix(chat-input): block unavailable model submissions

### DIFF
--- a/src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts
+++ b/src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts
@@ -100,7 +100,6 @@ export const useChatInputNotice = (): ChatInputNotice | undefined => {
     usePermission('manage_provider_key');
   const agentId = useAgentId();
   const [actionLoading, setActionLoading] = useState(false);
-
   const [isAgentConfigLoading, isHeterogeneousAgent] = useAgentStore((s) => [
     agentByIdSelectors.isAgentConfigLoadingById(agentId)(s),
     agentByIdSelectors.isAgentHeterogeneousById(agentId)(s),
@@ -221,4 +220,10 @@ export const useChatInputNotice = (): ChatInputNotice | undefined => {
     actionLoading,
     onAction: canManageAiInfra ? handleEnableModel : undefined,
   };
+};
+
+export const useIsChatInputModelUnavailable = (): boolean => {
+  const notice = useChatInputNotice();
+
+  return notice?.key === 'input.modelUnavailable' || notice?.key === 'input.modelDisabled';
 };

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/business/client/hooks/useBusinessChatInputSendAreaPrefix';
 import type { ActionKeys, ChatInputFeature } from '@/features/ChatInput';
 import { ChatInputProvider, DesktopChatInput } from '@/features/ChatInput';
+import { useIsChatInputModelUnavailable } from '@/features/ChatInput/ChatInputNotice/useChatInputNotice';
 import {
   type SendButtonHandler,
   type SendButtonProps,
@@ -43,6 +44,7 @@ import QueueTray from './QueueTray';
 import { sendVoiceMessage } from './sendVoiceMessage';
 import {
   getContextWindowMessages,
+  getConversationChatInputDisabled,
   getConversationChatInputUiState,
   toChatInputMessages,
 } from './utils';
@@ -267,6 +269,7 @@ const ChatInput = memo<ChatInputProps>(
     const hasQueuedMessages = useChatStore(
       (s) => operationSelectors.queuedMessageCount(context)(s) > 0,
     );
+    const isModelUnavailable = useIsChatInputModelUnavailable();
 
     // Detect whether TodoProgress will render (mirrors its own gating) so we
     // can square the top corners of OpStatusTray when it sits flush below.
@@ -296,8 +299,15 @@ const ChatInput = memo<ChatInputProps>(
     // Input stays enabled during agent execution — messages are queued.
     // When disableQueue is set (e.g. onboarding), block sending while loading.
     // disableSend hard-blocks regardless of content (host surface is read-only).
-    const disabled =
-      isInputEmpty || isUploadingFiles || (!!disableQueue && isInputQueueBlocked) || !!disableSend;
+    const disabled = getConversationChatInputDisabled({
+      disableQueue,
+      disableSend,
+      isInputEmpty,
+      isInputLoading,
+      isInputQueueBlocked,
+      isModelUnavailable,
+      isUploadingFiles,
+    });
 
     // `disabled` above lags the editor: `inputMessage` mirrors content through
     // the editor's debounced onChange, so a fast type→Enter arrives while the
@@ -306,7 +316,7 @@ const ChatInput = memo<ChatInputProps>(
     // at trigger time, so this only mirrors the visual disabled semantics.
     const customDisabled = customSendButtonProps?.disabled;
     const resolveSendBlocked = useCallback(() => {
-      if (disableSend) return true;
+      if (disableSend || (isModelUnavailable && !isInputLoading)) return true;
       if (customDisabled !== undefined) return customDisabled;
 
       const fileStore = useFileStore.getState();
@@ -324,7 +334,7 @@ const ChatInput = memo<ChatInputProps>(
       const hasContextSelections =
         fileChatSelectors.chatContextSelections(messageMapKey(liveContext))(fileStore).length > 0;
       return !hasText && !hasFiles && !hasContextSelections;
-    }, [customDisabled, disableQueue, disableSend, storeApi]);
+    }, [customDisabled, disableQueue, disableSend, isInputLoading, isModelUnavailable, storeApi]);
     const shouldUsePlainSendButton = !showSendMenu && !!sendMenu;
     const businessAlerts = useBusinessChatInputAlerts();
     const businessSendAreaPrefix = getBusinessChatInputSendAreaPrefix(sendAreaPrefix);
@@ -334,7 +344,7 @@ const ChatInput = memo<ChatInputProps>(
       async ({ clearContent, getMarkdownContent, getEditorData }) => {
         // Host surface is read-only (e.g. page locked) — block Enter too, not
         // just the grayed-out button.
-        if (disableSend) return;
+        if (disableSend || isModelUnavailable) return;
 
         // Get instant values from stores at trigger time
         const fileStore = useFileStore.getState();
@@ -394,7 +404,15 @@ const ChatInput = memo<ChatInputProps>(
           pageSelections,
         });
       },
-      [contextKey, sendMessage, storeApi, disableQueue, disableSend, isInputQueueBlocked],
+      [
+        contextKey,
+        sendMessage,
+        storeApi,
+        disableQueue,
+        disableSend,
+        isInputQueueBlocked,
+        isModelUnavailable,
+      ],
     );
 
     const sendButtonProps: SendButtonProps = {

--- a/src/features/Conversation/ChatInput/utils.test.ts
+++ b/src/features/Conversation/ChatInput/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getContextWindowMessages,
+  getConversationChatInputDisabled,
   getConversationChatInputUiState,
   toChatInputMessages,
 } from './utils';
@@ -141,5 +142,49 @@ describe('getConversationChatInputUiState', () => {
       showSendMenu: false,
       showStopButton: true,
     });
+  });
+});
+
+describe('getConversationChatInputDisabled', () => {
+  it('blocks sending when the selected model is unavailable', () => {
+    expect(
+      getConversationChatInputDisabled({
+        disableQueue: false,
+        disableSend: false,
+        isInputEmpty: false,
+        isInputLoading: false,
+        isInputQueueBlocked: false,
+        isModelUnavailable: true,
+        isUploadingFiles: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps a valid non-empty composer enabled', () => {
+    expect(
+      getConversationChatInputDisabled({
+        disableQueue: false,
+        disableSend: false,
+        isInputEmpty: false,
+        isInputLoading: false,
+        isInputQueueBlocked: false,
+        isModelUnavailable: false,
+        isUploadingFiles: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the stop control enabled when a model goes offline during generation', () => {
+    expect(
+      getConversationChatInputDisabled({
+        disableQueue: false,
+        disableSend: false,
+        isInputEmpty: false,
+        isInputLoading: true,
+        isInputQueueBlocked: true,
+        isModelUnavailable: true,
+        isUploadingFiles: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/features/Conversation/ChatInput/utils.ts
+++ b/src/features/Conversation/ChatInput/utils.ts
@@ -62,3 +62,35 @@ export const getConversationChatInputUiState = ({
     showStopButton: isInputLoading,
   };
 };
+
+interface GetConversationChatInputDisabledParams {
+  disableQueue?: boolean;
+  disableSend?: boolean;
+  isInputEmpty: boolean;
+  isInputLoading: boolean;
+  isInputQueueBlocked: boolean;
+  isModelUnavailable: boolean;
+  isUploadingFiles: boolean;
+}
+
+export const getConversationChatInputDisabled = ({
+  disableQueue,
+  disableSend,
+  isInputEmpty,
+  isInputLoading,
+  isInputQueueBlocked,
+  isModelUnavailable,
+  isUploadingFiles,
+}: GetConversationChatInputDisabledParams): boolean => {
+  // An unavailable model blocks new sends, but must not disable the Stop
+  // control for a request that was already running when the model went away.
+  const shouldBlockUnavailableModel = isModelUnavailable && !isInputLoading;
+
+  return (
+    isInputEmpty ||
+    isUploadingFiles ||
+    shouldBlockUnavailableModel ||
+    (!!disableQueue && isInputQueueBlocked) ||
+    !!disableSend
+  );
+};


### PR DESCRIPTION
### What this PR does

- disables new submissions when the selected model is disabled or unavailable
- blocks both the send button and Enter-key submission path
- keeps the Stop control enabled if a model becomes unavailable during an active generation
- centralizes the composer disabled-state calculation in a tested helper

### Why

The existing model-unavailable notice is informational, but the composer can still submit requests that are guaranteed to fail.

### Tests

- `bunx vitest run src/features/Conversation/ChatInput/utils.test.ts` (13 passed)
- ESLint on the four changed files
- `git diff --check`

No visual design change is intended beyond the correct disabled state.