### PR TITLE
fix(i18n): localize render gallery tool metadata

### DIFF
--- a/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.test.tsx
+++ b/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from '@testing-library/react';
+import { type ComponentType, createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { GitHubInspector } from './Inspector';
+
+describe('GitHubInspector', () => {
+  it('uses localized product and API display names when the caller provides them', () => {
+    render(
+      createElement(GitHubInspector as unknown as ComponentType<Record<string, unknown>>, {
+        apiDisplayName: '创建拉取请求',
+        apiName: 'create_pull_request',
+        args: {},
+        identifier: 'github',
+        toolDisplayName: 'GitHub 代码托管',
+      }),
+    );
+
+    expect(screen.getByText('GitHub 代码托管')).toBeTruthy();
+    expect(screen.getByText('创建拉取请求')).toBeTruthy();
+  });
+});

--- a/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.tsx
@@ -214,9 +214,17 @@ const pickChip = (args: Record<string, unknown> | undefined): ChipResult => ({
 });
 
 const GitHubInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>(
-  ({ apiName, args, partialArgs, isArgumentsStreaming, isLoading }) => {
+  ({
+    apiDisplayName,
+    apiName,
+    args,
+    partialArgs,
+    isArgumentsStreaming,
+    isLoading,
+    toolDisplayName,
+  }) => {
     const effectiveArgs = args ?? partialArgs;
-    const label = staticGitHubLabelFor(parseGitHubToolName(apiName));
+    const label = apiDisplayName || staticGitHubLabelFor(parseGitHubToolName(apiName));
     const { branch, primary } = pickChip(effectiveArgs);
 
     return (
@@ -227,7 +235,7 @@ const GitHubInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>
         )}
       >
         <GitHubMark />
-        <span className={styles.productPrefix}>GitHub</span>
+        <span className={styles.productPrefix}>{toolDisplayName || 'GitHub'}</span>
         <span className={styles.chip}>
           <span className={styles.chipAction}>{label}</span>
           {primary && (

--- a/packages/shared-tool-ui/src/Inspector/Linear/Inspector.test.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Linear/Inspector.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from '@testing-library/react';
+import { type ComponentType, createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { LinearInspector } from './Inspector';
+
+describe('LinearInspector', () => {
+  it('uses localized product and API display names when the caller provides them', () => {
+    render(
+      createElement(LinearInspector as unknown as ComponentType<Record<string, unknown>>, {
+        apiDisplayName: '删除附件',
+        apiName: 'delete_attachment',
+        args: {},
+        identifier: 'linear',
+        toolDisplayName: 'Linear 项目管理',
+      }),
+    );
+
+    expect(screen.getByText('Linear 项目管理')).toBeTruthy();
+    expect(screen.getByText('删除附件')).toBeTruthy();
+  });
+});

--- a/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
@@ -236,10 +236,18 @@ const pickChip = (parsed: ParsedTool, args: Record<string, unknown> | undefined)
 };
 
 const LinearInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>(
-  ({ apiName, args, partialArgs, isArgumentsStreaming, isLoading }) => {
+  ({
+    apiDisplayName,
+    apiName,
+    args,
+    partialArgs,
+    isArgumentsStreaming,
+    isLoading,
+    toolDisplayName,
+  }) => {
     const effectiveArgs = args ?? partialArgs;
     const parsed = parseToolName(apiName);
-    const label = labelFor(parsed, effectiveArgs);
+    const label = apiDisplayName || labelFor(parsed, effectiveArgs);
     const { primary, parentId } = pickChip(parsed, effectiveArgs);
 
     return (
@@ -250,7 +258,7 @@ const LinearInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>
         )}
       >
         <LinearLogomark />
-        <span className={styles.productPrefix}>Linear</span>
+        <span className={styles.productPrefix}>{toolDisplayName || 'Linear'}</span>
         <span className={styles.chip}>
           <span className={styles.chipAction}>{label}</span>
           {primary && (

--- a/packages/types/src/tool/builtin.ts
+++ b/packages/types/src/tool/builtin.ts
@@ -439,6 +439,8 @@ export type BuiltinPlaceholder = (props: BuiltinPlaceholderProps) => ReactNode;
 // ==================== Inspector Renderer Types ====================
 
 export interface BuiltinInspectorProps<Arguments = any, State = any> {
+  /** Optional localized API label supplied by preview or debug surfaces. */
+  apiDisplayName?: string;
   apiName: string;
   args: Arguments;
   identifier: string;
@@ -457,6 +459,8 @@ export interface BuiltinInspectorProps<Arguments = any, State = any> {
    * via `metadata.sourceToolCallId`.
    */
   toolCallId?: string;
+  /** Optional localized tool label supplied by preview or debug surfaces. */
+  toolDisplayName?: string;
 }
 
 export type BuiltinInspector = <A = any, S = any>(props: BuiltinInspectorProps<A, S>) => ReactNode;

--- a/src/features/DevPanel/RenderGallery/ApiList.tsx
+++ b/src/features/DevPanel/RenderGallery/ApiList.tsx
@@ -85,7 +85,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     min-width: 0;
 
-    font-family: ${cssVar.fontFamilyCode};
+    font-family: ${cssVar.fontFamily};
     font-size: 13px;
   `,
   /** Trailing action segment — always kept visible. */
@@ -150,14 +150,14 @@ const ApiList = memo<ApiListProps>(({ apis, activeApiName, onSelect }) => {
       <Flexbox className={styles.list} ref={listRef}>
         {apis.map((api) => {
           const active = api.apiName === activeApiName;
-          const { head, tail } = splitName(api.apiName);
+          const { head, tail } = splitName(api.apiDisplayName);
           return (
             <Flexbox
               horizontal
               className={cx(styles.item, active && styles.itemActive)}
               data-api={api.apiName}
               key={api.apiName}
-              title={api.apiName}
+              title={api.apiDisplayName}
               onClick={() => onSelect(api.apiName)}
             >
               <span className={cx(styles.dot, api.render && styles.dotActive)} />

--- a/src/features/DevPanel/RenderGallery/ToolPreview.tsx
+++ b/src/features/DevPanel/RenderGallery/ToolPreview.tsx
@@ -94,7 +94,7 @@ const ToolPreview = ({ api, mode }: ToolPreviewProps) => {
       <Flexbox className={styles.cardHeader}>
         <Flexbox horizontal align={'center'} gap={8} wrap={'wrap'}>
           <Text fontSize={18} weight={600}>
-            {api.apiName}
+            {api.apiDisplayName}
           </Text>
           <Tag>{api.identifier}</Tag>
           {variants.length > 1 && (

--- a/src/features/DevPanel/RenderGallery/localization.test.ts
+++ b/src/features/DevPanel/RenderGallery/localization.test.ts
@@ -1,0 +1,54 @@
+import { type TFunction } from 'i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { localizeRenderGalleryApi, localizeRenderGalleryToolset } from './localization';
+
+const createTranslator = (translations: Record<string, string> = {}) =>
+  vi.fn(
+    (key: string, options?: { defaultValue?: string }) =>
+      translations[key] ?? options?.defaultValue ?? key,
+  ) as unknown as TFunction<'plugin'>;
+
+describe('Render Gallery localization', () => {
+  it('localizes toolset and API metadata from the plugin namespace', () => {
+    const t = createTranslator({
+      'builtins.lobe-task.apiDescription.viewTask': '查看指定任务的详细信息。',
+      'builtins.lobe-task.apiName.viewTask': '查看任务',
+      'builtins.lobe-task.description': '管理并执行任务。',
+      'builtins.lobe-task.title': '任务工具',
+    });
+
+    expect(
+      localizeRenderGalleryToolset(
+        {
+          identifier: 'lobe-task',
+          toolsetDescription: 'Manage and execute tasks.',
+          toolsetName: 'Task Tools',
+        },
+        t,
+      ),
+    ).toMatchObject({ toolsetDescription: '管理并执行任务。', toolsetName: '任务工具' });
+
+    expect(
+      localizeRenderGalleryApi(
+        {
+          apiName: 'viewTask',
+          description: 'View details of a task.',
+          identifier: 'lobe-task',
+        },
+        t,
+      ),
+    ).toMatchObject({ apiDisplayName: '查看任务', description: '查看指定任务的详细信息。' });
+  });
+
+  it('falls back to registry metadata when translations are unavailable', () => {
+    const t = createTranslator();
+
+    expect(
+      localizeRenderGalleryApi(
+        { apiName: 'customAction', description: 'Custom action', identifier: 'custom-tool' },
+        t,
+      ),
+    ).toMatchObject({ apiDisplayName: 'customAction', description: 'Custom action' });
+  });
+});

--- a/src/features/DevPanel/RenderGallery/localization.ts
+++ b/src/features/DevPanel/RenderGallery/localization.ts
@@ -1,0 +1,43 @@
+import { type TFunction } from 'i18next';
+
+interface RenderGalleryApiMeta {
+  apiName: string;
+  description?: string;
+  identifier: string;
+}
+
+interface RenderGalleryToolsetMeta {
+  identifier: string;
+  toolsetDescription?: string;
+  toolsetName: string;
+}
+
+export const localizeRenderGalleryApi = <T extends RenderGalleryApiMeta>(
+  api: T,
+  t: TFunction<'plugin'>,
+) => ({
+  ...api,
+  apiDisplayName: t(`builtins.${api.identifier}.apiName.${api.apiName}`, {
+    defaultValue: api.apiName,
+  }),
+  description: api.description
+    ? t(`builtins.${api.identifier}.apiDescription.${api.apiName}`, {
+        defaultValue: api.description,
+      })
+    : undefined,
+});
+
+export const localizeRenderGalleryToolset = <T extends RenderGalleryToolsetMeta>(
+  toolset: T,
+  t: TFunction<'plugin'>,
+) => ({
+  ...toolset,
+  toolsetDescription: toolset.toolsetDescription
+    ? t(`builtins.${toolset.identifier}.description`, {
+        defaultValue: toolset.toolsetDescription,
+      })
+    : undefined,
+  toolsetName: t(`builtins.${toolset.identifier}.title`, {
+    defaultValue: toolset.toolsetName,
+  }),
+});

--- a/src/features/DevPanel/RenderGallery/toolSurfaces.test.tsx
+++ b/src/features/DevPanel/RenderGallery/toolSurfaces.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ToolInspectorSlot } from './toolSurfaces';
+import type { ApiEntry } from './useDevtoolsEntries';
+
+describe('ToolInspectorSlot', () => {
+  it('passes localized tool and API labels to the registered inspector', () => {
+    const api = {
+      apiDisplayName: '删除附件',
+      apiName: 'delete_attachment',
+      fixture: { variants: [] },
+      identifier: 'linear',
+      inspector: ((props: { apiDisplayName?: string; toolDisplayName?: string }) => (
+        <span>{`${props.toolDisplayName}｜${props.apiDisplayName}`}</span>
+      )) as ApiEntry['inspector'],
+      toolDisplayName: 'Linear 项目管理',
+    } as ApiEntry;
+
+    render(
+      <ToolInspectorSlot
+        api={api}
+        variant={{ args: {}, id: 'default', label: '默认' }}
+        derived={{
+          args: {},
+          content: '',
+          isArgumentsStreaming: false,
+          isLoading: false,
+          partialArgs: undefined,
+          pluginError: undefined,
+          pluginState: undefined,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Linear 项目管理｜删除附件')).toBeInTheDocument();
+  });
+});

--- a/src/features/DevPanel/RenderGallery/toolSurfaces.tsx
+++ b/src/features/DevPanel/RenderGallery/toolSurfaces.tsx
@@ -91,6 +91,7 @@ export const ToolInspectorSlot = memo<ToolInspectorSlotProps>(
     return (
       <RenderBoundary label={'Inspector'}>
         <Inspector
+          apiDisplayName={api.apiDisplayName}
           apiName={api.apiName}
           args={derived.args}
           identifier={api.identifier}
@@ -99,6 +100,7 @@ export const ToolInspectorSlot = memo<ToolInspectorSlotProps>(
           partialArgs={derived.partialArgs}
           pluginState={derived.pluginState}
           toolCallId={toolCallId}
+          toolDisplayName={api.toolDisplayName}
           result={{
             content: coerceInspectorContent(variant.content),
             error: derived.pluginError,

--- a/src/features/DevPanel/RenderGallery/useDevtoolsEntries.ts
+++ b/src/features/DevPanel/RenderGallery/useDevtoolsEntries.ts
@@ -13,11 +13,13 @@ import type {
   BuiltinStreaming,
 } from '@lobechat/types';
 import type { MenuProps } from '@lobehub/ui';
-import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { getToolRenderFixture, getToolRenderMeta, type ToolRenderFixture } from './fixtures';
+import { localizeRenderGalleryApi, localizeRenderGalleryToolset } from './localization';
 
 export interface ApiEntry {
+  apiDisplayName: string;
   apiName: string;
   description?: string;
   fixture: ToolRenderFixture;
@@ -27,6 +29,7 @@ export interface ApiEntry {
   placeholder?: BuiltinPlaceholder;
   render?: BuiltinRender;
   streaming?: BuiltinStreaming;
+  toolDisplayName: string;
 }
 
 export interface ToolsetEntry {
@@ -56,8 +59,12 @@ const isDeprecatedApi = (identifier: string, apiName: string) =>
 
 export const toApiAnchor = (apiName: string) => `api-${apiName}`;
 
-export const useDevtoolsEntries = (): DevtoolsEntries =>
-  useMemo(() => {
+export const useDevtoolsEntries = (): DevtoolsEntries => {
+  const { t } = useTranslation('plugin');
+
+  // This is a development-only gallery. Rebuild the small registry on render so
+  // language/resource hot updates cannot leave stale English labels in useMemo.
+  const buildEntries = () => {
     const pairKey = (identifier: string, apiName: string) => `${identifier}:${apiName}`;
 
     const byKey = new Map<
@@ -121,10 +128,26 @@ export const useDevtoolsEntries = (): DevtoolsEntries =>
 
       const meta = getToolRenderMeta(identifier, apiName);
       const fixture = getToolRenderFixture(identifier, apiName, meta.api);
+      const localizedApi = localizeRenderGalleryApi(
+        { apiName, description: meta.description, identifier },
+        t,
+      );
+      const toolset = toolsetMap.get(identifier);
+      const localizedToolset =
+        toolset ??
+        localizeRenderGalleryToolset(
+          {
+            identifier,
+            toolsetDescription: meta.toolsetDescription,
+            toolsetName: meta.toolsetName,
+          },
+          t,
+        );
 
       const api: ApiEntry = {
+        apiDisplayName: localizedApi.apiDisplayName,
         apiName,
-        description: meta.description,
+        description: localizedApi.description,
         fixture,
         identifier,
         inspector,
@@ -132,17 +155,17 @@ export const useDevtoolsEntries = (): DevtoolsEntries =>
         placeholder,
         render,
         streaming,
+        toolDisplayName: localizedToolset.toolsetName,
       };
 
-      const toolset = toolsetMap.get(identifier);
       if (toolset) {
         toolset.apis.push(api);
       } else {
         toolsetMap.set(identifier, {
           apis: [api],
           identifier,
-          toolsetDescription: meta.toolsetDescription,
-          toolsetName: meta.toolsetName,
+          toolsetDescription: localizedToolset.toolsetDescription,
+          toolsetName: localizedToolset.toolsetName,
         });
       }
     }
@@ -165,4 +188,7 @@ export const useDevtoolsEntries = (): DevtoolsEntries =>
       menuItems,
       toolsetMap,
     };
-  }, []);
+  };
+
+  return buildEntries();
+};


### PR DESCRIPTION
### What this PR does

- resolves Render Gallery toolset names, API names, and descriptions through the existing `plugin` locale resources
- falls back to registry metadata when a translation is unavailable
- displays translated API labels in the gallery list and preview cards
- lets registered inspectors receive optional localized tool/API labels
- updates the GitHub and Linear inspectors to honor those labels while preserving their existing static fallbacks

### Scope

This intentionally does not hardcode Chinese labels into the development UI. It uses the normal i18n resources, so every supported locale can benefit.

### Tests

- Render Gallery localization and inspector propagation: 3 passed
- shared-tool-ui GitHub and Linear inspectors: 2 passed
- ESLint on all 12 changed files
- `git diff --check`