### PR TITLE
💄 style(updater): use primary button for update toast

### DIFF
--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -47,14 +47,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     inset-inline-start: 16px;
 
     display: flex;
-    gap: 6px;
+    gap: 8px;
     align-items: center;
 
     max-inline-size: calc(100vw - 32px);
-    padding-block: 6px;
-    padding-inline: 12px 6px;
-    border-radius: ${cssVar.borderRadius};
+    padding-block: 8px;
+    padding-inline: 12px 8px;
+    border-radius: ${cssVar.borderRadiusLG};
 
+    font-size: 14px;
+    line-height: 1.25;
     color: ${cssVar.colorText};
 
     background: ${cssVar.colorBgElevated};

--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -47,12 +47,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     inset-inline-start: 16px;
 
     display: flex;
-    gap: 8px;
+    gap: 6px;
     align-items: center;
 
     max-inline-size: calc(100vw - 32px);
-    padding-block: 10px;
-    padding-inline: 16px 10px;
+    padding-block: 6px;
+    padding-inline: 12px 6px;
     border-radius: ${cssVar.borderRadius};
 
     color: ${cssVar.colorText};
@@ -174,7 +174,7 @@ export const UpdateNotification: React.FC = () => {
         </BaseButton>
         <BaseButton
           size={'small'}
-          type={'text'}
+          type={'primary'}
           onClick={() => {
             rendererOtaService.applyNow().catch(() => {});
           }}
@@ -227,7 +227,7 @@ export const UpdateNotification: React.FC = () => {
         <BaseButton
           loading={isInstalling}
           size={'small'}
-          type={'text'}
+          type={'primary'}
           onClick={() => {
             setIsInstalling(true);
             autoUpdateService.installNow();


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 💄 style

### 🔀 变更说明 | Description of Change

Update notification toast (both renderer OTA and app auto-update):

- "立即更新" / upgradeNow button is now `type="primary"` so the primary action is visually distinct from "稍后".
- Tightened the toast one notch: padding `10px / 16px 10px` → `6px / 12px 6px`, gap `8px` → `6px`.

### 📝 补充信息 | Additional Information

Style-only, no behavior change.

https://claude.ai/code/session_01HNtnp2V5PrHc6tgrjwLRwN