### PR TITLE
🐛 fix: redirect workspace provider path deep-links to query form

### DIFF
--- a/locales/ar/chat.json
+++ b/locales/ar/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "الرسالة السابقة",
   "minimap.senderAssistant": "الوكيل",
   "minimap.senderUser": "أنت",
+  "modelSelector.model": "النموذج",
   "newAgent": "إنشاء وكيل",
   "newAmpAgent": "أضف Amp",
   "newClaudeCodeAgent": "إضافة Claude Code",

--- a/locales/bg-BG/chat.json
+++ b/locales/bg-BG/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Предишно съобщение",
   "minimap.senderAssistant": "Агент",
   "minimap.senderUser": "Вие",
+  "modelSelector.model": "Модел",
   "newAgent": "Създай агент",
   "newAmpAgent": "Добавете Amp",
   "newClaudeCodeAgent": "Добавяне на Claude Code",

--- a/locales/de-DE/chat.json
+++ b/locales/de-DE/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Vorherige Nachricht",
   "minimap.senderAssistant": "Agent",
   "minimap.senderUser": "Du",
+  "modelSelector.model": "Modell",
   "newAgent": "Agent erstellen",
   "newAmpAgent": "Amp hinzufügen",
   "newClaudeCodeAgent": "Claude Code hinzufügen",

--- a/locales/es-ES/chat.json
+++ b/locales/es-ES/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Mensaje anterior",
   "minimap.senderAssistant": "Agente",
   "minimap.senderUser": "Tú",
+  "modelSelector.model": "Modelo",
   "newAgent": "Crear agente",
   "newAmpAgent": "Agregar Amp",
   "newClaudeCodeAgent": "Añadir Claude Code",

--- a/locales/fa-IR/chat.json
+++ b/locales/fa-IR/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "پیام قبلی",
   "minimap.senderAssistant": "نماینده",
   "minimap.senderUser": "شما",
+  "modelSelector.model": "مدل",
   "newAgent": "ایجاد نماینده",
   "newAmpAgent": "اضافه کردن Amp",
   "newClaudeCodeAgent": "افزودن Claude Code",

--- a/locales/fr-FR/chat.json
+++ b/locales/fr-FR/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Message précédent",
   "minimap.senderAssistant": "Agent",
   "minimap.senderUser": "Vous",
+  "modelSelector.model": "Modèle",
   "newAgent": "Créer un agent",
   "newAmpAgent": "Ajouter Amp",
   "newClaudeCodeAgent": "Ajouter Claude Code",

--- a/locales/it-IT/chat.json
+++ b/locales/it-IT/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Messaggio precedente",
   "minimap.senderAssistant": "Agente",
   "minimap.senderUser": "Tu",
+  "modelSelector.model": "Modello",
   "newAgent": "Crea agente",
   "newAmpAgent": "Aggiungi Amp",
   "newClaudeCodeAgent": "Aggiungi Claude Code",

--- a/locales/ja-JP/chat.json
+++ b/locales/ja-JP/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "前のメッセージ",
   "minimap.senderAssistant": "アシスタント",
   "minimap.senderUser": "あなた",
+  "modelSelector.model": "モデル",
   "newAgent": "アシスタントを作成",
   "newAmpAgent": "Ampを追加",
   "newClaudeCodeAgent": "Claude Code を追加",

--- a/locales/ko-KR/chat.json
+++ b/locales/ko-KR/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "이전 메시지",
   "minimap.senderAssistant": "도우미",
   "minimap.senderUser": "당신",
+  "modelSelector.model": "모델",
   "newAgent": "도우미 만들기",
   "newAmpAgent": "Amp 추가",
   "newClaudeCodeAgent": "Claude Code 추가",

--- a/locales/nl-NL/chat.json
+++ b/locales/nl-NL/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Vorig bericht",
   "minimap.senderAssistant": "Agent",
   "minimap.senderUser": "Jij",
+  "modelSelector.model": "Model",
   "newAgent": "Agent aanmaken",
   "newAmpAgent": "Amp toevoegen",
   "newClaudeCodeAgent": "Claude Code toevoegen",

--- a/locales/pl-PL/chat.json
+++ b/locales/pl-PL/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Poprzednia wiadomość",
   "minimap.senderAssistant": "Agent",
   "minimap.senderUser": "Ty",
+  "modelSelector.model": "Model",
   "newAgent": "Utwórz agenta",
   "newAmpAgent": "Dodaj Amp",
   "newClaudeCodeAgent": "Dodaj Claude Code",

--- a/locales/pt-BR/chat.json
+++ b/locales/pt-BR/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Mensagem anterior",
   "minimap.senderAssistant": "Agente",
   "minimap.senderUser": "Você",
+  "modelSelector.model": "Modelo",
   "newAgent": "Criar Agente",
   "newAmpAgent": "Adicionar Amp",
   "newClaudeCodeAgent": "Adicionar Claude Code",

--- a/locales/ru-RU/chat.json
+++ b/locales/ru-RU/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Предыдущее сообщение",
   "minimap.senderAssistant": "Агент",
   "minimap.senderUser": "Вы",
+  "modelSelector.model": "Модель",
   "newAgent": "Создать агента",
   "newAmpAgent": "Добавить Amp",
   "newClaudeCodeAgent": "Добавить Claude Code",

--- a/locales/tr-TR/chat.json
+++ b/locales/tr-TR/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Önceki mesaj",
   "minimap.senderAssistant": "Ajan",
   "minimap.senderUser": "Sen",
+  "modelSelector.model": "Model",
   "newAgent": "Ajan Oluştur",
   "newAmpAgent": "Amp Ekle",
   "newClaudeCodeAgent": "Claude Code ekle",

--- a/locales/vi-VN/chat.json
+++ b/locales/vi-VN/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "Tin nhắn trước",
   "minimap.senderAssistant": "Tác nhân",
   "minimap.senderUser": "Bạn",
+  "modelSelector.model": "Mô hình",
   "newAgent": "Tạo tác nhân",
   "newAmpAgent": "Thêm Amp",
   "newClaudeCodeAgent": "Thêm Claude Code",

--- a/locales/zh-TW/chat.json
+++ b/locales/zh-TW/chat.json
@@ -1059,6 +1059,7 @@
   "minimap.previousMessage": "上一條訊息",
   "minimap.senderAssistant": "Agent",
   "minimap.senderUser": "您",
+  "modelSelector.model": "模型",
   "newAgent": "建立助手",
   "newAmpAgent": "新增 Amp",
   "newClaudeCodeAgent": "新增 Claude Code",

--- a/src/components/ImperativeModal/index.test.tsx
+++ b/src/components/ImperativeModal/index.test.tsx
@@ -3,9 +3,25 @@ import { ModalHost } from '@lobehub/ui/base-ui';
 import { act, render, screen } from '@testing-library/react';
 import { motion } from 'motion/react';
 import { useState } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import ImperativeModal from '.';
+
+// Real WAAPI animations under happy-dom get canceled when the tree unmounts on
+// test cleanup, which rejects each animation's pending `finished` promise with
+// an AbortError nothing awaits and flakes CI with unhandled rejections. Mark
+// every animation's `finished` promise as handled at creation time.
+const originalAnimate = Element.prototype.animate;
+beforeAll(() => {
+  Element.prototype.animate = function (this: Element, ...args) {
+    const animation = originalAnimate.apply(this, args);
+    animation.finished.catch(() => {});
+    return animation;
+  } as typeof originalAnimate;
+});
+afterAll(() => {
+  Element.prototype.animate = originalAnimate;
+});
 
 /** A modal whose input is controlled by state living in the CALLER's tree. */
 const Harness = ({ open = true }: { open?: boolean }) => {

--- a/src/features/WorkspaceSetting/ProviderRedirect.tsx
+++ b/src/features/WorkspaceSetting/ProviderRedirect.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Navigate, useParams } from 'react-router';
+
+/**
+ * Personal settings deep-links use the `/settings/provider/:providerId` path
+ * shape, while the workspace provider page keeps the selected provider in the
+ * `provider` query param. Workspace-prefixed deep-links in the path shape
+ * (e.g. from `WorkspaceLink` / `useWorkspaceAwareNavigate` callsites) would
+ * otherwise fall through to the catch-all route and kick the user out of the
+ * workspace, so redirect them to the canonical query form.
+ */
+const WorkspaceProviderRedirect = () => {
+  const { providerId = 'all', workspaceSlug } = useParams<{
+    providerId: string;
+    workspaceSlug: string;
+  }>();
+
+  return (
+    <Navigate
+      replace
+      to={{
+        pathname: `/${workspaceSlug}/settings/provider`,
+        search: `?active=provider&provider=${encodeURIComponent(providerId)}`,
+      }}
+    />
+  );
+};
+
+WorkspaceProviderRedirect.displayName = 'WorkspaceProviderRedirect';
+
+export default WorkspaceProviderRedirect;

--- a/src/routes/(main)/[workspaceSlug]/settings/provider/index.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/provider/index.tsx
@@ -4,7 +4,7 @@ import SettingsContextProvider from '@/features/Settings/Layout/ContextProvider'
 import Page from '@/features/Settings/provider/(list)';
 import WorkspaceAdminOnly from '@/features/WorkspaceSetting/AdminOnly';
 
-const WorkspaceProviderSetting = () => (
+const WorkspaceProviderSetting = ({ mobile }: { mobile?: boolean }) => (
   <WorkspaceAdminOnly>
     <SettingsContextProvider
       value={{
@@ -12,11 +12,15 @@ const WorkspaceProviderSetting = () => (
         showOpenAIProxyUrl: true,
       }}
     >
-      <Page />
+      <Page mobile={mobile} />
     </SettingsContextProvider>
   </WorkspaceAdminOnly>
 );
 
 WorkspaceProviderSetting.displayName = 'WorkspaceProviderSetting';
+
+export const WorkspaceProviderSettingMobile = () => <WorkspaceProviderSetting mobile />;
+
+WorkspaceProviderSettingMobile.displayName = 'WorkspaceProviderSettingMobile';
 
 export default WorkspaceProviderSetting;

--- a/src/routes/(main)/[workspaceSlug]/settings/provider/redirect.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/provider/redirect.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Navigate, useParams } from 'react-router';
+
+/**
+ * Personal settings deep-links use the `/settings/provider/:providerId` path
+ * shape, while the workspace provider page keeps the selected provider in the
+ * `provider` query param. Workspace-prefixed deep-links in the path shape
+ * (e.g. from `WorkspaceLink` / `useWorkspaceAwareNavigate` callsites) would
+ * otherwise fall through to the catch-all route and kick the user out of the
+ * workspace, so redirect them to the canonical query form.
+ */
+const WorkspaceProviderRedirect = () => {
+  const { providerId = 'all', workspaceSlug } = useParams<{
+    providerId: string;
+    workspaceSlug: string;
+  }>();
+
+  return (
+    <Navigate
+      replace
+      to={{
+        pathname: `/${workspaceSlug}/settings/provider`,
+        search: `?active=provider&provider=${encodeURIComponent(providerId)}`,
+      }}
+    />
+  );
+};
+
+WorkspaceProviderRedirect.displayName = 'WorkspaceProviderRedirect';
+
+export default WorkspaceProviderRedirect;

--- a/src/routes/(main)/[workspaceSlug]/settings/provider/redirect.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/provider/redirect.tsx
@@ -1,32 +1,5 @@
 'use client';
 
-import { Navigate, useParams } from 'react-router';
-
-/**
- * Personal settings deep-links use the `/settings/provider/:providerId` path
- * shape, while the workspace provider page keeps the selected provider in the
- * `provider` query param. Workspace-prefixed deep-links in the path shape
- * (e.g. from `WorkspaceLink` / `useWorkspaceAwareNavigate` callsites) would
- * otherwise fall through to the catch-all route and kick the user out of the
- * workspace, so redirect them to the canonical query form.
- */
-const WorkspaceProviderRedirect = () => {
-  const { providerId = 'all', workspaceSlug } = useParams<{
-    providerId: string;
-    workspaceSlug: string;
-  }>();
-
-  return (
-    <Navigate
-      replace
-      to={{
-        pathname: `/${workspaceSlug}/settings/provider`,
-        search: `?active=provider&provider=${encodeURIComponent(providerId)}`,
-      }}
-    />
-  );
-};
-
-WorkspaceProviderRedirect.displayName = 'WorkspaceProviderRedirect';
+import WorkspaceProviderRedirect from '@/features/WorkspaceSetting/ProviderRedirect';
 
 export default WorkspaceProviderRedirect;

--- a/src/routes/(main)/[workspaceSlug]/settings/provider/redirect.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/provider/redirect.tsx
@@ -1,5 +1,0 @@
-'use client';
-
-import WorkspaceProviderRedirect from '@/features/WorkspaceSetting/ProviderRedirect';
-
-export default WorkspaceProviderRedirect;

--- a/src/routes/(mobile)/settings/_layout/Header.test.tsx
+++ b/src/routes/(mobile)/settings/_layout/Header.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment happy-dom
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import Header from './Header';
 
+const navigateMock = vi.fn();
+
 vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
-  useWorkspaceAwareNavigate: () => vi.fn(),
+  useWorkspaceAwareNavigate: () => navigateMock,
 }));
 
 vi.mock('@/hooks/useShowMobileWorkspace', () => ({ useShowMobileWorkspace: () => false }));
@@ -22,6 +24,10 @@ const renderHeader = (tab: string) =>
     </MemoryRouter>,
   );
 
+beforeEach(() => {
+  navigateMock.mockClear();
+});
+
 describe('mobile settings Header', () => {
   it.each([
     ['general', 'setting:workspaceSetting.tab.general'],
@@ -35,5 +41,29 @@ describe('mobile settings Header', () => {
     renderHeader(tab);
 
     expect(within(screen.getByRole('banner')).getByText(title)).toBeInTheDocument();
+  });
+
+  it('recognizes a query-selected workspace provider and titles it', () => {
+    render(
+      <MemoryRouter initialEntries={['/acme/settings/provider?active=provider&provider=openai']}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    expect(within(screen.getByRole('banner')).getByText('openai')).toBeInTheDocument();
+  });
+
+  it('goes back to the workspace provider list from a query-selected provider', () => {
+    render(
+      <MemoryRouter initialEntries={['/acme/settings/provider?active=provider&provider=openai']}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(within(screen.getByRole('banner')).getByRole('button'));
+
+    // Workspace-aware navigate without `escape` keeps the `/acme` prefix, so the
+    // user lands on the workspace provider list instead of personal settings.
+    expect(navigateMock).toHaveBeenCalledWith('/settings/provider');
   });
 });

--- a/src/routes/(mobile)/settings/_layout/Header.tsx
+++ b/src/routes/(mobile)/settings/_layout/Header.tsx
@@ -4,7 +4,7 @@ import { Flexbox } from '@lobehub/ui';
 import { ChatHeader } from '@lobehub/ui/mobile';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMatch, useParams } from 'react-router';
+import { useMatch, useParams, useSearchParams } from 'react-router';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useShowMobileWorkspace } from '@/hooks/useShowMobileWorkspace';
@@ -40,16 +40,26 @@ const Header = memo(() => {
   const showMobileWorkspace = useShowMobileWorkspace();
   const navigate = useWorkspaceAwareNavigate();
   const params = useParams<{ providerId?: string; tab?: string }>();
+  const [searchParams] = useSearchParams();
   const workspaceSettingsMatch = useMatch('/:workspaceSlug/settings/:workspaceTab/*');
 
   const isSessionActive = useSessionStore((s) => !!s.activeId);
-  const isProvider = params.providerId && params.providerId !== 'all';
+  // Personal provider details carry the id in the path; the workspace provider
+  // page canonicalizes it into the `provider` query param instead.
+  const queryProvider = searchParams.get('provider');
+  const providerId =
+    params.providerId ?? (queryProvider && queryProvider !== 'all' ? queryProvider : undefined);
+  const isProvider = providerId && providerId !== 'all';
 
   const handleBackClick = () => {
     if (isSessionActive && showMobileWorkspace) {
       navigate('/agent');
-    } else if (isProvider) {
+    } else if (params.providerId && params.providerId !== 'all') {
       navigate('/settings/provider/all', { escape: true });
+    } else if (isProvider) {
+      // Query-selected provider (workspace form): back to the workspace
+      // provider list instead of escaping to personal settings.
+      navigate('/settings/provider');
     } else {
       navigate('/me/settings', { escape: true });
     }
@@ -73,7 +83,7 @@ const Header = memo(() => {
         <ChatHeader.Title
           title={
             <Flexbox horizontal align={'center'} gap={8}>
-              <span style={{ lineHeight: 1.2 }}>{isProvider ? params.providerId : tabTitle}</span>
+              <span style={{ lineHeight: 1.2 }}>{isProvider ? providerId : tabTitle}</span>
             </Flexbox>
           }
         />

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -1170,6 +1170,16 @@ const createMainAreaChildrenDefinition = (options: MainAreaRouteOptions = {}): R
             ),
             path: 'provider',
           },
+          // Path-shaped provider deep-links (`/:slug/settings/provider/:id`)
+          // redirect to the query form the workspace provider page uses, so
+          // they don't fall through to the catch-all and leave the workspace.
+          {
+            element: dynamicElement(
+              () => import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect'),
+              'Desktop > Workspace > Settings > Provider > Redirect',
+            ),
+            path: 'provider/:providerId',
+          },
           {
             element: dynamicElement(
               () => import('@/routes/(main)/[workspaceSlug]/settings/skill'),

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -41,6 +41,7 @@ import { pageRouteMeta } from '@/features/Pages/routeMeta';
 import { projectsRouteMeta } from '@/features/Projects/routeMeta';
 import { settingsRouteMeta } from '@/features/Settings/features/routeMeta';
 import { workspaceHomeRouteMeta } from '@/features/Workspace/routeMeta';
+import WorkspaceProviderRedirect from '@/features/WorkspaceSetting/ProviderRedirect';
 import {
   agentChannelRouteMeta,
   agentPermissionRouteMeta,
@@ -1173,11 +1174,10 @@ const createMainAreaChildrenDefinition = (options: MainAreaRouteOptions = {}): R
           // Path-shaped provider deep-links (`/:slug/settings/provider/:id`)
           // redirect to the query form the workspace provider page uses, so
           // they don't fall through to the catch-all and leave the workspace.
+          // Static element: the redirect is tiny and lazy-loading it would
+          // flash the generic brand loader before redirecting.
           {
-            element: dynamicElement(
-              () => import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect'),
-              'Desktop > Workspace > Settings > Provider > Redirect',
-            ),
+            element: <WorkspaceProviderRedirect />,
             path: 'provider/:providerId',
           },
           {

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -456,6 +456,24 @@ describe('desktop router shared definition', () => {
   );
 
   it.each(mainAreaVariants)(
+    '%s keeps workspace provider deep-links inside the workspace',
+    (_, factory) => {
+      const routes = createMainAreaRoutes(factory);
+      const listMatches = matchRoutes(routes, '/acme/settings/provider');
+      const detailMatches = matchRoutes(routes, '/acme/settings/provider/lobehub');
+
+      expect(listMatches?.at(-1)?.route.path).toBe('provider');
+      // Before the redirect route existed, the detail path fell through to the
+      // root catch-all (`*`) and kicked the user out of the workspace.
+      expect(detailMatches?.at(-1)?.route.path).toBe('provider/:providerId');
+      expect(detailMatches?.at(-1)?.params).toMatchObject({
+        providerId: 'lobehub',
+        workspaceSlug: 'acme',
+      });
+    },
+  );
+
+  it.each(mainAreaVariants)(
     '%s registers workspace OAuth app list and detail routes',
     (_, factory) => {
       const routes = createMainAreaRoutes(factory);

--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -9,6 +9,7 @@ import {
 import AppsSkeleton from '@/components/Skeleton/Apps';
 import { acceptanceRouteMeta } from '@/features/Acceptance/routeMeta';
 import { mobileAgentSettingsRouteMeta } from '@/features/RouteMeta/mobileRouteMeta';
+import WorkspaceProviderRedirect from '@/features/WorkspaceSetting/ProviderRedirect';
 import { agentRouteMeta } from '@/routes/(main)/agent/features/routeMeta';
 import { loadRouteWithBuiltinToolSurfaces } from '@/spa/initialize/toolSurfaces';
 import { dynamicElement, dynamicLayout, ErrorBoundary, redirectElement } from '@/utils/router';
@@ -498,11 +499,10 @@ export const mobileRoutes: RouteObject[] = [
               // Path-shaped provider deep-links (`/:slug/settings/provider/:id`)
               // redirect to the query form the workspace provider page uses, so
               // they don't fall through to the catch-all and leave the workspace.
+              // Static element: the redirect is tiny and lazy-loading it would
+              // flash the generic brand loader before redirecting.
               {
-                element: dynamicElement(
-                  () => import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect'),
-                  'Mobile > Workspace > Settings > Provider > Redirect',
-                ),
+                element: <WorkspaceProviderRedirect />,
                 path: 'provider/:providerId',
               },
               {

--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -487,6 +487,23 @@ export const mobileRoutes: RouteObject[] = [
               },
               {
                 element: dynamicElement(
+                  () => import('@/routes/(main)/[workspaceSlug]/settings/provider'),
+                  'Mobile > Workspace > Settings > Provider',
+                ),
+                path: 'provider',
+              },
+              // Path-shaped provider deep-links (`/:slug/settings/provider/:id`)
+              // redirect to the query form the workspace provider page uses, so
+              // they don't fall through to the catch-all and leave the workspace.
+              {
+                element: dynamicElement(
+                  () => import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect'),
+                  'Mobile > Workspace > Settings > Provider > Redirect',
+                ),
+                path: 'provider/:providerId',
+              },
+              {
+                element: dynamicElement(
                   () => import('@/routes/(main)/[workspaceSlug]/settings/plans'),
                   'Mobile > Workspace > Settings > Plans',
                 ),

--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -487,7 +487,10 @@ export const mobileRoutes: RouteObject[] = [
               },
               {
                 element: dynamicElement(
-                  () => import('@/routes/(main)/[workspaceSlug]/settings/provider'),
+                  () =>
+                    import('@/routes/(main)/[workspaceSlug]/settings/provider').then(
+                      (m) => m.WorkspaceProviderSettingMobile,
+                    ),
                   'Mobile > Workspace > Settings > Provider',
                 ),
                 path: 'provider',

--- a/src/spa/router/mobileRouter.test.tsx
+++ b/src/spa/router/mobileRouter.test.tsx
@@ -21,3 +21,21 @@ describe('mobileRouter task routes', () => {
     expect(source).not.toContain("import('@/routes/(main)/tasks/_layout')");
   });
 });
+
+describe('mobileRouter workspace provider routes', () => {
+  it('registers workspace provider list and path-shaped deep-link redirect', async () => {
+    const source = await readFile(
+      path.join(process.cwd(), 'src/spa/router/mobileRouter.config.tsx'),
+      'utf8',
+    );
+
+    // Without these, workspace-aware provider links (`/:slug/settings/provider/:id`)
+    // fall through to the mobile `*` route and kick the user out of the workspace.
+    expect(source).toContain("import('@/routes/(main)/[workspaceSlug]/settings/provider')");
+    expect(source).toContain(
+      "import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect')",
+    );
+    expect(source).toContain("path: 'provider'");
+    expect(source).toContain("path: 'provider/:providerId'");
+  });
+});

--- a/src/spa/router/mobileRouter.test.tsx
+++ b/src/spa/router/mobileRouter.test.tsx
@@ -32,6 +32,9 @@ describe('mobileRouter workspace provider routes', () => {
     // Without these, workspace-aware provider links (`/:slug/settings/provider/:id`)
     // fall through to the mobile `*` route and kick the user out of the workspace.
     expect(source).toContain("import('@/routes/(main)/[workspaceSlug]/settings/provider')");
+    // The mobile route must use the mobile variant, otherwise the page renders
+    // the desktop 280px provider menu layout on phones.
+    expect(source).toContain('m.WorkspaceProviderSettingMobile');
     expect(source).toContain(
       "import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect')",
     );

--- a/src/spa/router/mobileRouter.test.tsx
+++ b/src/spa/router/mobileRouter.test.tsx
@@ -35,9 +35,9 @@ describe('mobileRouter workspace provider routes', () => {
     // The mobile route must use the mobile variant, otherwise the page renders
     // the desktop 280px provider menu layout on phones.
     expect(source).toContain('m.WorkspaceProviderSettingMobile');
-    expect(source).toContain(
-      "import('@/routes/(main)/[workspaceSlug]/settings/provider/redirect')",
-    );
+    // The redirect is statically imported: lazy-loading it would flash the
+    // generic brand loader before redirecting.
+    expect(source).toContain("from '@/features/WorkspaceSetting/ProviderRedirect'");
     expect(source).toContain("path: 'provider'");
     expect(source).toContain("path: 'provider/:providerId'");
   });


### PR DESCRIPTION
Workspace-prefixed provider deep-links in the path shape (`/:workspaceSlug/settings/provider/:providerId`) fell through to the root catch-all route and kicked the user out of the workspace. This adds a redirect route that forwards them to the canonical query form the workspace provider page uses (`?active=provider&provider=<id>`).

Also updates the i18n locale files via `bun run i18n` (includes pending untranslated entries from earlier canary commits, not only this change).

#### Key Decisions / Non-goals

- Personal settings keep the path shape (`/settings/provider/:providerId`); only the workspace-prefixed variant redirects, because the workspace provider page keeps the selected provider in the `provider` query param.
- The redirect defaults `providerId` to `all` when absent.

#### Test

- [x] Tested locally
- [x] Added/updated tests (`desktopRouter.sync.test.tsx` covers list + detail matching inside the workspace)