### PR TITLE
💄 style(devtools): stop Render Gallery control labels from breaking mid-word

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -595,6 +595,16 @@ agent-browser --cdp 9222 eval "(async()=>{const t=await (await fetch('app://rend
 A wrong-worktree hit means the instance is someone else's session: do not restart or
 reuse it, start a pool instance (`electron-dev.sh start <id>`) or switch surface.
 
+**Same failure, third shape — the pool port is not owned by Electron at all.**
+`electron-dev.sh start <id>` treats a reachable `CDP_BASE + id` as "already running"
+and skips the launch with `CDP already reachable on <port>. Skipping start`, so the
+run then drives whatever owns it. Any other debugger on that port claims the slot —
+`workerd`/`wrangler` defaults to 9229, which is pool id 7. The give-away is that
+`electron-dev.sh list` does not list the instance as up while the port answers.
+Before picking a pool id, read `/json/version` on its port and require an Electron
+`Browser` string (a `wrangler/*` or `node` answer means pick another id), or check
+the port is free at all.
+
 ### L-S6 — Reading or writing the url from a portal'd sidebar on desktop
 
 **Wrong approach:** use `useSearchParams`, `useQueryState`, `useParams`,

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -959,6 +959,34 @@ error shapes through a window flag (e.g. plain `Error` vs
 marker before clicking. Snapshot the dirty file first and restore byte-identically
 (cmp), never `git checkout --`.
 
+#### Render Gallery shows "No builtin tool renders registered." after a reload
+
+**Situation:** driving DevDock → Render Gallery to capture builtin-tool
+Inspector/Render evidence, after a renderer reload or an HMR update.
+
+**Doesn't work:** waiting. The gallery reads the builtin registries once through a
+`useMemo` with an empty dependency list, so a panel that mounts before the builtin
+tools finish registering caches an empty list for the lifetime of that mount. It
+renders "No builtin tool renders registered." indefinitely, which reads like the
+registries themselves broke.
+
+**Works:** remount the panel — click the dock's `Render Gallery` button twice
+(close, reopen) and re-select the toolset; the entries appear immediately. To land
+on the gallery straight after a reload, pre-seed the dock instead of clicking
+through it:
+
+```js
+localStorage.setItem(
+  'LOBE_DEV_DOCK_UI',
+  JSON.stringify({
+    ...JSON.parse(localStorage.getItem('LOBE_DEV_DOCK_UI') || '{}'),
+    activePanelId: 'render-gallery',
+    expanded: true,
+    maximized: true,
+  }),
+);
+```
+
 ### Capturing and publishing evidence
 
 #### Reading a transitioned CSS property immediately after focus/hover

--- a/src/features/DevPanel/RenderGallery/ToolPage.tsx
+++ b/src/features/DevPanel/RenderGallery/ToolPage.tsx
@@ -37,10 +37,27 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   controlGroup: css`
-    flex-shrink: 0;
     gap: 8px;
     align-items: center;
+    min-width: 0;
+  `,
+  /*
+   * The label sits next to a Tabs whose root is `width: 100%`, so the tabs claim the
+   * whole row and the label absorbs every pixel of shrink. With the app-wide
+   * `overflow-wrap: anywhere`, its min-content width is one character, so it breaks
+   * mid-word ("Vie / w"). Keep the guard on the label itself, not on the row.
+   */
+  controlLabel: css`
+    flex-shrink: 0;
     white-space: nowrap;
+  `,
+  /* Let the modes wrap onto a second row instead of overflowing a narrow panel. */
+  controlTabs: css`
+    min-width: 0;
+
+    [role='tablist'] {
+      flex-wrap: wrap;
+    }
   `,
   empty: css`
     flex: 1;
@@ -192,11 +209,12 @@ const DevtoolsToolPage = ({ toolset }: DevtoolsToolPageProps) => {
 
           <Flexbox horizontal className={styles.modeBar} wrap={'wrap'}>
             <Flexbox horizontal className={styles.controlGroup}>
-              <Text fontSize={12} type={'secondary'} weight={600}>
+              <Text className={styles.controlLabel} fontSize={12} type={'secondary'} weight={600}>
                 View
               </Text>
               <Tabs
                 activeKey={view}
+                className={styles.controlTabs}
                 size={'small'}
                 items={[
                   { key: 'api', label: 'By API' },
@@ -206,11 +224,12 @@ const DevtoolsToolPage = ({ toolset }: DevtoolsToolPageProps) => {
               />
             </Flexbox>
             <Flexbox horizontal className={styles.controlGroup}>
-              <Text fontSize={12} type={'secondary'} weight={600}>
+              <Text className={styles.controlLabel} fontSize={12} type={'secondary'} weight={600}>
                 Lifecycle
               </Text>
               <Tabs
                 activeKey={mode}
+                className={styles.controlTabs}
                 size={'small'}
                 items={LIFECYCLE_MODES.map((value) => ({
                   key: value,


### PR DESCRIPTION
## 💡 Motivation

Acceptance review feedback on the Browser tool-render round: the Render Gallery control bar wrapped its labels mid-word — `View` rendered as `Vie / w` and `Lifecycle` as one character per line.

Root cause, measured in the running Electron renderer: the label sits next to a base-ui `Tabs` whose root is `width: 100%`, so the tabs claim the whole row and the label absorbs every pixel of flex shrink. Combined with the app-wide `overflow-wrap: anywhere`, the label's min-content width is a single character, so it collapses and breaks inside the word. A `white-space: nowrap` on the row happened to mask it, but it was dropped once already by a restyle of the same bar.

## 🔍 Changes

- Move the no-wrap guard from the row onto the label itself (`flex-shrink: 0; white-space: nowrap`), so a later restyle of the bar cannot silently drop it.
- Let the lifecycle modes wrap onto a second row (`[role='tablist'] { flex-wrap: wrap }`) instead of overflowing a narrow panel — previously `Intervention` was clipped outside the bar at panel widths around 500px.

## ✅ Verification

Verified in the real Electron dev instance (Render Gallery → Browser, 8 APIs):

| width | before | after |
| --- | --- | --- |
| 500px control bar | `View` 2 lines / `Lifecycle` 9 lines, tabs overflow the bar by 18px | both labels 1 line, all 6 modes visible on 2 rows, nothing clipped |
| 1440px viewport | — | both labels 1 line, all modes on a single row (wrap only engages when needed) |

Pure CSS change, so no regression test per the repo's testing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)