### PR TITLE
⚡️ perf(styles): reuse the lobe-ui shiny text style

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.35.0",
+    "@lobehub/ui": "^5.36.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/packages/shared-tool-ui/src/styles.ts
+++ b/packages/shared-tool-ui/src/styles.ts
@@ -1,4 +1,5 @@
-import { createStaticStyles, keyframes } from 'antd-style';
+import { textStyles } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
 
 /**
  * Inspector text style — ellipsis + secondary color + flex align
@@ -42,32 +43,9 @@ export const highlightTextStyles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-const shine = keyframes`
-  0% {
-    background-position: 100%;
-  }
-
-  100% {
-    background-position: -100%;
-  }
-`;
-
 /**
  * Shiny loading text animation
  */
-export const shinyTextStyles = createStaticStyles(({ css, cssVar }) => ({
-  shinyText: css`
-    color: color-mix(in srgb, ${cssVar.colorText} 45%, transparent);
-
-    background: linear-gradient(
-      120deg,
-      color-mix(in srgb, ${cssVar.colorTextBase} 0%, transparent) 40%,
-      ${cssVar.colorTextSecondary} 50%,
-      color-mix(in srgb, ${cssVar.colorTextBase} 0%, transparent) 60%
-    );
-    background-clip: text;
-    background-size: 200% 100%;
-
-    animation: ${shine} 1.5s linear infinite;
-  `,
-}));
+export const shinyTextStyles = {
+  shinyText: textStyles.shiny,
+};

--- a/src/styles/loading.ts
+++ b/src/styles/loading.ts
@@ -1,4 +1,5 @@
-import { createStaticStyles, css, keyframes } from 'antd-style';
+import { textStyles } from '@lobehub/ui/base-ui';
+import { createStaticStyles, css } from 'antd-style';
 
 export const dotLoading = css`
   &::after {
@@ -27,42 +28,19 @@ export const dotLoading = css`
   }
 `;
 
-const shine = keyframes`
-  0% {
-    background-position: 100%;
-  }
-
-  100% {
-    background-position: -100%;
-  }
-`;
-
 export const elapsedTimeStyles = createStaticStyles(({ css, cssVar }) => ({
   elapsedTime: css`
     color: ${cssVar.colorTextTertiary};
   `,
 }));
 
-export const shinyTextStyles = createStaticStyles(({ css, cssVar }) => ({
+export const errorTextStyles = createStaticStyles(({ css, cssVar }) => ({
   errorText: css`
     color: ${cssVar.colorError};
   `,
-  shinyText: css`
-    color: color-mix(in srgb, ${cssVar.colorText} 45%, transparent);
-
-    background: linear-gradient(
-      120deg,
-      color-mix(in srgb, ${cssVar.colorTextBase} 0%, transparent) 40%,
-      ${cssVar.colorTextSecondary} 50%,
-      color-mix(in srgb, ${cssVar.colorTextBase} 0%, transparent) 60%
-    );
-    background-clip: text;
-    background-size: 200% 100%;
-
-    animation: ${shine} 1.5s linear infinite;
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-    }
-  `,
 }));
+
+export const shinyTextStyles = {
+  errorText: errorTextStyles.errorText,
+  shinyText: textStyles.shiny,
+};


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Local `shinyText` copies animated `background-position` (repaints every glyph each frame) | Reuse `@lobehub/ui` `textStyles.shiny` (mask + transform) |

#### Test

<!-- How you tested your changes -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

This is a CSS animation swap. Spot-check loading/shiny text in chat thinking and tool inspector: the sheen should still run, with `prefers-reduced-motion` still respected via the shared lobe-ui style.

#### 🔗 Related Issue

<!-- No matching GitHub/Linear issue found -->

---

Local `shinyText` styles in `src/styles/loading.ts` and `packages/shared-tool-ui/src/styles.ts` duplicated a `background-position` shine that forces a paint every frame. `@lobehub/ui@5.36.0` ships the compositor-friendly `textStyles.shiny`, so this PR drops the copies and bumps the dependency.