### PR TITLE
📝 docs(acceptance): forbid hard-wrapped prose in markdown evidence

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -286,6 +286,26 @@ where the action key is actually enabled (grep each route's `leftActions` array,
 the component's imports) and capture evidence for every surface that enables it. Mark
 any surface you deliberately skip as untested.
 
+### L-E19 — Hard-wrapping the prose inside a markdown evidence document
+
+**Wrong approach:** author a `markdown` / `text` evidence artifact the way you write
+a source file, folding every paragraph at \~80 columns, and assume the page reflows
+it like any other markdown.
+
+**Why it fails:** the Acceptance evidence renderer parses evidence documents in chat
+mode, where `remark-breaks` turns every single newline inside a paragraph into a
+`<br>`. The author's fold is frozen into the page: paragraphs break mid-sentence at a
+column count unrelated to the reader's viewport, next to a report body that reflows
+normally, so the same round shows two different text behaviours. Reviewers read the
+ragged block as a rendering defect and spend the round on the wrapping instead of the
+finding.
+
+**Correct approach:** keep each paragraph of evidence prose on ONE physical line and
+separate blocks with a blank line. Spend a newline only where it carries meaning —
+list items, table rows, fenced code, and literal transcript output, which are exactly
+the places the break is the content. Never run a proseWrap formatter over files under
+`assets/`.
+
 ## Product and interaction contracts
 
 ### L-D1 — Rebuilding a canonical surface from visual impression


### PR DESCRIPTION
Markdown/text evidence attached to an Acceptance round is rendered by `MarkdownEvidence` with `variant='chat'`, which enables `remark-breaks` — every single newline inside a paragraph becomes a `<br>`. Agents author those documents like source files, folding prose at ~80 columns, so the authoring fold gets frozen into the published page: paragraphs break mid-sentence at a column count unrelated to the reader's viewport, right next to a report body that reflows normally.

Observed on a real round (`case5-prompt-ab.md`), where the rendered breaks matched the source lines one for one — the content was plain markdown, the ragged rendering came from its hard wraps meeting chat-mode breaks.

Fixing it on the producing side keeps the renderer's chat semantics (intentional single-line breaks in agent-authored text still hold) and stops the ragged documents at the source. Recorded as `L-E19` in the project mistake log, under Evidence and publication.

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Documentation only — `bun run check --lint .agents/acceptance/common-mistakes.md` passes.

#### 🔗 Related Issue

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)