### PR TITLE
✨ feat(agent): separate overview from workspace panel

### DIFF
--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -310,13 +310,14 @@ const usePlusMenuItems = ({ close }: { close: () => void }): ActionDropdownMenuI
 
   const { model, provider } = useEffectiveModel(agentId);
   const isAgentModeEnabled = useAgentStore(agentSelectors.isAgentModeEnabled);
-  const [showRightPanel, workingSidebarTab, setWorkingSidebarTab, toggleRightPanel] =
-    useGlobalStore((s) => [
+  const [showRightPanel, workingSidebarTab, openWorkingSidebar, toggleRightPanel] = useGlobalStore(
+    (s) => [
       systemStatusSelectors.showRightPanel(s),
       s.status.workingSidebarTab,
-      s.setWorkingSidebarTab,
+      s.openWorkingSidebar,
       s.toggleRightPanel,
-    ]);
+    ],
+  );
   const isParamsPanelActive = Boolean(showRightPanel) && workingSidebarTab === 'params';
   const skillActivateMode = useAgentStore((s) =>
     chatConfigByIdSelectors.getSkillActivateModeById(agentId)(s),
@@ -407,9 +408,8 @@ const usePlusMenuItems = ({ close }: { close: () => void }): ActionDropdownMenuI
       toggleRightPanel(false);
       return;
     }
-    setWorkingSidebarTab('params');
-    toggleRightPanel(true);
-  }, [close, isParamsPanelActive, setWorkingSidebarTab, toggleRightPanel]);
+    openWorkingSidebar('params');
+  }, [close, isParamsPanelActive, openWorkingSidebar, toggleRightPanel]);
 
   const items = useMemo<ActionDropdownMenuItems>(() => {
     const renderActive = (label: string, active: boolean) =>

--- a/src/features/ChatInput/ControlBar/GitStatus.tsx
+++ b/src/features/ChatInput/ControlBar/GitStatus.tsx
@@ -185,7 +185,7 @@ const GitStatus = memo<GitStatusProps>(
     const [pulling, setPulling] = useState(false);
     const [pushing, setPushing] = useState(false);
     const toggleRightPanel = useGlobalStore((s) => s.toggleRightPanel);
-    const setWorkingSidebarTab = useGlobalStore((s) => s.setWorkingSidebarTab);
+    const openWorkingSidebar = useGlobalStore((s) => s.openWorkingSidebar);
     const showRightPanel = useGlobalStore(systemStatusSelectors.showRightPanel);
     const workingSidebarTab = useGlobalStore((s) => s.status.workingSidebarTab);
 
@@ -200,9 +200,8 @@ const GitStatus = memo<GitStatusProps>(
         toggleRightPanel(false);
         return;
       }
-      setWorkingSidebarTab('review');
-      toggleRightPanel(true);
-    }, [showRightPanel, workingSidebarTab, setWorkingSidebarTab, toggleRightPanel]);
+      openWorkingSidebar('review');
+    }, [openWorkingSidebar, showRightPanel, workingSidebarTab, toggleRightPanel]);
 
     const refreshAfterSync = useCallback(async () => {
       await Promise.all([

--- a/src/features/ChatInput/ControlBar/__tests__/GitStatus.test.tsx
+++ b/src/features/ChatInput/ControlBar/__tests__/GitStatus.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import GitStatus from '../GitStatus';
 
 const globalStoreMock = vi.hoisted(() => ({
-  setWorkingSidebarTab: vi.fn(),
+  openWorkingSidebar: vi.fn(),
   status: {
     showRightPanel: false,
     workingSidebarTab: 'resources',
@@ -152,8 +152,7 @@ describe('GitStatus', () => {
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(globalStoreMock.setWorkingSidebarTab).toHaveBeenCalledWith('review');
-    expect(globalStoreMock.toggleRightPanel).toHaveBeenCalledWith(true);
+    expect(globalStoreMock.openWorkingSidebar).toHaveBeenCalledWith('review');
   });
 
   it('renders the linked GitHub PR number as a live display (no topic write)', async () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -457,7 +457,7 @@ describe('WorkflowCollapse', () => {
     expect(icon).toHaveAttribute('data-icon', 'Check');
   });
 
-  it('shows check with a warning badge when some tools fail after completion', () => {
+  it('shows only a check when some tools fail after completion', () => {
     mockIsGenerating = false;
     const blocks: AssistantContentBlock[] = [
       {
@@ -488,7 +488,7 @@ describe('WorkflowCollapse', () => {
     const icons = screen.getAllByTestId('icon');
     const iconNames = icons.map((node) => node.getAttribute('data-icon'));
     expect(iconNames).toContain('Check');
-    expect(iconNames).toContain('TriangleAlert');
+    expect(iconNames).not.toContain('TriangleAlert');
   });
 
   it('shows red x when all tools fail after completion', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -2,7 +2,7 @@ import { type ChatToolPayloadWithResult } from '@lobechat/types';
 import { Accordion, AccordionItem, Block, Flexbox, Icon } from '@lobehub/ui';
 import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
-import { AlertTriangle, Check, HandIcon, Maximize2, Minimize2, X } from 'lucide-react';
+import { Check, HandIcon, Maximize2, Minimize2, X } from 'lucide-react';
 import { AnimatePresence, m as motion } from 'motion/react';
 import { type Key, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -392,30 +392,7 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
           return wrapInBlock(<Icon color={cssVar.colorError} icon={X} />);
         }
         case 'partial': {
-          // Mix of success + failure: show success as the primary state and
-          // surface a small warning badge slightly inset from the bottom-right
-          // so the overall turn still reads as "done" rather than "broken".
-          return (
-            <div style={{ flex: 'none', position: 'relative' }}>
-              {wrapInBlock(<Icon color={cssVar.colorSuccess} icon={Check} />)}
-              <div
-                style={{
-                  alignItems: 'center',
-                  background: cssVar.colorBgContainer,
-                  borderRadius: '50%',
-                  bottom: 2,
-                  display: 'flex',
-                  height: 10,
-                  justifyContent: 'center',
-                  position: 'absolute',
-                  right: 2,
-                  width: 10,
-                }}
-              >
-                <Icon color={cssVar.colorWarning} icon={AlertTriangle} size={8} />
-              </div>
-            </div>
-          );
+          return wrapInBlock(<Icon color={cssVar.colorSuccess} icon={Check} />);
         }
         default: {
           return wrapInBlock(<Icon color={cssVar.colorSuccess} icon={Check} />);

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.test.ts
@@ -59,9 +59,9 @@ describe('tool display names', () => {
     // total calls (15) leads, "calls total" / "共" wording is gone
     expect(summary.startsWith('15 calls:')).toBe(true);
     expect(summary).not.toContain('calls total');
-    // truncated tool list is followed by the kind count, then the failure count
+    // truncated tool list is followed by the kind count; failures stay in the details
     expect(summary).toContain('across 6 tools');
-    expect(summary).toContain('1 failed');
+    expect(summary).not.toContain('failed');
   });
 
   it('omits the total call count when each tool is called once', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
@@ -335,18 +335,16 @@ const WORKFLOW_SUMMARY_TOP_N = 3;
 export const getWorkflowSummaryText = (blocks: AssistantContentBlock[]): string => {
   const tools = blocks.flatMap((b) => b.tools ?? []);
 
-  const groups = new Map<string, { count: number; errorCount: number }>();
+  const groups = new Map<string, { count: number }>();
   for (const tool of tools) {
-    const existing = groups.get(tool.apiName) || { count: 0, errorCount: 0 };
+    const existing = groups.get(tool.apiName) || { count: 0 };
     existing.count++;
-    if (tool.result?.error) existing.errorCount++;
     groups.set(tool.apiName, existing);
   }
 
   const entries = [...groups.entries()];
   const totalKinds = entries.length;
   const totalCalls = entries.reduce((sum, [, { count }]) => sum + count, 0);
-  const totalErrors = entries.reduce((sum, [, { errorCount }]) => sum + errorCount, 0);
 
   const formatToolPart = ([apiName, info]: [string, { count: number }]): string => {
     const name = getToolDisplayName(apiName);
@@ -387,15 +385,6 @@ export const getWorkflowSummaryText = (blocks: AssistantContentBlock[]): string 
         ]
       : [toolsText];
 
-  if (totalErrors > 0) {
-    segments.push(
-      t('workflow.summaryFailed', {
-        count: totalErrors,
-        defaultValue: '{{count}} failed',
-        ns: 'chat',
-      }),
-    );
-  }
   let result = segments.join(' · ');
 
   const totalReasoningMs = blocks.reduce((sum, b) => sum + (b.reasoning?.duration ?? 0), 0);

--- a/src/features/Conversation/WorkingSidebar/Files/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/index.tsx
@@ -265,7 +265,7 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
   }, [defaultExpandedIds, isFiltering]);
 
   const revealRequest = useGlobalStore((s) => s.status.workingSidebarRevealRequest);
-  const setWorkingSidebarTab = useGlobalStore((s) => s.setWorkingSidebarTab);
+  const openWorkingSidebar = useGlobalStore((s) => s.openWorkingSidebar);
 
   useEffect(() => {
     if (!revealRequest) return;
@@ -369,7 +369,7 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
         items.push({
           key: 'show-in-review',
           label: t('workingPanel.files.showInReview'),
-          onClick: () => setWorkingSidebarTab('review'),
+          onClick: () => openWorkingSidebar('review'),
         });
       }
 
@@ -400,7 +400,7 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
 
       return items;
     },
-    [canOfferFile, dirtyFilePaths, isRemote, openNode, publishFile, setWorkingSidebarTab, t],
+    [canOfferFile, dirtyFilePaths, isRemote, openNode, openWorkingSidebar, publishFile, t],
   );
 
   const isEmpty = nodes.length === 0;

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -97,6 +97,7 @@ const chatStore = vi.hoisted(() => ({
 }));
 
 const globalStore = vi.hoisted(() => ({
+  openWorkingSidebar: vi.fn(),
   updateSystemStatus: vi.fn(),
   toggleRightPanel: vi.fn(),
   toggleTerminalPanel: vi.fn(),
@@ -387,6 +388,7 @@ beforeEach(() => {
   globalStore.status.workingSidebarTab = 'params';
   globalStore.status.workingSidebarTabRequest = undefined;
   globalStore.updateSystemStatus.mockReset();
+  globalStore.openWorkingSidebar.mockReset();
   globalStore.toggleRightPanel.mockReset();
   globalStore.toggleTerminalPanel.mockReset();
   globalStore.setWorkingSidebarTab.mockReset();
@@ -505,6 +507,20 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     render(<AgentWorkingSidebar availableWidth={600} />);
 
     expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+
+  it('uses the Overview minimum width even when Review previously needed two panes', () => {
+    agentStore.activeAgentId = 'agent';
+    reviewState.repoType = 'git';
+    reviewState.workingDirectory = '/repo';
+    reviewState.showTree = true;
+    localStorageState.openTabsByContext = { 'draft:agent:/repo': ['review'] };
+    globalStore.status.workingSidebarTab = 'review';
+    globalStore.status.showRightPanel = false;
+
+    render(<AgentWorkingSidebar availableWidth={850} />);
+
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
   });
 
   it('keeps a fitting stored width untouched on a measured row', () => {
@@ -868,7 +884,7 @@ describe('AgentWorkingSidebar — tab strip', () => {
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.review.title' }));
 
     expect(document.querySelectorAll('button[data-tab-key="review"]')).toHaveLength(1);
-    expect(globalStore.setWorkingSidebarTab).toHaveBeenCalledWith('review');
+    expect(globalStore.openWorkingSidebar).toHaveBeenCalledWith('review');
   });
 
   it('opens Skills and Documents by default for a new workspace context', () => {
@@ -1047,6 +1063,42 @@ describe('AgentWorkingSidebar — tab strip', () => {
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.close' }));
 
     expect(globalStore.setWorkingSidebarTab).toHaveBeenCalledWith('overview');
+  });
+
+  it('still exposes empty workspace chrome after all tabs close and the panel reopens', () => {
+    agentStore.activeAgentId = 'agent';
+    reviewState.repoType = 'git';
+    reviewState.workingDirectory = '/repo';
+    localStorageState.openTabsByContext = { 'draft:agent:/repo': [] };
+    globalStore.status.workingSidebarTab = 'overview';
+    globalStore.status.showWorkingOverview = false;
+
+    render(<AgentWorkingSidebar />);
+
+    expect(rightPanel.current?.expand).toBe(true);
+    expect(screen.getByRole('button', { name: 'workingPanel.openMenu.title' })).toBeInTheDocument();
+  });
+
+  it('clears an optimistic active tab when the topic context changes', async () => {
+    chatStore.activeTopicId = 'topic-a';
+    localStorageState.openTabsByContext = {
+      'topic:topic-a': ['skills', 'params'],
+      'topic:topic-b': ['skills'],
+    };
+    globalStore.status.workingSidebarTab = 'skills';
+
+    const { rerender } = render(<AgentWorkingSidebar availableWidth={1000} />);
+    fireEvent.click(screen.getByRole('button', { name: 'settingModel.params.panel.tab' }));
+
+    chatStore.activeTopicId = 'topic-b';
+    globalStore.status.workingSidebarTab = 'skills';
+    rerender(<AgentWorkingSidebar availableWidth={1001} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'workingPanel.resources.filter.skills' }),
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
   });
 
   it('collapses the panel when the last remaining tab is closed', () => {

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { MouseEvent, ReactNode } from 'react';
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PortalViewType } from '@/store/chat/slices/portal/initialState';
@@ -18,6 +18,7 @@ interface CapturedRightPanelProps {
   expand?: boolean;
   maxWidth?: number | string;
   onSizeChange?: (size?: { height?: number | string; width?: number | string }) => void;
+  style?: CSSProperties;
   width?: number | string;
 }
 
@@ -104,6 +105,7 @@ const globalStore = vi.hoisted(() => ({
     portalWidth: 400 as number | undefined,
     portalWidths: undefined as Record<string, number> | undefined,
     showRightPanel: true,
+    showWorkingOverview: true,
     workingSidebarTab: 'params' as string | undefined,
     workingSidebarTabRequest: undefined as { nonce: number; tab: string } | undefined,
     workingSidebarWidth: 360 as number | undefined,
@@ -113,7 +115,11 @@ const globalStore = vi.hoisted(() => ({
 vi.mock('@/features/RightPanel', () => ({
   default: (props: CapturedRightPanelProps) => {
     rightPanel.current = props;
-    return <div data-testid="right-panel">{props.children}</div>;
+    return (
+      <div data-testid="right-panel" style={props.style}>
+        {props.children}
+      </div>
+    );
   },
 }));
 
@@ -377,6 +383,7 @@ beforeEach(() => {
   dropdownMenuState.items = [];
   globalStore.status.workingSidebarWidth = 360;
   globalStore.status.showRightPanel = true;
+  globalStore.status.showWorkingOverview = true;
   globalStore.status.workingSidebarTab = 'params';
   globalStore.status.workingSidebarTabRequest = undefined;
   globalStore.updateSystemStatus.mockReset();
@@ -428,6 +435,7 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
 
     unmount();
     globalStore.status.workingSidebarTab = 'params';
+    localStorageState.openTabsByContext = { 'draft:agent:C:\\repo': ['params'] };
     render(<AgentWorkingSidebar />);
     expect(rightPanel.current?.width).toBe(360);
   });
@@ -560,7 +568,7 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     effectiveConfig.agencyConfig = { executionTarget: 'local' };
     reviewState.repoType = 'git';
     reviewState.workingDirectory = '/Users/me/project';
-    globalStore.status.workingSidebarTab = 'overview';
+    globalStore.status.workingSidebarTab = 'works';
 
     render(<AgentWorkingSidebar />);
 
@@ -678,23 +686,18 @@ describe('AgentWorkingSidebar — tab strip', () => {
       .map((button) => button.textContent)
       .filter(Boolean);
 
-    expect(labels).toEqual([
-      'workingPanel.overview.title',
-      'settingModel.params.panel.tab',
-      'workingPanel.deployments.tab',
-    ]);
+    expect(labels).toEqual(['settingModel.params.panel.tab', 'workingPanel.deployments.tab']);
   });
 
-  it('keeps Overview fixed and hides unopened workspace tabs', () => {
+  it('renders Overview as an independent reserved panel and hides unopened workspace tabs', () => {
     localStorageState.openTabsByContext = {};
+    globalStore.status.showRightPanel = false;
     globalStore.status.workingSidebarTab = undefined;
 
     render(<AgentWorkingSidebar />);
 
-    expect(screen.getByRole('button', { name: 'workingPanel.overview.title' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    expect(screen.getByRole('complementary')).toHaveTextContent('workingPanel.overview.title');
+    expect(screen.getByTestId('right-panel')).not.toBeVisible();
     expect(
       screen.queryByRole('button', { name: 'workingPanel.resources.filter.skills' }),
     ).not.toBeInTheDocument();
@@ -703,14 +706,16 @@ describe('AgentWorkingSidebar — tab strip', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('places Overview in the same horizontal scroll container as on-demand tabs', () => {
+  it('keeps the reserved Overview panel separate from the on-demand tab strip', () => {
+    globalStore.status.showRightPanel = false;
+    globalStore.status.workingSidebarTab = 'overview';
     render(<AgentWorkingSidebar />);
-    const overviewTab = screen.getByRole('button', { name: 'workingPanel.overview.title' });
-    const paramsTab = screen.getByRole('button', { name: 'settingModel.params.panel.tab' });
 
-    expect(overviewTab.parentElement?.parentElement?.parentElement).toBe(
-      paramsTab.parentElement?.parentElement?.parentElement,
-    );
+    expect(screen.getByRole('complementary')).toBeVisible();
+    expect(screen.getByTestId('right-panel')).not.toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'workingPanel.openMenu.title' }),
+    ).not.toBeInTheDocument();
   });
 
   it('keeps the working panel chrome visible while the Params pane is suspended', () => {
@@ -718,19 +723,22 @@ describe('AgentWorkingSidebar — tab strip', () => {
 
     render(<AgentWorkingSidebar />);
 
-    expect(screen.getByRole('button', { name: 'workingPanel.overview.title' })).toBeInTheDocument();
+    expect(screen.getByRole('complementary')).toHaveTextContent('workingPanel.overview.title');
     expect(screen.getByRole('button', { name: 'workingPanel.openMenu.title' })).toBeInTheDocument();
     expect(screen.getByTestId('params-loading')).toBeInTheDocument();
   });
 
   it('restores pinned tabs only for the agent that owns them', () => {
     agentStore.activeAgentId = 'agent-a';
-    localStorageState.openTabsByContext = {};
+    localStorageState.openTabsByContext = { 'draft:agent-a:none': [], 'draft:agent-b:none': [] };
     localStorageState.pinnedTabsByAgent = { 'agent-a': ['works'] };
-    globalStore.status.workingSidebarTab = 'overview';
+    globalStore.status.workingSidebarTab = 'works';
 
     const { unmount } = render(<AgentWorkingSidebar />);
-    const pinnedWorksTab = screen.getByRole('button', { name: 'workingPanel.works.title' });
+    const pinnedWorksTab = screen.getByRole('button', {
+      hidden: true,
+      name: 'workingPanel.works.title',
+    });
 
     expect(pinnedWorksTab.parentElement).toHaveAttribute('data-pinned', 'true');
     expect(
@@ -810,22 +818,46 @@ describe('AgentWorkingSidebar — tab strip', () => {
     agentStore.activeAgentId = 'agent';
     reviewState.repoType = 'git';
     reviewState.workingDirectory = '/repo';
-    localStorageState.openTabsByContext = {};
-    globalStore.status.workingSidebarTab = 'overview';
+    localStorageState.openTabsByContext = { 'draft:agent:/repo': ['params'] };
+    globalStore.status.workingSidebarTab = 'params';
 
     render(<AgentWorkingSidebar />);
 
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.openMenu.title' }));
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.review.title' }));
-    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.openMenu.title' }));
 
-    expect(screen.getAllByRole('button', { name: 'workingPanel.review.title' })).toHaveLength(1);
+    expect(document.querySelectorAll('button[data-tab-key="review"]')).toHaveLength(1);
     expect(globalStore.setWorkingSidebarTab).toHaveBeenCalledWith('review');
   });
 
-  it('creates an independent browser tab every time Browser is chosen', async () => {
+  it('opens Skills and Documents by default for a new workspace context', () => {
     localStorageState.openTabsByContext = {};
     globalStore.status.workingSidebarTab = 'overview';
+
+    render(<AgentWorkingSidebar />);
+
+    const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>('button[data-tab-key]'));
+    expect(tabs.map((tab) => tab.dataset.tabKey)).toEqual(['skills', 'documents']);
+    expect(tabs[0]).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('puts Files before Skills and Documents when a filesystem environment is available', () => {
+    agentStore.activeAgentId = 'agent';
+    effectiveConfig.agencyConfig = { executionTarget: 'local' };
+    reviewState.workingDirectory = '/repo';
+    localStorageState.openTabsByContext = {};
+    globalStore.status.workingSidebarTab = 'overview';
+
+    render(<AgentWorkingSidebar />);
+
+    const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>('button[data-tab-key]'));
+    expect(tabs.map((tab) => tab.dataset.tabKey)).toEqual(['files', 'skills', 'documents']);
+    expect(tabs[0]).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('creates an independent browser tab every time Browser is chosen', async () => {
+    localStorageState.openTabsByContext = { 'draft:default:none': ['params'] };
+    globalStore.status.workingSidebarTab = 'params';
 
     const { container } = render(<AgentWorkingSidebar />);
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.openMenu.title' }));
@@ -836,7 +868,7 @@ describe('AgentWorkingSidebar — tab strip', () => {
     fireEvent.click(
       screen
         .getAllByRole('button', { name: 'workingPanel.browser.title' })
-        .find((button) => !button.hasAttribute('aria-pressed'))!,
+        .find((button) => !button.dataset.tabKey)!,
     );
 
     await waitFor(() => {
@@ -939,8 +971,11 @@ describe('AgentWorkingSidebar — tab strip', () => {
   });
 
   it('moves focus to a tab opened from the grouped menu', async () => {
-    localStorageState.openTabsByContext = {};
-    globalStore.status.workingSidebarTab = 'overview';
+    agentStore.activeAgentId = 'agent';
+    reviewState.repoType = 'git';
+    reviewState.workingDirectory = '/repo';
+    localStorageState.openTabsByContext = { 'draft:agent:/repo': ['review'] };
+    globalStore.status.workingSidebarTab = 'review';
     globalStore.setWorkingSidebarTab.mockImplementation((tab: string) => {
       globalStore.status.workingSidebarTab = tab;
     });
@@ -981,28 +1016,22 @@ describe('AgentWorkingSidebar — tab strip', () => {
     globalStore.status.workingSidebarTab = 'review';
 
     render(<AgentWorkingSidebar />);
-    expect(
-      screen.queryByRole('button', { name: 'workingPanel.tabs.closePanel' }),
-    ).not.toBeInTheDocument();
-
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.close' }));
-    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
 
     expect(globalStore.toggleRightPanel).toHaveBeenCalledWith(false);
   });
 
-  it('keeps the last tab closable from its context menu', () => {
+  it('keeps the independent Overview panel closable', () => {
     localStorageState.openTabsByContext = {};
     globalStore.status.workingSidebarTab = 'overview';
 
     render(<AgentWorkingSidebar />);
-    fireEvent.contextMenu(screen.getByRole('button', { name: 'workingPanel.overview.title' }));
-    fireEvent.click(screen.getByText('workingPanel.tabs.closePanel'));
+    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
 
-    expect(globalStore.toggleRightPanel).toHaveBeenCalledWith(false);
+    expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ showWorkingOverview: false });
   });
 
-  it('leaves a pinned tab standing instead of collapsing the panel', () => {
+  it('lets the independent Overview close without removing pinned tabs', () => {
     agentStore.activeAgentId = 'agent';
     localStorageState.openTabsByContext = {};
     localStorageState.pinnedTabsByAgent = { agent: ['works'] };
@@ -1010,9 +1039,10 @@ describe('AgentWorkingSidebar — tab strip', () => {
 
     render(<AgentWorkingSidebar />);
 
-    expect(
-      screen.queryByRole('button', { name: 'workingPanel.tabs.closePanel' }),
-    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
+
+    expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ showWorkingOverview: false });
+    expect(localStorageState.pinnedTabsByAgent).toEqual({ agent: ['works'] });
   });
 
   it('reopens a closed tab when the same external target is requested again', async () => {
@@ -1030,24 +1060,24 @@ describe('AgentWorkingSidebar — tab strip', () => {
     globalStore.status.workingSidebarTabRequest = { nonce: 1, tab: 'review' };
     act(() => reviewState.setRepoType?.('git'));
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'workingPanel.review.title' })).toBeInTheDocument();
+      expect(document.querySelector('button[data-tab-key="review"]')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.close' }));
-    expect(
-      screen.queryByRole('button', { name: 'workingPanel.review.title' }),
-    ).not.toBeInTheDocument();
+    fireEvent.click(document.querySelector('button[data-tab-key="review"]')!.nextElementSibling!);
+    expect(document.querySelector('button[data-tab-key="review"]')).not.toBeInTheDocument();
 
     globalStore.status.workingSidebarTabRequest = { nonce: 2, tab: 'review' };
     act(() => reviewState.setRepoType?.('github'));
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'workingPanel.review.title' })).toBeInTheDocument();
+      expect(document.querySelector('button[data-tab-key="review"]')).toBeInTheDocument();
     });
   });
 
   it('offers Comments for a workspace topic and opens it in this panel', () => {
     workspace.id = 'workspace-1';
     chatStore.activeTopicId = 'topic-1';
+    localStorageState.openTabsByContext = { 'topic:topic-1': ['params'] };
+    globalStore.status.workingSidebarTab = 'params';
 
     render(<AgentWorkingSidebar />);
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.openMenu.title' }));
@@ -1059,6 +1089,9 @@ describe('AgentWorkingSidebar — tab strip', () => {
   });
 
   it('hides Comments when there is no workspace topic', () => {
+    localStorageState.openTabsByContext = { 'draft:default:none': ['params'] };
+    globalStore.status.workingSidebarTab = 'params';
+
     render(<AgentWorkingSidebar />);
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.openMenu.title' }));
 

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -105,7 +105,7 @@ const globalStore = vi.hoisted(() => ({
     portalWidth: 400 as number | undefined,
     portalWidths: undefined as Record<string, number> | undefined,
     showRightPanel: true,
-    showWorkingOverview: true,
+    showWorkingOverview: true as boolean | undefined,
     workingSidebarTab: 'params' as string | undefined,
     workingSidebarTabRequest: undefined as { nonce: number; tab: string } | undefined,
     workingSidebarWidth: 360 as number | undefined,
@@ -499,6 +499,14 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     expect(rightPanel.current?.expand).toBe(false);
   });
 
+  it('also yields the Overview card when the conversation width budget is too small', () => {
+    globalStore.status.showRightPanel = false;
+
+    render(<AgentWorkingSidebar availableWidth={600} />);
+
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+
   it('keeps a fitting stored width untouched on a measured row', () => {
     render(<AgentWorkingSidebar availableWidth={1540} />);
 
@@ -793,6 +801,39 @@ describe('AgentWorkingSidebar — tab strip', () => {
     expect(globalStore.setWorkingSidebarTab).toHaveBeenCalledWith('overview');
   });
 
+  it('preserves the other implicit default tabs when one default tab closes', () => {
+    localStorageState.openTabsByContext = {};
+    globalStore.status.workingSidebarTab = 'skills';
+
+    render(<AgentWorkingSidebar />);
+    const skillsTab = screen.getByRole('button', {
+      name: 'workingPanel.resources.filter.skills',
+    });
+    fireEvent.click(skillsTab.parentElement!.querySelector('[data-tab-close="true"]')!);
+
+    expect(
+      screen.queryByRole('button', { name: 'workingPanel.resources.filter.skills' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'workingPanel.resources.filter.documents' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(globalStore.toggleRightPanel).not.toHaveBeenCalled();
+  });
+
+  it('keeps the panel open and selects a surviving pinned tab when the active tab closes', () => {
+    agentStore.activeAgentId = 'agent';
+    localStorageState.openTabsByContext = { 'draft:agent:none': ['works', 'params'] };
+    localStorageState.pinnedTabsByAgent = { agent: ['works'] };
+    globalStore.status.workingSidebarTab = 'params';
+
+    render(<AgentWorkingSidebar />);
+    const paramsTab = screen.getByRole('button', { name: 'settingModel.params.panel.tab' });
+    fireEvent.click(paramsTab.parentElement!.querySelector('[data-tab-close="true"]')!);
+
+    expect(globalStore.setWorkingSidebarTab).toHaveBeenCalledWith('works');
+    expect(globalStore.toggleRightPanel).not.toHaveBeenCalled();
+  });
+
   it('preserves agent-pinned tabs when closing other tabs', () => {
     agentStore.activeAgentId = 'agent';
     localStorageState.openTabsByContext = {
@@ -1029,6 +1070,16 @@ describe('AgentWorkingSidebar — tab strip', () => {
     fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
 
     expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ showWorkingOverview: false });
+  });
+
+  it('does not show Overview beside a legacy persisted open workspace panel', () => {
+    globalStore.status.showRightPanel = true;
+    globalStore.status.showWorkingOverview = undefined;
+
+    render(<AgentWorkingSidebar />);
+
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(rightPanel.current?.expand).toBe(true);
   });
 
   it('lets the independent Overview close without removing pinned tabs', () => {

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -213,6 +213,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     portalWidths,
     updateSystemStatus,
     toggleRightPanel,
+    openWorkingSidebar,
     toggleTerminalPanel,
     setWorkingSidebarTab,
     showRightPanel,
@@ -225,6 +226,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     systemStatusSelectors.portalWidths(s),
     s.updateSystemStatus,
     s.toggleRightPanel,
+    s.openWorkingSidebar,
     s.toggleTerminalPanel,
     s.setWorkingSidebarTab,
     // Panel open/collapsed state (drives the `<RightPanel>` expand). Used to gate
@@ -467,8 +469,17 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     ]),
   );
   const openedTabsSignature = openedTabs.join('\0');
-  const [optimisticTab, setOptimisticTab] = useState<string>();
+  const [optimisticSelection, setOptimisticSelection] = useState<{
+    contextKey: string;
+    tab: string;
+  }>();
   const previousStoredTabRef = useRef(storedTab);
+  const resolvedActiveTab: string =
+    storedTab && openedTabs.includes(storedTab) ? storedTab : (openedTabs[0] ?? 'overview');
+  const activeTab =
+    optimisticSelection?.contextKey === openTabsContextKey
+      ? optimisticSelection.tab
+      : resolvedActiveTab;
 
   const updateOpenedTabs = useCallback(
     (updater: (tabs: string[]) => string[]) => {
@@ -493,17 +504,16 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
   const openTab = useCallback(
     (tab: string) => {
       if (tab !== 'overview' && !isAvailableTab(tab)) return;
-      setOptimisticTab(tab);
+      if (tab !== activeTab) setOptimisticSelection({ contextKey: openTabsContextKey, tab });
       if (tab !== 'overview') {
         updateOpenedTabs((current) => (current.includes(tab) ? current : [...current, tab]));
-        toggleRightPanel(true);
-        updateSystemStatus({ showWorkingOverview: false });
+        openWorkingSidebar(tab);
       }
       if (tab === 'comments' && topicId && !isCurrentTopicComments) {
         openTopicComments(topicId);
         return;
       }
-      setWorkingSidebarTab(tab);
+      if (tab === 'overview') setWorkingSidebarTab(tab);
     },
     [
       isAvailableTab,
@@ -511,8 +521,9 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       openTopicComments,
       setWorkingSidebarTab,
       topicId,
-      toggleRightPanel,
-      updateSystemStatus,
+      activeTab,
+      openWorkingSidebar,
+      openTabsContextKey,
       updateOpenedTabs,
     ],
   );
@@ -523,26 +534,26 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     const tab =
       currentBrowserTabs.length === 0 ? BROWSER_TAB_KEY : `${BROWSER_TAB_PREFIX}${nanoid(8)}`;
     updateOpenedTabs((current) => [...current, tab]);
-    setOptimisticTab(tab);
-    setWorkingSidebarTab(tab);
+    setOptimisticSelection({ contextKey: openTabsContextKey, tab });
+    openWorkingSidebar(tab);
     return tab;
   }, [
     browserAvailable,
     openTabsByContext,
     openTabsContextKey,
-    setWorkingSidebarTab,
+    openWorkingSidebar,
     updateOpenedTabs,
   ]);
-
-  const resolvedActiveTab: string =
-    storedTab && openedTabs.includes(storedTab) ? storedTab : (openedTabs[0] ?? 'overview');
-  const activeTab = optimisticTab ?? resolvedActiveTab;
 
   useEffect(() => {
     if (previousStoredTabRef.current === storedTab) return;
     previousStoredTabRef.current = storedTab;
-    setOptimisticTab(undefined);
+    setOptimisticSelection(undefined);
   }, [storedTab]);
+
+  useEffect(() => {
+    setOptimisticSelection(undefined);
+  }, [availableTabsSignature, openTabsContextKey]);
 
   useEffect(() => {
     if (
@@ -605,7 +616,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
         const nextTab = remainingTabs.includes(fallbackTab)
           ? fallbackTab
           : (remainingTabs[0] ?? 'overview');
-        setOptimisticTab(nextTab);
+        setOptimisticSelection({ contextKey: openTabsContextKey, tab: nextTab });
         setWorkingSidebarTab(nextTab);
       }
       if (remainingTabs.length === 0) {
@@ -615,6 +626,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     [
       activeTab,
       openedTabs,
+      openTabsContextKey,
       pinnedTabsSet,
       setWorkingSidebarTab,
       toggleRightPanel,
@@ -786,6 +798,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     portalWidth: portalOpen ? portalWidth : 0,
   });
   const fits = widthBudget >= minDisplayWidth;
+  const overviewFits = widthBudget >= MIN_PANEL_WIDTH;
   const renderWidth = Math.min(displayWidth, Math.max(widthBudget, minDisplayWidth));
   // Also cap the drag range so releasing a drag can never persist a width that
   // immediately fails the fit check and hides the panel.
@@ -873,7 +886,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     toggleTerminalPanel,
   ]);
 
-  const overviewPanel = showWorkingOverview && fits && (
+  const overviewPanel = showWorkingOverview && overviewFits && (
     <Flexbox className={styles.overviewPanel} role={'complementary'}>
       <Flexbox
         horizontal
@@ -914,10 +927,10 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
         stableLayout
         collapseThreshold={320}
         defaultWidth={renderWidth}
-        expand={Boolean(showRightPanel) && fits && activeTab !== 'overview'}
+        expand={Boolean(showRightPanel) && fits}
         maxWidth={maxPanelWidth}
         minWidth={MIN_PANEL_WIDTH}
-        style={!showRightPanel || activeTab === 'overview' ? { visibility: 'hidden' } : undefined}
+        style={!showRightPanel ? { visibility: 'hidden' } : undefined}
         width={renderWidth}
         onSizeChange={(size) => {
           if (!size?.width) return;

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -3,7 +3,7 @@ import { nanoid } from '@lobechat/utils';
 import { Flexbox, Icon, type IconProps, Skeleton } from '@lobehub/ui';
 import { ActionIcon, type DropdownItem, DropdownMenu } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
-import { createStaticStyles } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import {
   BoxesIcon,
   CheckIcon,
@@ -12,7 +12,6 @@ import {
   FileTextIcon,
   Globe2Icon,
   GlobeIcon,
-  LayoutDashboardIcon,
   MessageCircleIcon,
   PanelRightCloseIcon,
   PanelsTopLeftIcon,
@@ -112,6 +111,39 @@ const styles = createStaticStyles(({ css }) => ({
     border-radius: 2px;
     object-fit: contain;
   `,
+  overviewBody: css`
+    overflow-y: auto;
+    min-height: 0;
+  `,
+  overviewHeader: css`
+    flex-shrink: 0;
+    padding-block: 6px;
+    padding-inline: 12px 8px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  overviewPanel: css`
+    overflow: hidden;
+    flex-shrink: 0;
+    align-self: flex-start;
+
+    width: min(340px, calc(100% - 32px));
+    max-height: calc(100% - 32px);
+    margin: 16px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 20px;
+
+    background: ${cssVar.colorBgContainer};
+    box-shadow: ${cssVar.boxShadowTertiary};
+  `,
+  overviewTitle: css`
+    overflow: hidden;
+    flex: 1;
+
+    font-size: 14px;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
   tabs: css`
     overflow-anchor: none;
     scrollbar-width: none;
@@ -185,6 +217,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     toggleTerminalPanel,
     setWorkingSidebarTab,
     showRightPanel,
+    showWorkingOverview,
     storedTab,
     tabRequest,
   ] = useGlobalStore((s) => [
@@ -199,6 +232,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     // the resources pane's document fetch so a collapsed sidebar doesn't pull the
     // full agent-document list into the conversation's initial batch.
     s.status.showRightPanel,
+    s.status.showWorkingOverview ?? true,
     s.status.workingSidebarTab,
     s.status.workingSidebarTabRequest,
   ]);
@@ -395,6 +429,13 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     ? `topic:${topicId}`
     : `draft:${activeAgentId ?? 'default'}:${workingDirectory ?? 'none'}`;
   const pinnedTabsAgentKey = activeAgentId ?? 'default';
+  const defaultOpenedTabs = useMemo(
+    () =>
+      [filesAvailable ? 'files' : undefined, 'skills', isHetero ? undefined : 'documents'].filter(
+        (tab): tab is string => Boolean(tab) && isAvailableTab(tab!),
+      ),
+    [filesAvailable, isAvailableTab, isHetero],
+  );
   const [openTabsByContext, setOpenTabsByContext] = useLocalStorageState<Record<string, string[]>>(
     OPEN_TABS_STORAGE_KEY,
     {},
@@ -422,11 +463,13 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
   const openedTabs = Array.from(
     new Set([
       ...pinnedTabs,
-      ...(openTabsByContext[openTabsContextKey] ?? []).filter(isAvailableTab),
+      ...(openTabsByContext[openTabsContextKey] ?? defaultOpenedTabs).filter(isAvailableTab),
       ...(requestedTab ? [requestedTab] : []),
     ]),
   );
   const openedTabsSignature = openedTabs.join('\0');
+  const [optimisticTab, setOptimisticTab] = useState<string>();
+  const previousStoredTabRef = useRef(storedTab);
 
   const updateOpenedTabs = useCallback(
     (updater: (tabs: string[]) => string[]) => {
@@ -451,8 +494,11 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
   const openTab = useCallback(
     (tab: string) => {
       if (tab !== 'overview' && !isAvailableTab(tab)) return;
+      setOptimisticTab(tab);
       if (tab !== 'overview') {
         updateOpenedTabs((current) => (current.includes(tab) ? current : [...current, tab]));
+        toggleRightPanel(true);
+        updateSystemStatus({ showWorkingOverview: false });
       }
       if (tab === 'comments' && topicId && !isCurrentTopicComments) {
         openTopicComments(topicId);
@@ -466,6 +512,8 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       openTopicComments,
       setWorkingSidebarTab,
       topicId,
+      toggleRightPanel,
+      updateSystemStatus,
       updateOpenedTabs,
     ],
   );
@@ -476,6 +524,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     const tab =
       currentBrowserTabs.length === 0 ? BROWSER_TAB_KEY : `${BROWSER_TAB_PREFIX}${nanoid(8)}`;
     updateOpenedTabs((current) => [...current, tab]);
+    setOptimisticTab(tab);
     setWorkingSidebarTab(tab);
     return tab;
   }, [
@@ -486,10 +535,15 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     updateOpenedTabs,
   ]);
 
-  const activeTab: string =
-    storedTab && (storedTab === 'overview' || openedTabs.includes(storedTab))
-      ? storedTab
-      : 'overview';
+  const resolvedActiveTab: string =
+    storedTab && openedTabs.includes(storedTab) ? storedTab : (openedTabs[0] ?? 'overview');
+  const activeTab = optimisticTab ?? resolvedActiveTab;
+
+  useEffect(() => {
+    if (previousStoredTabRef.current === storedTab) return;
+    previousStoredTabRef.current = storedTab;
+    setOptimisticTab(undefined);
+  }, [storedTab]);
 
   useEffect(() => {
     if (
@@ -547,9 +601,22 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       if (removableTabs.size === 0) return;
 
       updateOpenedTabs((current) => current.filter((tab) => !removableTabs.has(tab)));
-      if (removableTabs.has(activeTab)) setWorkingSidebarTab(fallbackTab);
+      if (removableTabs.has(activeTab)) {
+        setOptimisticTab(fallbackTab);
+        setWorkingSidebarTab(fallbackTab);
+      }
+      if (openedTabs.every((tab) => removableTabs.has(tab) || pinnedTabsSet.has(tab))) {
+        toggleRightPanel(false);
+      }
     },
-    [activeTab, pinnedTabsSet, setWorkingSidebarTab, updateOpenedTabs],
+    [
+      activeTab,
+      openedTabs,
+      pinnedTabsSet,
+      setWorkingSidebarTab,
+      toggleRightPanel,
+      updateOpenedTabs,
+    ],
   );
 
   const closeTab = useCallback((tab: string) => closeTabs([tab]), [closeTabs]);
@@ -570,9 +637,6 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       };
     })
     .filter((tab): tab is SidebarTabDescriptor => Boolean(tab));
-  // Overview is the only tab that always exists, so once it stands alone the
-  // strip has nothing left to close — closing it collapses the whole panel.
-  const isOverviewOnlyTab = displayedTabs.length === 0;
   const createTabContextMenuItems = useCallback(
     (tab: string, index: number): NativeContextMenuItem[] => {
       const pinned = pinnedTabsSet.has(tab);
@@ -623,28 +687,6 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       ];
     },
     [closeTab, closeTabs, openedTabs, pinTab, pinnedTabsSet, t, unpinTab],
-  );
-  const overviewContextMenuItems = useMemo<NativeContextMenuItem[]>(
-    () => [
-      ...(isOverviewOnlyTab
-        ? [
-            {
-              icon: XIcon,
-              key: 'closePanel',
-              label: t('workingPanel.tabs.closePanel'),
-              onClick: () => toggleRightPanel(false),
-            } as NativeContextMenuItem,
-            { type: 'divider' as const },
-          ]
-        : []),
-      {
-        disabled: !openedTabs.some((tab) => !pinnedTabsSet.has(tab)),
-        key: 'closeOthers',
-        label: t('workingPanel.tabs.closeOthers'),
-        onClick: () => closeTabs(openedTabs),
-      },
-    ],
-    [closeTabs, isOverviewOnlyTab, openedTabs, pinnedTabsSet, t, toggleRightPanel],
   );
   const tabsRef = useRef<HTMLDivElement>(null);
   const pendingTabFocusRef = useRef<string | undefined>(undefined);
@@ -828,210 +870,228 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     toggleTerminalPanel,
   ]);
 
-  return (
-    <RightPanel
-      stableLayout
-      collapseThreshold={320}
-      defaultWidth={renderWidth}
-      expand={Boolean(showRightPanel) && fits}
-      maxWidth={maxPanelWidth}
-      minWidth={MIN_PANEL_WIDTH}
-      width={renderWidth}
-      onSizeChange={(size) => {
-        if (!size?.width) return;
-        // DraggablePanel emits width as a `"420px"` string on drag-stop; parse it so
-        // the controlled width actually updates (otherwise the panel snaps back).
-        const w = typeof size.width === 'string' ? Number.parseInt(size.width) : size.width;
-        if (!Number.isFinite(w) || w === storedWidth) return;
-        updateSystemStatus({ workingSidebarWidth: w });
-      }}
-    >
-      <Flexbox height={'100%'} width={'100%'}>
-        <Flexbox
-          horizontal
-          align={'center'}
-          className={styles.header}
-          gap={4}
-          height={44}
-          justify={'space-between'}
-          paddingInline={4}
-        >
-          <div className={styles.tabsArea}>
-            <div className={styles.tabs} ref={tabsRef}>
-              <WorkspaceTab
-                active={activeTab === 'overview'}
-                closeLabel={t('workingPanel.tabs.closePanel')}
-                contextMenuItems={overviewContextMenuItems}
-                icon={LayoutDashboardIcon}
-                label={t('workingPanel.overview.title')}
-                tabKey={'overview'}
-                onClose={isOverviewOnlyTab ? () => toggleRightPanel(false) : undefined}
-                onSelect={() => openTab('overview')}
-              />
-              {displayedTabs.map((tab, index) => (
-                <WorkspaceTab
-                  active={activeTab === tab.key}
-                  closeLabel={t('workingPanel.tabs.close')}
-                  contextMenuItems={createTabContextMenuItems(tab.key, index)}
-                  icon={tab.icon}
-                  iconNode={tab.iconNode}
-                  key={tab.key}
-                  label={tab.label}
-                  pinned={pinnedTabsSet.has(tab.key)}
-                  pinnedLabel={t('workingPanel.tabs.pinned')}
-                  tabKey={tab.key}
-                  onClose={pinnedTabsSet.has(tab.key) ? undefined : () => closeTab(tab.key)}
-                  onSelect={() => openTab(tab.key)}
-                />
-              ))}
-            </div>
-            <DropdownMenu
-              items={openMenuItems}
-              placement={'bottomRight'}
-              onOpenChangeComplete={(open) => {
-                if (open) return;
-                if (pendingTabFocusRef.current) focusPendingTab();
-                else scrollActiveTabIntoView();
-              }}
-            >
-              <ActionIcon
-                className={styles.add}
-                icon={PlusIcon}
-                size={DESKTOP_HEADER_ICON_SMALL_SIZE}
-                title={t('workingPanel.openMenu.title')}
-              />
-            </DropdownMenu>
-          </div>
-          <ActionIcon
-            className={styles.close}
-            icon={PanelRightCloseIcon}
-            size={DESKTOP_HEADER_ICON_SMALL_SIZE}
-            onClick={() => toggleRightPanel(false)}
+  const overviewPanel = showWorkingOverview && (
+    <Flexbox className={styles.overviewPanel} role={'complementary'}>
+      <Flexbox
+        horizontal
+        align={'center'}
+        className={styles.overviewHeader}
+        gap={8}
+        justify={'space-between'}
+      >
+        <span className={styles.overviewTitle}>{t('workingPanel.overview.title')}</span>
+        <ActionIcon
+          aria-label={t('workingPanel.tabs.closePanel')}
+          icon={PanelRightCloseIcon}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+          title={t('workingPanel.tabs.closePanel')}
+          onClick={() => updateSystemStatus({ showWorkingOverview: false })}
+        />
+      </Flexbox>
+      <Flexbox className={styles.overviewBody}>
+        {!contentReady && <SkeletonList paddingBlock={8} paddingInline={8} rows={6} />}
+        {contentReady && (
+          <Overview
+            active
+            deviceId={remoteDeviceId}
+            environmentAvailable={filesystemEnvironmentAvailable}
+            repoType={environmentRepoType}
+            workingDirectory={environmentWorkingDirectory}
+            onOpenTab={openTab}
           />
-        </Flexbox>
-        <Flexbox className={styles.body} width={'100%'}>
-          {!contentReady && <SkeletonList paddingBlock={8} paddingInline={8} rows={6} />}
-          {contentReady && (
-            <>
-              <Flexbox className={activeTab === 'overview' ? styles.pane : styles.paneHidden}>
-                <Overview
-                  active={Boolean(showRightPanel) && activeTab === 'overview'}
-                  deviceId={remoteDeviceId}
-                  environmentAvailable={filesystemEnvironmentAvailable}
-                  repoType={environmentRepoType}
-                  workingDirectory={environmentWorkingDirectory}
-                  onOpenTab={openTab}
-                />
-              </Flexbox>
-              {commentsAvailable && (
-                <Flexbox
-                  className={activeTab === 'comments' ? styles.pane : styles.paneHidden}
-                  style={{ overflow: 'hidden' }}
-                >
-                  <TopicCommentsSidebar />
-                </Flexbox>
-              )}
-              {paramsAvailable && activeTab === 'params' && (
-                <Flexbox className={styles.pane}>
-                  <Suspense
-                    fallback={
-                      <Skeleton
-                        active
-                        className={styles.paramsLoading}
-                        paragraph={{ rows: 6 }}
-                        title={false}
-                      />
-                    }
-                  >
-                    <ParamsSection />
-                  </Suspense>
-                </Flexbox>
-              )}
-              {reviewAvailable && (
-                <Flexbox className={activeTab === 'review' ? styles.pane : styles.paneHidden}>
-                  <Review
-                    active={activeTab === 'review'}
-                    composerTarget={composerTarget}
-                    deviceId={remoteDeviceId}
-                    showTree={showReviewTree}
-                    workingDirectory={workingDirectory}
-                    onToggleTree={() => setShowReviewTree((v) => !v)}
-                  />
-                </Flexbox>
-              )}
-              {filesAvailable && (
-                <Activity mode={showRightPanel && activeTab === 'files' ? 'visible' : 'hidden'}>
-                  <Flexbox className={styles.pane}>
-                    <Files deviceId={remoteDeviceId} workingDirectory={workingDirectory} />
-                  </Flexbox>
-                </Activity>
-              )}
-              {browserAvailable &&
-                openedTabs.filter(isBrowserTab).map((tab) => {
-                  const sessionId =
-                    tab === BROWSER_TAB_KEY
-                      ? browserSessionId
-                      : `${browserSessionId}:tab:${tab.slice(BROWSER_TAB_PREFIX.length)}`;
+        )}
+      </Flexbox>
+    </Flexbox>
+  );
 
-                  return (
-                    <Flexbox
-                      className={activeTab === tab ? styles.pane : styles.paneHidden}
-                      key={sessionId}
+  return (
+    <>
+      {overviewPanel}
+      <RightPanel
+        stableLayout
+        collapseThreshold={320}
+        defaultWidth={renderWidth}
+        expand={Boolean(showRightPanel) && fits && activeTab !== 'overview'}
+        maxWidth={maxPanelWidth}
+        minWidth={MIN_PANEL_WIDTH}
+        style={!showRightPanel || activeTab === 'overview' ? { visibility: 'hidden' } : undefined}
+        width={renderWidth}
+        onSizeChange={(size) => {
+          if (!size?.width) return;
+          // DraggablePanel emits width as a `"420px"` string on drag-stop; parse it so
+          // the controlled width actually updates (otherwise the panel snaps back).
+          const w = typeof size.width === 'string' ? Number.parseInt(size.width) : size.width;
+          if (!Number.isFinite(w) || w === storedWidth) return;
+          updateSystemStatus({ workingSidebarWidth: w });
+        }}
+      >
+        <Flexbox height={'100%'} width={'100%'}>
+          <Flexbox
+            horizontal
+            align={'center'}
+            className={styles.header}
+            gap={4}
+            height={44}
+            justify={'space-between'}
+            paddingInline={4}
+          >
+            <div className={styles.tabsArea}>
+              <div className={styles.tabs} ref={tabsRef}>
+                {displayedTabs.map((tab, index) => (
+                  <WorkspaceTab
+                    active={activeTab === tab.key}
+                    closeLabel={t('workingPanel.tabs.close')}
+                    contextMenuItems={createTabContextMenuItems(tab.key, index)}
+                    icon={tab.icon}
+                    iconNode={tab.iconNode}
+                    key={tab.key}
+                    label={tab.label}
+                    pinned={pinnedTabsSet.has(tab.key)}
+                    pinnedLabel={t('workingPanel.tabs.pinned')}
+                    tabKey={tab.key}
+                    onClose={pinnedTabsSet.has(tab.key) ? undefined : () => closeTab(tab.key)}
+                    onSelect={() => openTab(tab.key)}
+                  />
+                ))}
+              </div>
+              <DropdownMenu
+                items={openMenuItems}
+                placement={'bottomRight'}
+                onOpenChangeComplete={(open) => {
+                  if (open) return;
+                  if (pendingTabFocusRef.current) focusPendingTab();
+                  else scrollActiveTabIntoView();
+                }}
+              >
+                <ActionIcon
+                  className={styles.add}
+                  icon={PlusIcon}
+                  size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+                  title={t('workingPanel.openMenu.title')}
+                />
+              </DropdownMenu>
+            </div>
+            <ActionIcon
+              className={styles.close}
+              icon={PanelRightCloseIcon}
+              size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+              onClick={() => toggleRightPanel(false)}
+            />
+          </Flexbox>
+          <Flexbox className={styles.body} width={'100%'}>
+            {!contentReady && <SkeletonList paddingBlock={8} paddingInline={8} rows={6} />}
+            {contentReady && (
+              <>
+                {commentsAvailable && (
+                  <Flexbox
+                    className={activeTab === 'comments' ? styles.pane : styles.paneHidden}
+                    style={{ overflow: 'hidden' }}
+                  >
+                    <TopicCommentsSidebar />
+                  </Flexbox>
+                )}
+                {paramsAvailable && activeTab === 'params' && (
+                  <Flexbox className={styles.pane}>
+                    <Suspense
+                      fallback={
+                        <Skeleton
+                          active
+                          className={styles.paramsLoading}
+                          paragraph={{ rows: 6 }}
+                          title={false}
+                        />
+                      }
                     >
-                      <BrowserPane
-                        agentId={activeAgentId}
-                        composerTarget={composerTarget}
-                        sessionId={sessionId}
-                        onMetadataChange={(metadata) => {
-                          const metadataKey = `${openTabsContextKey}:${tab}`;
-                          setBrowserTabMetadata((current) =>
-                            current[metadataKey]?.faviconUrl === metadata.faviconUrl &&
-                            current[metadataKey]?.title === metadata.title &&
-                            current[metadataKey]?.url === metadata.url
-                              ? current
-                              : { ...current, [metadataKey]: metadata },
-                          );
-                        }}
-                      />
+                      <ParamsSection />
+                    </Suspense>
+                  </Flexbox>
+                )}
+                {reviewAvailable && (
+                  <Flexbox className={activeTab === 'review' ? styles.pane : styles.paneHidden}>
+                    <Review
+                      active={activeTab === 'review'}
+                      composerTarget={composerTarget}
+                      deviceId={remoteDeviceId}
+                      showTree={showReviewTree}
+                      workingDirectory={workingDirectory}
+                      onToggleTree={() => setShowReviewTree((v) => !v)}
+                    />
+                  </Flexbox>
+                )}
+                {filesAvailable && (
+                  <Activity mode={showRightPanel && activeTab === 'files' ? 'visible' : 'hidden'}>
+                    <Flexbox className={styles.pane}>
+                      <Files deviceId={remoteDeviceId} workingDirectory={workingDirectory} />
                     </Flexbox>
-                  );
-                })}
-              {businessTabs.map((tab) => (
-                <Flexbox
-                  className={activeTab === tab.key ? styles.pane : styles.paneHidden}
-                  key={tab.key}
-                >
-                  {tab.pane}
-                </Flexbox>
-              ))}
-              {/* Resource/works panes stay mounted to keep their state, but hidden ones
+                  </Activity>
+                )}
+                {browserAvailable &&
+                  openedTabs.filter(isBrowserTab).map((tab) => {
+                    const sessionId =
+                      tab === BROWSER_TAB_KEY
+                        ? browserSessionId
+                        : `${browserSessionId}:tab:${tab.slice(BROWSER_TAB_PREFIX.length)}`;
+
+                    return (
+                      <Flexbox
+                        className={activeTab === tab ? styles.pane : styles.paneHidden}
+                        key={sessionId}
+                      >
+                        <BrowserPane
+                          agentId={activeAgentId}
+                          composerTarget={composerTarget}
+                          sessionId={sessionId}
+                          onMetadataChange={(metadata) => {
+                            const metadataKey = `${openTabsContextKey}:${tab}`;
+                            setBrowserTabMetadata((current) =>
+                              current[metadataKey]?.faviconUrl === metadata.faviconUrl &&
+                              current[metadataKey]?.title === metadata.title &&
+                              current[metadataKey]?.url === metadata.url
+                                ? current
+                                : { ...current, [metadataKey]: metadata },
+                            );
+                          }}
+                        />
+                      </Flexbox>
+                    );
+                  })}
+                {businessTabs.map((tab) => (
+                  <Flexbox
+                    className={activeTab === tab.key ? styles.pane : styles.paneHidden}
+                    key={tab.key}
+                  >
+                    {tab.pane}
+                  </Flexbox>
+                ))}
+                {/* Resource/works panes stay mounted to keep their state, but hidden ones
            go through Activity so their updates render at background priority
            instead of blocking visible commits (BrowserPane must NOT move here —
            hiding it would unmount the effects keeping its session alive). */}
-              {['skills', ...(isHetero ? [] : ['documents', 'web'])].map((resourceTab) => (
-                <Activity
-                  key={resourceTab}
-                  mode={showRightPanel && activeTab === resourceTab ? 'visible' : 'hidden'}
-                >
-                  <Flexbox className={styles.pane} width={'100%'}>
-                    <ResourcesSection
-                      deviceId={remoteDeviceId}
-                      enabled={showRightPanel && activeTab === resourceTab}
-                      filter={resourceTab as 'skills' | 'documents' | 'web'}
-                    />
+                {['skills', ...(isHetero ? [] : ['documents', 'web'])].map((resourceTab) => (
+                  <Activity
+                    key={resourceTab}
+                    mode={showRightPanel && activeTab === resourceTab ? 'visible' : 'hidden'}
+                  >
+                    <Flexbox className={styles.pane} width={'100%'}>
+                      <ResourcesSection
+                        deviceId={remoteDeviceId}
+                        enabled={showRightPanel && activeTab === resourceTab}
+                        filter={resourceTab as 'skills' | 'documents' | 'web'}
+                      />
+                    </Flexbox>
+                  </Activity>
+                ))}
+                <Activity mode={showRightPanel && activeTab === 'works' ? 'visible' : 'hidden'}>
+                  <Flexbox className={styles.pane}>
+                    <WorksSection active={showRightPanel && activeTab === 'works'} />
                   </Flexbox>
                 </Activity>
-              ))}
-              <Activity mode={showRightPanel && activeTab === 'works' ? 'visible' : 'hidden'}>
-                <Flexbox className={styles.pane}>
-                  <WorksSection active={showRightPanel && activeTab === 'works'} />
-                </Flexbox>
-              </Activity>
-            </>
-          )}
+              </>
+            )}
+          </Flexbox>
         </Flexbox>
-      </Flexbox>
-    </RightPanel>
+      </RightPanel>
+    </>
   );
 });
 

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -231,7 +231,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     // the resources pane's document fetch so a collapsed sidebar doesn't pull the
     // full agent-document list into the conversation's initial batch.
     s.status.showRightPanel,
-    s.status.showWorkingOverview ?? true,
+    s.status.showWorkingOverview ?? !s.status.showRightPanel,
     s.status.workingSidebarTab,
     s.status.workingSidebarTabRequest,
   ]);
@@ -474,10 +474,10 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     (updater: (tabs: string[]) => string[]) => {
       setOpenTabsByContext((current) => ({
         ...current,
-        [openTabsContextKey]: updater(current[openTabsContextKey] ?? []),
+        [openTabsContextKey]: updater(current[openTabsContextKey] ?? defaultOpenedTabs),
       }));
     },
-    [openTabsContextKey, setOpenTabsByContext],
+    [defaultOpenedTabs, openTabsContextKey, setOpenTabsByContext],
   );
 
   const updatePinnedTabs = useCallback(
@@ -599,12 +599,16 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       const removableTabs = new Set(tabs.filter((tab) => !pinnedTabsSet.has(tab)));
       if (removableTabs.size === 0) return;
 
-      updateOpenedTabs((current) => current.filter((tab) => !removableTabs.has(tab)));
+      const remainingTabs = openedTabs.filter((tab) => !removableTabs.has(tab));
+      updateOpenedTabs(() => remainingTabs);
       if (removableTabs.has(activeTab)) {
-        setOptimisticTab(fallbackTab);
-        setWorkingSidebarTab(fallbackTab);
+        const nextTab = remainingTabs.includes(fallbackTab)
+          ? fallbackTab
+          : (remainingTabs[0] ?? 'overview');
+        setOptimisticTab(nextTab);
+        setWorkingSidebarTab(nextTab);
       }
-      if (openedTabs.every((tab) => removableTabs.has(tab) || pinnedTabsSet.has(tab))) {
+      if (remainingTabs.length === 0) {
         toggleRightPanel(false);
       }
     },
@@ -869,7 +873,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     toggleTerminalPanel,
   ]);
 
-  const overviewPanel = showWorkingOverview && (
+  const overviewPanel = showWorkingOverview && fits && (
     <Flexbox className={styles.overviewPanel} role={'complementary'}>
       <Flexbox
         horizontal

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -119,7 +119,6 @@ const styles = createStaticStyles(({ css }) => ({
     flex-shrink: 0;
     padding-block: 6px;
     padding-inline: 12px 8px;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   overviewPanel: css`
     overflow: hidden;
@@ -882,7 +881,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
         <span className={styles.overviewTitle}>{t('workingPanel.overview.title')}</span>
         <ActionIcon
           aria-label={t('workingPanel.tabs.closePanel')}
-          icon={PanelRightCloseIcon}
+          icon={XIcon}
           size={DESKTOP_HEADER_ICON_SMALL_SIZE}
           title={t('workingPanel.tabs.closePanel')}
           onClick={() => updateSystemStatus({ showWorkingOverview: false })}

--- a/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
@@ -16,7 +16,7 @@ const WorkingPanelToggle = memo(() => {
   const [showRightPanel, showWorkingOverview, toggleRightPanel, updateSystemStatus, isStatusInit] =
     useGlobalStore((s) => [
       systemStatusSelectors.showRightPanel(s),
-      s.status.showWorkingOverview ?? true,
+      s.status.showWorkingOverview ?? !s.status.showRightPanel,
       s.toggleRightPanel,
       s.updateSystemStatus,
       systemStatusSelectors.isStatusInit(s),

--- a/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
@@ -2,7 +2,7 @@
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@lobechat/const';
 import { ActionIcon } from '@lobehub/ui/base-ui';
-import { PanelRightOpenIcon } from 'lucide-react';
+import { LayoutDashboardIcon, PanelRightOpenIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
@@ -13,11 +13,14 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 const WorkingPanelToggle = memo(() => {
   const { t } = useTranslation('chat');
   const { pathname } = useLocation();
-  const [showRightPanel, toggleRightPanel, isStatusInit] = useGlobalStore((s) => [
-    systemStatusSelectors.showRightPanel(s),
-    s.toggleRightPanel,
-    systemStatusSelectors.isStatusInit(s),
-  ]);
+  const [showRightPanel, showWorkingOverview, toggleRightPanel, updateSystemStatus, isStatusInit] =
+    useGlobalStore((s) => [
+      systemStatusSelectors.showRightPanel(s),
+      s.status.showWorkingOverview ?? true,
+      s.toggleRightPanel,
+      s.updateSystemStatus,
+      systemStatusSelectors.isStatusInit(s),
+    ]);
 
   // The popup window has no WorkingSidebar — hide the toggle to avoid a
   // button that does nothing visible.
@@ -27,19 +30,33 @@ const WorkingPanelToggle = memo(() => {
   // !isStatusInit, so clicks here would otherwise be silently dropped.
   if (!isStatusInit) return null;
 
-  if (showRightPanel) return null;
-
-  // Open the panel without touching the tab preference — the sidebar's own
-  // resolveActiveTab will pick the right default (and honor the user's last
-  // explicit click). Force-setting `review` here would overwrite a previously
-  // picked Space/Files tab every time the panel is re-opened.
   return (
-    <ActionIcon
-      icon={PanelRightOpenIcon}
-      size={DESKTOP_HEADER_ICON_SMALL_SIZE}
-      title={t('workingPanel.title')}
-      onClick={() => toggleRightPanel(true)}
-    />
+    <>
+      {!showWorkingOverview && (
+        <ActionIcon
+          aria-label={t('workingPanel.overview.title')}
+          icon={LayoutDashboardIcon}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+          title={t('workingPanel.overview.title')}
+          onClick={() => {
+            toggleRightPanel(false);
+            updateSystemStatus({ showWorkingOverview: true });
+          }}
+        />
+      )}
+      {!showRightPanel && (
+        <ActionIcon
+          aria-label={t('workingPanel.title')}
+          icon={PanelRightOpenIcon}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+          title={t('workingPanel.title')}
+          onClick={() => {
+            updateSystemStatus({ showWorkingOverview: false });
+            toggleRightPanel(true);
+          }}
+        />
+      )}
+    </>
   );
 });
 

--- a/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
@@ -13,14 +13,21 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 const WorkingPanelToggle = memo(() => {
   const { t } = useTranslation('chat');
   const { pathname } = useLocation();
-  const [showRightPanel, showWorkingOverview, toggleRightPanel, updateSystemStatus, isStatusInit] =
-    useGlobalStore((s) => [
-      systemStatusSelectors.showRightPanel(s),
-      s.status.showWorkingOverview ?? !s.status.showRightPanel,
-      s.toggleRightPanel,
-      s.updateSystemStatus,
-      systemStatusSelectors.isStatusInit(s),
-    ]);
+  const [
+    showRightPanel,
+    showWorkingOverview,
+    toggleRightPanel,
+    openWorkingSidebar,
+    updateSystemStatus,
+    isStatusInit,
+  ] = useGlobalStore((s) => [
+    systemStatusSelectors.showRightPanel(s),
+    s.status.showWorkingOverview ?? !s.status.showRightPanel,
+    s.toggleRightPanel,
+    s.openWorkingSidebar,
+    s.updateSystemStatus,
+    systemStatusSelectors.isStatusInit(s),
+  ]);
 
   // The popup window has no WorkingSidebar — hide the toggle to avoid a
   // button that does nothing visible.
@@ -50,10 +57,7 @@ const WorkingPanelToggle = memo(() => {
           icon={PanelRightOpenIcon}
           size={DESKTOP_HEADER_ICON_SMALL_SIZE}
           title={t('workingPanel.title')}
-          onClick={() => {
-            updateSystemStatus({ showWorkingOverview: false });
-            toggleRightPanel(true);
-          }}
+          onClick={() => openWorkingSidebar()}
         />
       )}
     </>

--- a/src/store/chat/slices/portal/action.ts
+++ b/src/store/chat/slices/portal/action.ts
@@ -647,9 +647,7 @@ export class ChatPortalActionImpl {
   };
 
   openTopicComments = (topicId: string, messageId?: string): void => {
-    const { setWorkingSidebarTab, toggleRightPanel } = useGlobalStore.getState();
-    toggleRightPanel(true);
-    setWorkingSidebarTab('comments');
+    useGlobalStore.getState().openWorkingSidebar('comments');
     this.#get().pushPortalView({ messageId, topicId, type: PortalViewType.TopicComments });
   };
 

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -95,6 +95,20 @@ describe('createPreferenceSlice', () => {
     });
   });
 
+  describe('toggleWorkingOverview', () => {
+    it('toggles the overview independently from the workspace panel', () => {
+      const { result } = renderHook(() => useGlobalStore());
+
+      act(() => {
+        useGlobalStore.setState({ isStatusInit: true });
+        result.current.toggleWorkingOverview(false);
+      });
+
+      expect(result.current.status.showWorkingOverview).toBe(false);
+      expect(result.current.status.showRightPanel).toBe(false);
+    });
+  });
+
   describe('setWorkingSidebarTab', () => {
     it('emits a new request when the already-selected tab is requested again', () => {
       const { result } = renderHook(() => useGlobalStore());

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -153,6 +153,29 @@ describe('createPreferenceSlice', () => {
     });
   });
 
+  describe('openWorkingSidebar', () => {
+    it('opens a requested workspace tab and closes the independent overview atomically', () => {
+      const { result } = renderHook(() => useGlobalStore());
+
+      act(() => {
+        useGlobalStore.setState({
+          isStatusInit: true,
+          status: {
+            ...initialState.status,
+            showRightPanel: false,
+            showWorkingOverview: true,
+          },
+        });
+        result.current.openWorkingSidebar('review');
+      });
+
+      expect(result.current.status.showRightPanel).toBe(true);
+      expect(result.current.status.showWorkingOverview).toBe(false);
+      expect(result.current.status.workingSidebarTab).toBe('review');
+      expect(result.current.status.workingSidebarTabRequest?.tab).toBe('review');
+    });
+  });
+
   describe('openInBrowserTab / clearBrowserTabRequest', () => {
     it('should raise a one-shot browser request and retire it once consumed', () => {
       const { result } = renderHook(() => useGlobalStore());

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -107,6 +107,24 @@ describe('createPreferenceSlice', () => {
       expect(result.current.status.showWorkingOverview).toBe(false);
       expect(result.current.status.showRightPanel).toBe(false);
     });
+
+    it('derives a missing legacy overview flag from the workspace panel state', () => {
+      const { result } = renderHook(() => useGlobalStore());
+
+      act(() => {
+        useGlobalStore.setState({
+          isStatusInit: true,
+          status: {
+            ...initialState.status,
+            showRightPanel: true,
+            showWorkingOverview: undefined,
+          },
+        });
+        result.current.toggleWorkingOverview();
+      });
+
+      expect(result.current.status.showWorkingOverview).toBe(true);
+    });
   });
 
   describe('setWorkingSidebarTab', () => {

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -141,7 +141,8 @@ export class GlobalWorkspacePaneActionImpl {
   };
 
   toggleWorkingOverview = (newValue?: boolean): void => {
-    const currentValue = this.#get().status.showWorkingOverview ?? true;
+    const currentValue =
+      this.#get().status.showWorkingOverview ?? !this.#get().status.showRightPanel;
     const showWorkingOverview = typeof newValue === 'boolean' ? newValue : !currentValue;
 
     this.#get().updateSystemStatus({ showWorkingOverview }, n('toggleWorkingOverview', newValue));

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -173,8 +173,25 @@ export class GlobalWorkspacePaneActionImpl {
     );
   };
 
+  openWorkingSidebar = (tab?: WorkingSidebarTab): void => {
+    const previousNonce = this.#get().status.workingSidebarTabRequest?.nonce ?? 0;
+    this.#get().updateSystemStatus(
+      {
+        showRightPanel: true,
+        showWorkingOverview: false,
+        ...(tab
+          ? {
+              workingSidebarTab: tab,
+              workingSidebarTabRequest: { nonce: previousNonce + 1, tab },
+            }
+          : {}),
+      },
+      n('openWorkingSidebar', tab),
+    );
+  };
+
   revealInFilesTab = (relativePath: string): void => {
-    this.#get().setWorkingSidebarTab('files');
+    this.#get().openWorkingSidebar('files');
     this.#get().updateSystemStatus(
       { workingSidebarRevealRequest: { nonce: Date.now(), path: relativePath } },
       n('revealInFilesTab'),
@@ -182,8 +199,7 @@ export class GlobalWorkspacePaneActionImpl {
   };
 
   openInBrowserTab = (url: string): void => {
-    this.#get().toggleRightPanel(true);
-    this.#get().setWorkingSidebarTab('browser');
+    this.#get().openWorkingSidebar('browser');
     this.#get().updateSystemStatus(
       { workingSidebarBrowserRequest: { nonce: Date.now(), url } },
       n('openInBrowserTab'),

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -140,6 +140,13 @@ export class GlobalWorkspacePaneActionImpl {
     this.#get().updateSystemStatus({ showRightPanel }, n('toggleRightPanel', newValue));
   };
 
+  toggleWorkingOverview = (newValue?: boolean): void => {
+    const currentValue = this.#get().status.showWorkingOverview ?? true;
+    const showWorkingOverview = typeof newValue === 'boolean' ? newValue : !currentValue;
+
+    this.#get().updateSystemStatus({ showWorkingOverview }, n('toggleWorkingOverview', newValue));
+  };
+
   toggleTerminalPanel = (newValue?: boolean): void => {
     const showTerminalPanel =
       typeof newValue === 'boolean' ? newValue : !this.#get().status.showTerminalPanel;

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -571,7 +571,6 @@ export const INITIAL_STATUS = {
   showLeftPanel: true,
   showPageAgentPanel: true,
   showRightPanel: false,
-  showWorkingOverview: true,
   showSystemRole: false,
   showTaskAgentPanel: false,
   showTerminalPanel: false,

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -342,6 +342,8 @@ export interface SystemStatus {
   showVerifyReportPanel?: boolean;
   showVideoPanel?: boolean;
   showVideoTopicPanel?: boolean;
+  /** Visibility of the lightweight chat overview card. Independent from the workspace panel. */
+  showWorkingOverview?: boolean;
   /**
    * Flat ordered list of sidebar items.
    */
@@ -569,6 +571,7 @@ export const INITIAL_STATUS = {
   showLeftPanel: true,
   showPageAgentPanel: true,
   showRightPanel: false,
+  showWorkingOverview: true,
   showSystemRole: false,
   showTaskAgentPanel: false,
   showTerminalPanel: false,


### PR DESCRIPTION
## Summary

- split the lightweight conversation overview from the full workspace panel, with independent controls and mutually exclusive presentation
- make the overview card more compact and open Files / Skills / Documents by default in priority order
- remove failure counts and partial-failure warning badges from collapsed workflow summaries

## Verification

- `bun run check` on the original workspace: 80 related tests passed, followed by 75 and 41 focused tests after review refinements
- clean `origin/canary` worktree: 96 tests passed; one WorkflowCollapse suite could not resolve the app alias because the temporary worktree reused the main checkout node_modules through a symlink (the same suite passes in the original workspace)
- agent-testing web verification completed on fresh ports through Round 7

## Acceptance

https://app.lobehub.com/acceptance/956873b9-d4da-4eac-a3d2-b55857337b78?r=7