### PR TITLE
🐛 fix(openapi): complete Responses usage for Grok Build

### DIFF
--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -541,7 +541,15 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(terminalEvents).toHaveLength(1);
     expect(terminalEvents[0]).toMatchObject({
       data: {
-        response: { usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 } },
+        response: {
+          usage: {
+            input_tokens: 2,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 1,
+            output_tokens_details: { reasoning_tokens: 0 },
+            total_tokens: 3,
+          },
+        },
         type: 'response.completed',
       },
       type: 'response.completed',
@@ -552,6 +560,47 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(events.slice(events.indexOf(terminalEvents[0]) + 1)).toEqual([
       { data: '[DONE]', type: undefined },
     ]);
+  });
+
+  it('encodes complete Responses usage details without stringifying null chunks', async () => {
+    const events = parseSseEvents(
+      await readText(
+        responsesSse(
+          protocolStream([
+            { data: 'answer', type: 'text' },
+            { data: null, type: 'text' },
+            { data: null, type: 'reasoning' },
+            {
+              data: {
+                inputCachedTokens: 3,
+                outputReasoningTokens: 2,
+                totalInputTokens: 7,
+                totalOutputTokens: 4,
+              },
+              type: 'usage',
+            },
+          ]),
+        ),
+      ),
+    );
+    const textDeltas = events
+      .filter(({ type }) => type === 'response.output_text.delta')
+      .map(({ data }) => data.delta);
+    const reasoningDeltas = events.filter(
+      ({ type }) => type === 'response.reasoning_summary_text.delta',
+    );
+    const completed = events.find(({ type }) => type === 'response.completed');
+
+    expect(textDeltas).toEqual(['answer']);
+    expect(reasoningDeltas).toHaveLength(0);
+    expect(completed?.data.response.output[0].content[0].text).toBe('answer');
+    expect(completed?.data.response.usage).toEqual({
+      input_tokens: 7,
+      input_tokens_details: { cached_tokens: 3 },
+      output_tokens: 4,
+      output_tokens_details: { reasoning_tokens: 2 },
+      total_tokens: 11,
+    });
   });
 
   it('encodes Responses incomplete and failed terminal lifecycle events', async () => {

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -20,7 +20,7 @@ import {
   resolveServerDefaultHeterogeneousModel,
 } from '@/server/modules/ModelRuntime';
 
-import type { BaseStreamEvent } from '../types/responses.type';
+import type { BaseStreamEvent, ResponseUsage } from '../types/responses.type';
 
 export const SERVER_DEFAULT_MODEL_ALIAS = SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS;
 
@@ -540,7 +540,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
   let stopReason: unknown;
   let textOutputIndex: number | undefined;
   let outputText = '';
-  let usage: { input_tokens: number; output_tokens: number; total_tokens: number } | undefined;
+  let usage: ResponseUsage | undefined;
   const toolItems = new Map<
     number,
     { arguments: string; callId: string; id: string; name: string; outputIndex: number }
@@ -717,8 +717,8 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
         },
         transform(event, controller) {
           if (finalized) return;
-          if (event.type === 'text') {
-            outputText += String(event.data);
+          if (event.type === 'text' && typeof event.data === 'string' && event.data) {
+            outputText += event.data;
             if (textOutputIndex === undefined) {
               textOutputIndex = nextOutputIndex++;
               controller.enqueue(
@@ -747,14 +747,14 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
             controller.enqueue(
               responseSse('response.output_text.delta', {
                 content_index: 0,
-                delta: String(event.data),
+                delta: event.data,
                 item_id: `msg_${responseId}`,
                 output_index: textOutputIndex,
                 type: 'response.output_text.delta',
               }),
             );
-          } else if (event.type === 'reasoning') {
-            reasoningText += String(event.data);
+          } else if (event.type === 'reasoning' && typeof event.data === 'string' && event.data) {
+            reasoningText += event.data;
             if (reasoningOutputIndex === undefined) {
               reasoningItemId = event.id || `rs_${responseId}`;
               reasoningOutputIndex = nextOutputIndex++;
@@ -773,7 +773,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
             }
             controller.enqueue(
               responseSse('response.reasoning_summary_text.delta', {
-                delta: String(event.data),
+                delta: event.data,
                 item_id: reasoningItemId,
                 output_index: reasoningOutputIndex,
                 summary_index: 0,
@@ -824,11 +824,17 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
               }
             }
           } else if (event.type === 'usage' && isRecord(event.data)) {
-            const inputTokens = Number(event.data.totalInputTokens || 0);
-            const outputTokens = Number(event.data.totalOutputTokens || 0);
+            const inputTokens = nonNegativeNumber(event.data.totalInputTokens) ?? 0;
+            const outputTokens = nonNegativeNumber(event.data.totalOutputTokens) ?? 0;
             usage = {
               input_tokens: inputTokens,
+              input_tokens_details: {
+                cached_tokens: nonNegativeNumber(event.data.inputCachedTokens) ?? 0,
+              },
               output_tokens: outputTokens,
+              output_tokens_details: {
+                reasoning_tokens: nonNegativeNumber(event.data.outputReasoningTokens) ?? 0,
+              },
               total_tokens: inputTokens + outputTokens,
             };
           } else if (event.type === 'stop') {


### PR DESCRIPTION
<!-- Brief and heads-up -->

Grok Build 1.0.13 rejects the server-default Responses terminal event after receiving the model output because `response.completed.usage` omits the token detail objects required by its decoder. Null protocol chunks are also stringified and appended to the visible output.

This change:

- emits `input_tokens_details.cached_tokens` and `output_tokens_details.reasoning_tokens` from LobeHub usage events;
- normalizes invalid token counts to zero;
- ignores null/non-string text and reasoning chunks instead of emitting literal `null` output;
- adds regression coverage for the complete terminal usage shape and null chunks.

| Before | After |
| ------ | ----- |
| Grok Build ends with `serialization error: missing field input_tokens_details` and appends `null` | Grok Build receives complete Responses usage, preserves exact model text, and reaches the completed ACP terminal state |

#### Test

- `bun run check packages/openapi/src/services/heterogeneous-direct.service.ts packages/openapi/src/services/heterogeneous-direct.service.test.ts` — lint clean, 26 tests passed
- Grok Build 1.0.13 ACP smoke with `lobehub/lobehub-kimi-k3-fast` — exact marker, no `null`, exit 0, terminal reason `complete`
- Grok Build 1.0.13 ACP smoke with `lobehub/gpt-5.6-sol` — exact marker, no `null`, exit 0, terminal reason `complete`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None.
