### PR TITLE
💄 style(devdock): flatten panel chrome and stop dock bar overlap

### DIFF
--- a/src/features/AgentMockDevtools/Controls.tsx
+++ b/src/features/AgentMockDevtools/Controls.tsx
@@ -11,6 +11,17 @@ import { useMockCases } from './hooks/useMockCases';
 import { useAgentMockStore } from './store/agentMockStore';
 
 const styles = createStaticStyles(({ css }) => ({
+  actions: css`
+    flex-shrink: 0;
+    height: 40px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  controls: css`
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  `,
   counter: css`
     font-size: 11px;
     font-feature-settings: 'tnum';
@@ -21,9 +32,12 @@ const styles = createStaticStyles(({ css }) => ({
     cursor: pointer;
 
     display: flex;
+    flex-shrink: 0;
     align-items: center;
 
-    height: 14px;
+    height: 28px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
     &:hover .agent-mock-progress-track {
       background: ${cssVar.colorFillTertiary};
@@ -56,6 +70,12 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   progressTrackScrubbing: css`
     background: ${cssVar.colorFillTertiary} !important;
+  `,
+  selection: css`
+    flex-shrink: 0;
+    height: 44px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
 }));
 
@@ -153,8 +173,8 @@ export const Controls = memo(() => {
     : 0;
 
   return (
-    <Flexbox gap={12}>
-      <Flexbox horizontal align={'center'} gap={8}>
+    <div className={styles.controls}>
+      <Flexbox horizontal align={'center'} className={styles.selection} gap={8}>
         <CaseTrigger placement={'topLeft'} />
         <span style={{ flex: 1 }} />
         <span className={styles.counter}>
@@ -179,7 +199,7 @@ export const Controls = memo(() => {
           <div className={styles.progressFill} style={{ width: `${pct}%` }} />
         </div>
       </div>
-      <Flexbox horizontal align={'center'} gap={4}>
+      <Flexbox horizontal align={'center'} className={styles.actions} gap={4}>
         <ActionIcon
           disabled={disabled}
           icon={running ? Pause : Play}
@@ -220,7 +240,7 @@ export const Controls = memo(() => {
         <span style={{ flex: 1 }} />
         <span className={styles.counter}>{selected ? selected.name : 'No case selected'}</span>
       </Flexbox>
-    </Flexbox>
+    </div>
   );
 });
 

--- a/src/features/AgentMockDevtools/index.tsx
+++ b/src/features/AgentMockDevtools/index.tsx
@@ -1,23 +1,34 @@
-import { Flexbox } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { memo } from 'react';
 import { useMatches } from 'react-router';
 
+import { devDockPanelStyles } from '@/features/DevDock/panelStyles';
+
 import { Controls } from './Controls';
+
+const styles = createStaticStyles(({ css }) => ({
+  notice: css`
+    display: block;
+    flex-shrink: 0;
+    padding: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+}));
 
 const AgentMockPanel = memo(() => {
   const matches = useMatches();
   const isAgentTopicRoute = matches.some((m) => 'topicId' in m.params);
 
   return (
-    <Flexbox gap={12} padding={16} style={{ marginInline: 'auto', maxWidth: 560, width: '100%' }}>
+    <div className={devDockPanelStyles.root}>
       {!isAgentTopicRoute && (
-        <Text fontSize={12} type={'secondary'}>
+        <Text className={styles.notice} fontSize={12} type={'secondary'}>
           Open an agent topic conversation to replay mock cases into it.
         </Text>
       )}
       <Controls />
-    </Flexbox>
+    </div>
   );
 });
 

--- a/src/features/DevDock/Bar.tsx
+++ b/src/features/DevDock/Bar.tsx
@@ -5,7 +5,7 @@ import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDown, Wrench } from 'lucide-react';
 import { Fragment, memo } from 'react';
 
-import { BAR_HEIGHT, DOCK_Z_INDEX } from './const';
+import { BAR_HEIGHT, BAR_OVERLAP, DOCK_Z_INDEX } from './const';
 import OverflowMenu from './OverflowMenu';
 import { PinnedAction, PinnedSelect, PinnedToggle, WidgetSlot } from './pinnedItems';
 import {
@@ -22,7 +22,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     height: ${BAR_HEIGHT}px;
-    margin-block-start: -8px;
+    margin-block-start: -${BAR_OVERLAP}px;
     padding-inline: 8px;
 
     font-size: 11px;

--- a/src/features/DevDock/PanelHost.tsx
+++ b/src/features/DevDock/PanelHost.tsx
@@ -6,15 +6,16 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { Maximize2, Minimize2, XIcon } from 'lucide-react';
 import { memo, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 
-import { BAR_HEIGHT } from './const';
+import { BAR_HEIGHT, BAR_OVERLAP } from './const';
 import PanelErrorBoundary from './PanelErrorBoundary';
 import { type DevDockPanelItem, getItemComponent, useDevDockItems } from './registry';
 import { MIN_PANEL_HEIGHT, useDevDockStore } from './store';
 
 const styles = createStaticStyles(({ css }) => ({
   content: css`
-    overflow: auto;
+    overflow: hidden;
     flex: 1;
+    min-width: 0;
     min-height: 0;
   `,
   header: css`
@@ -36,6 +37,7 @@ const styles = createStaticStyles(({ css }) => ({
     flex-shrink: 0;
 
     width: 100%;
+    margin-block-end: ${BAR_OVERLAP}px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 
     background: ${cssVar.colorBgContainer};

--- a/src/features/DevDock/const.ts
+++ b/src/features/DevDock/const.ts
@@ -1,2 +1,5 @@
 export const BAR_HEIGHT = 28;
+// The dock bar is lifted into the preceding surface; an open panel must
+// reserve the same space below so the bar does not cover its lower edge.
+export const BAR_OVERLAP = 8;
 export const DOCK_Z_INDEX = 1100;

--- a/src/features/DevDock/panelStyles.ts
+++ b/src/features/DevDock/panelStyles.ts
@@ -1,0 +1,79 @@
+import { createStaticStyles, cssVar } from 'antd-style';
+
+export const devDockPanelStyles = createStaticStyles(({ css }) => ({
+  flatSection: css`
+    flex-shrink: 0;
+    padding: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  paneDividerEnd: css`
+    border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  paneDividerStart: css`
+    border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  paneHeader: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+
+    height: 36px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-size: ${cssVar.fontSizeSM};
+    font-weight: 600;
+    color: ${cssVar.colorText};
+  `,
+  paneSearch: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: stretch;
+
+    height: 44px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  root: css`
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+  `,
+  searchInput: css`
+    flex: 1;
+
+    height: 100%;
+    border: 0 !important;
+    border-radius: 0 !important;
+
+    background: transparent !important;
+    box-shadow: none !important;
+  `,
+  statusBar: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: space-between;
+
+    height: 28px;
+    padding-inline: 12px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: ${cssVar.fontSizeSM};
+    color: ${cssVar.colorTextTertiary};
+  `,
+  toolbar: css`
+    display: flex;
+    flex-shrink: 0;
+    gap: 8px;
+    align-items: center;
+
+    height: 44px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+}));

--- a/src/features/DevFeatureFlagPanel/FlagRow.tsx
+++ b/src/features/DevFeatureFlagPanel/FlagRow.tsx
@@ -2,7 +2,7 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { Segmented, Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { snakeCase } from 'es-toolkit/compat';
 import { memo, useMemo } from 'react';
 
@@ -32,12 +32,10 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: center;
     justify-content: space-between;
 
-    margin-block: 2px;
-    margin-inline: 4px;
     padding-block: 6px;
-    padding-inline: 8px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
     border-inline-start: 2px solid transparent;
-    border-radius: 6px;
 
     transition: background 120ms ease;
 
@@ -89,7 +87,7 @@ const FlagRow = memo<FlagRowProps>(({ flagKey }) => {
   };
 
   return (
-    <div className={`${styles.row} ${isOverridden ? styles.rowOverridden : ''}`}>
+    <div className={cx(styles.row, isOverridden && styles.rowOverridden)}>
       <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
         <Text ellipsis className={styles.name}>
           {snakeCase(flagKey as string)}

--- a/src/features/DevFeatureFlagPanel/Panel.tsx
+++ b/src/features/DevFeatureFlagPanel/Panel.tsx
@@ -7,6 +7,7 @@ import { snakeCase } from 'es-toolkit/compat';
 import { ListRestartIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 
+import { devDockPanelStyles } from '@/features/DevDock/panelStyles';
 import { useServerConfigStore } from '@/store/serverConfig';
 import {
   type FeatureFlagKey,
@@ -19,19 +20,7 @@ const styles = createStaticStyles(({ css }) => ({
   body: css`
     overflow: auto;
     flex: 1;
-
     min-height: 0;
-    padding-block: 4px;
-    padding-inline: 4px;
-  `,
-  container: css`
-    display: flex;
-    flex-direction: column;
-
-    width: 100%;
-    max-width: 720px;
-    height: 100%;
-    margin-inline: auto;
   `,
   empty: css`
     padding-block: 32px;
@@ -51,12 +40,21 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   toolbar: css`
     display: flex;
-    gap: 12px;
+    flex-shrink: 0;
     align-items: center;
 
-    padding-block: 8px;
-    padding-inline: 12px;
+    height: 44px;
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  toolbarFilter: css`
+    display: flex;
+    flex-shrink: 0;
+    gap: 6px;
+    align-items: center;
+
+    height: 100%;
+    padding-inline: 12px;
+    border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
 }));
 
@@ -86,20 +84,25 @@ const Panel = memo(() => {
   }, [flagKeys, overrides, overriddenOnly, search]);
 
   if (!originalFlags)
-    return <div className={styles.empty}>Server feature flags are not loaded yet.</div>;
+    return (
+      <div className={devDockPanelStyles.root}>
+        <div className={styles.empty}>Server feature flags are not loaded yet.</div>
+      </div>
+    );
 
   return (
-    <div className={styles.container}>
+    <div className={devDockPanelStyles.root}>
       <div className={styles.toolbar}>
         <Input
           allowClear
+          className={devDockPanelStyles.searchInput}
           placeholder={'Search flag name…'}
           size={'small'}
-          style={{ flex: 1 }}
           value={search}
+          variant={'borderless'}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <Flexbox horizontal align={'center'} gap={6}>
+        <Flexbox horizontal className={styles.toolbarFilter}>
           <Switch checked={overriddenOnly} size={'small'} onChange={setOverriddenOnly} />
           <Text style={{ fontSize: 12, whiteSpace: 'nowrap' }} type={'secondary'}>
             overridden only

--- a/src/features/DevPanel/GpuStatus/index.tsx
+++ b/src/features/DevPanel/GpuStatus/index.tsx
@@ -5,12 +5,14 @@ import { Flexbox } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { Fragment, memo, useEffect, useState } from 'react';
 
+import { devDockPanelStyles } from '@/features/DevDock/panelStyles';
 import { electronDevtoolsService } from '@/services/electron/devtools';
 
 const styles = createStaticStyles(({ css }) => ({
   device: css`
     display: grid;
     grid-template-columns: 96px 1fr;
+    flex-shrink: 0;
     gap: 4px 8px;
 
     padding-block: 10px;
@@ -34,8 +36,11 @@ const styles = createStaticStyles(({ css }) => ({
     color: ${cssVar.colorTextQuaternary};
   `,
   legend: css`
+    flex-shrink: 0;
+
     padding-block: 8px 12px;
     padding-inline: 12px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 
     font-size: 10px;
     line-height: 1.6;
@@ -46,6 +51,11 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   ok: css`
     color: ${cssVar.colorSuccess};
+  `,
+  rows: css`
+    overflow: auto;
+    flex: 1;
+    min-height: 0;
   `,
   row: css`
     display: grid;
@@ -103,13 +113,18 @@ const GpuStatusPanel = memo(() => {
     };
   }, []);
 
-  if (failed) return <div className={styles.empty}>GPU status unavailable over ipc.</div>;
+  if (failed)
+    return (
+      <div className={devDockPanelStyles.root}>
+        <div className={styles.empty}>GPU status unavailable over ipc.</div>
+      </div>
+    );
   if (!status) return null;
 
   const features = Object.entries(status.featureStatus).sort(([a], [b]) => a.localeCompare(b));
 
   return (
-    <Flexbox height={'100%'}>
+    <Flexbox className={devDockPanelStyles.root}>
       <div className={styles.device}>
         {DEVICE_LABELS.map(([label, key]) => (
           <Fragment key={key}>
@@ -120,12 +135,14 @@ const GpuStatusPanel = memo(() => {
           </Fragment>
         ))}
       </div>
-      {features.map(([feature, value]) => (
-        <div className={styles.row} key={feature}>
-          <span className={styles.muted}>{feature}</span>
-          <span className={statusClass(value)}>{value}</span>
-        </div>
-      ))}
+      <div className={styles.rows}>
+        {features.map(([feature, value]) => (
+          <div className={styles.row} key={feature}>
+            <span className={styles.muted}>{feature}</span>
+            <span className={statusClass(value)}>{value}</span>
+          </div>
+        ))}
+      </div>
       <div className={styles.legend}>
         `enabled_*` runs on the GPU, `*_software` fell back to the CPU renderer, `*_off_ok` is
         switched off by design, and anything else is a hard disable worth investigating on

--- a/src/features/DevPanel/RenderGallery/ApiList.tsx
+++ b/src/features/DevPanel/RenderGallery/ApiList.tsx
@@ -5,6 +5,8 @@ import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { memo, useEffect, useRef } from 'react';
 
+import { devDockPanelStyles } from '@/features/DevDock/panelStyles';
+
 import type { ApiEntry } from './useDevtoolsEntries';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -31,12 +33,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   dotActive: css`
     background: ${cssVar.colorPrimary};
   `,
-  header: css`
-    flex-shrink: 0;
-    padding-block: 14px 10px;
-    padding-inline: 16px;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
-  `,
   item: css`
     cursor: pointer;
 
@@ -46,8 +42,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     height: 30px;
-    padding-inline: 10px;
-    border-radius: 6px;
+    padding-inline: 12px;
 
     color: ${cssVar.colorTextSecondary};
 
@@ -99,8 +94,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 2px;
 
     min-height: 0;
-    padding-block: 8px;
-    padding-inline: 8px;
+    padding-block: 4px;
   `,
 }));
 
@@ -142,7 +136,7 @@ const ApiList = memo<ApiListProps>(({ apis, activeApiName, onSelect }) => {
 
   return (
     <aside className={styles.column}>
-      <div className={styles.header}>
+      <div className={devDockPanelStyles.paneHeader}>
         <Text fontSize={12} type={'secondary'} weight={600}>
           APIs · {apis.length}
         </Text>

--- a/src/features/DevPanel/RenderGallery/MessageList.tsx
+++ b/src/features/DevPanel/RenderGallery/MessageList.tsx
@@ -26,12 +26,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   thread: css`
     width: 100%;
-    max-width: 820px;
-    margin-inline: auto;
     padding-block: 8px 48px;
     padding-inline: 12px;
-    border-radius: 14px;
-
     background: ${cssVar.colorBgContainer};
   `,
 }));

--- a/src/features/DevPanel/RenderGallery/Sidebar.tsx
+++ b/src/features/DevPanel/RenderGallery/Sidebar.tsx
@@ -5,15 +5,19 @@ import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 
+import { devDockPanelStyles } from '@/features/DevDock/panelStyles';
+
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  header: css`
-    padding-block: 16px 12px;
-    padding-inline: 20px;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
-  `,
   menu: css`
-    padding-block: 8px;
+    padding-block: 4px;
     border-inline-end: none !important;
+
+    .ant-menu-item,
+    .ant-menu-submenu-title {
+      width: 100%;
+      margin-inline: 0;
+      border-radius: 0;
+    }
   `,
   sidebar: css`
     display: flex;
@@ -40,7 +44,7 @@ interface SidebarProps {
 
 const Sidebar = memo<SidebarProps>(({ items, selectedKey, onSelect }) => (
   <aside className={styles.sidebar}>
-    <div className={styles.header}>
+    <div className={devDockPanelStyles.paneHeader}>
       <Text fontSize={13} type={'secondary'} weight={600}>
         Builtin Tool Renders
       </Text>

--- a/src/features/DevPanel/RenderGallery/ToolPage.tsx
+++ b/src/features/DevPanel/RenderGallery/ToolPage.tsx
@@ -24,9 +24,7 @@ const isGalleryView = (value: string | null): value is GalleryView =>
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   body: css`
-    gap: 24px;
-    max-width: 1200px;
-    padding: 28px;
+    width: 100%;
   `,
   content: css`
     position: relative;
@@ -39,8 +37,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   controlGroup: css`
+    flex-shrink: 0;
     gap: 8px;
     align-items: center;
+    white-space: nowrap;
   `,
   empty: css`
     flex: 1;
@@ -52,7 +52,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   header: css`
     gap: 8px;
-    padding-block-end: 4px;
+    padding: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   modeBar: css`
     position: sticky;
@@ -62,13 +63,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 16px;
     align-items: center;
 
-    padding-block: 10px;
-    padding-inline: 14px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: 14px;
+    min-height: 44px;
+    padding-block: 6px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
     background: ${cssVar.colorBgContainer};
-    box-shadow: ${cssVar.boxShadowTertiary};
   `,
 }));
 

--- a/src/features/DevPanel/RenderGallery/ToolPreview.tsx
+++ b/src/features/DevPanel/RenderGallery/ToolPreview.tsx
@@ -18,29 +18,18 @@ import { toApiAnchor } from './useDevtoolsEntries';
 const styles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
     scroll-margin-block-start: 16px;
-
     overflow: hidden;
-
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: 20px;
-
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
     background: ${cssVar.colorBgContainer};
   `,
   cardBody: css`
-    padding: 20px;
+    gap: 0;
   `,
   cardHeader: css`
-    gap: 10px;
-
-    padding-block: 20px;
-    padding-inline: 24px;
+    gap: 6px;
+    padding: 12px;
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
-
-    background: linear-gradient(
-      180deg,
-      ${cssVar.colorFillQuaternary} 0%,
-      ${cssVar.colorBgContainer} 100%
-    );
+    background: ${cssVar.colorFillQuaternary};
   `,
   code: css`
     overflow: auto;
@@ -48,13 +37,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     max-height: 320px;
     margin: 0;
     padding: 12px;
-    border-radius: 12px;
 
     font-size: 12px;
     line-height: 1.55;
     color: ${cssVar.colorTextSecondary};
 
     background: ${cssVar.colorFillQuaternary};
+  `,
+  fixture: css`
+    padding: 12px;
   `,
   fixtureSummary: css`
     cursor: pointer;
@@ -63,9 +54,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextTertiary};
   `,
   previewShell: css`
-    padding: 16px;
-    border-radius: 16px;
+    padding: 12px;
     background: ${cssVar.colorFillQuaternary};
+  `,
+  previewSection: css`
+    gap: 8px;
+    padding: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   sectionLabel: css`
     gap: 8px;
@@ -116,8 +111,8 @@ const ToolPreview = ({ api, mode }: ToolPreviewProps) => {
         )}
       </Flexbox>
 
-      <Flexbox className={styles.cardBody} gap={16}>
-        <Flexbox gap={8}>
+      <Flexbox className={styles.cardBody}>
+        <Flexbox className={styles.previewSection}>
           <Flexbox horizontal className={styles.sectionLabel}>
             <Text fontSize={12} type={'secondary'} weight={600}>
               Inspector
@@ -133,7 +128,7 @@ const ToolPreview = ({ api, mode }: ToolPreviewProps) => {
           </div>
         </Flexbox>
 
-        <Flexbox gap={8}>
+        <Flexbox className={styles.previewSection}>
           <Flexbox horizontal className={styles.sectionLabel}>
             <Text fontSize={12} type={'secondary'} weight={600}>
               Body
@@ -151,7 +146,7 @@ const ToolPreview = ({ api, mode }: ToolPreviewProps) => {
           </div>
         </Flexbox>
 
-        <details>
+        <details className={styles.fixture}>
           <summary className={styles.fixtureSummary}>Fixture payload</summary>
           <pre className={styles.code}>
             {JSON.stringify(

--- a/src/features/DevPanel/RenderGallery/index.tsx
+++ b/src/features/DevPanel/RenderGallery/index.tsx
@@ -33,14 +33,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     min-width: 0;
     min-height: 0;
 
-    background:
-      radial-gradient(circle at top, ${cssVar.colorFillTertiary} 0%, transparent 35%),
-      ${cssVar.colorBgLayout};
+    background: ${cssVar.colorBgContainer};
   `,
   page: css`
     overflow: hidden;
     width: 100%;
     height: 100%;
+    background: ${cssVar.colorBgContainer};
   `,
 }));
 

--- a/src/features/DevPanel/TabRouters/index.tsx
+++ b/src/features/DevPanel/TabRouters/index.tsx
@@ -4,6 +4,7 @@ import { Flexbox } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { memo } from 'react';
 
+import { devDockPanelStyles } from '@/features/DevDock/panelStyles';
 import { useElectronStore } from '@/store/electron';
 
 import { type TabRouterRow, useTabRouterDebug } from './useTabRouterDebug';
@@ -38,8 +39,11 @@ const styles = createStaticStyles(({ css }) => ({
     background: ${cssVar.colorBgContainer};
   `,
   legend: css`
+    flex-shrink: 0;
+
     padding-block: 8px 12px;
     padding-inline: 12px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 
     font-size: 10px;
     line-height: 1.6;
@@ -76,6 +80,11 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   rowActive: css`
     background: ${cssVar.colorFillTertiary};
+  `,
+  rows: css`
+    overflow: auto;
+    flex: 1;
+    min-height: 0;
   `,
   summary: css`
     flex-shrink: 0;
@@ -157,7 +166,7 @@ const TabRouters = memo(() => {
       : null;
 
   return (
-    <Flexbox height={'100%'}>
+    <Flexbox className={devDockPanelStyles.root}>
       <div className={styles.summary}>
         scope <b>{scopeKey}</b> · tabs <b>{rows.length}</b> · live routers{' '}
         <b className={liveCount > cap ? styles.drift : undefined}>
@@ -170,7 +179,7 @@ const TabRouters = memo(() => {
       {rows.length === 0 ? (
         <div className={styles.empty}>No tabs in this scope.</div>
       ) : (
-        <div>
+        <div className={styles.rows}>
           <div className={cx(styles.row, styles.head)}>
             <span>#</span>
             <span>tab id</span>


### PR DESCRIPTION
<!-- Brief and heads-up -->

Extracts the DevDock UI polish that was stranded on the outdated projection branch in #18076. No projection / local-database inspector work is included.

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| Dock bar overlapped an open panel's lower edge (`margin-block-start: -8px` with no reserved space). Panel host scrolled internally, so child inspectors mixed rounded/card chrome with the dock. | Shared flat workspace chrome (`devDockPanelStyles`); panel host reserves `BAR_OVERLAP` below so the bar no longer covers the panel; inspectors fill the host edge-to-edge. |

#### Test

Style-only CSS/layout. Local SPA at `:9876` currently fails on a pre-existing Vite cache error (`Cannot find module .../vite/dist/node/chunks/dist.js`), so visual check is blocked until that server is healthy.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Related to #18076 (extracted DevDock style-only changes; does not replace that PR)