### PR TITLE
🐛 fix: reject acceptance checks without valid evidence

### DIFF
--- a/packages/prompts/src/chains/verify.test.ts
+++ b/packages/prompts/src/chains/verify.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { chainVerifyReviewPrediction, REVIEW_PREDICT_PROMPT_VERSION } from './verify';
+
+const buildSystemPrompt = () => {
+  const { messages } = chainVerifyReviewPrediction({
+    title: 'The overview is presented in a standalone floating layer',
+    visuals: [{ accessUrl: 'https://example.com/evidence.png' }],
+  });
+
+  return messages[0].content;
+};
+
+describe('chainVerifyReviewPrediction', () => {
+  it('requires affirmative evidence before accepting a check', () => {
+    const system = buildSystemPrompt();
+
+    expect(system).toContain('Accept only when the attached evidence visibly and sufficiently');
+    expect(system).toContain('The absence of a visible defect is not proof of success');
+  });
+
+  it('rejects invalid or insufficient evidence instead of treating uncertainty as acceptance', () => {
+    const system = buildSystemPrompt();
+
+    expect(system).toContain(
+      'Reject when the expected product state is missing, blank, still loading, replaced by an error or placeholder',
+    );
+    expect(system).toContain(
+      'Reject when the verifier reasoning or cited evidence says the target could not be loaded, reached, exercised, or observed',
+    );
+    expect(system).toContain(
+      'Missing, invalid, or insufficient evidence is a failed acceptance check',
+    );
+    expect(system).not.toContain('accept despite being unsure');
+    expect(system).not.toContain('if the check depends on one of those, accept');
+  });
+
+  it('uses a new prompt cohort for the stricter evidence contract', () => {
+    expect(REVIEW_PREDICT_PROMPT_VERSION).toBe('v2');
+  });
+});

--- a/packages/prompts/src/chains/verify.ts
+++ b/packages/prompts/src/chains/verify.ts
@@ -12,7 +12,7 @@ export const VERIFY_REPORT_PROMPT_VERSION = 'v1';
  * run write a NEW opinion instead of overwriting the old one — which is what
  * keeps two prompt versions comparable on the same checks.
  */
-export const REVIEW_PREDICT_PROMPT_VERSION = 'v1';
+export const REVIEW_PREDICT_PROMPT_VERSION = 'v2';
 
 export const VERIFY_VERIFIER_TYPES = ['program', 'agent', 'llm'] as const;
 export const VERIFY_ON_FAIL_ACTIONS = ['manual', 'auto_repair'] as const;
@@ -437,12 +437,12 @@ export interface ReviewPredictPromptInput {
  *     的轻微右偏,在可接受容差内" against a human "这个不在图片中间哎". Adding an
  *     explicit zero-tolerance rule recovered every one of those. Hence the
  *     hard ban on hedging vocabulary rather than a polite "be strict".
- *  2. Of the checks all three models let through, roughly three quarters were
- *     cases where the human was answering a different question — proposing new
- *     design, or objecting that the evidence was insufficient. Those are NOT
- *     this prompt's job (the UI routes them to their own intents), so the rules
- *     below deliberately scope the model to "does the evidence show THIS check
- *     satisfied" and tell it to pass anything it cannot judge from the frame.
+ *  2. A review is an evidence gate, not a defect detector. "I cannot see a
+ *     problem" is weaker than "the evidence proves this check passed". Missing,
+ *     invalid, or irrelevant evidence therefore rejects the check even when it
+ *     does not prove a product defect; the actionable comment tells the verifier
+ *     to re-run or capture the required state instead of telling the developer to
+ *     change working product code.
  */
 export const chainVerifyReviewPrediction = (input: ReviewPredictPromptInput) => {
   const system = [
@@ -460,12 +460,16 @@ export const chainVerifyReviewPrediction = (input: ReviewPredictPromptInput) => 
     'Judge only the check quoted below. A delivery you find ugly, over-complicated, or designed differently than you would have designed it still PASSES if it does what the check asks — taste is not your call here.',
     'Do not reject for something the check does not ask for, however reasonable that request would be.',
     '',
-    '## Only what the frame shows',
-    'Judge from what is visible in the attached images. Scroll behaviour, hover states, navigation results and anything that needs a second moment in time cannot be judged from a still — if the check depends on one of those, accept and say the frame cannot show it.',
-    'Missing evidence is not a reject. It is the one case where you accept despite being unsure, and lower confidence to say so.',
+    '## Acceptance requires affirmative proof',
+    'Accept only when the attached evidence visibly and sufficiently demonstrates that this exact check is satisfied. The absence of a visible defect is not proof of success.',
+    'Reject when the expected product state is missing, blank, still loading, replaced by an error or placeholder, or otherwise not observable in the evidence.',
+    'Reject when the evidence does not show the state or interaction required by the check. Scroll, hover, navigation, animation, and other time-dependent behaviour need evidence that actually captures the relevant state or outcome.',
+    'Reject when the verifier reasoning or cited evidence says the target could not be loaded, reached, exercised, or observed, including environment and network failures.',
+    'Missing, invalid, or insufficient evidence is a failed acceptance check even when it does not prove a product defect. Say that verification must be re-run or recaptured; do not invent a product fix.',
+    'Use confidence to express certainty about your reject reason, never to turn a lack of proof into an accept.',
     '',
     '## When you reject',
-    'Circle the exact region at fault using coordinates normalized 0-1 against the WHOLE image (x/y = top-left corner), and name the problem in that region.',
+    'Circle the exact region at fault using coordinates normalized 0-1 against the WHOLE image (x/y = top-left corner), and name the problem in that region. For a blank, error, loading, or otherwise invalid frame, circle the visible invalid state.',
     'Write `comment` as one sentence a developer can act on. State what is wrong and where — not "the layout has issues".',
     '',
     'Answer in the language the check is written in. Set confidence honestly: it is read as a number, not as reassurance.',

--- a/packages/prompts/src/chains/verify.ts
+++ b/packages/prompts/src/chains/verify.ts
@@ -445,35 +445,33 @@ export interface ReviewPredictPromptInput {
  *     change working product code.
  */
 export const chainVerifyReviewPrediction = (input: ReviewPredictPromptInput) => {
-  const system = [
-    'You audit whether a delivery really satisfies ONE acceptance check, by looking at the screenshots captured during verification.',
-    '',
-    'An automated verifier already judged this check. It is systematically too lenient — in production it wrongly passed 40x more often than it wrongly failed. Your job is to independently re-judge, not to restate its conclusion.',
-    '',
-    '## Tolerance is zero',
-    'When the check names a number (20px), a position (centered), an alignment (same height), or a width (full-bleed), any visible deviation is a reject.',
-    'Never write "roughly matches", "approximately centered", "within acceptable tolerance", or "slight deviation" as a reason to pass — if you are reaching for that phrasing, the check did not pass.',
-    'If your own reasoning describes an offset, a size difference, a misalignment or uneven spacing, that IS the reject. Do not then argue it away.',
-    '"Looks about right" is not a pass. Being unable to see any difference is.',
-    '',
-    '## Stay inside this check',
-    'Judge only the check quoted below. A delivery you find ugly, over-complicated, or designed differently than you would have designed it still PASSES if it does what the check asks — taste is not your call here.',
-    'Do not reject for something the check does not ask for, however reasonable that request would be.',
-    '',
-    '## Acceptance requires affirmative proof',
-    'Accept only when the attached evidence visibly and sufficiently demonstrates that this exact check is satisfied. The absence of a visible defect is not proof of success.',
-    'Reject when the expected product state is missing, blank, still loading, replaced by an error or placeholder, or otherwise not observable in the evidence.',
-    'Reject when the evidence does not show the state or interaction required by the check. Scroll, hover, navigation, animation, and other time-dependent behaviour need evidence that actually captures the relevant state or outcome.',
-    'Reject when the verifier reasoning or cited evidence says the target could not be loaded, reached, exercised, or observed, including environment and network failures.',
-    'Missing, invalid, or insufficient evidence is a failed acceptance check even when it does not prove a product defect. Say that verification must be re-run or recaptured; do not invent a product fix.',
-    'Use confidence to express certainty about your reject reason, never to turn a lack of proof into an accept.',
-    '',
-    '## When you reject',
-    'Circle the exact region at fault using coordinates normalized 0-1 against the WHOLE image (x/y = top-left corner), and name the problem in that region. For a blank, error, loading, or otherwise invalid frame, circle the visible invalid state.',
-    'Write `comment` as one sentence a developer can act on. State what is wrong and where — not "the layout has issues".',
-    '',
-    'Answer in the language the check is written in. Set confidence honestly: it is read as a number, not as reassurance.',
-  ].join('\n');
+  const system = `You audit whether a delivery really satisfies ONE acceptance check, by looking at the screenshots captured during verification.
+
+An automated verifier already judged this check. It is systematically too lenient — in production it wrongly passed 40x more often than it wrongly failed. Your job is to independently re-judge, not to restate its conclusion.
+
+## Tolerance is zero
+When the check names a number (20px), a position (centered), an alignment (same height), or a width (full-bleed), any visible deviation is a reject.
+Never write "roughly matches", "approximately centered", "within acceptable tolerance", or "slight deviation" as a reason to pass — if you are reaching for that phrasing, the check did not pass.
+If your own reasoning describes an offset, a size difference, a misalignment or uneven spacing, that IS the reject. Do not then argue it away.
+"Looks about right" is not a pass. The evidence must positively show compliance.
+
+## Stay inside this check
+Judge only the check quoted below. A delivery you find ugly, over-complicated, or designed differently than you would have designed it still PASSES if it does what the check asks — taste is not your call here.
+Do not reject for something the check does not ask for, however reasonable that request would be.
+
+## Acceptance requires affirmative proof
+Accept only when the attached evidence visibly and sufficiently demonstrates that this exact check is satisfied. The absence of a visible defect is not proof of success.
+Reject when the expected product state is missing, blank, still loading, replaced by an error or placeholder, or otherwise not observable in the evidence.
+Reject when the evidence does not show the state or interaction required by the check. Scroll, hover, navigation, animation, and other time-dependent behaviour need evidence that actually captures the relevant state or outcome.
+Reject when the verifier reasoning or cited evidence says the target could not be loaded, reached, exercised, or observed, including environment and network failures.
+Missing, invalid, or insufficient evidence is a failed acceptance check even when it does not prove a product defect. Say that verification must be re-run or recaptured; do not invent a product fix.
+Use confidence to express certainty about your reject reason, never to turn a lack of proof into an accept.
+
+## When you reject
+Circle the exact region at fault using coordinates normalized 0-1 against the WHOLE image (x/y = top-left corner), and name the problem in that region. For a blank, error, loading, or otherwise invalid frame, circle the visible invalid state.
+Write \`comment\` as one sentence a developer can act on. State what is wrong and where — not "the layout has issues".
+
+Answer in the language the check is written in. Set confidence honestly: it is read as a number, not as reassurance.`;
 
   const visualBlock = input.visuals.length
     ? input.visuals


### PR DESCRIPTION
## Summary

- require affirmative, sufficient evidence before an AI acceptance review can return `accept`
- reject blank, loading, error, unreachable, and interaction-uncaptured evidence while distinguishing evidence failures from product defects in the reviewer comment
- bump the review prediction prompt cohort to `v2` and add regression coverage for the evidence contract

## Why

The previous prompt explicitly told the review model to accept when evidence was missing or a still frame could not prove the check. This allowed blank/error screenshots and verifier notes such as `ECONNRESET` / “unable to observe” to produce an all-clear review.

## Testing

- `bun run check packages/prompts/src/chains/verify.ts packages/prompts/src/chains/verify.test.ts` (lint clean, 3 tests passed)
- pre-commit lint/style/format hooks passed
- full type check was attempted from an isolated worktree, but the shared dependency links resolved into the caller worktree and surfaced unrelated existing desktop/missing-dependency errors; this change adds no new type surface