### PR TITLE
💄 style: align disabled model action with notice

### DIFF
--- a/src/features/ChatInput/ChatInputNotice/index.tsx
+++ b/src/features/ChatInput/ChatInputNotice/index.tsx
@@ -59,6 +59,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
+/**
+ * Base Alert fills the available width, which pushes its action away from the notice text.
+ * Keep this notice content-sized while its max-width rule handles long translations.
+ */
+const alertStyle = { fontSize: 12, width: 'fit-content' } as const;
+
 const ChatInputNotice = memo(() => {
   const { t } = useTranslation('chat');
   const notice = useChatInputNotice();
@@ -91,7 +97,7 @@ const ChatInputNotice = memo(() => {
     <Alert
       action={action}
       classNames={{ alert: cx(styles.alert), title: styles.title }}
-      style={{ fontSize: 12 }}
+      style={alertStyle}
       title={t(notice.key)}
       type={notice.type}
       variant={'borderless'}


### PR DESCRIPTION
Keep the disabled-model recovery action next to its notice instead of pushing it to the far edge of the chat input.

The base Alert fills the available width by default. This change keeps this notice content-sized while preserving the existing maximum width and ellipsis behavior for long translations.

Related: [PR lobehub#18730](https://github.com/lobehub/lobehub/pull/18730)

#### Key Decisions / Non-goals

- Keep the button in the Alert action slot so permission tooltips and long-title truncation remain safe.
- Scope the width override to ChatInputNotice; the shared Alert layout is unchanged.
- This PR does not change disabled-model detection or recovery behavior.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- `bun run check lobehub/src/features/ChatInput/ChatInputNotice/index.tsx` — lint clean; no related tests.