### PR TITLE
💄 style(topic): replace draft label with icon

### DIFF
--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -62,7 +62,7 @@
   "doctor.summary_one": "{{count}} message exists in this topic but is not being shown.",
   "doctor.summary_other": "{{count}} messages exist in this topic but are not being shown.",
   "doctor.title": "Message Chain Check",
-  "draft": "[Draft]",
+  "draft": "Draft",
   "duplicateLoading": "Copying Topic...",
   "duplicateSuccess": "Topic Copied Successfully",
   "failedStatusTip": "This run hit an error — open it to take a look.",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -62,7 +62,7 @@
   "doctor.summary_one": "这个话题里有 {{count}} 条消息存在，但没有显示出来。",
   "doctor.summary_other": "这个话题里有 {{count}} 条消息存在，但没有显示出来。",
   "doctor.title": "消息链路检查",
-  "draft": "[草稿]",
+  "draft": "草稿",
   "duplicateLoading": "话题复制中…",
   "duplicateSuccess": "话题复制成功",
   "failedStatusTip": "当前执行遇到了错误，点击查看详情",

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -75,7 +75,7 @@ export default {
   'doctor.summary_other': '{{count}} messages exist in this topic but are not being shown.',
   'doctor.title': 'Message Chain Check',
   'displayItems': 'Display Items',
-  'draft': '[Draft]',
+  'draft': 'Draft',
   'duplicateLoading': 'Copying Topic...',
   'duplicateSuccess': 'Topic Copied Successfully',
   'failedStatusTip': 'This run hit an error — open it to take a look.',

--- a/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
@@ -1,9 +1,11 @@
 /**
  * @vitest-environment happy-dom
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { removeDraft, saveDraft } from '@/features/ChatInput/draftStorage';
 
 import TopicItem from './index';
 
@@ -16,13 +18,27 @@ const topicUnreadCompletedMock = vi.hoisted(() => ({ value: false }));
 const topicMetaCardMock = vi.hoisted(() => ({
   value: undefined as { pullRequest?: { state: string } } | undefined,
 }));
+const topicDraftKey = 'main_agt_test_tpc_test';
 
 // Assertions key on the raw lucide displayName, which the real Icon does not
 // expose in the DOM.
 vi.mock('@lobehub/ui', async (importOriginal) => ({
   ...(await importOriginal<object>()),
-  Icon: ({ icon }: { icon?: { displayName?: string } }) => (
-    <div data-icon={icon?.displayName} data-testid="topic-item-icon" />
+  Icon: ({
+    'aria-label': ariaLabel,
+    icon,
+    role,
+  }: {
+    'aria-label'?: string;
+    'icon'?: { displayName?: string };
+    'role'?: string;
+  }) => (
+    <div
+      aria-label={ariaLabel}
+      data-icon={icon?.displayName}
+      data-testid="topic-item-icon"
+      role={role}
+    />
   ),
 }));
 
@@ -46,6 +62,7 @@ vi.mock('@/features/NavPanel/components/NavItem', () => ({
     extra,
     href,
     icon,
+    slots,
     title,
   }: {
     active?: boolean;
@@ -53,13 +70,15 @@ vi.mock('@/features/NavPanel/components/NavItem', () => ({
     extra?: ReactNode;
     href?: string;
     icon?: ReactNode;
+    slots?: { titlePrefix?: ReactNode };
     title?: ReactNode;
   }) => (
     <div data-active={String(active)} data-href={href} data-testid="nav-item">
       {icon}
+      <span data-testid="nav-item-title-prefix">{slots?.titlePrefix}</span>
       {title}
       {description}
-      {extra}
+      <span data-testid="nav-item-extra">{extra}</span>
     </div>
   ),
 }));
@@ -140,6 +159,7 @@ describe('TopicItem active state', () => {
     runningStartTimeMock.value = undefined;
     topicUnreadCompletedMock.value = false;
     topicMetaCardMock.value = undefined;
+    removeDraft(topicDraftKey);
     vi.useRealTimers();
   });
 
@@ -187,6 +207,23 @@ describe('TopicItem active state', () => {
       'data-href',
       '/team/agent/agt_test/tpc_test',
     );
+  });
+
+  it('replaces the draft title prefix text with a pencil icon', () => {
+    saveDraft(topicDraftKey, { root: {} });
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(<TopicItem id="tpc_test" title="Topic" />);
+
+    const draftIcon = within(screen.getByTestId('nav-item-title-prefix')).getByRole('img');
+    expect(draftIcon).toHaveAttribute('data-icon', 'PencilLine');
+    expect(draftIcon).toHaveAccessibleName();
+    expect(within(screen.getByTestId('nav-item-extra')).queryByRole('img')).not.toBeInTheDocument();
   });
 
   it('shows running elapsed time in the nav item extra slot', () => {

--- a/src/features/AgentSidebar/Topic/List/Item/index.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/index.tsx
@@ -10,7 +10,7 @@ import { Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, useTheme } from 'antd-style';
 import dayjs from 'dayjs';
 import isEqual from 'fast-deep-equal';
-import { MessageSquareDashed } from 'lucide-react';
+import { MessageSquareDashed, PencilLine } from 'lucide-react';
 import type { CSSProperties, DragEvent, RefObject } from 'react';
 import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -296,19 +296,25 @@ const TopicItemRow = memo<TopicItemRowProps>(
         .prefetchMessages({ agentId: activeAgentId, scope: 'main', topicId: id });
     }, [activeAgentId, hasLocalRunningRuntime, id, isUnreadCompleted]);
 
-    // Surface a WeChat-style red "[Draft]" hint when this topic holds unsent
-    // input. Drafts live in localStorage keyed by messageMapKey; the default
-    // topic (no id) maps to the new-topic draft. `useHasDraft` re-renders the
-    // row only when the draft appears or clears.
+    // Surface a pencil before the title when this topic holds unsent input.
+    // Drafts live in localStorage keyed by messageMapKey; the default topic (no
+    // id) maps to the new-topic draft. `useHasDraft` re-renders the row only when
+    // the draft appears or clears.
     const draftKey = useMemo(
       () => (activeAgentId ? messageMapKey({ agentId: activeAgentId, topicId: id }) : undefined),
       [activeAgentId, id],
     );
     const hasDraft = useHasDraft(draftKey);
-    const draftPrefix = hasDraft ? (
-      <Text fontSize={12} style={{ color: cssVar.colorError, flex: 'none' }}>
-        {t('draft')}
-      </Text>
+    const draftIndicator = hasDraft ? (
+      <Tooltip title={t('draft')}>
+        <Icon
+          aria-label={t('draft')}
+          color={cssVar.colorError}
+          icon={PencilLine}
+          role={'img'}
+          size={'small'}
+        />
+      </Tooltip>
     ) : undefined;
 
     // Codex-style hover detail card: when the topic carries git context, hovering
@@ -321,7 +327,7 @@ const TopicItemRow = memo<TopicItemRowProps>(
       return (
         <NavItem
           active={defaultTopicActive}
-          slots={{ titlePrefix: draftPrefix }}
+          slots={{ titlePrefix: draftIndicator }}
           titleColor={cssVar.colorText}
           icon={
             isLoading ? (
@@ -454,7 +460,7 @@ const TopicItemRow = memo<TopicItemRowProps>(
           description={workingDirectoryNode}
           href={href}
           icon={leadingIconNode}
-          slots={{ titlePrefix: draftPrefix }}
+          slots={{ titlePrefix: draftIndicator }}
           title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
           titleColor={cssVar.colorText}
           extra={

--- a/src/features/ChatInput/draftStorage.ts
+++ b/src/features/ChatInput/draftStorage.ts
@@ -51,11 +51,11 @@ const writeAll = (map: DraftMap): boolean => {
 
 // --- Reactive draft-key registry -------------------------------------------
 // localStorage isn't reactive, but the topic list needs to react when a draft
-// appears or clears so it can show a "[draft]" hint next to the topic title. We
-// mirror the *set of keys that currently hold a draft* into an in-memory
-// snapshot and notify subscribers whenever that set changes — not on every
-// keystroke-level save, so a topic that already shows the hint doesn't re-render
-// while the user keeps typing.
+// appears or clears so it can show a draft indicator on the topic row. We mirror
+// the *set of keys that currently hold a draft* into an in-memory snapshot and
+// notify subscribers whenever that set changes — not on every keystroke-level
+// save, so a topic that already shows the indicator doesn't re-render while the
+// user keeps typing.
 
 const draftKeysListeners = new Set<() => void>();
 let draftKeysSnapshot: ReadonlySet<string> = new Set<string>();
@@ -86,8 +86,8 @@ const subscribeDraftKeys = (listener: () => void) => {
 
 /**
  * Reactively report whether a draft currently exists for the given draft key.
- * Returns false for an empty key. Used by the topic list to show a "[draft]"
- * hint on topics that hold unsent input.
+ * Returns false for an empty key. Used by the topic list to mark topics that
+ * hold unsent input.
  */
 export const useHasDraft = (key: string | undefined): boolean =>
   useSyncExternalStore(

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,9 +1,9 @@
 import { GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import { Flexbox, Icon, Skeleton, Tooltip } from '@lobehub/ui';
-import { Tag, Text } from '@lobehub/ui/base-ui';
+import { Tag } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, useTheme } from 'antd-style';
-import { HashIcon, MessageSquareDashed } from 'lucide-react';
+import { HashIcon, MessageSquareDashed, PencilLine } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
 import { memo, Suspense, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -230,9 +230,9 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
     </span>
   );
 
-  // Surface a WeChat-style red "[Draft]" hint when this topic holds unsent
-  // input. Group drafts live in localStorage keyed by messageMapKey under the
-  // group scope; the default topic (no id) maps to the new-topic draft.
+  // Surface a pencil before the title when this topic holds unsent input. Group
+  // drafts live in localStorage keyed by messageMapKey under the group scope;
+  // the default topic (no id) maps to the new-topic draft.
   const draftKey = useMemo(
     () =>
       activeGroupId
@@ -241,10 +241,16 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
     [activeGroupId, id],
   );
   const hasDraft = useHasDraft(draftKey);
-  const draftPrefix = hasDraft ? (
-    <Text fontSize={12} style={{ color: cssVar.colorError, flex: 'none' }}>
-      {t('draft')}
-    </Text>
+  const draftIndicator = hasDraft ? (
+    <Tooltip title={t('draft')}>
+      <Icon
+        aria-label={t('draft')}
+        color={cssVar.colorError}
+        icon={PencilLine}
+        role={'img'}
+        size={'small'}
+      />
+    </Tooltip>
   ) : undefined;
 
   // For default topic (no id)
@@ -252,7 +258,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
     return (
       <NavItem
         active={active}
-        slots={{ titlePrefix: draftPrefix }}
+        slots={{ titlePrefix: draftIndicator }}
         titleColor={cssVar.colorText}
         icon={
           isLoading ? (
@@ -343,7 +349,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         }
         slots={{
           iconPostfix: unreadNode,
-          titlePrefix: draftPrefix,
+          titlePrefix: draftIndicator,
         }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}


### PR DESCRIPTION
Replaces the bracketed draft label in topic rows with a compact pencil icon while preserving its original position before the title.

The icon remains red to retain the existing visual emphasis, includes a localized tooltip and accessible label, and is applied consistently to agent and group topic lists.

| Before | After |
| ------ | ----- |
| `[Draft] Topic title` | `✎ Topic title` |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check <changed files>` — 25 tests passed. One pre-existing unused `fav` parameter warning remains in the group topic item.

#### 🔗 Related Issue

None found.