### PR TITLE
🐛 fix(openapi): accept Pi Responses easy input messages

### DIFF
--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -312,6 +312,30 @@ describe('heterogeneous direct invocation protocol', () => {
     });
   });
 
+  it('normalizes Pi Responses messages whose optional type is omitted', () => {
+    const payload = normalizeResponsesRequest(
+      {
+        input: [
+          { content: 'Pi coding assistant', role: 'system' },
+          {
+            content: [{ text: 'LOBEHUB_HETERO_SMOKE_OK', type: 'input_text' }],
+            role: 'user',
+          },
+        ],
+        max_output_tokens: 16_384,
+        model: 'lobehub/glm-5.2',
+        stream: true,
+      },
+      'lobehub-default',
+    );
+
+    expect(payload.messages).toEqual([
+      { content: 'Pi coding assistant', role: 'system' },
+      { content: 'LOBEHUB_HETERO_SMOKE_OK', role: 'user' },
+    ]);
+    expect(payload.max_tokens).toBe(16_384);
+  });
+
   it('normalizes two-round Responses reasoning and function call continuity', () => {
     const firstReasoning = {
       encrypted_content: 'encrypted-first',

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -236,7 +236,7 @@ export const normalizeResponsesRequest = (request: Record<string, unknown>, mode
           tool_call_id: item.call_id,
         });
       } else if (
-        item.type === 'message' &&
+        (item.type === undefined || item.type === 'message') &&
         ['assistant', 'developer', 'system', 'user'].includes(String(item.role))
       ) {
         messages.push({


### PR DESCRIPTION
### Summary

- accept OpenAI Responses `EasyInputMessage` items whose optional `type` field is omitted
- preserve Pi's system and user prompts when routing through the LobeHub official provider
- add a regression test based on Pi's actual request shape

Pi emits valid Responses input messages without `type: "message"`. The relay previously discarded those items and forwarded an empty `messages` array, leading to upstream 502 responses, empty assistant content, or unrelated output.

### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check packages/openapi/src/services/heterogeneous-direct.service.ts packages/openapi/src/services/heterogeneous-direct.service.test.ts
```

Result: 27 tests passed; lint clean.
