### PR TITLE
fix(mobile): align agent search results

### DIFF
--- a/src/features/MobileHome/Layout/SessionSearchBar.tsx
+++ b/src/features/MobileHome/Layout/SessionSearchBar.tsx
@@ -6,6 +6,7 @@ import { type ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useHomeStore } from '@/store/home';
 import { useSessionStore } from '@/store/session';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
@@ -15,13 +16,13 @@ const SessionSearchBar = memo<{ mobile?: boolean }>(({ mobile }) => {
   const isLoaded = useUserStore((s) => s.isLoaded);
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.Search));
 
-  const [keywords, useSearchSessions, updateSearchKeywords] = useSessionStore((s) => [
+  const [keywords, updateSearchKeywords] = useSessionStore((s) => [
     s.sessionSearchKeywords,
-    s.useSearchSessions,
     s.updateSearchKeywords,
   ]);
+  const useSearchAgents = useHomeStore((s) => s.useSearchAgents);
 
-  const { isValidating } = useSearchSessions(keywords);
+  const { isValidating } = useSearchAgents(keywords?.trim() || undefined);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/features/MobileHome/SessionListContent/AgentSearchList.tsx
+++ b/src/features/MobileHome/SessionListContent/AgentSearchList.tsx
@@ -1,0 +1,62 @@
+import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
+import type { SidebarAgentItem } from '@lobechat/types';
+import { agentDisplayName } from '@lobechat/types';
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import LazyLoad from 'react-lazy-load';
+
+import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
+import { useServerConfigStore } from '@/store/serverConfig';
+
+import ListItem from './ListItem';
+
+const styles = createStaticStyles(({ css }) => ({
+  container: css`
+    min-height: 70px;
+  `,
+  link: css`
+    display: block;
+  `,
+}));
+
+interface AgentSearchListProps {
+  dataSource?: SidebarAgentItem[];
+}
+
+export const AgentSearchList = memo<AgentSearchListProps>(({ dataSource }) => {
+  const { t } = useTranslation('chat');
+  const isMobile = useServerConfigStore((s) => s.isMobile);
+
+  return dataSource?.map((item) => {
+    const title = agentDisplayName(item, t('untitledAgent'));
+
+    return (
+      <LazyLoad className={styles.container} key={item.id}>
+        <WorkspaceLink
+          aria-label={title}
+          className={styles.link}
+          to={item.type === 'group' ? GROUP_CHAT_URL(item.id) : AGENT_CHAT_URL(item.id, isMobile)}
+        >
+          <ListItem
+            avatar={item.avatar || DEFAULT_AVATAR}
+            avatarBackground={item.backgroundColor || undefined}
+            title={title}
+            type={item.type}
+            styles={{
+              container: {
+                gap: 12,
+              },
+              content: {
+                gap: 6,
+                maskImage: `linear-gradient(90deg, #000 90%, transparent)`,
+              },
+            }}
+          />
+        </WorkspaceLink>
+      </LazyLoad>
+    );
+  });
+});
+
+AgentSearchList.displayName = 'AgentSearchList';

--- a/src/features/MobileHome/SessionListContent/ListItem/index.tsx
+++ b/src/features/MobileHome/SessionListContent/ListItem/index.tsx
@@ -30,7 +30,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
 });
 
 const ListItem = memo<
-  ListItemProps & {
+  Omit<ListItemProps, 'avatar' | 'key'> & {
     avatar: string | { avatar: string; background?: string }[];
     avatarBackground?: string;
     type?: 'agent' | 'group' | 'inbox';
@@ -47,8 +47,10 @@ const ListItem = memo<
     }
 
     // For regular sessions, use the regular Avatar component
+    const agentAvatar = typeof avatar === 'string' ? avatar : avatar[0]?.avatar;
+
     return (
-      <Avatar animation={isHovering} avatar={avatar} background={avatarBackground} size={40} />
+      <Avatar animation={isHovering} avatar={agentAvatar} background={avatarBackground} size={40} />
     );
   }, [isHovering, avatar, avatarBackground, type]);
 

--- a/src/features/MobileHome/SessionListContent/SearchMode.tsx
+++ b/src/features/MobileHome/SessionListContent/SearchMode.tsx
@@ -1,42 +1,24 @@
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
+import { useHomeStore } from '@/store/home';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 import { useSessionStore } from '@/store/session';
-import { type LobeAgentSession, type LobeSessions } from '@/types/session';
-import { LobeSessionType } from '@/types/session';
 
 import SkeletonList from '../SkeletonList';
-import SessionList from './List';
+import { AgentSearchList } from './AgentSearchList';
+import { getVisibleAgentSearchResults } from './agentSearchResults';
 
 const SearchMode = memo(() => {
-  const [sessionSearchKeywords, useSearchSessions] = useSessionStore((s) => [
-    s.sessionSearchKeywords,
-    s.useSearchSessions,
-  ]);
+  const sessionSearchKeywords = useSessionStore((s) => s.sessionSearchKeywords);
+  const useSearchAgents = useHomeStore((s) => s.useSearchAgents);
 
   const isMobile = useServerConfigStore(serverConfigSelectors.isMobile);
 
-  const { data, isLoading } = useSearchSessions(sessionSearchKeywords);
+  const { data, isLoading } = useSearchAgents(sessionSearchKeywords?.trim() || undefined);
+  const filteredData = getVisibleAgentSearchResults(data, isMobile);
 
-  const filteredData = useMemo(() => {
-    if (!data) return data;
-
-    if (isMobile) {
-      return data.filter((session: LobeSessions[0]) => session.type !== LobeSessionType.Group);
-    }
-
-    return data.filter(
-      (session: LobeSessions[0]) =>
-        session.type !== LobeSessionType.Agent || !(session as LobeAgentSession).config?.virtual,
-    );
-  }, [data, isMobile]);
-
-  return isLoading ? (
-    <SkeletonList />
-  ) : (
-    <SessionList dataSource={filteredData} showAddButton={false} />
-  );
+  return isLoading ? <SkeletonList /> : <AgentSearchList dataSource={filteredData} />;
 });
 
 SearchMode.displayName = 'SessionSearchMode';

--- a/src/features/MobileHome/SessionListContent/agentSearchResults.test.ts
+++ b/src/features/MobileHome/SessionListContent/agentSearchResults.test.ts
@@ -1,0 +1,31 @@
+import type { SidebarAgentItem } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleAgentSearchResults } from './agentSearchResults';
+
+const createSearchResult = (overrides: Partial<SidebarAgentItem> = {}): SidebarAgentItem => ({
+  id: 'agent-1',
+  pinned: false,
+  title: 'Social Agent',
+  type: 'agent',
+  updatedAt: new Date('2026-08-29T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('getVisibleAgentSearchResults', () => {
+  it('keeps mobile agent results that do not have a legacy session', () => {
+    const agentWithoutSession = createSearchResult({ sessionId: undefined });
+
+    expect(getVisibleAgentSearchResults([agentWithoutSession], true)).toEqual([
+      agentWithoutSession,
+    ]);
+  });
+
+  it('hides chat groups only on the mobile home', () => {
+    const agent = createSearchResult();
+    const group = createSearchResult({ id: 'group-1', type: 'group' });
+
+    expect(getVisibleAgentSearchResults([agent, group], true)).toEqual([agent]);
+    expect(getVisibleAgentSearchResults([agent, group], false)).toEqual([agent, group]);
+  });
+});

--- a/src/features/MobileHome/SessionListContent/agentSearchResults.ts
+++ b/src/features/MobileHome/SessionListContent/agentSearchResults.ts
@@ -1,0 +1,10 @@
+import type { SidebarAgentItem } from '@lobechat/types';
+
+export const getVisibleAgentSearchResults = (
+  results: SidebarAgentItem[] | undefined,
+  isMobile: boolean,
+): SidebarAgentItem[] | undefined => {
+  if (!results || !isMobile) return results;
+
+  return results.filter((item) => item.type === 'agent');
+};


### PR DESCRIPTION
## Summary

- switch Mobile Web assistant search from the legacy session query to the canonical Home agent search
- render agent-only results with workspace-aware links while preserving the mobile group filter
- retain lazy loading for large result lists and add regression coverage for assistants without legacy sessions

## Testing

- `bun run check` on the 6 changed files: lint clean, 2 tests passed
- `bun run check --type`: types clean
- `git diff --check`: passed
- agent-testing: Mobile Web search and direct agent navigation passed on the final commit

## Acceptance

https://app.lobehub.com/acceptance/d0e2dcd3-f1ad-4d44-a093-44369a64ff87

Fixes #18128
