### PR TITLE
♻️ refactor(acceptance): move report output out of the repo into a temp root

### DIFF
--- a/.agents/acceptance/PROCESS.md
+++ b/.agents/acceptance/PROCESS.md
@@ -198,11 +198,14 @@ publishes green with its evidence silently degraded.
 
 What is specific to this repository:
 
-- **Reports live in `.records/reports/<subject-key>/<timestamp>-<slug>/`**
-  (gitignored), grouped by acceptance subject; the subject directory holds an
-  `acceptance.json` marker and one subdirectory per immutable round. Scaffold with
+- **Reports live outside the repo**, under
+  `${TMPDIR:-/tmp}/lobe-acceptance/reports/<subject-key>/<timestamp>-<slug>/`
+  (override with `ACCEPTANCE_REPORT_ROOT`), grouped by acceptance subject; the
+  subject directory holds an `acceptance.json` marker and one subdirectory per
+  immutable round. Scaffold with
   `report-init.sh --subject topic:tpc_xxx <slug> "<title>"`, which also pre-fills
-  `result.json.subject`.
+  `result.json.subject`. Reports are per-run scratch — the published round is the
+  durable copy — so they never touch the working tree.
 
 - **Reusable per-check inputs** live in `.records/fixtures/<subject-key>/<check-id>/`
   (`check.json` + `seed/`). Execution outputs stay in the round's `assets/` and are
@@ -255,8 +258,9 @@ in a source file corrupts the next run and the next agent's mental model.
   returns nothing. When you injected into a file that already had uncommitted
   changes, `git checkout --` is the WRONG revert — it wipes the branch's edits too;
   snapshot the file first and restore from the snapshot.
-- **Keep the report and its evidence.** `.records/reports/**` is the deliverable and
-  is gitignored; the published round points at it.
+- **Keep the report and its evidence** until the round is published. It lives in
+  the temp report root, never in the working tree; the published round is the
+  durable copy.
 - **Check `git status` before calling the tree clean.** Some dev servers write
   managed files on start.
 

--- a/.agents/acceptance/scripts/fixture.mjs
+++ b/.agents/acceptance/scripts/fixture.mjs
@@ -12,7 +12,7 @@
  * CONSUMES (files to upload, DB seed fragments, config, stand-in evidence for
  * synthetic ingest rounds). What a run PRODUCES (screenshots, transcripts) is
  * tied to that one execution and lives only in the round dir's assets/ under
- * .records/reports/ — never copy it back into the fixture.
+ * the report root — never copy it back into the fixture.
  *
  * Layout (gitignored, like all .records/ output):
  *   .records/fixtures/<subject-key>/<check-id>/
@@ -20,7 +20,8 @@
  *   └── seed/          # reusable INPUT assets referenced by check.json / steps
  *
  * <subject-key> = task-<id> | topic-<id> | document-<id> (subject with ':'→'-'),
- * matching the report group dirs under .records/reports/.
+ * matching the report group dirs under the report root
+ * (ACCEPTANCE_REPORT_ROOT, default ${TMPDIR:-/tmp}/lobe-acceptance/reports).
  *
  * Usage:
  *   fixture.mjs init-check --subject topic:tpc_xxx <check-id>
@@ -29,7 +30,7 @@
  *   fixture.mjs compose --subject topic:tpc_xxx --slug <slug> [--title "..."]
  *                       [--focus "..."] [--entry "..."] <check-id> [<check-id>...]
  *       Assemble a report-shaped round dir from the given checks:
- *       .records/reports/topic-tpc_xxx/<ts>-<slug>/  (ready for
+ *       <report-root>/topic-tpc_xxx/<ts>-<slug>/  (ready for
  *       `lh acceptance run ingest <dir>`). Files referenced by case.evidence
  *       (seed/…) are copied into the round's assets/<check-id>/ and paths
  *       rewritten. Prints the dir path.
@@ -45,6 +46,9 @@ const { basename, join } = path;
 // The generic skill is invoked from the consumer repository. Keep all
 // generated fixtures and reports anchored to that explicit working directory.
 const REPO_ROOT = process.cwd();
+const REPORT_ROOT =
+  process.env.ACCEPTANCE_REPORT_ROOT ||
+  join(process.env.TMPDIR || '/tmp', 'lobe-acceptance/reports');
 
 const fail = (msg) => {
   console.error(`fixture.mjs: ${msg}`);
@@ -120,7 +124,7 @@ if (command === 'init-check') {
   const now = new Date();
   const pad = (n) => String(n).padStart(2, '0');
   const ts = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-  const dir = join(REPO_ROOT, '.records/reports', key, `${ts}-${slug}`);
+  const dir = join(REPORT_ROOT, key, `${ts}-${slug}`);
   mkdirSync(join(dir, 'assets'), { recursive: true });
 
   const plan = [];

--- a/.agents/acceptance/scripts/report-init.sh
+++ b/.agents/acceptance/scripts/report-init.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# report-init.sh — scaffold a structured test report under .records/reports/.
+# report-init.sh — scaffold a structured test report under the report root
+# ($ACCEPTANCE_REPORT_ROOT, default ${TMPDIR:-/tmp}/lobe-acceptance/reports).
 #
 # Format spec and evidence rules: ../references/report.md
 #
@@ -8,12 +9,12 @@
 #
 # With --subject (task:<id> | topic:<id> | document:<id>) the run is grouped
 # under its acceptance:
-#   .records/reports/<type>-<id>/<YYYYMMDD-HHMMSS>-<slug>/
+#   <report-root>/<type>-<id>/<YYYYMMDD-HHMMSS>-<slug>/
 # and the group directory gets an acceptance.json marker. The subject is also
 # pre-filled into result.json so acceptance run ingest attaches the run automatically.
 #
-# Run this from the CONSUMER repo root — the report is created relative to the
-# current working directory, not relative to this script's own location.
+# Run this from the CONSUMER repo root — branch/commit provenance is read from
+# the current working directory, not from this script's own location.
 #
 # Prints the report directory path (capture it: DIR=$(report-init.sh my-test)).
 
@@ -39,6 +40,7 @@ json_escape() {
 }
 
 REPO_ROOT="$(pwd)"
+REPORT_ROOT="${ACCEPTANCE_REPORT_ROOT:-${TMPDIR:-/tmp}/lobe-acceptance/reports}"
 TS="$(date +%Y%m%d-%H%M%S)"
 
 SUBJECT_JSON="null"
@@ -48,11 +50,11 @@ if [[ -n "$SUBJECT" ]]; then
     exit 1
   fi
   SUBJECT_KEY="${SUBJECT/:/-}"
-  GROUP_DIR="$REPO_ROOT/.records/reports/$SUBJECT_KEY"
+  GROUP_DIR="$REPORT_ROOT/$SUBJECT_KEY"
   DIR="$GROUP_DIR/$TS-$SLUG"
   SUBJECT_JSON="\"$(json_escape "$SUBJECT")\""
 else
-  DIR="$REPO_ROOT/.records/reports/$TS-$SLUG"
+  DIR="$REPORT_ROOT/$TS-$SLUG"
 fi
 mkdir -p "$DIR/assets"
 


### PR DESCRIPTION
#### 💡 Change Type

- [x] ♻️ refactor

#### 🔀 Description of Change

Acceptance report rounds were scaffolded into the working tree at `.records/reports/`. They are per-run scratch — the published round on LobeHub Acceptance is the durable copy — so they now land outside the repo.

- `report-init.sh` and `fixture.mjs compose` create rounds under `$ACCEPTANCE_REPORT_ROOT`, default `${TMPDIR:-/tmp}/lobe-acceptance/reports/<subject-key>/<ts>-<slug>/`
- `PROCESS.md` §Step 5 and §Step 6 (teardown) updated to match

Deliberately **not** moved, and still under `.records/`:

- `env/` `runtime/` `logs/` `data/` — dev-server ports, JWKS and S3 state that `init-dev-env.sh` anchors at the workspace root so parallel worktrees share one stack
- `fixtures/` — reusable check inputs, durable across runs

The portable skill (`.agents/skills/acceptance/`) needs no change; it already states "Any directory works — no repo convention required".

#### 📝 How to Test

```bash
DIR=$(.agents/acceptance/scripts/report-init.sh --subject topic:tpc_demo smoke "Smoke")
# → $TMPDIR/lobe-acceptance/reports/topic-tpc_demo/<ts>-smoke with result.json, report.md, assets/
```

Verified locally: scaffold lands in the temp root with `acceptance.json` written to the subject dir; `bash -n` / `node --check` pass on both scripts.

https://claude.ai/code/session_01RvzF4TbDHJRi19AzTBhLRb