### PR TITLE
🐛 fix: remove bulk topic deletion menu actions

### DIFF
--- a/src/features/AgentSidebar/Topic/useDropdownMenu.test.tsx
+++ b/src/features/AgentSidebar/Topic/useDropdownMenu.test.tsx
@@ -131,41 +131,15 @@ describe('useTopicActionsDropdownMenu', () => {
     expect(getMenuItem(result.current()!, 'archiveMergedPullRequests')).toMatchObject({
       disabled: true,
     });
-    expect(getMenuItem(result.current()!, 'deleteUnstarred')).toMatchObject({ disabled: true });
-    expect(getMenuItem(result.current()!, 'deleteAll')).toMatchObject({ disabled: true });
+    expect(getMenuItem(result.current()!, 'deleteUnstarred')).toBeUndefined();
+    expect(getMenuItem(result.current()!, 'deleteAll')).toBeUndefined();
   });
 
-  it('keeps the personal delete-all copy', () => {
+  it('does not expose bulk delete actions in the topic menu', () => {
     const { result } = renderHook(() => useTopicActionsDropdownMenu());
-    const item = getMenuItem(result.current()!, 'deleteAll');
 
-    expect(item).toMatchObject({ label: 'actions.removeAll' });
-    if (item && 'onClick' in item) item.onClick?.({} as never);
-    expect(confirmModalMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: 'actions.confirmRemoveAll',
-        title: 'actions.removeAll',
-      }),
-    );
-  });
-
-  it('uses caller-scoped delete-all copy for workspace members', async () => {
-    workspaceMock.activeWorkspaceId = 'workspace-1';
-
-    const { result } = renderHook(() => useTopicActionsDropdownMenu());
-    const item = getMenuItem(result.current()!, 'deleteAll');
-
-    expect(item).toMatchObject({ label: 'actions.removeAllOwn' });
-    if (item && 'onClick' in item) item.onClick?.({} as never);
-    expect(confirmModalMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: 'actions.confirmRemoveAllOwn',
-        title: 'actions.removeAllOwn',
-      }),
-    );
-    expect(getMenuItem(result.current()!, 'deleteAllWorkspace')).toBeUndefined();
-    await confirmModalMock.mock.calls[0][0].onOk();
-    expect(removeSessionTopicsMock).toHaveBeenCalledWith('own');
+    expect(getMenuItem(result.current()!, 'deleteUnstarred')).toBeUndefined();
+    expect(getMenuItem(result.current()!, 'deleteAll')).toBeUndefined();
   });
 
   it('gives workspace owners separate own and workspace maintenance actions', async () => {
@@ -191,18 +165,12 @@ describe('useTopicActionsDropdownMenu', () => {
     ];
 
     const { result } = renderHook(() => useTopicActionsDropdownMenu());
-    const ownItem = getMenuItem(result.current()!, 'deleteAll');
     const workspaceArchiveItem = getMenuItem(
       result.current()!,
       'archiveMergedPullRequestsWorkspace',
     );
     const workspaceUnstarredItem = getMenuItem(result.current()!, 'deleteUnstarredWorkspace');
     const workspaceItem = getMenuItem(result.current()!, 'deleteAllWorkspace');
-
-    expect(ownItem).toMatchObject({ label: 'actions.removeAllOwn' });
-    if (ownItem && 'onClick' in ownItem) ownItem.onClick?.({} as never);
-    await confirmModalMock.mock.calls[0][0].onOk();
-    expect(removeSessionTopicsMock).toHaveBeenCalledWith('own');
 
     expect(workspaceArchiveItem).toMatchObject({
       label: 'actions.archiveMergedPullRequestsWorkspace',
@@ -213,7 +181,7 @@ describe('useTopicActionsDropdownMenu', () => {
     expect(confirmModalMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ title: 'actions.confirmArchiveMergedPullRequestsWorkspace' }),
     );
-    await confirmModalMock.mock.calls[1][0].onOk();
+    await confirmModalMock.mock.calls[0][0].onOk();
     expect(chatStoreMock.updateTopicStatus).toHaveBeenCalledTimes(2);
     expect(chatStoreMock.updateTopicStatus).toHaveBeenCalledWith({
       status: 'completed',
@@ -276,7 +244,6 @@ describe('useTopicActionsDropdownMenu', () => {
 
     const { result } = renderHook(() => useTopicActionsDropdownMenu());
     const archiveItem = getMenuItem(result.current()!, 'archiveMergedPullRequests');
-    const deleteUnstarredItem = getMenuItem(result.current()!, 'deleteUnstarred');
 
     expect(archiveItem).toMatchObject({ label: 'actions.archiveMergedPullRequestsOwn' });
     if (archiveItem && 'onClick' in archiveItem) await archiveItem.onClick?.({} as never);
@@ -286,16 +253,8 @@ describe('useTopicActionsDropdownMenu', () => {
       topicId: 'own-merged',
     });
 
-    expect(deleteUnstarredItem).toMatchObject({ label: 'actions.removeUnstarredOwn' });
-    if (deleteUnstarredItem && 'onClick' in deleteUnstarredItem) {
-      deleteUnstarredItem.onClick?.({} as never);
-    }
-    expect(confirmModalMock.mock.calls[0][0]).toMatchObject({
-      content: 'actions.confirmRemoveUnstarredOwn',
-      title: 'actions.removeUnstarredOwn',
-    });
-    await confirmModalMock.mock.calls[0][0].onOk();
-    expect(removeUnstarredTopicMock).toHaveBeenCalledWith({ onlyOwn: true });
+    expect(getMenuItem(result.current()!, 'deleteUnstarred')).toBeUndefined();
+    expect(getMenuItem(result.current()!, 'deleteAll')).toBeUndefined();
     expect(getMenuItem(result.current()!, 'archiveMergedPullRequestsWorkspace')).toBeUndefined();
     expect(getMenuItem(result.current()!, 'deleteUnstarredWorkspace')).toBeUndefined();
   });

--- a/src/features/AgentSidebar/Topic/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/useDropdownMenu.tsx
@@ -193,45 +193,6 @@ export const useTopicActionsDropdownMenu = (
         ),
         onClick: () => handleArchiveMergedPullRequests('own'),
       },
-      {
-        disabled: !canEditTopic,
-        icon: <Icon icon={Trash} />,
-        key: 'deleteUnstarred',
-        label: t(activeWorkspaceId ? 'actions.removeUnstarredOwn' : 'actions.removeUnstarred'),
-        onClick: () => {
-          confirmModal({
-            cancelText: t('cancel', { ns: 'common' }),
-            content: t(
-              activeWorkspaceId
-                ? 'actions.confirmRemoveUnstarredOwn'
-                : 'actions.confirmRemoveUnstarred',
-            ),
-            okButtonProps: { danger: true },
-            okText: t('ok', { ns: 'common' }),
-            onOk: () => removeUnstarredTopic({ onlyOwn: !!activeWorkspaceId }),
-            title: t(activeWorkspaceId ? 'actions.removeUnstarredOwn' : 'actions.removeUnstarred'),
-          });
-        },
-      },
-      {
-        danger: true,
-        disabled: !canEditTopic,
-        icon: <Icon icon={Trash} />,
-        key: 'deleteAll',
-        label: t(activeWorkspaceId ? 'actions.removeAllOwn' : 'actions.removeAll'),
-        onClick: () => {
-          confirmModal({
-            cancelText: t('cancel', { ns: 'common' }),
-            content: t(
-              activeWorkspaceId ? 'actions.confirmRemoveAllOwn' : 'actions.confirmRemoveAll',
-            ),
-            okButtonProps: { danger: true },
-            okText: t('ok', { ns: 'common' }),
-            onOk: () => removeAllTopic('own'),
-            title: t(activeWorkspaceId ? 'actions.removeAllOwn' : 'actions.removeAll'),
-          });
-        },
-      },
       ...(activeWorkspaceId && isWorkspaceOwner
         ? [
             { type: 'divider' as const },

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.test.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.test.tsx
@@ -132,41 +132,15 @@ describe('group useTopicActionsDropdownMenu', () => {
     expect(getMenuItem(result.current!, 'archiveMergedPullRequests')).toMatchObject({
       disabled: true,
     });
-    expect(getMenuItem(result.current!, 'deleteUnstarred')).toMatchObject({ disabled: true });
-    expect(getMenuItem(result.current!, 'deleteAll')).toMatchObject({ disabled: true });
+    expect(getMenuItem(result.current!, 'deleteUnstarred')).toBeUndefined();
+    expect(getMenuItem(result.current!, 'deleteAll')).toBeUndefined();
   });
 
-  it('keeps the personal delete-all copy and deletes through the group scope', async () => {
+  it('does not expose bulk delete actions in the topic menu', () => {
     const { result } = renderHook(() => useTopicActionsDropdownMenu());
-    const item = getMenuItem(result.current!, 'deleteAll');
 
-    expect(item).toMatchObject({ label: 'actions.removeAll' });
-    if (item && 'onClick' in item) item.onClick?.({} as never);
-
-    const [{ content, onOk, title }] = confirmModalMock.mock.calls[0];
-    expect(content).toBe('actions.confirmRemoveAll');
-    expect(title).toBe('actions.removeAll');
-    await onOk();
-    expect(removeGroupTopicsMock).toHaveBeenCalledWith('group-1', 'own');
-  });
-
-  it('uses caller-scoped delete-all copy for workspace members', async () => {
-    workspaceMock.activeWorkspaceId = 'workspace-1';
-
-    const { result } = renderHook(() => useTopicActionsDropdownMenu());
-    const item = getMenuItem(result.current!, 'deleteAll');
-
-    expect(item).toMatchObject({ label: 'actions.removeAllOwn' });
-    if (item && 'onClick' in item) item.onClick?.({} as never);
-    expect(confirmModalMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: 'actions.confirmRemoveAllOwn',
-        title: 'actions.removeAllOwn',
-      }),
-    );
-    expect(getMenuItem(result.current!, 'deleteAllWorkspace')).toBeUndefined();
-    await confirmModalMock.mock.calls[0][0].onOk();
-    expect(removeGroupTopicsMock).toHaveBeenCalledWith('group-1', 'own');
+    expect(getMenuItem(result.current!, 'deleteUnstarred')).toBeUndefined();
+    expect(getMenuItem(result.current!, 'deleteAll')).toBeUndefined();
   });
 
   it('gives workspace owners separate own and workspace maintenance actions', async () => {
@@ -192,15 +166,9 @@ describe('group useTopicActionsDropdownMenu', () => {
     ];
 
     const { result } = renderHook(() => useTopicActionsDropdownMenu());
-    const ownItem = getMenuItem(result.current!, 'deleteAll');
     const workspaceArchiveItem = getMenuItem(result.current!, 'archiveMergedPullRequestsWorkspace');
     const workspaceUnstarredItem = getMenuItem(result.current!, 'deleteUnstarredWorkspace');
     const workspaceItem = getMenuItem(result.current!, 'deleteAllWorkspace');
-
-    expect(ownItem).toMatchObject({ label: 'actions.removeAllOwn' });
-    if (ownItem && 'onClick' in ownItem) ownItem.onClick?.({} as never);
-    await confirmModalMock.mock.calls[0][0].onOk();
-    expect(removeGroupTopicsMock).toHaveBeenCalledWith('group-1', 'own');
 
     expect(workspaceArchiveItem).toMatchObject({
       label: 'actions.archiveMergedPullRequestsWorkspace',
@@ -211,7 +179,7 @@ describe('group useTopicActionsDropdownMenu', () => {
     expect(confirmModalMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ title: 'actions.confirmArchiveMergedPullRequestsWorkspace' }),
     );
-    await confirmModalMock.mock.calls[1][0].onOk();
+    await confirmModalMock.mock.calls[0][0].onOk();
     expect(chatStoreMock.updateTopicStatus).toHaveBeenCalledTimes(2);
     expect(chatStoreMock.updateTopicStatus).toHaveBeenCalledWith({
       status: 'completed',
@@ -274,7 +242,6 @@ describe('group useTopicActionsDropdownMenu', () => {
 
     const { result } = renderHook(() => useTopicActionsDropdownMenu());
     const archiveItem = getMenuItem(result.current!, 'archiveMergedPullRequests');
-    const deleteUnstarredItem = getMenuItem(result.current!, 'deleteUnstarred');
 
     expect(archiveItem).toMatchObject({ label: 'actions.archiveMergedPullRequestsOwn' });
     if (archiveItem && 'onClick' in archiveItem) await archiveItem.onClick?.({} as never);
@@ -284,16 +251,8 @@ describe('group useTopicActionsDropdownMenu', () => {
       topicId: 'own-merged',
     });
 
-    expect(deleteUnstarredItem).toMatchObject({ label: 'actions.removeUnstarredOwn' });
-    if (deleteUnstarredItem && 'onClick' in deleteUnstarredItem) {
-      deleteUnstarredItem.onClick?.({} as never);
-    }
-    expect(confirmModalMock.mock.calls[0][0]).toMatchObject({
-      content: 'actions.confirmRemoveUnstarredOwn',
-      title: 'actions.removeUnstarredOwn',
-    });
-    await confirmModalMock.mock.calls[0][0].onOk();
-    expect(removeUnstarredTopicMock).toHaveBeenCalledWith({ onlyOwn: true });
+    expect(getMenuItem(result.current!, 'deleteUnstarred')).toBeUndefined();
+    expect(getMenuItem(result.current!, 'deleteAll')).toBeUndefined();
     expect(getMenuItem(result.current!, 'archiveMergedPullRequestsWorkspace')).toBeUndefined();
     expect(getMenuItem(result.current!, 'deleteUnstarredWorkspace')).toBeUndefined();
   });

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx
@@ -182,45 +182,6 @@ export const useTopicActionsDropdownMenu = (
         ),
         onClick: () => handleArchiveMergedPullRequests('own'),
       },
-      {
-        disabled: !canEditTopic,
-        icon: <Icon icon={Trash} />,
-        key: 'deleteUnstarred',
-        label: t(activeWorkspaceId ? 'actions.removeUnstarredOwn' : 'actions.removeUnstarred'),
-        onClick: () => {
-          confirmModal({
-            cancelText: t('cancel', { ns: 'common' }),
-            content: t(
-              activeWorkspaceId
-                ? 'actions.confirmRemoveUnstarredOwn'
-                : 'actions.confirmRemoveUnstarred',
-            ),
-            okButtonProps: { danger: true },
-            okText: t('ok', { ns: 'common' }),
-            onOk: () => removeUnstarredTopic({ onlyOwn: !!activeWorkspaceId }),
-            title: t(activeWorkspaceId ? 'actions.removeUnstarredOwn' : 'actions.removeUnstarred'),
-          });
-        },
-      },
-      {
-        danger: true,
-        disabled: !canEditTopic,
-        icon: <Icon icon={Trash} />,
-        key: 'deleteAll',
-        label: t(activeWorkspaceId ? 'actions.removeAllOwn' : 'actions.removeAll'),
-        onClick: () => {
-          confirmModal({
-            cancelText: t('cancel', { ns: 'common' }),
-            content: t(
-              activeWorkspaceId ? 'actions.confirmRemoveAllOwn' : 'actions.confirmRemoveAll',
-            ),
-            okButtonProps: { danger: true },
-            okText: t('ok', { ns: 'common' }),
-            onOk: () => removeAllTopic('own'),
-            title: t(activeWorkspaceId ? 'actions.removeAllOwn' : 'actions.removeAll'),
-          });
-        },
-      },
       ...(activeWorkspaceId && isWorkspaceOwner
         ? [
             { type: 'divider' as const },


### PR DESCRIPTION
## Summary

- remove the unstarred-topic bulk delete action from topic overflow menus
- remove the all-topics bulk delete action from Agent and Group sidebars
- keep workspace-owner cleanup actions available behind their stronger confirmation flow
- update menu regression tests to assert the removed actions are absent

## Testing

- `bun run check` on the four changed files: lint clean, 10 tests passed
- Agent Testing Electron preflight attempted, but the current canary desktop dev process exits before CDP starts because `electron.app` is undefined in the generated main bundle; no visual acceptance result is claimed