### PR TITLE
fix(connectors): localize tool permission details

### DIFF
--- a/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { ConnectorToolPermission } from '@/database/schemas';
 import type { ConnectorTool } from '@/store/tool/slices/connector';
 
+import { getConnectorPermissionStatus } from './localization';
 import ToolPermissionRow from './ToolPermissionRow';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -53,6 +54,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 interface ToolPermissionGroupProps {
   /** Read-only mode — the caller lacks the manage permission for this connector. */
+  connectorIdentifier: string;
   disabled?: boolean;
   label: string;
   onBatchPermission: (toolIds: string[], permission: ConnectorToolPermission) => void;
@@ -61,13 +63,20 @@ interface ToolPermissionGroupProps {
 }
 
 const ToolPermissionGroup = memo<ToolPermissionGroupProps>(
-  ({ disabled, label, tools, onPermissionChange, onBatchPermission }) => {
+  ({ connectorIdentifier, disabled, label, tools, onPermissionChange, onBatchPermission }) => {
     const { t } = useTranslation('tool');
     const [expanded, setExpanded] = useState(true);
 
     if (tools.length === 0) return null;
 
     const toolIds = tools.map((tool) => tool.id);
+    const permissionStatus = getConnectorPermissionStatus(tools);
+    const permissionStatusLabels = {
+      auto: t('connector.permission.auto', 'Auto — AI calls directly'),
+      custom: t('connector.permission.custom', 'Custom'),
+      disabled: t('connector.permission.disabled', 'Disabled — hidden from AI'),
+      needs_approval: t('connector.permission.approval', 'Needs approval'),
+    } satisfies Record<typeof permissionStatus, string>;
 
     const batchItems = [
       {
@@ -104,7 +113,7 @@ const ToolPermissionGroup = memo<ToolPermissionGroupProps>(
                 onClick={(e) => e.stopPropagation()}
               >
                 <MoreHorizontalIcon size={12} />
-                {t('connector.permission.custom', 'Custom')}
+                {permissionStatusLabels[permissionStatus]}
                 <ChevronDownIcon size={12} />
               </Button>
             </DropdownMenu>
@@ -115,6 +124,7 @@ const ToolPermissionGroup = memo<ToolPermissionGroupProps>(
           <div>
             {tools.map((tool) => (
               <ToolPermissionRow
+                connectorIdentifier={connectorIdentifier}
                 disabled={disabled}
                 key={tool.id}
                 tool={tool}

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -2,9 +2,12 @@ import { Tooltip } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { BanIcon, CheckIcon, HandIcon } from 'lucide-react';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { ConnectorToolPermission } from '@/database/schemas';
 import type { ConnectorTool } from '@/store/tool/slices/connector';
+
+import { getLocalizedConnectorTool } from './localization';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   btn: css`
@@ -82,66 +85,72 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 interface ToolPermissionRowProps {
   /** Read-only mode — the caller lacks the manage permission for this connector. */
+  connectorIdentifier: string;
   disabled?: boolean;
   onPermissionChange: (toolId: string, permission: ConnectorToolPermission) => void;
   tool: ConnectorTool;
 }
 
-const ToolPermissionRow = memo<ToolPermissionRowProps>(({ disabled, tool, onPermissionChange }) => {
-  const btnClass = (permission: ConnectorToolPermission) =>
-    tool.permission === permission ? `${styles.btn} ${styles.btnActive}` : styles.btn;
+const ToolPermissionRow = memo<ToolPermissionRowProps>(
+  ({ connectorIdentifier, disabled, tool, onPermissionChange }) => {
+    const { t } = useTranslation('plugin');
+    const { t: tt } = useTranslation('tool');
+    const localizedTool = getLocalizedConnectorTool(connectorIdentifier, tool, t);
+    const btnClass = (permission: ConnectorToolPermission) =>
+      tool.permission === permission ? `${styles.btn} ${styles.btnActive}` : styles.btn;
 
-  const handleChange = (permission: ConnectorToolPermission) => {
-    if (disabled) return;
-    onPermissionChange(tool.id, permission);
-  };
+    const handleChange = (permission: ConnectorToolPermission) => {
+      if (disabled) return;
+      onPermissionChange(tool.id, permission);
+    };
 
-  return (
-    <div className={styles.row}>
-      <div className={styles.nameCell}>
-        <div className={styles.toolName}>{tool.toolName}</div>
-        {tool.description && (
-          <Tooltip mouseEnterDelay={0.5} title={tool.description}>
-            <div className={styles.description}>{tool.description}</div>
-          </Tooltip>
-        )}
+    return (
+      <div className={styles.row}>
+        <div className={styles.nameCell}>
+          <div className={styles.toolName}>{localizedTool.name}</div>
+          {localizedTool.description && (
+            <Tooltip mouseEnterDelay={0.5} title={localizedTool.description}>
+              <div className={styles.description}>{localizedTool.description}</div>
+            </Tooltip>
+          )}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexShrink: 0,
+            gap: 2,
+            ...(disabled && { cursor: 'not-allowed', opacity: 0.45 }),
+          }}
+        >
+          <div
+            className={btnClass(ConnectorToolPermission.auto)}
+            style={disabled ? { pointerEvents: 'none' } : undefined}
+            title={tt('connector.permission.auto', 'Auto — AI calls directly')}
+            onClick={() => handleChange(ConnectorToolPermission.auto)}
+          >
+            <CheckIcon size={15} />
+          </div>
+          <div
+            className={btnClass(ConnectorToolPermission.needs_approval)}
+            style={disabled ? { pointerEvents: 'none' } : undefined}
+            title={tt('connector.permission.approval', 'Needs approval')}
+            onClick={() => handleChange(ConnectorToolPermission.needs_approval)}
+          >
+            <HandIcon size={15} />
+          </div>
+          <div
+            className={btnClass(ConnectorToolPermission.disabled)}
+            style={disabled ? { pointerEvents: 'none' } : undefined}
+            title={tt('connector.permission.disabled', 'Disabled — hidden from AI')}
+            onClick={() => handleChange(ConnectorToolPermission.disabled)}
+          >
+            <BanIcon size={15} />
+          </div>
+        </div>
       </div>
-      <div
-        style={{
-          display: 'flex',
-          flexShrink: 0,
-          gap: 2,
-          ...(disabled && { cursor: 'not-allowed', opacity: 0.45 }),
-        }}
-      >
-        <div
-          className={btnClass(ConnectorToolPermission.auto)}
-          style={disabled ? { pointerEvents: 'none' } : undefined}
-          title="Auto — AI calls directly"
-          onClick={() => handleChange(ConnectorToolPermission.auto)}
-        >
-          <CheckIcon size={15} />
-        </div>
-        <div
-          className={btnClass(ConnectorToolPermission.needs_approval)}
-          style={disabled ? { pointerEvents: 'none' } : undefined}
-          title="Needs approval"
-          onClick={() => handleChange(ConnectorToolPermission.needs_approval)}
-        >
-          <HandIcon size={15} />
-        </div>
-        <div
-          className={btnClass(ConnectorToolPermission.disabled)}
-          style={disabled ? { pointerEvents: 'none' } : undefined}
-          title="Disabled — hidden from AI"
-          onClick={() => handleChange(ConnectorToolPermission.disabled)}
-        >
-          <BanIcon size={15} />
-        </div>
-      </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 ToolPermissionRow.displayName = 'ToolPermissionRow';
 

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -366,6 +366,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(
           {hasTools ? (
             <div style={{ flex: 1, overflowY: 'auto' }}>
               <ToolPermissionGroup
+                connectorIdentifier={connector.identifier}
                 disabled={!canManage}
                 label={t('connector.readOnlyTools', 'Read-only tools')}
                 tools={readTools}
@@ -373,6 +374,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(
                 onPermissionChange={handlePermissionChange}
               />
               <ToolPermissionGroup
+                connectorIdentifier={connector.identifier}
                 disabled={!canManage}
                 label={t('connector.createTools', 'Create tools')}
                 tools={createTools}
@@ -380,6 +382,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(
                 onPermissionChange={handlePermissionChange}
               />
               <ToolPermissionGroup
+                connectorIdentifier={connector.identifier}
                 disabled={!canManage}
                 label={t('connector.updateTools', 'Update tools')}
                 tools={updateTools}
@@ -387,6 +390,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(
                 onPermissionChange={handlePermissionChange}
               />
               <ToolPermissionGroup
+                connectorIdentifier={connector.identifier}
                 disabled={!canManage}
                 label={t('connector.deleteTools', 'Delete tools')}
                 tools={deleteTools}

--- a/src/features/Connectors/ConnectorDetail/localization.test.ts
+++ b/src/features/Connectors/ConnectorDetail/localization.test.ts
@@ -1,13 +1,21 @@
 import { type TFunction } from 'i18next';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getLocalizedConnectorDetail } from './localization';
+import { ConnectorToolPermission } from '@/database/schemas';
 
-const createTranslator = (translations: Record<string, string> = {}) =>
+import {
+  getConnectorPermissionStatus,
+  getLocalizedConnectorDetail,
+  getLocalizedConnectorTool,
+} from './localization';
+
+const createTranslator = <Namespace extends 'plugin' | 'setting' = 'setting'>(
+  translations: Record<string, string> = {},
+) =>
   vi.fn(
     (key: string, options?: { defaultValue?: string }) =>
       translations[key] ?? options?.defaultValue ?? key,
-  ) as unknown as TFunction<'setting'>;
+  ) as unknown as TFunction<Namespace>;
 
 describe('getLocalizedConnectorDetail', () => {
   it('localizes builtin connector name and description with setting keys', () => {
@@ -110,5 +118,53 @@ describe('getLocalizedConnectorDetail', () => {
     });
 
     expect(result).toEqual({ description: undefined, name: 'Custom HTTP' });
+  });
+});
+
+describe('getLocalizedConnectorTool', () => {
+  it('localizes builtin tool names and descriptions while preserving the callable name', () => {
+    const t = createTranslator<'plugin'>({
+      'builtins.lobe-task.apiDescription.viewTask': '查看指定任务的详细信息。',
+      'builtins.lobe-task.apiName.viewTask': '查看任务',
+    });
+    const tool = {
+      description: 'View details of a specific task.',
+      displayName: null,
+      toolName: 'viewTask',
+    };
+
+    const result = getLocalizedConnectorTool('lobe-task', tool, t);
+
+    expect(result).toEqual({
+      description: '查看指定任务的详细信息。',
+      name: '查看任务',
+      toolName: 'viewTask',
+    });
+    expect(tool.toolName).toBe('viewTask');
+  });
+});
+
+describe('getConnectorPermissionStatus', () => {
+  it.each([
+    {
+      expected: ConnectorToolPermission.auto,
+      permissions: [ConnectorToolPermission.auto, ConnectorToolPermission.auto],
+    },
+    {
+      expected: ConnectorToolPermission.needs_approval,
+      permissions: [ConnectorToolPermission.needs_approval, ConnectorToolPermission.needs_approval],
+    },
+    {
+      expected: ConnectorToolPermission.disabled,
+      permissions: [ConnectorToolPermission.disabled, ConnectorToolPermission.disabled],
+    },
+    {
+      expected: 'custom',
+      permissions: [ConnectorToolPermission.auto, ConnectorToolPermission.disabled],
+    },
+  ])('returns $expected for the group state', ({ expected, permissions }) => {
+    expect(getConnectorPermissionStatus(permissions.map((permission) => ({ permission })))).toBe(
+      expected,
+    );
   });
 });

--- a/src/features/Connectors/ConnectorDetail/localization.ts
+++ b/src/features/Connectors/ConnectorDetail/localization.ts
@@ -1,5 +1,7 @@
 import { type TFunction } from 'i18next';
 
+import { type ConnectorToolPermission } from '@/database/schemas';
+
 interface LocalizableConnector {
   identifier: string;
   metadata?: Record<string, unknown> | null;
@@ -12,12 +14,30 @@ interface LocalizableProvider {
   label: string;
 }
 
+interface LocalizableConnectorTool {
+  description?: string | null;
+  displayName?: string | null;
+  toolName: string;
+}
+
 interface GetLocalizedConnectorDetailOptions {
   composioApp?: LocalizableProvider;
   connector: LocalizableConnector;
   lobehubProvider?: LocalizableProvider;
   t: TFunction<'setting'>;
 }
+
+type ConnectorPermissionStatus = ConnectorToolPermission | 'custom';
+
+export const getConnectorPermissionStatus = (
+  tools: Array<{ permission: ConnectorToolPermission }>,
+): ConnectorPermissionStatus => {
+  const firstPermission = tools[0]?.permission;
+
+  if (!firstPermission) return 'custom';
+
+  return tools.every((tool) => tool.permission === firstPermission) ? firstPermission : 'custom';
+};
 
 export const getLocalizedConnectorDetail = ({
   composioApp,
@@ -64,3 +84,19 @@ export const getLocalizedConnectorDetail = ({
     name: connector.name,
   };
 };
+
+export const getLocalizedConnectorTool = (
+  connectorIdentifier: string,
+  tool: LocalizableConnectorTool,
+  t: TFunction<'plugin'>,
+) => ({
+  description: tool.description
+    ? t(`builtins.${connectorIdentifier}.apiDescription.${tool.toolName}`, {
+        defaultValue: tool.description,
+      })
+    : undefined,
+  name: t(`builtins.${connectorIdentifier}.apiName.${tool.toolName}`, {
+    defaultValue: tool.displayName || tool.toolName,
+  }),
+  toolName: tool.toolName,
+});


### PR DESCRIPTION
### What this PR does

- uses existing plugin translations for connector tool names and descriptions
- keeps the callable tool name unchanged
- reports a uniform permission group as Auto, Needs approval, or Disabled instead of always showing Custom
- retains Custom for mixed permission groups
- localizes permission control tooltips with the existing tool namespace keys

### Tests

- `bunx vitest run src/features/Connectors/ConnectorDetail/localization.test.ts` (10 passed)
- ESLint on the five changed files
- `git diff --check`

No connector execution or permission persistence behavior is changed.