### PR TITLE
🐛 fix(openapi): relay Gemini part events to Claude Code

### DIFF
--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -484,6 +484,30 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(events.at(-1)?.type).toBe('message_stop');
   });
 
+  it('preserves Anthropic signature-only reasoning blocks', async () => {
+    const events = parseSseEvents(
+      await readText(
+        anthropicSse(
+          protocolStream([
+            { data: '', type: 'reasoning' },
+            { data: 'hidden-thinking-signature', type: 'reasoning_signature' },
+          ]),
+        ),
+      ),
+    );
+    const thinkingStart = events.find(({ type }) => type === 'content_block_start');
+    const deltas = events
+      .filter(({ type }) => type === 'content_block_delta')
+      .map(({ data }) => data.delta);
+
+    expect(thinkingStart?.data).toMatchObject({
+      content_block: { signature: '', thinking: '', type: 'thinking' },
+      index: 0,
+    });
+    expect(deltas).toEqual([{ signature: 'hidden-thinking-signature', type: 'signature_delta' }]);
+    expect(events.filter(({ type }) => type === 'content_block_stop')).toHaveLength(1);
+  });
+
   it('does not stringify null Anthropic text and reasoning chunks', async () => {
     const events = parseSseEvents(
       await readText(

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -449,6 +449,61 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(output).toContain('"stop_reason":"tool_use"');
   });
 
+  it('encodes Gemini textual part events through the Anthropic relay', async () => {
+    const events = parseSseEvents(
+      await readText(
+        anthropicSse(
+          protocolStream([
+            {
+              data: { content: 'thinking', inReasoning: true, partType: 'text' },
+              type: 'reasoning_part',
+            },
+            { data: { content: 'answer', partType: 'text' }, type: 'content_part' },
+            {
+              data: { content: 'base64-image', mimeType: 'image/png', partType: 'image' },
+              type: 'content_part',
+            },
+            { data: 'STOP', type: 'stop' },
+            { data: { totalInputTokens: 7, totalOutputTokens: 4 }, type: 'usage' },
+          ]),
+        ),
+      ),
+    );
+    const deltas = events
+      .filter(({ type }) => type === 'content_block_delta')
+      .map(({ data }) => data.delta);
+
+    expect(deltas).toEqual([
+      { thinking: 'thinking', type: 'thinking_delta' },
+      { text: 'answer', type: 'text_delta' },
+    ]);
+    expect(events.at(-2)?.data).toMatchObject({
+      delta: { stop_reason: 'end_turn' },
+      usage: { input_tokens: 7, output_tokens: 4 },
+    });
+    expect(events.at(-1)?.type).toBe('message_stop');
+  });
+
+  it('does not stringify null Anthropic text and reasoning chunks', async () => {
+    const events = parseSseEvents(
+      await readText(
+        anthropicSse(
+          protocolStream([
+            { data: 'answer', type: 'text' },
+            { data: null, type: 'text' },
+            { data: null, type: 'reasoning' },
+            { data: null, type: 'reasoning_signature' },
+          ]),
+        ),
+      ),
+    );
+    const deltas = events
+      .filter(({ type }) => type === 'content_block_delta')
+      .map(({ data }) => data.delta);
+
+    expect(deltas).toEqual([{ text: 'answer', type: 'text_delta' }]);
+  });
+
   it('finalizes Anthropic stop, usage, and message_stop exactly once', async () => {
     const output = await readText(
       anthropicSse(

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -449,7 +449,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>, model:
               : typeof part?.content === 'string'
                 ? part.content
                 : undefined;
-          if (content) {
+          if (content !== undefined) {
             const isThinking = event.type === 'reasoning' || event.type === 'reasoning_part';
             let index = isThinking ? thinkingIndex : textIndex;
             if (index === undefined) {
@@ -467,15 +467,17 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>, model:
               if (isThinking) thinkingIndex = index;
               else textIndex = index;
             }
-            controller.enqueue(
-              sse('content_block_delta', {
-                delta: isThinking
-                  ? { thinking: content, type: 'thinking_delta' }
-                  : { text: content, type: 'text_delta' },
-                index,
-                type: 'content_block_delta',
-              }),
-            );
+            if (content) {
+              controller.enqueue(
+                sse('content_block_delta', {
+                  delta: isThinking
+                    ? { thinking: content, type: 'thinking_delta' }
+                    : { text: content, type: 'text_delta' },
+                  index,
+                  type: 'content_block_delta',
+                }),
+              );
+            }
           } else if (
             event.type === 'reasoning_signature' &&
             thinkingIndex !== undefined &&

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -435,8 +435,22 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>, model:
         },
         transform(event, controller) {
           if (finalized) return;
-          if (event.type === 'text' || event.type === 'reasoning') {
-            const isThinking = event.type === 'reasoning';
+          const part =
+            (event.type === 'content_part' || event.type === 'reasoning_part') &&
+            isRecord(event.data) &&
+            event.data.partType === 'text'
+              ? event.data
+              : undefined;
+          const content =
+            event.type === 'text' || event.type === 'reasoning'
+              ? typeof event.data === 'string'
+                ? event.data
+                : undefined
+              : typeof part?.content === 'string'
+                ? part.content
+                : undefined;
+          if (content) {
+            const isThinking = event.type === 'reasoning' || event.type === 'reasoning_part';
             let index = isThinking ? thinkingIndex : textIndex;
             if (index === undefined) {
               closeTextBlocks(controller);
@@ -456,16 +470,21 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>, model:
             controller.enqueue(
               sse('content_block_delta', {
                 delta: isThinking
-                  ? { thinking: String(event.data), type: 'thinking_delta' }
-                  : { text: String(event.data), type: 'text_delta' },
+                  ? { thinking: content, type: 'thinking_delta' }
+                  : { text: content, type: 'text_delta' },
                 index,
                 type: 'content_block_delta',
               }),
             );
-          } else if (event.type === 'reasoning_signature' && thinkingIndex !== undefined) {
+          } else if (
+            event.type === 'reasoning_signature' &&
+            thinkingIndex !== undefined &&
+            typeof event.data === 'string' &&
+            event.data
+          ) {
             controller.enqueue(
               sse('content_block_delta', {
-                delta: { signature: String(event.data), type: 'signature_delta' },
+                delta: { signature: event.data, type: 'signature_delta' },
                 index: thinkingIndex,
                 type: 'content_block_delta',
               }),


### PR DESCRIPTION
## Brief

Fix Claude Code returning an empty response when the official LobeHub provider routes Gemini models through the Anthropic-compatible endpoint.

Gemini 3 emits visible text and reasoning as internal `content_part` and `reasoning_part` events. The Anthropic stream encoder previously ignored these events while still forwarding usage and stop events, so Claude Code received a completed message with no content blocks.

This change:

- converts textual `content_part` events to Anthropic text deltas;
- converts textual `reasoning_part` events to Anthropic thinking deltas;
- ignores non-text part events instead of exposing image payloads as text;
- prevents null text, reasoning, and signature chunks from becoming a visible `"null"` string.

No UI changes.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation: `bun run check --lint --test packages/openapi/src/services/heterogeneous-direct.service.ts packages/openapi/src/services/heterogeneous-direct.service.test.ts` (29 tests passed)

#### 🔗 Related Issue

No matching issue found.
