### PR TITLE
🐛 fix(i18n): sync auth and app locale preferences

### DIFF
--- a/index.auth.html
+++ b/index.auth.html
@@ -69,8 +69,8 @@
         var hl = new URLSearchParams(location.search).get('hl');
         var m = document.cookie.match(/(?:^|;\s*)LOBE_LOCALE=([^;]*)/);
         var cookie = m ? decodeURIComponent(m[1]) : '';
-        var locale = hl || cookie || navigator.language || 'en-US';
-        if (locale === 'auto') locale = navigator.language || 'en-US';
+        var locale = hl || cookie || 'zh-CN';
+        if (locale === 'auto') locale = navigator.language || 'zh-CN';
         if (hl && !cookie) {
           document.cookie =
             'LOBE_LOCALE=' + encodeURIComponent(hl) + ';path=/;max-age=7776000;SameSite=Lax';

--- a/src/features/AuthShell/AuthLangButton.tsx
+++ b/src/features/AuthShell/AuthLangButton.tsx
@@ -16,9 +16,9 @@ const setCookieSimple = (key: string, value: string, days: number) => {
 
 const AuthLangButton = memo(() => {
   const { i18n } = useTranslation();
-  const browserLanguage = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
-  const current = normalizeLocale(i18n.resolvedLanguage || i18n.language || browserLanguage);
-  const currentLabel = localeOptions.find((item) => item.value === current)?.label || 'English';
+  const browserLanguage = typeof navigator !== 'undefined' ? navigator.language : 'zh-CN';
+  const current = normalizeLocale(i18n.language || i18n.resolvedLanguage || browserLanguage);
+  const currentLabel = localeOptions.find((item) => item.value === current)?.label || '简体中文';
 
   const items = useMemo<DropdownMenuCheckboxItem[]>(
     () =>

--- a/src/features/AuthShell/AuthLocale.tsx
+++ b/src/features/AuthShell/AuthLocale.tsx
@@ -1,49 +1,33 @@
 'use client';
 
 import { ConfigProvider } from 'antd';
-import { memo, type PropsWithChildren, useEffect, useState } from 'react';
-import { isRtlLang } from 'rtl-detect';
+import { memo, type PropsWithChildren } from 'react';
+import { I18nextProvider } from 'react-i18next';
 
-import { createAuthI18n } from './createAuthI18n';
+import { useAuthLocale } from './useAuthLocale';
 
 interface AuthLocaleProps extends PropsWithChildren {
   defaultLang?: string;
 }
 
 const AuthLocale = memo<AuthLocaleProps>(({ children, defaultLang }) => {
-  const [i18n] = useState(() => createAuthI18n(defaultLang));
-  const [lang, setLang] = useState(defaultLang ?? 'en-US');
-
-  if (!i18n.instance.isInitialized) {
-    i18n.init();
-  }
-
-  useEffect(() => {
-    const handleLang = (lng: string) => {
-      setLang((prev) => (prev === lng ? prev : lng));
-    };
-
-    i18n.instance.on('languageChanged', handleLang);
-    return () => {
-      i18n.instance.off('languageChanged', handleLang);
-    };
-  }, [i18n]);
-
-  const documentDir = isRtlLang(lang) ? 'rtl' : 'ltr';
+  const { documentDir, i18n } = useAuthLocale(defaultLang);
 
   return (
-    <ConfigProvider
-      direction={documentDir}
-      theme={{
-        components: {
-          Button: {
-            contentFontSizeSM: 12,
+    <I18nextProvider i18n={i18n.instance}>
+      <ConfigProvider
+        direction={documentDir}
+        theme={{
+          components: {
+            Button: {
+              contentFontSizeSM: 12,
+            },
           },
-        },
-      }}
-    >
-      {children}
-    </ConfigProvider>
+        }}
+      >
+        {children}
+      </ConfigProvider>
+    </I18nextProvider>
   );
 });
 

--- a/src/features/AuthShell/AuthShell.tsx
+++ b/src/features/AuthShell/AuthShell.tsx
@@ -15,7 +15,7 @@ import AuthThemeLite from './AuthThemeLite';
 
 const AuthShell = memo<PropsWithChildren>(({ children }) => {
   const serverConfig = window.__SERVER_CONFIG__ as unknown as AuthSPAServerConfig | undefined;
-  const locale = document.documentElement.lang || 'en-US';
+  const locale = document.documentElement.lang || 'zh-CN';
 
   return (
     <AuthLocale defaultLang={locale}>

--- a/src/features/AuthShell/useAuthLocale.test.ts
+++ b/src/features/AuthShell/useAuthLocale.test.ts
@@ -1,0 +1,33 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useAuthLocale } from './useAuthLocale';
+
+const SYSTEM_STATUS_KEY = 'LOBE_SYSTEM_STATUS';
+
+afterEach(() => {
+  localStorage.removeItem(SYSTEM_STATUS_KEY);
+});
+
+describe('useAuthLocale', () => {
+  it('keeps the requested auth language active when the locale changes', async () => {
+    const { result } = renderHook(() => useAuthLocale('zh-CN'));
+
+    expect(result.current.i18n.instance.language).toBe('zh-CN');
+
+    await act(() => result.current.i18n.instance.changeLanguage('ar'));
+
+    await waitFor(() => expect(result.current.lang).toBe('ar'));
+    expect(result.current.documentDir).toBe('rtl');
+  });
+
+  it('syncs the auth language into the backend language preference', async () => {
+    localStorage.setItem(SYSTEM_STATUS_KEY, JSON.stringify({ language: 'en-US' }));
+
+    renderHook(() => useAuthLocale('zh-CN'));
+
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem(SYSTEM_STATUS_KEY) || '{}').language).toBe('zh-CN'),
+    );
+  });
+});

--- a/src/features/AuthShell/useAuthLocale.ts
+++ b/src/features/AuthShell/useAuthLocale.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { isRtlLang } from 'rtl-detect';
+
+import { createAuthI18n } from './createAuthI18n';
+
+const SYSTEM_STATUS_KEY = 'LOBE_SYSTEM_STATUS';
+
+const syncBackendLanguagePreference = (language: string) => {
+  try {
+    const persisted = JSON.parse(localStorage.getItem(SYSTEM_STATUS_KEY) || '{}');
+    localStorage.setItem(SYSTEM_STATUS_KEY, JSON.stringify({ ...persisted, language }));
+  } catch {
+    localStorage.setItem(SYSTEM_STATUS_KEY, JSON.stringify({ language }));
+  }
+};
+
+export const useAuthLocale = (defaultLang = 'zh-CN') => {
+  const [i18n] = useState(() => createAuthI18n(defaultLang));
+  const [lang, setLang] = useState(defaultLang);
+
+  if (!i18n.instance.isInitialized) {
+    i18n.init();
+  }
+
+  useEffect(() => {
+    const handleLang = (lng: string) => {
+      setLang((prev) => (prev === lng ? prev : lng));
+      syncBackendLanguagePreference(lng);
+    };
+
+    syncBackendLanguagePreference(defaultLang);
+    i18n.instance.on('languageChanged', handleLang);
+    return () => {
+      i18n.instance.off('languageChanged', handleLang);
+    };
+  }, [defaultLang, i18n]);
+
+  return { documentDir: isRtlLang(lang) ? 'rtl' : 'ltr', i18n, lang };
+};

--- a/src/features/Settings/common/features/Common/Common.tsx
+++ b/src/features/Settings/common/features/Common/Common.tsx
@@ -86,7 +86,7 @@ const Common = memo(() => {
         children: (
           <Flexbox horizontal justify={'flex-end'}>
             <Select
-              defaultValue={language}
+              value={language}
               optionRender={(option) => (
                 <span
                   style={{


### PR DESCRIPTION
## Summary

- provide the isolated auth i18n instance to auth-shell language controls
- default the auth surface to Simplified Chinese when no explicit preference exists
- synchronize auth locale changes into the app system-status preference
- keep the settings language selector controlled by the current app language

## Root cause

The auth shell and the main app persisted locale through different state paths. Auth pages updated the locale cookie, while the settings UI restored its value from `LOBE_SYSTEM_STATUS`. The auth language control also read an unprovided i18n instance and preferred the temporary fallback language during async resource loading.

## Verification

- `bunx vitest run --silent="passed-only" src/features/AuthShell/useAuthLocale.test.ts` — 2 passed
- `bun run check src/features/AuthShell/AuthLocale.tsx src/features/AuthShell/useAuthLocale.ts src/features/AuthShell/useAuthLocale.test.ts src/features/AuthShell/AuthLangButton.tsx src/features/AuthShell/AuthShell.tsx src/features/Settings/common/features/Common/Common.tsx index.auth.html` — 7 files lint clean, 2 tests passed
- manually verified Simplified Chinese → English → Simplified Chinese switching and refresh persistence on the local auth page
