### PR TITLE
🐛 fix(acceptance): refuse a round that writes to an already-accepted check

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -157,6 +157,26 @@ the image lands unpaired and unlabeled. Publish a fresh round carrying the compl
 evidence set instead, and say in `report.md` that it re-publishes the same
 observations rather than re-running the cases.
 
+### L-E11b — Publishing a new round onto a check the reviewer already accepted
+
+**Wrong approach:** when new feedback arrives about a check the user has already
+accepted, reuse that check's id for the new work — because reusing ids is the rule for
+rejected checks.
+
+**Why it fails:** an accepted verdict is deliberately sticky (`acceptanceService`
+computes `stale` only for rejects, and a test pins that behaviour by name). A later
+result on a settled id therefore inherits the tick: the round publishes green and the
+reviewer is never told there is anything new to look at. Since 2026-08, `attachRun`
+refuses such a round outright — the error names the offending ids and nothing is
+written, so a partially attached round cannot happen.
+
+**Correct approach:** read `userReview.action` before writing the plan. `accept` means
+settled: the new work needs a NEW check id, which appears unreviewed and can actually
+be judged. Reuse the id only while the check is rejected or never reviewed. Decide by
+_is the criterion new, and has the old one been accepted_ — not by how big the change
+is: a presentation fix on a still-open check reuses its id (\[\[L-E1]]), while a newly
+raised criterion on an accepted check must not.
+
 ### L-E12 — Expressing multimodal disclosure through the `verifier` enum
 
 **Wrong approach:** write a value such as `"verifier": "multimodal LLM"` in a plan

--- a/apps/server/src/services/verify/__tests__/acceptanceSettledCheck.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceSettledCheck.test.ts
@@ -112,6 +112,44 @@ describe('attaching a round that targets an accepted check', () => {
     expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
   });
 
+  it("refuses a fresh plan-item id that carries the settled check's sourceCriterionId", async () => {
+    // The union keys rows by `sourceCriterionId ?? id`, so a brand-new physical
+    // id pointing at the same criterion still lands on the settled row.
+    mocks.listByAcceptance.mockResolvedValue([
+      {
+        acceptanceId: 'acc-1',
+        id: 'run-1',
+        plan: [{ id: 'physical-1', index: 0, sourceCriterionId: 'crit-a', title: 'crit-a' }],
+        roundIndex: 1,
+      },
+    ]);
+    mocks.listByRuns.mockResolvedValue([acceptedResult('physical-1', 'run-1')]);
+    mocks.runFindById.mockResolvedValue({
+      acceptanceId: null,
+      id: 'run-2',
+      plan: [{ id: 'physical-2', index: 0, sourceCriterionId: 'crit-a', title: 'crit-a' }],
+      userId: 'u1',
+    });
+
+    // Names the plan item the author can actually edit, not the criterion id.
+    await expect(service().attachRun('run-2', 'acc-1')).rejects.toThrow(/physical-2/);
+    expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
+  });
+
+  it('refuses a new id that declares it supersedes the settled check', async () => {
+    // Superseding folds the accepted row's timeline into the newcomer, so the
+    // new result would render under the accepted verdict just the same.
+    mocks.runFindById.mockResolvedValue({
+      acceptanceId: null,
+      id: 'run-2',
+      plan: [{ id: 'replacement', index: 0, supersedes: ['settled-check'], title: 'replacement' }],
+      userId: 'u1',
+    });
+
+    await expect(service().attachRun('run-2', 'acc-1')).rejects.toThrow(/replacement/);
+    expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
+  });
+
   it('attaches a round that only touches unreviewed or brand-new checks', async () => {
     mocks.runFindById.mockResolvedValue({
       acceptanceId: null,

--- a/apps/server/src/services/verify/__tests__/acceptanceSettledCheck.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceSettledCheck.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  acceptanceFindById: vi.fn(),
+  attachToAcceptance: vi.fn(),
+  listByAcceptance: vi.fn(),
+  listByRuns: vi.fn(),
+  runFindById: vi.fn(),
+}));
+
+vi.mock('@/database/models/acceptance', () => ({
+  AcceptanceModel: vi.fn(() => ({
+    findById: mocks.acceptanceFindById,
+    findPolicyById: mocks.acceptanceFindById,
+    update: vi.fn(),
+    updatePolicyStatus: vi.fn(),
+  })),
+}));
+
+vi.mock('@/database/models/verifyRun', () => ({
+  VerifyRunModel: vi.fn(() => ({
+    attachToAcceptance: mocks.attachToAcceptance,
+    findById: mocks.runFindById,
+    listByAcceptance: mocks.listByAcceptance,
+  })),
+}));
+
+vi.mock('@/database/models/verifyCheckResult', () => ({
+  VerifyCheckResultModel: vi.fn(() => ({ listByRuns: mocks.listByRuns })),
+}));
+
+vi.mock('@/database/models/verifyEvidence', () => ({ VerifyEvidenceModel: vi.fn(() => ({})) }));
+vi.mock('@/database/models/verifyReport', () => ({
+  VerifyReportModel: vi.fn(() => ({ findByRun: vi.fn().mockResolvedValue(null) })),
+}));
+
+const { AcceptanceService } = await import('../acceptanceService');
+
+const ACCEPTANCE = { id: 'acc-1', status: 'delivered', userId: 'u1', visibility: 'public' };
+
+/** A settled result row: passed, and the reviewer accepted it. */
+const acceptedResult = (checkItemId: string, verifyRunId: string) => ({
+  checkItemId,
+  checkItemTitle: checkItemId,
+  completedAt: new Date('2026-08-01T00:00:00.000Z'),
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  id: `res-${checkItemId}`,
+  required: true,
+  status: 'passed',
+  userDecision: 'accepted',
+  userDecisionDetail: { decidedAt: '2026-08-01T01:00:00.000Z', roundIndex: 1 },
+  verdict: 'passed',
+  verifyRunId,
+});
+
+const planned = (...ids: string[]) => ids.map((id, index) => ({ id, index, title: id }));
+
+const service = () => new AcceptanceService({} as any, 'u1');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.acceptanceFindById.mockResolvedValue(ACCEPTANCE);
+  mocks.attachToAcceptance.mockResolvedValue({ id: 'run-2', roundIndex: 2 });
+  // Round 1 accepted `settled-check`; `open-check` was never ruled on.
+  mocks.listByAcceptance.mockResolvedValue([{ acceptanceId: 'acc-1', id: 'run-1', roundIndex: 1 }]);
+  mocks.listByRuns.mockResolvedValue([
+    acceptedResult('settled-check', 'run-1'),
+    { ...acceptedResult('open-check', 'run-1'), userDecision: null, userDecisionDetail: null },
+  ]);
+});
+
+describe('attaching a round that targets an accepted check', () => {
+  it('refuses the round and names the settled check', async () => {
+    mocks.runFindById.mockResolvedValue({
+      acceptanceId: null,
+      id: 'run-2',
+      plan: planned('settled-check'),
+      userId: 'u1',
+    });
+
+    await expect(service().attachRun('run-2', 'acc-1')).rejects.toThrow(/settled-check/);
+    // Nothing may be written: a partially attached round is worse than none.
+    expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the settled check is reached through a superseded id', async () => {
+    // Round 1 ran `old-id`; round 2 replaced it with `settled-check`, whose
+    // result the reviewer accepted. The union folded `old-id` into that row, so
+    // re-running `old-id` now writes straight back into the settled check.
+    mocks.listByAcceptance.mockResolvedValue([
+      { acceptanceId: 'acc-1', id: 'run-1', plan: planned('old-id'), roundIndex: 1 },
+      {
+        acceptanceId: 'acc-1',
+        id: 'run-1b',
+        plan: [{ id: 'settled-check', index: 0, supersedes: ['old-id'], title: 'settled-check' }],
+        roundIndex: 2,
+      },
+    ]);
+    mocks.listByRuns.mockResolvedValue([
+      { ...acceptedResult('old-id', 'run-1'), userDecision: null, userDecisionDetail: null },
+      acceptedResult('settled-check', 'run-1b'),
+    ]);
+    mocks.runFindById.mockResolvedValue({
+      acceptanceId: null,
+      id: 'run-2',
+      plan: planned('old-id'),
+      userId: 'u1',
+    });
+
+    await expect(service().attachRun('run-2', 'acc-1')).rejects.toThrow(/old-id/);
+    expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
+  });
+
+  it('attaches a round that only touches unreviewed or brand-new checks', async () => {
+    mocks.runFindById.mockResolvedValue({
+      acceptanceId: null,
+      id: 'run-2',
+      plan: planned('open-check', 'brand-new-check'),
+      userId: 'u1',
+    });
+
+    await expect(service().attachRun('run-2', 'acc-1')).resolves.toMatchObject({ roundIndex: 2 });
+    expect(mocks.attachToAcceptance).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/src/services/verify/acceptanceService.ts
+++ b/apps/server/src/services/verify/acceptanceService.ts
@@ -547,8 +547,20 @@ export class AcceptanceService {
     run: VerifyRunItem,
     acceptanceId: string,
   ): Promise<void> => {
-    const planIds = (run.plan ?? []).map((item) => item.id).filter(Boolean);
-    if (planIds.length === 0) return;
+    // Every identity by which an incoming item could come to rest on an
+    // existing row. The union keys rows by `sourceCriterionId ?? id`, and a
+    // `supersedes` declaration folds the named row into this one — so comparing
+    // physical ids alone lets both routes write into a settled row unblocked.
+    const candidates = new Map<string, string>();
+    for (const item of run.plan ?? []) {
+      const logicalId = item.sourceCriterionId ?? item.id;
+      if (logicalId) candidates.set(logicalId, item.id);
+      if (item.id) candidates.set(item.id, item.id);
+      for (const superseded of item.supersedes ?? []) {
+        if (superseded) candidates.set(superseded, item.id);
+      }
+    }
+    if (candidates.size === 0) return;
 
     const runs = await this.runModel.listByAcceptance(acceptanceId);
     if (runs.length === 0) return;
@@ -584,7 +596,15 @@ export class AcceptanceService {
       for (const superseded of check.supersededIds ?? []) blocked.add(superseded);
     }
 
-    const offenders = planIds.filter((id) => blocked.has(id));
+    // Report the plan item the author has to change, not the internal identity
+    // it collided through — those can differ, and only the former is editable.
+    const offenders = [
+      ...new Set(
+        [...candidates]
+          .filter(([identity]) => blocked.has(identity))
+          .map(([, planItemId]) => planItemId),
+      ),
+    ];
     if (offenders.length === 0) return;
 
     throw new Error(

--- a/apps/server/src/services/verify/acceptanceService.ts
+++ b/apps/server/src/services/verify/acceptanceService.ts
@@ -531,6 +531,68 @@ export class AcceptanceService {
     return this.attachResolvedRun(runId, acceptance);
   };
 
+  /**
+   * An accepted check is settled and its verdict is sticky: a later result on
+   * the same id inherits the tick, so the round publishes green and the
+   * reviewer is never told there is anything new to look at. That is only safe
+   * while nothing writes to a settled check, which is what this enforces —
+   * refusing the whole round rather than letting the write through, because a
+   * partially attached round is harder to reason about than a rejected one.
+   *
+   * The escape hatch is a new check id: a criterion the reviewer has not ruled
+   * on gets its own row and shows up unreviewed, which is what "there is more
+   * to look at here" should look like.
+   */
+  private assertPlanLeavesAcceptedChecksAlone = async (
+    run: VerifyRunItem,
+    acceptanceId: string,
+  ): Promise<void> => {
+    const planIds = (run.plan ?? []).map((item) => item.id).filter(Boolean);
+    if (planIds.length === 0) return;
+
+    const runs = await this.runModel.listByAcceptance(acceptanceId);
+    if (runs.length === 0) return;
+
+    const results = await this.resultModel.listByRuns(runs.map((item) => item.id));
+    const resultsById = new Map(results.map((result) => [result.id, result]));
+    const resultsByRun = new Map<string, VerifyCheckResultItem[]>();
+    for (const result of results) {
+      if (!result.verifyRunId) continue;
+      const bucket = resultsByRun.get(result.verifyRunId) ?? [];
+      bucket.push(result);
+      resultsByRun.set(result.verifyRunId, bucket);
+    }
+
+    const currentRoundIndex = runs.at(-1)?.roundIndex ?? 0;
+    const checks = buildAcceptanceCheckUnion(
+      runs.map((item) => ({ results: resultsByRun.get(item.id) ?? [], run: item })),
+    );
+
+    // Read the standing verdict exactly the way the page renders it, so the
+    // rule cannot diverge from the tick the reviewer actually sees.
+    const settled = checks.filter((check) => {
+      const { userReview } = buildCheckReviewOverlay(check, resultsById, currentRoundIndex);
+      return userReview?.action === 'accept' && !userReview.stale;
+    });
+
+    // A superseded generation's id is folded into its successor's row, so match
+    // on both — re-running `old-id` after `new-id supersedes: [old-id]` was
+    // accepted is the same write to the same settled row.
+    const blocked = new Set<string>();
+    for (const check of settled) {
+      blocked.add(check.id);
+      for (const superseded of check.supersededIds ?? []) blocked.add(superseded);
+    }
+
+    const offenders = planIds.filter((id) => blocked.has(id));
+    if (offenders.length === 0) return;
+
+    throw new Error(
+      `Already accepted, so ${offenders.length === 1 ? 'this check' : 'these checks'} cannot take another result: ` +
+        `${offenders.join(', ')}. An accepted check is settled — publish new work under a new check id instead.`,
+    );
+  };
+
   private attachResolvedRun = async (
     runId: string,
     acceptance: AcceptanceItem,
@@ -550,6 +612,8 @@ export class AcceptanceService {
         `This acceptance has already been ${acceptance.status} — reopen it before attaching another round`,
       );
     }
+
+    await this.assertPlanLeavesAcceptedChecksAlone(existing, acceptanceId);
 
     // Rounds inherit the aggregate's visibility so a private acceptance's new
     // round never leaks through its own report URL.


### PR DESCRIPTION
An accepted verdict is sticky on purpose — `buildCheckReviewOverlay` computes staleness for rejects only, and a test pins that behaviour by name. That design holds because nothing is supposed to write to a settled check.

Nothing enforced it. A later round landing on a settled check silently inherited the tick: the round published green, and the reviewer was never told there was anything new to look at. It happened twice in one session with only the prose rule ("accept → user-settled; do not re-run it") to go on, which is a good sign the rule needs teeth rather than better wording.

`attachRun` now reads the standing verdict **the same way the acceptance page renders it** — via `buildCheckReviewOverlay` — and refuses the whole round when its plan would land on a settled check, naming the offending plan items:

```
Already accepted, so this check cannot take another result: intent-clarify.
An accepted check is settled — publish new work under a new check id instead.
```

### Matching on identity, not on id

`buildAcceptanceCheckUnion` keys rows by `sourceCriterionId ?? id`, and a `supersedes` declaration folds the named row into the declaring one. So there are three ways an incoming item can come to rest on a settled row, and the guard has to know all of them:

- the same **logical id** (`sourceCriterionId`) under a fresh physical id
- the same **physical id**
- a **`supersedes`** naming the settled check — folding copies the accepted row's timeline into the newcomer, so the new result renders under the accepted verdict

The guard builds that identity set per plan item and compares it against the settled rows (including their already-folded `supersededIds`). Errors name the plan item the author can edit, not the internal identity it collided through.

### Other choices worth calling out

- **Refuse the round, don't drop the item.** Silently skipping the offending case is the failure mode we already have with evidence uploads: the publish "succeeds" while quietly missing a piece. A round that never landed is easier to reason about than a partially attached one.
- **Idempotent re-ingest is untouched.** Re-attaching a run already on the same acceptance returns before the guard, so the CLI's remembered-session path still works.

The escape hatch is the one the reviewer needs anyway: a genuinely new check id, which shows up unreviewed instead of wearing someone else's tick.

`ignore` / `overridden` is deliberately left alone. It also carries a standing verdict, but it means "I'm not looking at this one" rather than "this passed", so whether it should block a re-run is a separate call.

| Before | After |
| ------ | ----- |
| A round landing on an accepted check attaches, and the work renders with the earlier round's ✅ | The attach is refused, naming the offending plan items and pointing at the fix |

#### Test

Unit, `apps/server/src/services/verify/__tests__/acceptanceSettledCheck.test.ts` — five cases, one per route in and one for the path that must stay open:

- plan reuses an accepted check id → rejects, and `attachToAcceptance` is never called
- plan reaches it through an already-folded superseded id → rejects
- plan uses a fresh physical id carrying the accepted check's `sourceCriterionId` → rejects
- plan declares `supersedes: [accepted-id]` → rejects
- plan touches only unreviewed / brand-new checks → attaches normally

Each was confirmed to fail against the pre-fix code, so none of them pass vacuously.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None — found while iterating on an unrelated acceptance and reported by the reviewer, who pointed out that an accepted item should not be able to take another run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)