### PR TITLE
♻️ refactor: move RecentItem to shared types

### DIFF
--- a/apps/server/src/routers/lambda/recent.ts
+++ b/apps/server/src/routers/lambda/recent.ts
@@ -1,29 +1,11 @@
 import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
-import type { TaskStatus } from '@lobechat/types';
+import type { ChatTopicMetadata, RecentItem } from '@lobechat/types';
 import { z } from 'zod';
 
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
 import { RecentModel } from '@/database/models/recent';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
-import type { ChatTopicMetadata } from '@/types/topic';
-
-export interface RecentItem {
-  agentId?: string | null;
-  description?: string | null;
-  icon: string;
-  id: string;
-  lastAssistantMessage?: string | null;
-  metadata?: ChatTopicMetadata;
-  routePath: string;
-  /** Task lifecycle status when `type === 'task'`; null for topic/document. */
-  status: TaskStatus | null;
-  title: string;
-  type: 'topic' | 'document' | 'task';
-  updatedAt: Date;
-  /** The member who owns this item — for author attribution in workspace team views. */
-  userId?: string;
-}
 
 const recentProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -39,6 +39,7 @@ export * from './notification';
 export * from './plugins';
 export * from './project';
 export * from './rag';
+export * from './recent';
 export * from './redis';
 export * from './resourceTransfer';
 export * from './search';

--- a/packages/types/src/recent.ts
+++ b/packages/types/src/recent.ts
@@ -1,0 +1,19 @@
+import type { TaskStatus } from './task';
+import type { ChatTopicMetadata } from './topic';
+
+export interface RecentItem {
+  agentId?: string | null;
+  description?: string | null;
+  icon: string;
+  id: string;
+  lastAssistantMessage?: string | null;
+  metadata?: ChatTopicMetadata;
+  routePath: string;
+  /** Task lifecycle status when `type === 'task'`; null for topic/document. */
+  status: TaskStatus | null;
+  title: string;
+  type: 'topic' | 'document' | 'task';
+  updatedAt: Date;
+  /** The member who owns this item — for author attribution in workspace team views. */
+  userId?: string;
+}

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -1,5 +1,5 @@
 import { TASK_STATUSES } from '@lobechat/builtin-tool-task';
-import type { TaskStatus } from '@lobechat/types';
+import type { RecentItem, TaskStatus } from '@lobechat/types';
 import { agentDisplayName } from '@lobechat/types';
 import type { FlexboxProps } from '@lobehub/ui';
 import { Flexbox, Icon, Skeleton } from '@lobehub/ui';
@@ -26,7 +26,6 @@ import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useClientDataSWR } from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
 import { useCacheScope } from '@/libs/swr/useCacheScope';
-import { type RecentItem } from '@/server/routers/lambda/recent';
 import { recentService } from '@/services/recent';
 import { useBriefStore } from '@/store/brief';
 import { briefListSelectors } from '@/store/brief/selectors';

--- a/src/features/Home/Recents/Item.tsx
+++ b/src/features/Home/Recents/Item.tsx
@@ -1,3 +1,4 @@
+import type { RecentItem } from '@lobechat/types';
 import { DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { ActionIcon } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
@@ -11,7 +12,6 @@ import NavItem from '@/features/NavPanel/components/NavItem';
 import { usePrefetchAgent } from '@/hooks/usePrefetchAgent';
 import { usePrefetchPage } from '@/hooks/usePrefetchPage';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
-import { type RecentItem } from '@/server/routers/lambda/recent';
 
 import { useRecentItemDropdownMenu } from './useDropdownMenu';
 

--- a/src/features/Home/Recents/useDropdownMenu.tsx
+++ b/src/features/Home/Recents/useDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import type { RecentItem } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
@@ -10,7 +11,6 @@ import { useTaskTransferMenuItem } from '@/business/client/hooks/useTaskTransfer
 import { confirmRemoveTopic } from '@/features/DeleteTopicConfirm';
 import { usePermission } from '@/hooks/usePermission';
 import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
-import { type RecentItem } from '@/server/routers/lambda/recent';
 import { documentService } from '@/services/document';
 import { taskService } from '@/services/task';
 import { topicService } from '@/services/topic';

--- a/src/services/recent/index.ts
+++ b/src/services/recent/index.ts
@@ -1,5 +1,6 @@
+import type { RecentItem } from '@lobechat/types';
+
 import { lambdaClient } from '@/libs/trpc/client';
-import { type RecentItem } from '@/server/routers/lambda/recent';
 
 export const RECENT_SIDEBAR_TYPES = [
   'document',

--- a/src/store/home/slices/recent/action.test.ts
+++ b/src/store/home/slices/recent/action.test.ts
@@ -1,10 +1,10 @@
+import type { RecentItem } from '@lobechat/types';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as swr from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
 import * as cacheScope from '@/libs/swr/useCacheScope';
-import { type RecentItem } from '@/server/routers/lambda/recent';
 import { recentService } from '@/services/recent';
 import { useHomeStore } from '@/store/home';
 import { initialRecentState } from '@/store/home/slices/recent/initialState';

--- a/src/store/home/slices/recent/action.ts
+++ b/src/store/home/slices/recent/action.ts
@@ -1,10 +1,10 @@
+import type { RecentItem } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 import { type SWRResponse } from 'swr';
 
 import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
 import { getCacheScope } from '@/libs/swr/useCacheScope';
-import { type RecentItem } from '@/server/routers/lambda/recent';
 import { RECENT_SIDEBAR_TYPES, recentService } from '@/services/recent';
 import { type HomeStore } from '@/store/home/store';
 import { type StoreSetter } from '@/store/types';

--- a/src/store/home/slices/recent/initialState.ts
+++ b/src/store/home/slices/recent/initialState.ts
@@ -1,4 +1,4 @@
-import { type RecentItem } from '@/server/routers/lambda/recent';
+import type { RecentItem } from '@lobechat/types';
 
 export interface RecentState {
   allRecentsDrawerOpen: boolean;


### PR DESCRIPTION
## Summary

- move `RecentItem` from the server router into `@lobechat/types`
- update server and client consumers to use the shared DTO
- keep runtime behavior unchanged

## Validation

- `bun run check --lint <changed-files>`
- `bun run check --type`