### PR TITLE
fix(skill): hide guide wrappers in details

### DIFF
--- a/src/features/Settings/skill/features/SkillDetail/index.tsx
+++ b/src/features/Settings/skill/features/SkillDetail/index.tsx
@@ -259,8 +259,11 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
     type === 'mcp-connector' ||
     type === 'lobehub-connector';
 
-  const { title: builtinSkillTitle, description: builtinSkillDescription } =
-    getLocalizedBuiltinSkillDetail(builtinSkill, identifier, ts);
+  const {
+    content: builtinSkillContent,
+    title: builtinSkillTitle,
+    description: builtinSkillDescription,
+  } = getLocalizedBuiltinSkillDetail(builtinSkill, identifier, ts);
   const noPermissionsTitle = getNoPermissionsTitle(identifier, type, ts);
 
   const renderLobehubConnectorAction = (onDisconnected?: () => void) => {
@@ -467,9 +470,9 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
             )}
           </div>
         </div>
-        {builtinSkill?.content && (
+        {builtinSkillContent && (
           <div style={{ padding: '16px 24px' }}>
-            <Markdown variant="chat">{builtinSkill.content}</Markdown>
+            <Markdown variant="chat">{builtinSkillContent}</Markdown>
           </div>
         )}
       </div>

--- a/src/features/Settings/skill/features/SkillDetail/localization.test.ts
+++ b/src/features/Settings/skill/features/SkillDetail/localization.test.ts
@@ -1,3 +1,4 @@
+import { ArtifactsIdentifier, builtinSkills } from '@lobechat/builtin-skills';
 import { type TFunction } from 'i18next';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -10,6 +11,48 @@ const createTranslator = (translations: Record<string, string> = {}) =>
   ) as unknown as TFunction<'setting'>;
 
 describe('SkillDetail localization helpers', () => {
+  it('preserves unwrapped builtin skill content without changing the source skill', () => {
+    const t = createTranslator();
+    const skill = {
+      content: '# Artifacts Guide',
+      description: 'Generate interactive content.',
+      identifier: 'lobe-artifacts',
+      name: 'Artifacts',
+      source: 'builtin' as const,
+    };
+
+    const result = getLocalizedBuiltinSkillDetail(skill, 'lobe-artifacts', t);
+
+    expect(result.content).toBe('# Artifacts Guide');
+    expect(skill.content).toBe('# Artifacts Guide');
+  });
+
+  it('hides a matching outer guide tag from builtin skill content', () => {
+    const t = createTranslator();
+    const skill = {
+      content: '<lobehub_platform_guides>\n# Identity\n</lobehub_platform_guides>',
+      description: 'Manage LobeHub.',
+      identifier: 'lobehub',
+      name: 'LobeHub',
+      source: 'builtin' as const,
+    };
+
+    const result = getLocalizedBuiltinSkillDetail(skill, 'lobehub', t);
+
+    expect(result.content).toBe('# Identity');
+    expect(skill.content).toBe('<lobehub_platform_guides>\n# Identity\n</lobehub_platform_guides>');
+  });
+
+  it('hides the outer tag from the built-in artifacts guide', () => {
+    const skill = builtinSkills.find(({ identifier }) => identifier === ArtifactsIdentifier);
+
+    const result = getLocalizedBuiltinSkillDetail(skill, ArtifactsIdentifier, createTranslator());
+
+    expect(result.content).not.toContain('<artifacts_guides>');
+    expect(result.content).not.toContain('</artifacts_info>');
+    expect(result.content).toContain('# 1. Evaluation Criteria');
+  });
+
   it('localizes builtin skill title and description', () => {
     const t = createTranslator({
       'tools.builtins.lobe-agent-browser.description': '浏览器自动化命令行工具',
@@ -28,7 +71,11 @@ describe('SkillDetail localization helpers', () => {
       t,
     );
 
-    expect(result).toEqual({ description: '浏览器自动化命令行工具', title: '助手浏览器' });
+    expect(result).toEqual({
+      content: '# Agent Browser',
+      description: '浏览器自动化命令行工具',
+      title: '助手浏览器',
+    });
     expect(t).toHaveBeenCalledWith('tools.builtins.lobe-agent-browser.title', {
       defaultValue: 'Agent Browser',
     });
@@ -62,7 +109,7 @@ describe('SkillDetail localization helpers', () => {
         'task',
         t,
       ),
-    ).toEqual({ description: undefined, title: '任务' });
+    ).toEqual({ content: '# Task', description: undefined, title: '任务' });
     expect(t).toHaveBeenCalledTimes(1);
   });
 

--- a/src/features/Settings/skill/features/SkillDetail/localization.ts
+++ b/src/features/Settings/skill/features/SkillDetail/localization.ts
@@ -3,6 +3,20 @@ import { type TFunction } from 'i18next';
 
 type Translate = TFunction<'setting'>;
 
+const stripOuterGuideTag = (content: string) => {
+  const trimmedContent = content.trim();
+  const openingTag = trimmedContent.match(/^<([A-Za-z][\w.-]*_guides)>/);
+
+  if (!openingTag) return content;
+
+  const closingTags = [`</${openingTag[1]}>`, `</${openingTag[1].replace(/_guides$/, '_info')}>`];
+  const closingTag = closingTags.find((tag) => trimmedContent.endsWith(tag));
+
+  if (!closingTag) return content;
+
+  return trimmedContent.slice(openingTag[0].length, -closingTag.length).trim();
+};
+
 export const getLocalizedBuiltinSkillDetail = (
   builtinSkill: BuiltinSkill | undefined,
   identifier: string,
@@ -13,6 +27,7 @@ export const getLocalizedBuiltinSkillDetail = (
   }
 
   return {
+    content: builtinSkill.content ? stripOuterGuideTag(builtinSkill.content) : undefined,
     description: builtinSkill.description
       ? t(`tools.builtins.${builtinSkill.identifier}.description`, {
           defaultValue: builtinSkill.description,


### PR DESCRIPTION
### What this PR does

- removes a matching outer `*_guides` wrapper before rendering built-in Skill content in Settings
- supports the legacy `*_info` closing suffix used by the current Artifacts guide
- leaves the underlying Skill content unchanged
- routes displayed content through the existing Skill detail helper alongside localized title and description metadata

### Why

Guide wrapper tags are runtime control markers, not user-facing documentation. Showing them in the Skill detail Markdown makes localized settings pages look like raw prompt source.

### Tests

- `bunx vitest run src/features/Settings/skill/features/SkillDetail/localization.test.ts` (7 passed)
- ESLint on the three changed files
- `git diff --check`