### PR TITLE
fix(agent-runtime): bound client retry attempts

### DIFF
--- a/src/store/chat/agents/transports/ClientLLMTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.test.ts
@@ -132,6 +132,16 @@ describe('ClientLLMTransport.runAttempt · empty-completion grounding guard', ()
   });
 });
 
+describe('ClientLLMTransport retry budget', () => {
+  it('keeps interactive chat failures bounded to one retry', () => {
+    const retryPolicy = createTransport().transport.retryPolicy;
+
+    expect(retryPolicy.maxAttempts('qwen')).toBe(2);
+    expect(retryPolicy.maxAttempts('chatgpt')).toBe(2);
+    expect(retryPolicy.maxAttempts('lobehub')).toBe(1);
+  });
+});
+
 describe('ClientLLMTransport.retryPolicy.onError · terminal operation teardown', () => {
   it('writes the message error and fails the running operation immediately', () => {
     const { store, transport } = createTransport();

--- a/src/store/chat/agents/transports/ClientLLMTransport.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.ts
@@ -36,6 +36,8 @@ import type { ClientLLMModelParameters } from './ClientContextBuilder';
 import type { ClientRuntimeSession } from './ClientRuntimeStreamSink';
 
 const CLIENT_LLM_RETRY_POLICY = {
+  // Keep the app-level retry budget to one attempt beyond the initial call.
+  maxRetries: 1,
   noRetryProviders: [BRANDING_PROVIDER],
 };
 


### PR DESCRIPTION
### What this PR does

- limits client-side LLM execution to one retry after the initial attempt
- keeps the existing no-retry behavior for the LobeHub provider
- adds regression coverage for both ordinary and no-retry providers

### Why

The shared runtime default allows five retries. For an interactive chat request that can multiply latency and provider calls after a failure; one retry retains transient recovery without a long retry loop.

### Tests

- `bunx vitest run src/store/chat/agents/transports/ClientLLMTransport.test.ts` (8 passed)
- ESLint on both changed files
- `git diff --check`