### PR TITLE
🐛 fix(heterogeneous-agent): gate Kimi Code models by profile

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -267,11 +267,9 @@ describe('getServerDefaultHeterogeneousModels', () => {
         { model: 'gemini-3.1-pro-preview' },
       ],
       'kimi-code': [
-        { model: 'kimi-k2.6' },
         { model: 'deepseek-v4-flash' },
         { model: 'deepseek-v4-pro' },
         { model: 'glm-5.2' },
-        { model: 'gemini-3.1-pro-preview' },
       ],
       'pi': [
         { model: 'kimi-k2.6' },
@@ -283,13 +281,86 @@ describe('getServerDefaultHeterogeneousModels', () => {
     });
   });
 
+  it('does not offer the failed GPT and Gemini matrix cells to Kimi based on tools alone', async () => {
+    const failedKimiModels = [
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.5-pro',
+      'gemini-3.7-flash',
+      'gemini-3.6-flash',
+      'gemini-3.5-flash-lite',
+      'gemini-3.1-pro-preview',
+    ];
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        lobehub: {
+          enabled: true,
+          serverModelLists: failedKimiModels.map((id) => ({
+            abilities: { functionCall: true },
+            enabled: true,
+            id,
+            type: 'chat',
+          })),
+        },
+      },
+    });
+
+    const models = await getServerDefaultHeterogeneousModels();
+
+    expect(models['kimi-code']).toEqual([]);
+    expect(models['claude-code']).toEqual(failedKimiModels.map((model) => ({ model })));
+  });
+
+  it('uses deployment profile metadata as a replacement for the certified defaults', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        lobehub: {
+          enabled: true,
+          serverModelLists: [
+            {
+              abilities: { functionCall: true },
+              agentCompatibility: {
+                serverDefaultHeterogeneousProfiles: ['kimi-code/anthropic-v1'],
+              },
+              enabled: true,
+              id: 'private-kimi-model',
+              type: 'chat',
+            },
+            {
+              abilities: { functionCall: true },
+              agentCompatibility: { serverDefaultHeterogeneousProfiles: [] },
+              enabled: true,
+              id: 'kimi-k3',
+              type: 'chat',
+            },
+            {
+              abilities: { functionCall: false },
+              agentCompatibility: {
+                serverDefaultHeterogeneousProfiles: ['kimi-code/anthropic-v1'],
+              },
+              enabled: true,
+              id: 'no-tools-model',
+              type: 'chat',
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(getServerDefaultHeterogeneousModels()).resolves.toMatchObject({
+      'kimi-code': [{ model: 'private-kimi-model' }],
+    });
+  });
+
   it('does not advertise hidden runtime-only models', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         lobehub: {
           enabled: true,
           serverModelLists: [
-            { abilities: { functionCall: true }, enabled: true, id: 'kimi-k2.6', type: 'chat' },
+            { abilities: { functionCall: true }, enabled: true, id: 'kimi-k3', type: 'chat' },
             {
               abilities: { functionCall: true },
               enabled: true,
@@ -303,11 +374,11 @@ describe('getServerDefaultHeterogeneousModels', () => {
     });
 
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
-      'claude-code': [{ model: 'kimi-k2.6' }],
+      'claude-code': [{ model: 'kimi-k3' }],
       'codex': [],
-      'grok-build': [{ model: 'kimi-k2.6' }],
-      'kimi-code': [{ model: 'kimi-k2.6' }],
-      'pi': [{ model: 'kimi-k2.6' }],
+      'grok-build': [{ model: 'kimi-k3' }],
+      'kimi-code': [{ model: 'kimi-k3' }],
+      'pi': [{ model: 'kimi-k3' }],
     });
   });
 
@@ -370,6 +441,9 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     await expect(resolveServerDefaultHeterogeneousModel('claude-code', 'gpt-5.4')).rejects.toThrow(
       'not compatible with this heterogeneous agent',
     );
+    await expect(resolveServerDefaultHeterogeneousModel('kimi-code', 'gpt-5.4')).rejects.toThrow(
+      'not compatible with this heterogeneous agent',
+    );
     await expect(resolveServerDefaultHeterogeneousModel('codex', 'gpt-4o')).rejects.toThrow(
       'not compatible with this heterogeneous agent',
     );
@@ -401,13 +475,21 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     });
   });
 
-  it('accepts a tool-capable third-party relay model for all non-Codex agents', async () => {
+  it('accepts an explicitly attested third-party relay model for Kimi', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         lobehub: {
           enabled: true,
           serverModelLists: [
-            { abilities: { functionCall: true }, enabled: true, id: 'kimi-k2.6', type: 'chat' },
+            {
+              abilities: { functionCall: true },
+              agentCompatibility: {
+                serverDefaultHeterogeneousProfiles: ['kimi-code/anthropic-v1'],
+              },
+              enabled: true,
+              id: 'kimi-k2.6',
+              type: 'chat',
+            },
             { abilities: { reasoning: true }, enabled: true, id: 'no-tools-model', type: 'chat' },
           ],
         },

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -1,6 +1,7 @@
 import { type GoogleGenAIOptions } from '@google/genai';
 import type { ServerDefaultHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
 import {
+  isServerDefaultHeterogeneousProfileModel,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
 } from '@lobechat/heterogeneous-agents';
@@ -551,22 +552,30 @@ export type ServerDefaultHeterogeneousModels = Record<
  * `lobehub/${catalogId}`. The operation token remains the source of truth and
  * the request must match that selection.
  *
- * Most agents can use any tool-capable chat model in the relay catalog; the
+ * Legacy agent policies accept any tool-capable chat model; the
  * `parseClaudeModelId` arm keeps Claude ids eligible in deployments whose
- * catalog omits `abilities`. Codex retains a narrower policy: it accepts native
- * Responses models plus an explicit set of tool-capable relay models configured
- * through its custom model-catalog path because its reasoning and continuation
- * behavior also depends on model metadata.
+ * catalog omits `abilities`. Profile-attested agents instead require a tested
+ * client payload/continuation contract. Codex retains its narrower policy: it
+ * accepts native Responses models plus an explicit set of tool-capable relay
+ * models configured through its custom model-catalog path.
  */
 const supportsServerDefaultHeterogeneousAgent = (
   agentType: ServerDefaultHeterogeneousAgentType,
-  model: Pick<AiFullModelCard, 'abilities' | 'id' | 'visible'>,
+  model: Pick<AiFullModelCard, 'abilities' | 'agentCompatibility' | 'id' | 'visible'>,
 ) => {
   if (!isAiModelVisible(model)) return false;
 
-  const { modelPolicy } = SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG[agentType];
+  const config = SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG[agentType];
+  const { modelPolicy } = config;
   if (modelPolicy === 'tool-capable') {
     return parseClaudeModelId(model.id) !== undefined || model.abilities?.functionCall === true;
+  }
+  if (modelPolicy === 'profile-attested') {
+    if (model.abilities?.functionCall === false) return false;
+    const deploymentProfiles = model.agentCompatibility?.serverDefaultHeterogeneousProfiles;
+    return deploymentProfiles
+      ? deploymentProfiles.includes(config.compatibilityProfile)
+      : isServerDefaultHeterogeneousProfileModel(config.compatibilityProfile, model.id);
   }
 
   return (

--- a/packages/heterogeneous-agents/src/index.ts
+++ b/packages/heterogeneous-agents/src/index.ts
@@ -103,6 +103,7 @@ export type {
   ResolveHeterogeneousProviderBindingInput,
   ResolveHeterogeneousProviderBindingResult,
   ServerDefaultHeterogeneousAgentType,
+  ServerDefaultHeterogeneousCompatibilityProfile,
   ServerDefaultHeterogeneousIngress,
   ServerDefaultHeterogeneousModelPolicy,
   ServerDefaultHeterogeneousTokenHeader,
@@ -115,10 +116,12 @@ export {
   HETEROGENEOUS_PROVIDER_BINDING_AGENT_TYPES,
   isHeterogeneousProviderBindingSupported,
   isServerDefaultHeterogeneousAgentType,
+  isServerDefaultHeterogeneousProfileModel,
   resolveHeterogeneousProviderBinding,
   resolveProviderBindingProtocol,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
+  SERVER_DEFAULT_HETEROGENEOUS_PROFILE_DEFAULT_MODELS,
 } from './providerBinding';
 export { createAdapter, listAgentTypes, listLocalAgentTypes } from './registry';
 export type { HeterogeneousAgentScanMap, HeterogeneousAgentScanStatus } from './scan/types';

--- a/packages/heterogeneous-agents/src/providerBinding/index.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/index.ts
@@ -9,6 +9,7 @@ export {
 } from './resolveBinding';
 export type {
   ServerDefaultHeterogeneousAgentType,
+  ServerDefaultHeterogeneousCompatibilityProfile,
   ServerDefaultHeterogeneousIngress,
   ServerDefaultHeterogeneousModelPolicy,
   ServerDefaultHeterogeneousTokenHeader,
@@ -16,8 +17,10 @@ export type {
 export {
   getServerDefaultHeterogeneousAgentConfig,
   isServerDefaultHeterogeneousAgentType,
+  isServerDefaultHeterogeneousProfileModel,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
+  SERVER_DEFAULT_HETEROGENEOUS_PROFILE_DEFAULT_MODELS,
 } from './serverDefault';
 export type {
   EnabledProviderBindingModelRef,

--- a/packages/heterogeneous-agents/src/providerBinding/serverDefault.test.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/serverDefault.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
   getServerDefaultHeterogeneousAgentConfig,
   isServerDefaultHeterogeneousAgentType,
+  isServerDefaultHeterogeneousProfileModel,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG,
   SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
+  SERVER_DEFAULT_HETEROGENEOUS_PROFILE_DEFAULT_MODELS,
 } from './serverDefault';
 
 describe('server-default heterogeneous agent matrix', () => {
@@ -33,8 +35,9 @@ describe('server-default heterogeneous agent matrix', () => {
         tokenHeader: 'bearer',
       },
       'kimi-code': {
+        compatibilityProfile: 'kimi-code/anthropic-v1',
         ingress: 'anthropic-messages',
-        modelPolicy: 'tool-capable',
+        modelPolicy: 'profile-attested',
         tokenHeader: 'x-api-key',
       },
       'pi': {
@@ -47,13 +50,52 @@ describe('server-default heterogeneous agent matrix', () => {
 
   it('looks up and narrows only supported agent types', () => {
     expect(getServerDefaultHeterogeneousAgentConfig('kimi-code')).toEqual({
+      compatibilityProfile: 'kimi-code/anthropic-v1',
       ingress: 'anthropic-messages',
-      modelPolicy: 'tool-capable',
+      modelPolicy: 'profile-attested',
       tokenHeader: 'x-api-key',
     });
     expect(isServerDefaultHeterogeneousAgentType('pi')).toBe(true);
     expect(isServerDefaultHeterogeneousAgentType('opencode')).toBe(false);
     expect(isServerDefaultHeterogeneousAgentType('toString')).toBe(false);
     expect(getServerDefaultHeterogeneousAgentConfig(undefined)).toBeUndefined();
+  });
+
+  it('bootstraps the Kimi Anthropic profile from the clean compatibility matrix', () => {
+    expect(SERVER_DEFAULT_HETEROGENEOUS_PROFILE_DEFAULT_MODELS['kimi-code/anthropic-v1']).toEqual([
+      'deepseek-v4-flash-vision-exp',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'claude-fable-5',
+      'claude-opus-5',
+      'claude-sonnet-5',
+      'claude-sonnet-4-6',
+      'claude-opus-4-8',
+      'claude-haiku-4-5-20251001',
+      'grok-4.6',
+      'grok-4.5',
+      'glm-5.3-flash',
+      'glm-5.3',
+      'glm-5.2',
+      'lobehub-glm-5.2-fast',
+      'kimi-k3',
+      'lobehub-kimi-k3-fast',
+      'kimi-k2.7-code',
+      'qwen3.8-max',
+      'qwen3.8-max-preview',
+      'MiniMax-M3',
+      'mimo-v2.5-pro',
+      'mimo-v2.5',
+      'lobehub-onboarding-v1',
+    ]);
+    expect(isServerDefaultHeterogeneousProfileModel('kimi-code/anthropic-v1', 'kimi-k3')).toBe(
+      true,
+    );
+    expect(isServerDefaultHeterogeneousProfileModel('kimi-code/anthropic-v1', 'gpt-5.6-sol')).toBe(
+      false,
+    );
+    expect(
+      isServerDefaultHeterogeneousProfileModel('kimi-code/anthropic-v1', 'gemini-3.7-flash'),
+    ).toBe(false);
   });
 });

--- a/packages/heterogeneous-agents/src/providerBinding/serverDefault.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/serverDefault.ts
@@ -2,15 +2,71 @@ import type { LocalHeterogeneousAgentType } from '../config';
 
 export type ServerDefaultHeterogeneousIngress = 'anthropic-messages' | 'openai-responses';
 
-export type ServerDefaultHeterogeneousModelPolicy = 'codex' | 'tool-capable';
+export type ServerDefaultHeterogeneousCompatibilityProfile = 'kimi-code/anthropic-v1';
+
+export type ServerDefaultHeterogeneousModelPolicy = 'codex' | 'profile-attested' | 'tool-capable';
 
 export type ServerDefaultHeterogeneousTokenHeader = 'bearer' | 'x-api-key';
 
-interface ServerDefaultHeterogeneousAgentConfig {
+interface ServerDefaultHeterogeneousAgentConfigBase {
   ingress: ServerDefaultHeterogeneousIngress;
-  modelPolicy: ServerDefaultHeterogeneousModelPolicy;
   tokenHeader: ServerDefaultHeterogeneousTokenHeader;
 }
+
+type ServerDefaultHeterogeneousAgentConfig = ServerDefaultHeterogeneousAgentConfigBase &
+  (
+    | {
+        compatibilityProfile: ServerDefaultHeterogeneousCompatibilityProfile;
+        modelPolicy: 'profile-attested';
+      }
+    | {
+        compatibilityProfile?: never;
+        modelPolicy: Exclude<ServerDefaultHeterogeneousModelPolicy, 'profile-attested'>;
+      }
+  );
+
+/**
+ * Bootstrap attestations from the real server-default compatibility matrix.
+ * Deployment model cards may replace these defaults with their own explicit
+ * `serverDefaultHeterogeneousProfiles` metadata. New models therefore remain
+ * unavailable until either the deployment or this certified baseline opts in.
+ */
+export const SERVER_DEFAULT_HETEROGENEOUS_PROFILE_DEFAULT_MODELS = {
+  'kimi-code/anthropic-v1': [
+    'deepseek-v4-flash-vision-exp',
+    'deepseek-v4-flash',
+    'deepseek-v4-pro',
+    'claude-fable-5',
+    'claude-opus-5',
+    'claude-sonnet-5',
+    'claude-sonnet-4-6',
+    'claude-opus-4-8',
+    'claude-haiku-4-5-20251001',
+    'grok-4.6',
+    'grok-4.5',
+    'glm-5.3-flash',
+    'glm-5.3',
+    'glm-5.2',
+    'lobehub-glm-5.2-fast',
+    'kimi-k3',
+    'lobehub-kimi-k3-fast',
+    'kimi-k2.7-code',
+    'qwen3.8-max',
+    'qwen3.8-max-preview',
+    'MiniMax-M3',
+    'mimo-v2.5-pro',
+    'mimo-v2.5',
+    'lobehub-onboarding-v1',
+  ],
+} as const satisfies Record<ServerDefaultHeterogeneousCompatibilityProfile, readonly string[]>;
+
+export const isServerDefaultHeterogeneousProfileModel = (
+  profile: ServerDefaultHeterogeneousCompatibilityProfile,
+  model: string,
+) =>
+  (SERVER_DEFAULT_HETEROGENEOUS_PROFILE_DEFAULT_MODELS[profile] as readonly string[]).includes(
+    model,
+  );
 
 export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG = {
   'claude-code': {
@@ -29,8 +85,9 @@ export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_CONFIG = {
     tokenHeader: 'bearer',
   },
   'kimi-code': {
+    compatibilityProfile: 'kimi-code/anthropic-v1',
     ingress: 'anthropic-messages',
-    modelPolicy: 'tool-capable',
+    modelPolicy: 'profile-attested',
     tokenHeader: 'x-api-key',
   },
   'pi': {

--- a/packages/model-bank/src/types/aiModel.test.ts
+++ b/packages/model-bank/src/types/aiModel.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { CreateAiModelSchema, UpdateAiModelSchema } from './aiModel';
+
+describe('AI model mutation schemas', () => {
+  it('strips deployment-owned compatibility metadata from user mutations', () => {
+    const agentCompatibility = {
+      serverDefaultHeterogeneousProfiles: ['kimi-code/anthropic-v1'],
+    };
+
+    expect(
+      CreateAiModelSchema.parse({
+        agentCompatibility,
+        id: 'custom-model',
+        providerId: 'custom-provider',
+      }),
+    ).toEqual({ id: 'custom-model', providerId: 'custom-provider' });
+
+    expect(UpdateAiModelSchema.parse({ agentCompatibility })).toEqual({});
+  });
+});

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -688,7 +688,6 @@ export interface LobeDefaultAiModelListItem extends AiFullModelCard {
 // create
 export const CreateAiModelSchema = z.object({
   abilities: AiModelAbilitiesSchema.optional(),
-  agentCompatibility: AgentCompatibilitySchema.optional(),
   contextWindowTokens: z.number().optional(),
   displayName: z.string().optional(),
   id: z.string(),
@@ -730,7 +729,6 @@ export interface AiProviderModelListItem {
 // Update
 export const UpdateAiModelSchema = z.object({
   abilities: AiModelAbilitiesSchema.optional(),
-  agentCompatibility: AgentCompatibilitySchema.optional(),
   // NOTE: `chatConfig` is deliberately NOT accepted here — model-instance reasoning
   // defaults go through the dedicated updateAiModelReasoningConfig procedure so the
   // generic update path can never carry (and thus never stomp) that namespace.

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -25,6 +25,14 @@ export const AiModelTypeSchema = z.enum([
 
 export type AiModelType = z.infer<typeof AiModelTypeSchema>;
 
+export const AgentCompatibilitySchema = z
+  .object({
+    serverDefaultHeterogeneousProfiles: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
+
+export type AgentCompatibility = z.infer<typeof AgentCompatibilitySchema>;
+
 /**
  * The speech-to-text model type was renamed from the legacy `stt` to the
  * standard `asr`. Instead of a bulk DB data migration, persisted rows and
@@ -593,6 +601,7 @@ export const AiModelSettingsSchema = z.object({
 
 export interface AIChatModelCard extends AIBaseModelCard {
   abilities?: ModelAbilities;
+  agentCompatibility?: AgentCompatibility;
   config?: AiModelConfig;
   maxOutput?: number;
   pricing?: Pricing;
@@ -659,6 +668,7 @@ export interface AIRealtimeModelCard extends AIBaseModelCard {
 
 export interface AiFullModelCard extends AIBaseModelCard {
   abilities?: ModelAbilities;
+  agentCompatibility?: AgentCompatibility;
   config?: AiModelConfig;
   contextWindowTokens?: number;
   displayName?: string;
@@ -678,6 +688,7 @@ export interface LobeDefaultAiModelListItem extends AiFullModelCard {
 // create
 export const CreateAiModelSchema = z.object({
   abilities: AiModelAbilitiesSchema.optional(),
+  agentCompatibility: AgentCompatibilitySchema.optional(),
   contextWindowTokens: z.number().optional(),
   displayName: z.string().optional(),
   id: z.string(),
@@ -697,6 +708,7 @@ export type CreateAiModelParams = z.infer<typeof CreateAiModelSchema>;
 
 export interface AiProviderModelListItem {
   abilities?: ModelAbilities;
+  agentCompatibility?: AgentCompatibility;
   config?: AiModelConfig;
   contextWindowTokens?: number;
   description?: string;
@@ -718,6 +730,7 @@ export interface AiProviderModelListItem {
 // Update
 export const UpdateAiModelSchema = z.object({
   abilities: AiModelAbilitiesSchema.optional(),
+  agentCompatibility: AgentCompatibilitySchema.optional(),
   // NOTE: `chatConfig` is deliberately NOT accepted here — model-instance reasoning
   // defaults go through the dedicated updateAiModelReasoningConfig procedure so the
   // generic update path can never carry (and thus never stomp) that namespace.


### PR DESCRIPTION
Kimi Code's Anthropic-compatible relay was previously offered every tool-capable model, even when the model could not complete Kimi's payload and continuation contract. This change moves Kimi Code to an explicit, versioned compatibility profile.

- Adds the `kimi-code/anthropic-v1` server-default compatibility profile.
- Bootstraps the profile with the 24 models verified by the clean compatibility matrix.
- Excludes the five GPT and four Gemini models that timed out or returned empty completions during verification.
- Lets deployment model cards replace the bootstrap decision through `agentCompatibility.serverDefaultHeterogeneousProfiles`, including explicit opt-out with `[]`.
- Uses the same predicate for capability discovery and operation startup.
- Leaves Claude Code, Codex, Grok Build, and Pi policies unchanged.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check packages/model-bank/src/types/aiModel.ts packages/heterogeneous-agents/src/providerBinding/serverDefault.ts packages/heterogeneous-agents/src/providerBinding/index.ts packages/heterogeneous-agents/src/index.ts packages/heterogeneous-agents/src/providerBinding/serverDefault.test.ts apps/server/src/modules/ModelRuntime/index.ts apps/server/src/modules/ModelRuntime/index.test.ts` — 83 tests passed
- `bunx tsc --noEmit -p packages/model-bank/tsconfig.json`

#### 🔗 Related Issue

- Related to #18879
- Cloud model-catalog validation: https://github.com/lobehub-biz/lobehub-cloud/pull/1547
