### PR TITLE
🐛 fix(chat): make todo tray list scrollable

### DIFF
--- a/src/features/Conversation/TodoProgress/index.tsx
+++ b/src/features/Conversation/TodoProgress/index.tsx
@@ -75,7 +75,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   listContainer: css`
-    overflow: hidden;
+    overflow: hidden auto;
+    overscroll-behavior: contain;
 
     /* The rows are Base UI Checkbox labels, which are inline-flex. In a plain
        block container they lay out as INLINE boxes — two or three short todos

--- a/src/features/Conversation/TodoProgress/index.tsx
+++ b/src/features/Conversation/TodoProgress/index.tsx
@@ -76,7 +76,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   listContainer: css`
     overflow: hidden auto;
-    overscroll-behavior: contain;
+    overscroll-behavior-y: contain;
 
     /* The rows are Base UI Checkbox labels, which are inline-flex. In a plain
        block container they lay out as INLINE boxes — two or three short todos


### PR DESCRIPTION
#### Description of Change

- allow the expanded TodoProgress tray list to scroll within its existing 300px height cap
- contain overscroll so reaching the list boundary does not move the surrounding conversation
- keep the tray header outside the scrollable item region

#### How to Test

- `bun run check src/features/Conversation/TodoProgress/index.tsx`
- expand a Todo tray with enough items to exceed 300px
- verify the item list scrolls to the final item while the tray header stays visible