### PR TITLE
💄 style(chat): use theme color for active dictation

### DIFF
--- a/src/features/ChatInput/Dictation/index.tsx
+++ b/src/features/ChatInput/Dictation/index.tsx
@@ -38,10 +38,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillSecondary};
   `,
   listening: css`
-    color: ${cssVar.colorWhite};
+    color: ${cssVar.colorBgContainer};
 
-    background: ${cssVar.colorSuccess};
-    box-shadow: 0 0 0 3px ${cssVar.colorSuccessBg};
+    background: ${cssVar.colorPrimary};
+    box-shadow: 0 0 0 3px ${cssVar.colorPrimaryBg};
 
     transition:
       color 160ms ease,
@@ -51,29 +51,29 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     animation: dictation-halo-breathe 1.6s ease-in-out infinite;
 
     &:hover {
-      color: ${cssVar.colorWhite};
-      background: ${cssVar.colorSuccessHover};
-      box-shadow: 0 0 0 4px ${cssVar.colorSuccessBgHover};
+      color: ${cssVar.colorBgContainer};
+      background: ${cssVar.colorPrimaryHover};
+      box-shadow: 0 0 0 4px ${cssVar.colorPrimaryBgHover};
     }
 
     &:active {
       transform: scale(0.94);
-      background: ${cssVar.colorSuccessActive};
+      background: ${cssVar.colorPrimaryActive};
     }
 
     &:focus-visible {
-      outline: 2px solid ${cssVar.colorSuccess};
+      outline: 2px solid ${cssVar.colorPrimary};
       outline-offset: 3px;
     }
 
     @keyframes dictation-halo-breathe {
       0%,
       100% {
-        box-shadow: 0 0 0 3px ${cssVar.colorSuccessBg};
+        box-shadow: 0 0 0 3px ${cssVar.colorPrimaryBg};
       }
 
       50% {
-        box-shadow: 0 0 0 6px ${cssVar.colorSuccessBgHover};
+        box-shadow: 0 0 0 6px ${cssVar.colorPrimaryBgHover};
       }
     }
 

--- a/src/features/ChatInput/Dictation/index.tsx
+++ b/src/features/ChatInput/Dictation/index.tsx
@@ -38,48 +38,34 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillSecondary};
   `,
   listening: css`
-    color: ${cssVar.colorBgContainer};
-
-    background: ${cssVar.colorPrimary};
-    box-shadow: 0 0 0 3px ${cssVar.colorPrimaryBg};
-
     transition:
       color 160ms ease,
       background 160ms ease,
-      box-shadow 160ms ease,
       transform 120ms ease;
-    animation: dictation-halo-breathe 1.6s ease-in-out infinite;
 
-    &:hover {
+    && {
       color: ${cssVar.colorBgContainer};
-      background: ${cssVar.colorPrimaryHover};
-      box-shadow: 0 0 0 4px ${cssVar.colorPrimaryBgHover};
+      background: ${cssVar.colorPrimary};
     }
 
-    &:active {
+    &&:hover {
+      color: ${cssVar.colorBgContainer};
+      background: ${cssVar.colorPrimaryHover};
+    }
+
+    &&:active {
       transform: scale(0.94);
       background: ${cssVar.colorPrimaryActive};
     }
 
-    &:focus-visible {
-      outline: 2px solid ${cssVar.colorPrimary};
-      outline-offset: 3px;
-    }
-
-    @keyframes dictation-halo-breathe {
-      0%,
-      100% {
-        box-shadow: 0 0 0 3px ${cssVar.colorPrimaryBg};
-      }
-
-      50% {
-        box-shadow: 0 0 0 6px ${cssVar.colorPrimaryBgHover};
-      }
+    &&:focus-visible {
+      outline: 2px solid ${cssVar.colorBgContainer};
+      outline-offset: -3px;
+      box-shadow: none;
     }
 
     @media (prefers-reduced-motion: reduce) {
       transition: none;
-      animation: none;
     }
   `,
   listeningStatus: css`

--- a/src/features/ChatInput/Dictation/index.tsx
+++ b/src/features/ChatInput/Dictation/index.tsx
@@ -44,22 +44,23 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       transform 120ms ease;
 
     && {
-      color: ${cssVar.colorBgContainer};
+      color: contrast-color(${cssVar.colorPrimary});
       background: ${cssVar.colorPrimary};
     }
 
     &&:hover {
-      color: ${cssVar.colorBgContainer};
+      color: contrast-color(${cssVar.colorPrimaryHover});
       background: ${cssVar.colorPrimaryHover};
     }
 
     &&:active {
       transform: scale(0.94);
+      color: contrast-color(${cssVar.colorPrimaryActive});
       background: ${cssVar.colorPrimaryActive};
     }
 
     &&:focus-visible {
-      outline: 2px solid ${cssVar.colorBgContainer};
+      outline: 2px solid currentcolor;
       outline-offset: -3px;
       box-shadow: none;
     }


### PR DESCRIPTION
Uses the configured primary theme color for the active voice-dictation control instead of the success-green palette.

The active state now stays fully inside the 32px action button. The previous breathing halo extended beyond the button bounds and was clipped by the composer action slot's required `overflow: hidden`, which made the top and bottom look cut off. Hover and pressed states still follow the theme-aware `colorPrimary*` ramp.

The microphone foreground is derived with CSS `contrast-color(...)` against each state's actual primary background. Bright supported presets such as yellow and lime therefore choose a dark foreground, while dark primary colors choose a light foreground. Keyboard focus reuses that computed foreground for its internal outline.

| Before | After |
| ------ | ----- |
| Active dictation used the fixed green palette; the external halo was clipped and a near-white foreground lost contrast on bright primary presets. | Active dictation uses the current primary theme color with a complete circular silhouette and an automatically contrasting foreground. |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- `bun run check src/features/ChatInput/Dictation/index.tsx` — lint clean, no related tests
- `git diff --check` — passed
- Agent Testing on the local full-stack app — rendered listening control is 32×32, circular, theme-primary, with no external shadow or animation; screenshot inspected after HMR
- Browser runtime check — `contrast-color(...)` is supported and the HMR stylesheet contains the primary, hover, and active contrast rules
- Pure CSS style fix; per repository guidance, no stylesheet source-string regression test was added

#### 🔗 Related Issue

Fixes LOBE-13531 and follows up #18709.
