### PR TITLE
🐛 fix(desktop): recognize AVIF files as images

### DIFF
--- a/apps/desktop/src/main/controllers/LocalFileCtr.ts
+++ b/apps/desktop/src/main/controllers/LocalFileCtr.ts
@@ -72,16 +72,17 @@ const PROJECT_FILE_GLOB_LIMIT = 5000;
 
 /**
  * Image extensions `readFile` uploads to file storage instead of refusing as
- * binary. The agent then sees the image (vision) via an `image_url` part,
+ * binary. The runtime can then route the image to downstream media analysis
  * rather than hitting "Unsupported binary file".
  *
- * Limited to the formats vision providers accept (Anthropic/OpenAI:
- * png/jpeg/gif/webp) — anything else would be silently dropped by the
- * model-runtime builders, which is worse than the binary refusal. SVG is
- * intentionally absent: it's text, and reading the source is more useful to
- * the model than a rasterization we can't produce here.
+ * AVIF is included for Analyze Media, whose request-boundary normalization
+ * converts unsupported image formats for its fallback vision model. This does
+ * not imply native AVIF support across providers. SVG is intentionally absent:
+ * it's text, and reading the source is more useful to the model than a
+ * rasterization we can't produce here.
  */
 const LOCAL_IMAGE_EXT_TO_MIME: Record<string, string> = {
+  avif: 'image/avif',
   gif: 'image/gif',
   jpeg: 'image/jpeg',
   jpg: 'image/jpeg',

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.readFile.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.readFile.test.ts
@@ -154,6 +154,24 @@ describe('LocalFileCtr — readFile / readFiles (real fs)', () => {
       expect(result.content).toBe('[Image: cat.png]');
     });
 
+    it('should upload AVIF as an image for downstream media analysis', async () => {
+      mockUploadService.uploadLocalFile.mockResolvedValue({
+        id: 'file-avif',
+        url: 'https://files.example.com/sample.avif',
+      });
+      const filePath = path.join(tmpDir, 'sample.avif');
+      await writeFile(filePath, Buffer.from('avif'));
+
+      const result = await localFileCtr.readFile({ path: filePath });
+
+      expect(mockUploadService.uploadLocalFile).toHaveBeenCalledWith(filePath);
+      expect(result.isImage).toBe(true);
+      expect(result.fileType).toBe('image/avif');
+      expect(result.imageFileId).toBe('file-avif');
+      expect(result.imageUrl).toBe('https://files.example.com/sample.avif');
+      expect(result.content).toBe('[Image: sample.avif]');
+    });
+
     it('should resolve a relative image path against cwd', async () => {
       mockUploadService.uploadLocalFile.mockResolvedValue({
         id: 'file-2',

--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -32,6 +32,14 @@ export const VISION_DOWNGRADE_PLACEHOLDER =
   '[image omitted: native vision is not supported. Do not infer or describe the image. If the request depends on it, use an available visual-analysis tool before answering; otherwise state that the image cannot be inspected.]';
 
 /**
+ * AVIF must stay as a media ref even when the active model supports vision.
+ * Model capability flags do not describe per-format support, while Analyze Media
+ * normalizes AVIF at its request boundary.
+ */
+const requiresVisualAnalysis = (mediaType: unknown): boolean =>
+  typeof mediaType === 'string' && mediaType.split(';', 1)[0].trim().toLowerCase() === 'image/avif';
+
+/**
  * Heterogeneous-agent image uploads mirror each persisted image URL into tool
  * text as `![mediaType](url)`. Non-vision models must receive only the opaque
  * media ref, otherwise they can copy the signed URL into a later tool call.
@@ -510,7 +518,9 @@ export class MessageContentProcessor extends BaseProcessor {
     // Fast path: no usable images — plain text tool result passes through unchanged.
     if (images.length === 0) return message;
 
-    const canUseVision = !!this.config.isCanUseVision?.(this.config.model, this.config.provider);
+    const canUseVision =
+      !!this.config.isCanUseVision?.(this.config.model, this.config.provider) &&
+      !images.some((image) => requiresVisualAnalysis(image.mediaType));
 
     // Normalize text content (historical messages may already be multimodal).
     let textContent = '';
@@ -523,8 +533,8 @@ export class MessageContentProcessor extends BaseProcessor {
         .join('\n\n');
     }
 
-    // Vision not supported: drop the image parts but surface a placeholder so
-    // the model can pass a stable opaque ref to the visual-analysis fallback.
+    // Native vision unavailable or image format unsupported: surface stable
+    // opaque refs so the model can call the visual-analysis fallback.
     // The signed URL stays out of model-visible text, which prevents the model
     // from copying opaque image data between tool calls.
     if (!canUseVision) {

--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -518,9 +518,13 @@ export class MessageContentProcessor extends BaseProcessor {
     // Fast path: no usable images — plain text tool result passes through unchanged.
     if (images.length === 0) return message;
 
-    const canUseVision =
-      !!this.config.isCanUseVision?.(this.config.model, this.config.provider) &&
-      !images.some((image) => requiresVisualAnalysis(image.mediaType));
+    const canUseVision = !!this.config.isCanUseVision?.(this.config.model, this.config.provider);
+    const fallbackImages = canUseVision
+      ? images.filter((image) => requiresVisualAnalysis(image.mediaType))
+      : images;
+    const visionImages = canUseVision
+      ? images.filter((image) => !requiresVisualAnalysis(image.mediaType))
+      : [];
 
     // Normalize text content (historical messages may already be multimodal).
     let textContent = '';
@@ -537,9 +541,10 @@ export class MessageContentProcessor extends BaseProcessor {
     // opaque refs so the model can call the visual-analysis fallback.
     // The signed URL stays out of model-visible text, which prevents the model
     // from copying opaque image data between tool calls.
-    if (!canUseVision) {
-      const fallbackTextContent = stripUploadedImageMarkdown(textContent, images);
-      const placeholders = images
+    let processedTextContent = textContent;
+    if (fallbackImages.length > 0) {
+      const fallbackTextContent = stripUploadedImageMarkdown(textContent, fallbackImages);
+      const placeholders = fallbackImages
         .map(({ sourceIndex, url }) => {
           // Inline image data is safe to send as a structured vision input but
           // must never be copied into text or exposed as a reusable media ref.
@@ -554,20 +559,20 @@ export class MessageContentProcessor extends BaseProcessor {
           return `[image omitted: native vision is not supported. Media ref: ${ref}. Do not infer or describe the image. Use an available visual-analysis tool with this ref before answering.]`;
         })
         .join('\n');
-      const content = fallbackTextContent
+      processedTextContent = fallbackTextContent
         ? `${fallbackTextContent}\n\n${placeholders}`
         : placeholders;
-
-      return { ...message, content };
     }
+
+    if (visionImages.length === 0) return { ...message, content: processedTextContent };
 
     const contentParts: UserMessageContentPart[] = [];
 
-    if (textContent) {
-      contentParts.push({ text: textContent, type: 'text' });
+    if (processedTextContent) {
+      contentParts.push({ text: processedTextContent, type: 'text' });
     }
 
-    contentParts.push(...(await this.processImageList(images)));
+    contentParts.push(...(await this.processImageList(visionImages)));
 
     return { ...message, content: contentParts };
   }

--- a/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
+++ b/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
@@ -393,7 +393,7 @@ describe('MessageContentProcessor', () => {
       expect(result.messages[0].tool_call_id).toBe('call_abc');
     });
 
-    it('should keep AVIF tool images as media refs for vision models', async () => {
+    it('should keep AVIF as a media ref while forwarding supported tool images', async () => {
       mockIsCanUseVision.mockReturnValue(true);
 
       const processor = new MessageContentProcessor({
@@ -402,12 +402,18 @@ describe('MessageContentProcessor', () => {
         isCanUseVision: mockIsCanUseVision,
         fileContext: { enabled: false },
       });
-      const imageUrl = 'https://example.com/f/image-id.avif?signature=secret';
+      const avifUrl = 'https://example.com/f/image-id.avif?signature=secret';
+      const pngUrl = 'https://example.com/f/image-id.png?signature=secret';
       const messages: UIChatMessage[] = [
         {
-          content: 'Read AVIF image result',
+          content: 'Read image results',
           id: 'tool-avif',
-          pluginState: { images: [{ mediaType: 'image/avif', url: imageUrl }] },
+          pluginState: {
+            images: [
+              { mediaType: 'image/avif', url: avifUrl },
+              { mediaType: 'image/png', url: pngUrl },
+            ],
+          },
           role: 'tool',
           tool_call_id: 'call_avif',
           createdAt: Date.now(),
@@ -416,13 +422,25 @@ describe('MessageContentProcessor', () => {
       ];
 
       const result = await processor.process(createContext(messages));
-      const content = result.messages[0].content as string;
+      const content = result.messages[0].content;
 
-      expect(content).toContain(
+      expect(content).toBeInstanceOf(Array);
+      const contentParts = content as Array<{
+        image_url?: { detail: string; url: string };
+        text?: string;
+        type: string;
+      }>;
+      const textContent = contentParts.find((part) => part.type === 'text')?.text;
+
+      expect(textContent).toContain(
         createMediaFileRef({ index: 0, messageId: 'tool-avif', type: 'image' }),
       );
-      expect(content).toContain('visual-analysis tool');
-      expect(content).not.toContain(imageUrl);
+      expect(textContent).toContain('visual-analysis tool');
+      expect(textContent).not.toContain(avifUrl);
+      expect(contentParts).toContainEqual({
+        image_url: { detail: 'auto', url: pngUrl },
+        type: 'image_url',
+      });
       expect(result.messages[0].tool_call_id).toBe('call_avif');
     });
 

--- a/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
+++ b/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
@@ -393,6 +393,39 @@ describe('MessageContentProcessor', () => {
       expect(result.messages[0].tool_call_id).toBe('call_abc');
     });
 
+    it('should keep AVIF tool images as media refs for vision models', async () => {
+      mockIsCanUseVision.mockReturnValue(true);
+
+      const processor = new MessageContentProcessor({
+        model: 'gpt-4-vision',
+        provider: 'openai',
+        isCanUseVision: mockIsCanUseVision,
+        fileContext: { enabled: false },
+      });
+      const imageUrl = 'https://example.com/f/image-id.avif?signature=secret';
+      const messages: UIChatMessage[] = [
+        {
+          content: 'Read AVIF image result',
+          id: 'tool-avif',
+          pluginState: { images: [{ mediaType: 'image/avif', url: imageUrl }] },
+          role: 'tool',
+          tool_call_id: 'call_avif',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        } as any,
+      ];
+
+      const result = await processor.process(createContext(messages));
+      const content = result.messages[0].content as string;
+
+      expect(content).toContain(
+        createMediaFileRef({ index: 0, messageId: 'tool-avif', type: 'image' }),
+      );
+      expect(content).toContain('visual-analysis tool');
+      expect(content).not.toContain(imageUrl);
+      expect(result.messages[0].tool_call_id).toBe('call_avif');
+    });
+
     it('should remove uploaded image markdown URLs before adding a media ref', async () => {
       mockIsCanUseVision.mockReturnValue(false);
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

Desktop readFile currently rejects AVIF as unsupported binary data, forcing agents to run OS-specific conversions. This change classifies AVIF as an image and uploads it unchanged. At the model request boundary, AVIF stays as an opaque media ref even when the active model supports vision, so the agent can route it through Analyze Media without exposing an unsupported AVIF input to native vision.

No UI change.

#### Key Decisions / Non-goals

- readFile does not convert AVIF.
- AVIF is not forwarded directly to native vision models; Analyze Media handles request-time normalization.
- Native AVIF support for arbitrary provider models is unchanged.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated test:

- bun run check lobehub/apps/desktop/src/main/controllers/LocalFileCtr.ts lobehub/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.readFile.test.ts lobehub/packages/context-engine/src/processors/MessageContent.ts lobehub/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
- Result: lint clean and 128 tests passed.

#### 🔗 Related Issue

N/A