### PR TITLE
✨ feat: graduate in-app browser from labs

### DIFF
--- a/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
+++ b/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
@@ -17,12 +17,14 @@ const {
   opFindById,
   taskFindById,
   taskUpdateStatus,
+  briefModelConstruct,
   briefCreate,
   serviceUpdateStatus,
   statusRecompute,
   deliverMock,
 } = vi.hoisted(() => ({
   briefCreate: vi.fn(),
+  briefModelConstruct: vi.fn(),
   deliverMock: vi.fn(),
   opFindById: vi.fn(),
   runFindByOperation: vi.fn(),
@@ -55,7 +57,7 @@ vi.mock('@/database/models/task', () => ({
   })),
 }));
 vi.mock('@/database/models/brief', () => ({
-  BriefModel: vi.fn(() => ({ create: briefCreate })),
+  BriefModel: briefModelConstruct,
 }));
 // Resolved via dynamic import inside driveTaskFromVerify (cycle break).
 vi.mock('@/server/services/task', () => ({
@@ -77,6 +79,7 @@ describe('driveTaskFromVerify', () => {
       opFindById,
       taskFindById,
       taskUpdateStatus,
+      briefModelConstruct,
       briefCreate,
       serviceUpdateStatus,
       statusRecompute,
@@ -85,6 +88,7 @@ describe('driveTaskFromVerify', () => {
     // The drive is claimed before any side effect; unclaimed means "someone
     // else is driving this run", which every test here is not.
     runClaimTaskDrive.mockResolvedValue(true);
+    briefModelConstruct.mockImplementation(() => ({ create: briefCreate }));
     opFindById.mockResolvedValue({ taskId: 'task-1', topicId: 'topic-done' });
     taskFindById.mockResolvedValue({
       assigneeAgentId: 'a1',
@@ -165,13 +169,10 @@ describe('driveTaskFromVerify', () => {
     expect(statusRecompute.mock.calls).toEqual([['repair-op-1'], ['root-op']]);
   });
 
-  it('failed → urgent brief + pauses with the reason on the task row', async () => {
+  it('failed → pauses with the reason on the task row without creating an inbox brief', async () => {
     runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'failed' });
     await driveTaskFromVerify(db, 'u1', 'op-1');
-    expect(briefCreate).toHaveBeenCalled();
-    // The reason must live on the task row, not only in a brief: the task
-    // detail feed deliberately excludes briefs, so a brief-only explanation is
-    // unreachable from the task page.
+    expect(briefModelConstruct).not.toHaveBeenCalled();
     expect(taskUpdateStatus).toHaveBeenCalledWith('task-1', 'paused', {
       error: 'Delivery did not pass verification.',
     });
@@ -180,7 +181,7 @@ describe('driveTaskFromVerify', () => {
     expect(deliverMock.mock.calls[0][0]).toMatchObject({ reason: 'error', taskId: 'task-1' });
   });
 
-  it('errored → pauses with a non-accusatory brief; never claims the delivery "did not pass"', async () => {
+  it('errored → pauses without an inbox brief; never claims the delivery "did not pass"', async () => {
     runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'errored' });
     await driveTaskFromVerify(db, 'u1', 'op-1');
 
@@ -192,10 +193,7 @@ describe('driveTaskFromVerify', () => {
     );
     expect(serviceUpdateStatus).not.toHaveBeenCalled();
 
-    // The brief frames it as an internal verification error, not a rejected delivery.
-    const briefArg = briefCreate.mock.calls[0][0];
-    expect(briefArg.summary).not.toContain('did not pass');
-    expect(briefArg.summary.toLowerCase()).toContain('could not run');
+    expect(briefModelConstruct).not.toHaveBeenCalled();
 
     // The creator callback is an error, but the message must NOT accuse the
     // delivery of failing verification.

--- a/apps/server/src/services/verify/settle.ts
+++ b/apps/server/src/services/verify/settle.ts
@@ -1,8 +1,6 @@
-import { DEFAULT_BRIEF_ACTIONS } from '@lobechat/types';
 import debug from 'debug';
 
 import { AgentOperationModel } from '@/database/models/agentOperation';
-import { BriefModel } from '@/database/models/brief';
 import { GoalModel } from '@/database/models/goal';
 import { TaskModel } from '@/database/models/task';
 import { VerifyRunModel } from '@/database/models/verifyRun';
@@ -71,7 +69,7 @@ interface ReportContext {
  * (`submitVerifyResult`) — so the task is driven from exactly one place.
  *
  * Once a task-bound run reaches a terminal verdict: `passed` → complete the task
- * (with cascade); `failed` → raise an urgent brief + pause it for the user.
+ * (with cascade); `failed` / `errored` → pause it with the reason on the task.
  * Idempotent via a run-metadata marker; best-effort (never throws into verify).
  */
 export const driveTaskFromVerify = async (
@@ -132,26 +130,11 @@ export const driveTaskFromVerify = async (
       const pauseSummary = isErrored
         ? 'Verification could not run (internal error); the delivery was not evaluated.'
         : 'Delivery did not pass verification.';
-      await new BriefModel(db, userId, workspaceId).create({
-        actions: DEFAULT_BRIEF_ACTIONS['error'],
-        agentId: task.assigneeAgentId || undefined,
-        priority: 'urgent',
-        summary: pauseSummary,
-        taskId: taskOperation.taskId,
-        title: isErrored
-          ? `${task.identifier} verification errored`
-          : `${task.identifier} failed verification`,
-        trigger: 'task',
-        type: 'error',
-      });
-      // Same reasoning as the passed branch: the reason has to live on the task
-      // row, not only in a brief. The task detail feed deliberately excludes
-      // briefs, so a brief-only explanation is invisible from the task page.
+      // Verification outcomes belong to the task itself. Do not create an inbox
+      // brief here: a verifier rejection/error is not a separate user todo.
       await taskModel.updateStatus(taskOperation.taskId, 'paused', { error: pauseSummary });
       log(
-        isErrored
-          ? 'verify errored → task %s paused + brief'
-          : 'verify failed → task %s paused + brief',
+        isErrored ? 'verify errored → task %s paused' : 'verify failed → task %s paused',
         taskOperation.taskId,
       );
     }

--- a/packages/builtin-tool-browser/src/client/executor/index.ts
+++ b/packages/builtin-tool-browser/src/client/executor/index.ts
@@ -1,4 +1,4 @@
-import type { BuiltinToolContext, BuiltinToolResult } from '@lobechat/types';
+import type { BuiltinToolContext } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 
 import type {
@@ -36,28 +36,8 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
   readonly identifier = BrowserIdentifier;
   protected readonly apiEnum = BrowserApiEnum;
 
-  /**
-   * Every execution path funnels through this executor (local runtime, the
-   * DesktopBrowserGatewayBridge for cloud runs, and the CC MCP bridge), so a
-   * single Labs-toggle gate here covers them all: with the in-app browser lab
-   * off, the sidebar tab is hidden and driving it would be invisible to the
-   * user.
-   */
-  private async labDisabledFailure(): Promise<BuiltinToolResult | undefined> {
-    const [{ useUserStore }, { labPreferSelectors }] = await Promise.all([
-      import('@/store/user'),
-      import('@/store/user/selectors'),
-    ]);
-    if (labPreferSelectors.enableInAppBrowser(useUserStore.getState())) return undefined;
-    return this.failure(
-      'The in-app browser is disabled. Ask the user to enable "In-App Browser" under Settings → Advanced → Labs, then retry.',
-    );
-  }
-
   navigate = async (params: BrowserNavigateArgs, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       const sessionId = this.sessionIdOf(ctx);
       const { electronBrowserSidebarService } = await import('@/services/electron/browserSidebar');
 
@@ -81,8 +61,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   snapshot = async (_params: object, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.snapshot({
         sessionId: this.sessionIdOf(ctx),
@@ -103,8 +81,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   click = async (params: BrowserClickArgs, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       await this.revealBrowserTab(ctx);
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.click({
@@ -126,8 +102,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   fill = async (params: BrowserFillArgs, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       await this.revealBrowserTab(ctx);
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.fill({
@@ -148,8 +122,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   press = async (params: BrowserPressArgs, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.press({
         key: params.key,
@@ -164,8 +136,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   scroll = async (params: BrowserScrollArgs, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.scroll({
         dx: params.dx,
@@ -181,8 +151,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   screenshot = async (_params: object, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       await this.revealBrowserTab(ctx);
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.screenshot({
@@ -202,8 +170,6 @@ class BrowserExecutor extends BaseExecutor<typeof BrowserApiEnum> {
 
   readPage = async (_params: object, ctx?: BuiltinToolContext) => {
     try {
-      const disabled = await this.labDisabledFailure();
-      if (disabled) return disabled;
       const { electronBrowserControlService } = await import('@/services/electron/browserControl');
       const result = await electronBrowserControlService.readPage({
         sessionId: this.sessionIdOf(ctx),

--- a/packages/builtin-tool-browser/src/client/executor/index.ts
+++ b/packages/builtin-tool-browser/src/client/executor/index.ts
@@ -1,4 +1,4 @@
-import type { BuiltinToolContext } from '@lobechat/types';
+import type { BuiltinToolContext, BuiltinToolResult } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 
 import type {

--- a/packages/builtin-tool-web-browsing/src/client/Portal/Search/ResultList/SearchItem/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Portal/Search/ResultList/SearchItem/index.tsx
@@ -9,8 +9,6 @@ import { memo } from 'react';
 
 import WebFavicon from '@/components/WebFavicon';
 import { useGlobalStore } from '@/store/global';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 import TitleExtra from './TitleExtra';
 import Video from './Video';
@@ -65,12 +63,11 @@ interface SearchResultProps extends UniformSearchResult {
 const SearchItem = memo<SearchResultProps>((props) => {
   const { content, url, score, engines, title, category } = props;
   const openInBrowserTab = useGlobalStore((s) => s.openInBrowserTab);
-  const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
 
   // Only claim the click when this onClick will actually handle it. Otherwise the
   // anchor's default behavior — and the desktop preload's external-link branch —
   // opens the system browser.
-  const handlesClick = isDesktop && enableInAppBrowser && !!url;
+  const handlesClick = isDesktop && !!url;
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     if (!handlesClick) return;

--- a/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchResult/SearchResultItem.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchResult/SearchResultItem.tsx
@@ -9,8 +9,6 @@ import { memo } from 'react';
 
 import WebFavicon from '@/components/WebFavicon';
 import { useGlobalStore } from '@/store/global';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 const styles = createStaticStyles(({ css }) => ({
   container: css`
@@ -29,12 +27,11 @@ const SearchResultItem = memo<UniformSearchResult & { style?: CSSProperties }>(
     const urlObj = new URL(url);
     const host = urlObj.hostname;
     const openInBrowserTab = useGlobalStore((s) => s.openInBrowserTab);
-    const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
 
     // Only claim the click when this onClick will actually handle it. Otherwise the
     // anchor's default behavior — and the desktop preload's external-link branch —
     // opens the system browser.
-    const handlesClick = isDesktop && enableInAppBrowser;
+    const handlesClick = isDesktop;
 
     const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
       if (!handlesClick) return;

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -197,10 +197,6 @@ export const UserLabSchema = z.object({
    */
   enableImessage: z.boolean().optional(),
   /**
-   * show the in-app Browser tab in the conversation WorkingSidebar (desktop only)
-   */
-  enableInAppBrowser: z.boolean().optional(),
-  /**
    * enable markdown rendering in chat input editor
    */
   enableInputMarkdown: z.boolean().optional(),

--- a/src/features/Conversation/Markdown/plugins/Link/Render/LinkChip.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/LinkChip.tsx
@@ -8,8 +8,6 @@ import { memo, type MouseEvent, type ReactNode, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useGlobalStore } from '@/store/global';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
@@ -55,7 +53,6 @@ const isWebUrl = (href?: string) => !!href && /^https?:\/\//i.test(href);
 const LinkChip = memo<LinkChipProps>(({ href, icon, label }) => {
   const { t } = useTranslation('chat');
   const openInBrowserTab = useGlobalStore((s) => s.openInBrowserTab);
-  const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
 
   const openInSideBrowser = useCallback(
     (event: MouseEvent<HTMLElement>) => {
@@ -72,7 +69,7 @@ const LinkChip = memo<LinkChipProps>(({ href, icon, label }) => {
     </a>
   );
 
-  if (!isDesktop || !enableInAppBrowser || !isWebUrl(href)) return link;
+  if (!isDesktop || !isWebUrl(href)) return link;
 
   return (
     <span className={styles.wrapper}>

--- a/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx
@@ -26,7 +26,6 @@ vi.mock('@lobechat/const', async (importOriginal) => ({
 // selector's return value through this module-level flag so each case can flip
 // the "Link Icon" setting on/off without a real store.
 let mockShowIcon = true;
-let mockEnableInAppBrowser = false;
 const mockOpenInBrowserTab = vi.fn();
 const mockNavigate = vi.fn();
 const mockOpenAcceptance = vi.fn();
@@ -75,9 +74,6 @@ vi.mock('@/store/user', () => ({
 }));
 
 vi.mock('@/store/user/selectors', () => ({
-  labPreferSelectors: {
-    enableInAppBrowser: () => mockEnableInAppBrowser,
-  },
   userGeneralSettingsSelectors: {
     enableMessageLinkIcon: () => mockShowIcon,
   },
@@ -98,7 +94,6 @@ const renderLink = (properties: Record<string, unknown>) =>
 afterEach(() => {
   mockShowIcon = true;
   mockIsDesktop = false;
-  mockEnableInAppBrowser = false;
   vi.restoreAllMocks();
 });
 
@@ -324,9 +319,8 @@ describe('Link Render — open an external link in the side browser', () => {
       linkLabel: 'http://localhost:3022/observability/context',
     });
 
-  it('offers the side-browser action on desktop when the in-app browser is enabled', () => {
+  it('offers the side-browser action on desktop', () => {
     mockIsDesktop = true;
-    mockEnableInAppBrowser = true;
 
     const { container } = renderExternal();
     const action = container.querySelector('[data-side-browser]')!;
@@ -341,7 +335,6 @@ describe('Link Render — open an external link in the side browser', () => {
 
   it('keeps the action OUTSIDE the anchor, or the preload would swallow its click', () => {
     mockIsDesktop = true;
-    mockEnableInAppBrowser = true;
 
     const { container } = renderExternal();
 
@@ -353,7 +346,6 @@ describe('Link Render — open an external link in the side browser', () => {
 
   it('leaves the anchor itself untouched, so a plain click still opens the system browser', () => {
     mockIsDesktop = true;
-    mockEnableInAppBrowser = true;
 
     const { container } = renderExternal();
     const anchor = container.querySelector('a')!;
@@ -365,22 +357,14 @@ describe('Link Render — open an external link in the side browser', () => {
     expect(mockOpenInBrowserTab).not.toHaveBeenCalled();
   });
 
-  it('hides the action on web, and on desktop with the lab flag off', () => {
+  it('hides the action on web', () => {
     mockIsDesktop = false;
-    mockEnableInAppBrowser = true;
     const web = renderExternal();
     expect(web.container.querySelector('[data-side-browser]')).toBeNull();
-    web.unmount();
-
-    mockIsDesktop = true;
-    mockEnableInAppBrowser = false;
-    const flagOff = renderExternal();
-    expect(flagOff.container.querySelector('[data-side-browser]')).toBeNull();
   });
 
   it('hides the action for non-web links (mailto) and for portal-bound internal links', () => {
     mockIsDesktop = true;
-    mockEnableInAppBrowser = true;
 
     const email = renderLink({
       linkHref: 'mailto:a@b.com',

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -268,11 +268,6 @@ vi.mock('@/const/version', () => ({
     return platform.isDesktop;
   },
 }));
-vi.mock('@/store/user', () => ({ useUserStore: () => true }));
-vi.mock('@/store/user/selectors', () => ({
-  labPreferSelectors: { enableInAppBrowser: () => true },
-}));
-
 vi.mock('@lobehub/ui', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   ActionIcon: ({ onClick, title }: { onClick?: () => void; title?: string }) => (

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -62,8 +62,6 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useElectronStore } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 import { type ComposerTarget, createComposerTarget, resolveThreadComposerTarget } from '../types';
 import Files from './Files';
@@ -338,10 +336,8 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
   const filesAvailable = !isChatMode && (isLocalExecution || isDeviceMode) && !!workingDirectory;
   const reviewAvailable = (isLocalExecution || isDeviceMode) && !!workingDirectory && !!repoType;
   const paramsAvailable = !isHetero;
-  // The in-app browser pages are renderer-retained Electron webviews — desktop only,
-  // and gated behind the Labs toggle while the feature matures.
-  const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
-  const browserAvailable = isDesktop && enableInAppBrowser;
+  // The in-app browser pages are renderer-retained Electron webviews — desktop only.
+  const browserAvailable = isDesktop;
   const terminalAvailable = isDesktop;
   // Must mint the same key the browser tools do (`sessionIdOf` in
   // builtin-tool-browser), or the user and the agent would be looking at two

--- a/src/features/Settings/labs/features.ts
+++ b/src/features/Settings/labs/features.ts
@@ -20,7 +20,6 @@ type LabFeatureI18nKey =
   | 'desktopSplitView'
   | 'heteroSessionImport'
   | 'imessage'
-  | 'inAppBrowser'
   | 'inputMarkdown'
   | 'messageTextSelectionActions'
   | 'oauthApps'
@@ -137,13 +136,6 @@ export const LAB_FEATURES: LabFeatureItem[] = [
     flag: 'enableHeteroSessionImport',
     i18nKey: 'heteroSessionImport',
     searchKeywords: ['import session', 'claude code', 'codex'],
-    stage: 'beta',
-  },
-  {
-    desktopOnly: true,
-    flag: 'enableInAppBrowser',
-    i18nKey: 'inAppBrowser',
-    searchKeywords: ['in-app browser', 'inapp browser', 'embedded browser', 'browser tab'],
     stage: 'beta',
   },
 ];

--- a/src/features/Settings/labs/index.test.tsx
+++ b/src/features/Settings/labs/index.test.tsx
@@ -119,13 +119,19 @@ describe('Labs settings page', () => {
     expect(screen.queryByText('features.taskVerify.title')).toBeNull();
   });
 
+  it('does not render the released in-app browser as a lab toggle', () => {
+    renderPage();
+
+    expect(screen.queryByText('features.inAppBrowser.title')).toBeNull();
+  });
+
   it('labels every experiment with a maturity stage tag', () => {
     renderPage();
 
     const alphaTags = screen.getAllByText('stage.alpha.label');
     const betaTags = screen.getAllByText('stage.beta.label');
     // Every toggle carries exactly one stage tag.
-    expect(alphaTags.length + betaTags.length).toBe(15);
+    expect(alphaTags.length + betaTags.length).toBe(14);
   });
 
   it('marks internal-testing experiments as alpha and usable ones as beta', () => {

--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -185,9 +185,6 @@ vi.mock('@/store/user', () => ({
 }));
 
 vi.mock('@/store/user/selectors', () => ({
-  labPreferSelectors: {
-    enableInAppBrowser: () => false,
-  },
   settingsSelectors: {
     memoryEnabled: () => false,
   },

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -34,7 +34,7 @@ import {
 } from '@/store/tool/selectors';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 import { useUserStore } from '@/store/user';
-import { labPreferSelectors, settingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors } from '@/store/user/selectors';
 
 import { getSearchConfig } from '../getSearchConfig';
 import { isCanUseFC } from '../isCanUseFC';
@@ -262,13 +262,9 @@ export const createAgentToolsEngine = (
     // Always-on builtin tools
     ...Object.fromEntries(alwaysOnToolIds.map((id) => [id, true])),
     // System-level rules (may override user selection for specific tools)
-    // Browser rides the same local-runtime gate as local-system (the control
-    // IPC only exists in the desktop main process), plus the in-app browser
-    // Labs toggle that also governs the sidebar tab — with the lab off the
-    // tool would drive a pane the user can't see.
-    [BrowserManifest.identifier]:
-      agentChatConfigSelectors.isLocalSystemEnabled(agentState) &&
-      labPreferSelectors.enableInAppBrowser(useUserStore.getState()),
+    // Browser rides the same local-runtime gate as local-system because the
+    // control IPC only exists in the desktop main process.
+    [BrowserManifest.identifier]: agentChatConfigSelectors.isLocalSystemEnabled(agentState),
     [CloudSandboxManifest.identifier]: agentChatConfigSelectors.isCloudSandboxEnabled(agentState),
     [KnowledgeBaseManifest.identifier]: kbEnabled,
     [LocalSystemManifest.identifier]: agentChatConfigSelectors.isLocalSystemEnabled(agentState),

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -22,7 +22,6 @@ export const labPreferSelectors = {
   enableHeteroSessionImport: (s: UserState): boolean =>
     s.preference.lab?.enableHeteroSessionImport ?? false,
   enableImessage: (s: UserState): boolean => s.preference.lab?.enableImessage ?? false,
-  enableInAppBrowser: (s: UserState): boolean => s.preference.lab?.enableInAppBrowser ?? false,
   enableInputMarkdown: (s: UserState): boolean =>
     s.preference.lab?.enableInputMarkdown ?? DEFAULT_PREFERENCE.lab?.enableInputMarkdown ?? true,
   enableMessageTextSelectionActions: (s: UserState): boolean =>


### PR DESCRIPTION
## Summary

- graduate the desktop In-App Browser from its beta Labs toggle and enable it for all desktop users
- remove the legacy browser preference gate from the sidebar, link/search entry points, tool engineering, and browser executor
- stop creating urgent inbox briefs when task verification fails or errors
- keep failed verification state on the paused task while preserving creator callbacks and goal retry/coordination behavior

## Test plan

- `bun run check`
- 13 changed files lint clean, 112 related tests passed