### PR TITLE
🐛 fix(agent): wait for installed plugins before cleanup

### DIFF
--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -116,6 +116,7 @@ const AgentTool = memo<AgentToolProps>(
 
     const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
     const installedPluginList = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
+    const loadingInstallPlugins = useToolStore((s) => s.loadingInstallPlugins);
 
     // Keep the broad list for stale-config validation. The picker uses the
     // narrower profile list below so runtime-owned tools never become choices.
@@ -797,6 +798,7 @@ const AgentTool = memo<AgentToolProps>(
           canEditResource,
           isAccessResolved,
           isConnectorsInit,
+          loadingInstallPlugins,
           plugins: config?.plugins,
           validIdentifiers,
         });
@@ -817,7 +819,14 @@ const AgentTool = memo<AgentToolProps>(
 
       return () => clearTimeout(timer);
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [validIdentifiers, canEdit, canEditResource, isAccessResolved, isConnectorsInit]);
+    }, [
+      validIdentifiers,
+      canEdit,
+      canEditResource,
+      isAccessResolved,
+      isConnectorsInit,
+      loadingInstallPlugins,
+    ]);
 
     // Only display tools that this profile surface actually manages. Runtime-
     // managed entries remain untouched in config for compatibility with other

--- a/src/features/ProfileEditor/staleProfilePlugins.test.ts
+++ b/src/features/ProfileEditor/staleProfilePlugins.test.ts
@@ -7,6 +7,7 @@ const baseInput = (overrides: Partial<StalePluginCleanupInput> = {}): StalePlugi
   canEditResource: true,
   isAccessResolved: true,
   isConnectorsInit: true,
+  loadingInstallPlugins: false,
   plugins: ['web-search', 'ghost-tool'],
   validIdentifiers: new Set(['web-search']),
   ...overrides,
@@ -37,6 +38,18 @@ describe('resolveStalePluginCleanup', () => {
 
   it('returns null before the connector store has loaded', () => {
     expect(resolveStalePluginCleanup(baseInput({ isConnectorsInit: false }))).toBeNull();
+  });
+
+  it('does not clean up while installed plugin metadata is loading', () => {
+    expect(
+      resolveStalePluginCleanup({
+        ...baseInput({
+          plugins: ['custom-plugin'],
+          validIdentifiers: new Set(['known-tool']),
+        }),
+        loadingInstallPlugins: true,
+      }),
+    ).toBeNull();
   });
 
   it('returns null when no identifiers are known yet', () => {

--- a/src/features/ProfileEditor/staleProfilePlugins.ts
+++ b/src/features/ProfileEditor/staleProfilePlugins.ts
@@ -22,6 +22,11 @@ export interface StalePluginCleanupInput {
    * connectors as stale.
    */
   isConnectorsInit: boolean;
+  /**
+   * Installed plugin metadata is incomplete until the initial fetch settles.
+   * Cleanup must not treat the temporary empty list as stale.
+   */
+  loadingInstallPlugins: boolean;
   plugins: AgentPluginEntry[] | undefined;
   validIdentifiers: ReadonlySet<string>;
 }
@@ -45,11 +50,13 @@ export const resolveStalePluginCleanup = ({
   canEditResource,
   isAccessResolved,
   isConnectorsInit,
+  loadingInstallPlugins,
   plugins,
   validIdentifiers,
 }: StalePluginCleanupInput): AgentPluginEntry[] | null => {
   if (!canEditContent || !isAccessResolved || !canEditResource) return null;
   if (!isConnectorsInit) return null;
+  if (loadingInstallPlugins) return null;
   if (validIdentifiers.size === 0) return null;
 
   const rawPlugins = plugins ?? [];


### PR DESCRIPTION
The profile editor could treat an installed custom plugin as stale during cold start because cleanup ran before its catalog finished loading. This gates cleanup on the installed-plugin loading state and retries when loading completes.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test that fails before the fix and passes after it. The focused test file passes all 10 tests.

#### 🔗 Related Issue

Fixes #18856