### PR TITLE
🐛 fix(heterogeneous-agent): hide runtime-only server models

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -283,6 +283,34 @@ describe('getServerDefaultHeterogeneousModels', () => {
     });
   });
 
+  it('does not advertise hidden runtime-only models', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        lobehub: {
+          enabled: true,
+          serverModelLists: [
+            { abilities: { functionCall: true }, enabled: true, id: 'kimi-k2.6', type: 'chat' },
+            {
+              abilities: { functionCall: true },
+              enabled: true,
+              id: 'lobehub-onboarding-v1',
+              type: 'chat',
+              visible: false,
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
+      'claude-code': [{ model: 'kimi-k2.6' }],
+      'codex': [],
+      'grok-build': [{ model: 'kimi-k2.6' }],
+      'kimi-code': [{ model: 'kimi-k2.6' }],
+      'pi': [{ model: 'kimi-k2.6' }],
+    });
+  });
+
   it('keeps Claude ids eligible when the relay catalog declares no abilities', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
@@ -409,6 +437,33 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     );
     await expect(
       resolveServerDefaultHeterogeneousModel('claude-code', 'no-tools-model'),
+    ).rejects.toThrow('not compatible with this heterogeneous agent');
+  });
+
+  it('keeps hidden runtime aliases resolvable but rejects them for heterogeneous agents', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        lobehub: {
+          enabled: true,
+          serverModelLists: [
+            {
+              abilities: { functionCall: true },
+              enabled: true,
+              id: 'lobehub-onboarding-v1',
+              type: 'chat',
+              visible: false,
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(resolveServerModel('lobehub', 'lobehub-onboarding-v1')).resolves.toEqual({
+      model: 'lobehub-onboarding-v1',
+      provider: 'lobehub',
+    });
+    await expect(
+      resolveServerDefaultHeterogeneousModel('claude-code', 'lobehub-onboarding-v1'),
     ).rejects.toThrow('not compatible with this heterogeneous agent');
   });
 

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -28,7 +28,8 @@ import {
 } from '@lobechat/types';
 import { isCodexServerDefaultCustomModel } from '@lobechat/types';
 import { safeParseJSON } from '@lobechat/utils';
-import { type AiFullModelCard, ModelProvider } from 'model-bank';
+import type { AiFullModelCard } from 'model-bank';
+import { isAiModelVisible, ModelProvider } from 'model-bank';
 import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 
@@ -559,8 +560,10 @@ export type ServerDefaultHeterogeneousModels = Record<
  */
 const supportsServerDefaultHeterogeneousAgent = (
   agentType: ServerDefaultHeterogeneousAgentType,
-  model: Pick<AiFullModelCard, 'abilities' | 'id'>,
+  model: Pick<AiFullModelCard, 'abilities' | 'id' | 'visible'>,
 ) => {
+  if (!isAiModelVisible(model)) return false;
+
   const { modelPolicy } = SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG[agentType];
   if (modelPolicy === 'tool-capable') {
     return parseClaudeModelId(model.id) !== undefined || model.abilities?.functionCall === true;


### PR DESCRIPTION
Prevent runtime-only LobeHub model aliases from leaking into the server-default heterogeneous-agent model matrix.

- exclude models with `visible: false` from heterogeneous-agent compatibility
- enforce the same visibility rule during direct server-default model selection
- keep hidden aliases resolvable through the generic runtime path for internal use

| Before | After |
| ------ | ----- |
| Hidden runtime aliases such as `lobehub-onboarding-v1` were advertised to tool-capable heterogeneous agents and could be selected directly. | Hidden aliases are omitted from the capability matrix and rejected by heterogeneous-agent selection. |

#### Test

`bun run check apps/server/src/modules/ModelRuntime/index.ts apps/server/src/modules/ModelRuntime/index.test.ts`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.