### PR TITLE
✨ feat(acceptance): give report rounds a structured, git-invisible home

### DIFF
--- a/apps/cli/src/commands/acceptanceRun.ts
+++ b/apps/cli/src/commands/acceptanceRun.ts
@@ -8,6 +8,7 @@ import pc from 'picocolors';
 
 import { getTrpcClient } from '../api/client';
 import { resolveServerUrl } from '../settings';
+import { ensureAcceptanceDirIgnored, ensureAcceptanceDirIgnoredFor } from '../utils/acceptanceDir';
 import { confirm, outputJson, printTable, timeAgo, truncate } from '../utils/format';
 import { log } from '../utils/logger';
 import type { LinkResult } from '../utils/skillWiring';
@@ -111,9 +112,14 @@ async function installAction(options: InstallOptions): Promise<void> {
   }
 
   const link = linkHarnessSkills(baseDir, bundle.identifier);
+  // The skill is committed; its OUTPUT is not. Seed the artifact directory's own
+  // self-ignoring file now, so the first run's screenshots never land as
+  // untracked noise in a repo that has never heard of us.
+  const ignored = ensureAcceptanceDirIgnored(baseDir);
 
   const result = {
     dir: skillDir,
+    ignored,
     link,
     removed,
     skill: bundle.identifier,
@@ -522,6 +528,10 @@ interface IngestReportOptions {
 
 async function ingestReportAction(reportDir: string, options: IngestReportOptions): Promise<void> {
   const dir = path.resolve(reportDir);
+  // The guarantee has to hold however the round got here — a project that never
+  // ran `acceptance install`, or an agent that wrote the round by hand, still
+  // must not leave evidence binaries untracked in someone's repo.
+  ensureAcceptanceDirIgnoredFor(dir);
   const resultPath = path.join(dir, 'result.json');
   if (!existsSync(resultPath)) {
     log.error(`result.json not found in ${dir}`);

--- a/apps/cli/src/utils/acceptanceDir.test.ts
+++ b/apps/cli/src/utils/acceptanceDir.test.ts
@@ -116,8 +116,23 @@ describe('acceptanceRoundDirName', () => {
   });
 
   it('places a round under its subject group', () => {
-    expect(acceptanceRoundDir('/repo', 'topic:tpc_x', 'first', at)).toBe(
-      path.join('/repo', ACCEPTANCE_DIR, 'topic-tpc_x', '20260831-010203-first'),
+    expect(acceptanceRoundDir(root, 'topic:tpc_x', 'first', at)).toBe(
+      path.join(root, ACCEPTANCE_DIR, 'topic-tpc_x', '20260831-010203-first'),
     );
+  });
+
+  it('never hands out a directory that already exists', () => {
+    // Two rounds started in the same second — parallel workers, or a fast
+    // fix-and-reverify. Sharing a name would let the second writer mix its
+    // evidence into a round the reviewer has already been shown.
+    const first = acceptanceRoundDir(root, 'topic:tpc_x', 'first', at);
+    mkdirSync(first, { recursive: true });
+
+    const second = acceptanceRoundDir(root, 'topic:tpc_x', 'first', at);
+    expect(second).not.toBe(first);
+    expect(second).toBe(`${first}-2`);
+
+    mkdirSync(second, { recursive: true });
+    expect(acceptanceRoundDir(root, 'topic:tpc_x', 'first', at)).toBe(`${first}-3`);
   });
 });

--- a/apps/cli/src/utils/acceptanceDir.test.ts
+++ b/apps/cli/src/utils/acceptanceDir.test.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ACCEPTANCE_DIR,
+  acceptanceRoundDir,
+  acceptanceRoundDirName,
+  acceptanceSubjectKey,
+  ensureAcceptanceDirIgnored,
+  ensureAcceptanceDirIgnoredFor,
+} from './acceptanceDir';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'acceptance-dir-'));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const gitInit = (dir: string) => execFileSync('git', ['init', '-q'], { cwd: dir, stdio: 'ignore' });
+
+const gitStatus = (dir: string) =>
+  execFileSync('git', ['status', '--porcelain'], { cwd: dir }).toString();
+
+describe('ensureAcceptanceDirIgnored', () => {
+  it('ignores the whole tree from inside it, leaving the root .gitignore alone', () => {
+    gitInit(root);
+    writeFileSync(path.join(root, '.gitignore'), 'node_modules\n');
+
+    expect(ensureAcceptanceDirIgnored(root)).toMatchObject({ kind: 'added' });
+
+    expect(readFileSync(path.join(root, ACCEPTANCE_DIR, '.gitignore'), 'utf8')).toBe('*\n');
+    // The project's own file is not ours to rewrite.
+    expect(readFileSync(path.join(root, '.gitignore'), 'utf8')).toBe('node_modules\n');
+  });
+
+  it('hides a written round from git, including the ignore file itself', () => {
+    gitInit(root);
+    ensureAcceptanceDirIgnored(root);
+
+    const round = path.join(root, ACCEPTANCE_DIR, 'topic-tpc_x', '20260831-010203-first');
+    mkdirSync(path.join(round, 'assets'), { recursive: true });
+    writeFileSync(path.join(round, 'result.json'), '{}');
+    writeFileSync(path.join(round, 'assets', 'shot.png'), 'binary');
+
+    // Nothing from the tree — not the evidence, not the .gitignore we wrote.
+    expect(gitStatus(root)).toBe('');
+  });
+
+  it('leaves an existing ignore file alone', () => {
+    gitInit(root);
+    mkdirSync(path.join(root, ACCEPTANCE_DIR), { recursive: true });
+    writeFileSync(path.join(root, ACCEPTANCE_DIR, '.gitignore'), '/assets/\n');
+
+    expect(ensureAcceptanceDirIgnored(root)).toEqual({ kind: 'present' });
+    expect(readFileSync(path.join(root, ACCEPTANCE_DIR, '.gitignore'), 'utf8')).toBe('/assets/\n');
+  });
+
+  it('creates nothing outside a git repository', () => {
+    expect(ensureAcceptanceDirIgnored(root)).toMatchObject({ kind: 'skipped' });
+    expect(existsSync(path.join(root, ACCEPTANCE_DIR))).toBe(false);
+  });
+});
+
+describe('ensureAcceptanceDirIgnoredFor', () => {
+  it('seeds the tree a round directory belongs to', () => {
+    gitInit(root);
+
+    const round = path.join(root, ACCEPTANCE_DIR, 'task-T-12', '20260831-010203-round');
+    expect(ensureAcceptanceDirIgnoredFor(round)).toMatchObject({ kind: 'added' });
+    expect(existsSync(path.join(root, ACCEPTANCE_DIR, '.gitignore'))).toBe(true);
+  });
+
+  it('never creates the directory for a round kept somewhere else', () => {
+    gitInit(root);
+
+    expect(ensureAcceptanceDirIgnoredFor(path.join(root, 'my-reports', 'round'))).toMatchObject({
+      kind: 'skipped',
+    });
+    expect(existsSync(path.join(root, ACCEPTANCE_DIR))).toBe(false);
+  });
+});
+
+describe('acceptanceSubjectKey', () => {
+  it('mirrors the --subject vocabulary as a directory name', () => {
+    expect(acceptanceSubjectKey('topic:tpc_q11dU2Erfsjp')).toBe('topic-tpc_q11dU2Erfsjp');
+    expect(acceptanceSubjectKey('task:T-12')).toBe('task-T-12');
+    expect(acceptanceSubjectKey('document:doc_9')).toBe('document-doc_9');
+  });
+
+  it('keeps a bare subject usable as a directory name', () => {
+    expect(acceptanceSubjectKey('standalone')).toBe('standalone');
+  });
+});
+
+describe('acceptanceRoundDirName', () => {
+  const at = new Date(2026, 7, 31, 1, 2, 3);
+
+  it('sorts by time and stays unique per round', () => {
+    expect(acceptanceRoundDirName('list panel', at)).toBe('20260831-010203-list-panel');
+  });
+
+  it('normalizes a slug down to path-safe characters', () => {
+    expect(acceptanceRoundDirName('  Round #2: 验收 ', at)).toBe('20260831-010203-round-2');
+  });
+
+  it('still names the round when the slug reduces to nothing', () => {
+    expect(acceptanceRoundDirName('验收', at)).toBe('20260831-010203');
+  });
+
+  it('places a round under its subject group', () => {
+    expect(acceptanceRoundDir('/repo', 'topic:tpc_x', 'first', at)).toBe(
+      path.join('/repo', ACCEPTANCE_DIR, 'topic-tpc_x', '20260831-010203-first'),
+    );
+  });
+});

--- a/apps/cli/src/utils/acceptanceDir.ts
+++ b/apps/cli/src/utils/acceptanceDir.ts
@@ -72,8 +72,10 @@ export function acceptanceSubjectKey(subject: string): string {
 const pad = (value: number): string => String(value).padStart(2, '0');
 
 /**
- * `YYYYMMDD-HHMMSS-<slug>` — sortable, and unique per round so an immutable
- * round can never overwrite the one before it.
+ * `YYYYMMDD-HHMMSS-<slug>` — sortable, and the base name a round is written
+ * under. Second resolution alone does NOT guarantee uniqueness (two workers can
+ * start the same round in the same second), so allocation goes through
+ * {@link acceptanceRoundDir}, which resolves collisions against the disk.
  */
 export function acceptanceRoundDirName(slug: string, now: Date = new Date()): string {
   const stamp =
@@ -86,19 +88,28 @@ export function acceptanceRoundDirName(slug: string, now: Date = new Date()): st
   return normalized ? `${stamp}-${normalized}` : stamp;
 }
 
-/** The directory one round should be written to, under its subject's group. */
+/**
+ * Allocate the directory one round is written to, under its subject's group.
+ *
+ * A round is immutable, so this never returns a path that already exists: two
+ * rounds started inside the same second — parallel workers, or a fast
+ * fix-and-reverify — would otherwise share a name and the second writer would
+ * mix its evidence into the first one's published round.
+ */
 export function acceptanceRoundDir(
   baseDir: string,
   subject: string,
   slug: string,
   now?: Date,
 ): string {
-  return path.join(
-    baseDir,
-    ACCEPTANCE_DIR,
-    acceptanceSubjectKey(subject),
-    acceptanceRoundDirName(slug, now),
-  );
+  const group = path.join(baseDir, ACCEPTANCE_DIR, acceptanceSubjectKey(subject));
+  const base = acceptanceRoundDirName(slug, now);
+
+  let candidate = path.join(group, base);
+  for (let suffix = 2; existsSync(candidate); suffix += 1) {
+    candidate = path.join(group, `${base}-${suffix}`);
+  }
+  return candidate;
 }
 
 /**

--- a/apps/cli/src/utils/acceptanceDir.ts
+++ b/apps/cli/src/utils/acceptanceDir.ts
@@ -1,0 +1,115 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Every acceptance artifact a run produces lands under one project-local
+ * directory, grouped the way the product itself groups them.
+ *
+ * ```
+ * .acceptances/
+ * ├── .gitignore                     # `*` — the whole tree stays out of git
+ * └── <subject-key>/                 # topic-tpc_x | task-T-12 | document-doc_x | standalone-<id>
+ *     ├── acceptance.json            # which acceptance these rounds belong to
+ *     └── <YYYYMMDD-HHMMSS>-<slug>/  # ONE immutable round
+ *         ├── result.json
+ *         ├── report.md
+ *         └── assets/
+ * ```
+ *
+ * The subject key mirrors the `--subject <type>:<id>` vocabulary the CLI already
+ * speaks, so a directory listing answers the same question the acceptance page
+ * does: which delivery is this, and how many rounds has it had.
+ */
+export const ACCEPTANCE_DIR = '.acceptances';
+
+export type IgnoreResult =
+  { file: string; kind: 'added' } | { kind: 'present' } | { kind: 'skipped'; reason: string };
+
+function isGitRepository(baseDir: string): boolean {
+  try {
+    execFileSync('git', ['rev-parse', '--git-dir'], { cwd: baseDir, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Keep the artifact tree out of git, without touching the project's own
+ * `.gitignore`.
+ *
+ * A round is a throwaway: a `result.json`, a narrative tail, and however many
+ * screenshots and GIFs the evidence needed — megabytes of binaries that belong
+ * on the acceptance page, not in a repository's history. Writing `*` into a
+ * `.gitignore` INSIDE the directory ignores the whole tree including that file
+ * (git still reads an ignore file that ignores itself), so the project's root
+ * file is never rewritten and a `.acceptances/` line never shows up in someone
+ * else's diff.
+ *
+ * This is deliberately the opposite call from the materialized skill, which is
+ * a reviewable team asset and is meant to be committed. Artifacts are not.
+ */
+export function ensureAcceptanceDirIgnored(baseDir: string): IgnoreResult {
+  if (!isGitRepository(baseDir)) return { kind: 'skipped', reason: 'not a git repository' };
+
+  const dir = path.join(baseDir, ACCEPTANCE_DIR);
+  const file = path.join(dir, '.gitignore');
+  if (existsSync(file)) return { kind: 'present' };
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(file, '*\n', 'utf8');
+  return { file: path.join(ACCEPTANCE_DIR, '.gitignore'), kind: 'added' };
+}
+
+/** `topic:tpc_x` → `topic-tpc_x`; the directory name for one delivery's rounds. */
+export function acceptanceSubjectKey(subject: string): string {
+  const [type, ...rest] = subject.split(':');
+  const id = rest.join(':').trim();
+  return id ? `${type.trim()}-${id}` : type.trim();
+}
+
+const pad = (value: number): string => String(value).padStart(2, '0');
+
+/**
+ * `YYYYMMDD-HHMMSS-<slug>` — sortable, and unique per round so an immutable
+ * round can never overwrite the one before it.
+ */
+export function acceptanceRoundDirName(slug: string, now: Date = new Date()): string {
+  const stamp =
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+    `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  const normalized = slug
+    .toLowerCase()
+    .replaceAll(/[^\da-z]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '');
+  return normalized ? `${stamp}-${normalized}` : stamp;
+}
+
+/** The directory one round should be written to, under its subject's group. */
+export function acceptanceRoundDir(
+  baseDir: string,
+  subject: string,
+  slug: string,
+  now?: Date,
+): string {
+  return path.join(
+    baseDir,
+    ACCEPTANCE_DIR,
+    acceptanceSubjectKey(subject),
+    acceptanceRoundDirName(slug, now),
+  );
+}
+
+/**
+ * Seed the ignore file for whichever `.acceptances/` tree a round directory
+ * belongs to. A no-op when the round was written somewhere else — this must
+ * never create the directory in a project that keeps its reports elsewhere.
+ */
+export function ensureAcceptanceDirIgnoredFor(roundDir: string): IgnoreResult {
+  const segments = path.resolve(roundDir).split(path.sep);
+  const index = segments.lastIndexOf(ACCEPTANCE_DIR);
+  if (index <= 0) return { kind: 'skipped', reason: `not inside ${ACCEPTANCE_DIR}/` };
+
+  return ensureAcceptanceDirIgnored(segments.slice(0, index).join(path.sep));
+}

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -80,8 +80,9 @@ discover or author plan  →  pick the surface  →  capture evidence  →  publ
 
 The skill package is portable, but execution capabilities are surface-specific:
 `agent-browser` serves Web/Electron, while native macOS and iOS Simulator require
-a local macOS display and their platform tools. No repository-specific scripts
-or fixed report directory are required.
+a local macOS display and their platform tools. No repository-specific scripts are
+required; rounds land under `.acceptances/`, which the CLI keeps out of git for
+you (see [report.md](./references/report.md#directory-layout)).
 
 ## Two entry points — an operation id is NOT required
 

--- a/packages/builtin-skills/src/acceptance/references/common-mistakes.md
+++ b/packages/builtin-skills/src/acceptance/references/common-mistakes.md
@@ -79,7 +79,7 @@ The task lives in the user's words.
 before course-correcting.
 
 **Correct approach**: when the user references a task you don't have in context, say
-so plainly and RECOVER it before acting — check `.records/reports/` for prior
+so plainly and RECOVER it before acting — check `.acceptances/` for prior
 sessions on this branch, read the live conversation's own messages (the first user
 turn is usually the task), or ask for a pointer. Only translate the ask into
 code/commits after it's grounded.

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -28,18 +28,32 @@ structured round ingest.** Never mix both for the same delivery round.
 `--operation` is optional on every command in this skill. Without one, author
 the checks and use one of these first-class paths:
 
-```bash
-# One directory per round, under the delivery it belongs to.
-REPORT_DIR=.acceptances/topic-tpc_xxx/$(date +%Y%m%d-%H%M%S)-<slug>
+A round is immutable, so **allocate a fresh directory before every ingest** —
+never point a second ingest at a directory you already published:
 
-# A. first external-project round — creates a standalone acceptance automatically
+```bash
+# $1 = subject key (see Directory layout), $2 = a short slug for this round.
+new_round() {
+  dir=".acceptances/$1/$(date +%Y%m%d-%H%M%S)-$2"
+  mkdir -p "$dir/assets" && printf '%s' "$dir"
+}
+```
+
+```bash
+# A. first external-project round — creates a standalone acceptance.
+# It has no subject yet, so group it under `standalone-<slug>` until the
+# returned acceptance id gives the tree its permanent name.
+REPORT_DIR=$(new_round standalone-checkout-flow first-pass)
 lh acceptance run ingest "$REPORT_DIR" \
   --requirement "<one-sentence business goal>" --json
 
-# Re-verification — append a new immutable round to the same acceptance
+# Re-verification after a fix — a NEW round on the SAME acceptance.
+REPORT_DIR=$(new_round standalone-checkout-flow repair)
 lh acceptance run ingest "$REPORT_DIR" --acceptance "$ACCEPTANCE_ID" --json
 
-# Attach to a subject you were told to use — a Task, Topic, or Document
+# Attach to a subject you were told to use — a Task, Topic, or Document.
+# Group the round under that same subject so the tree and the page agree.
+REPORT_DIR=$(new_round topic-tpc_xxx first-pass)
 lh acceptance run ingest "$REPORT_DIR" --subject topic:tpc_xxx --json
 
 # B. atomic fallback — create the round first, then submit into it with --run
@@ -79,7 +93,8 @@ Rounds live under `.acceptances/`, grouped by the delivery they belong to:
 ```
 .acceptances/
 ├── .gitignore                     # `*` — the whole tree stays out of git
-└── <subject-key>/                 # topic-tpc_x | task-T-12 | document-doc_x | standalone-<id>
+└── <subject-key>/                 # topic-tpc_x | task-T-12 | document-doc_x
+    │                              # standalone-<slug> until an acceptance id exists
     ├── acceptance.json            # which acceptance these rounds belong to
     └── <YYYYMMDD-HHMMSS>-<slug>/  # ONE round — never write into an existing one
         ├── result.json            # THE report — the page renders from this
@@ -91,7 +106,9 @@ Three things the shape buys, none of them cosmetic:
 
 - **The subject key mirrors `--subject <type>:<id>`**, so a directory listing
   answers what the acceptance page answers: which delivery is this, and how many
-  rounds has it had. A flat `./acceptance-report` answers neither.
+  rounds has it had. A flat `./acceptance-report` answers neither. A standalone
+  round has no subject to key on, so group it under `standalone-<slug>` and keep
+  every later round of that delivery in the same directory.
 - **A round is immutable**, so its directory name carries the timestamp and is
   written once. Re-verification after a fix creates the NEXT directory; reusing
   one silently destroys the evidence a reviewer already decided against.

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -29,7 +29,8 @@ structured round ingest.** Never mix both for the same delivery round.
 the checks and use one of these first-class paths:
 
 ```bash
-REPORT_DIR=./acceptance-report
+# One directory per round, under the delivery it belongs to.
+REPORT_DIR=.acceptances/topic-tpc_xxx/$(date +%Y%m%d-%H%M%S)-<slug>
 
 # A. first external-project round — creates a standalone acceptance automatically
 lh acceptance run ingest "$REPORT_DIR" \
@@ -73,14 +74,35 @@ lh acceptance view "$ACCEPTANCE_ID" --json
 
 ## Directory layout
 
-Any directory works — no repo convention required:
+Rounds live under `.acceptances/`, grouped by the delivery they belong to:
 
 ```
-<report-dir>/
-├── result.json     # THE report — the page renders from this
-├── report.md       # narrative tail only (verdict notes, follow-ups, score)
-└── assets/         # evidence files referenced from cases[].evidence
+.acceptances/
+├── .gitignore                     # `*` — the whole tree stays out of git
+└── <subject-key>/                 # topic-tpc_x | task-T-12 | document-doc_x | standalone-<id>
+    ├── acceptance.json            # which acceptance these rounds belong to
+    └── <YYYYMMDD-HHMMSS>-<slug>/  # ONE round — never write into an existing one
+        ├── result.json            # THE report — the page renders from this
+        ├── report.md              # narrative tail only (verdict, follow-ups, score)
+        └── assets/                # evidence referenced from cases[].evidence
 ```
+
+Three things the shape buys, none of them cosmetic:
+
+- **The subject key mirrors `--subject <type>:<id>`**, so a directory listing
+  answers what the acceptance page answers: which delivery is this, and how many
+  rounds has it had. A flat `./acceptance-report` answers neither.
+- **A round is immutable**, so its directory name carries the timestamp and is
+  written once. Re-verification after a fix creates the NEXT directory; reusing
+  one silently destroys the evidence a reviewer already decided against.
+- **The tree is git-invisible.** `.acceptances/.gitignore` contains `*`, which
+  ignores the whole directory including itself, so evidence binaries never land
+  as untracked noise and the project's own `.gitignore` is never rewritten.
+  `lh acceptance install` and `lh acceptance run ingest` both seed that file, so
+  the guarantee does not depend on which entry point a run came through.
+
+Writing a round somewhere else still works — `ingest` takes an explicit path —
+but then keeping it out of git is on you.
 
 ## Workflow
 


### PR DESCRIPTION
Report rounds had no convention. The skill said *"any directory works — no repo convention required"* and showed a flat `REPORT_DIR=./acceptance-report`, so on an external project the first run drops a bare, untracked directory of screenshots and GIFs into the repo root — easy for an agent to sweep into a commit with `git add -A`, and impossible to tell one round from the next because every round shares the same path.

Rounds now land under `.acceptances/<subject-key>/<YYYYMMDD-HHMMSS>-<slug>/`:

```
.acceptances/
├── .gitignore                     # `*` — the whole tree stays out of git
└── topic-tpc_q11dU2Erfsjp/
    ├── acceptance.json
    └── 20260831-010203-list-panel/
        ├── result.json
        ├── report.md
        └── assets/
```

Three properties, none cosmetic:

- **The subject key mirrors `--subject <type>:<id>`.** A directory listing answers what the acceptance page answers: which delivery is this, and how many rounds has it had. A flat directory answers neither.
- **One directory per round.** Rounds are immutable; reusing a directory silently destroys evidence a reviewer already decided against, and the timestamp keeps them sorted.
- **The tree is git-invisible.** `.acceptances/.gitignore` contains `*`, which ignores the directory *including that file* (git still reads an ignore file that ignores itself). The project's own `.gitignore` is never rewritten, so nothing about us shows up in someone else's diff.

Both `acceptance install` and `acceptance run ingest` seed the ignore file, so the guarantee holds however a round got there — a project that never ran install, or an agent that wrote the round by hand. `ingest` only seeds it when the round actually lives under `.acceptances/`, so a project that keeps reports elsewhere never gets the directory created behind its back.

This is deliberately the opposite call from #18830, which stopped ignoring the materialized skill. That reasoning was right and still holds: the skill is a reviewable team asset and belongs in history. Its *output* — megabytes of evidence binaries per round — does not.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`acceptanceDir.test.ts` covers it against real git repositories: the ignore file hides a written round *and itself* from `git status`, the project's root `.gitignore` is left byte-identical, an existing ignore file is never rewritten, nothing is created outside a git repo or for a round kept elsewhere, plus the subject-key and round-name derivations (including a slug that normalizes away to nothing).

Note: `apps/cli`'s `src/utils` suite has one pre-existing failure on canary (`HeteroTraceRecorder`, only when the whole directory runs together) — verified present with these changes reverted, and unaffected by them.

#### 🔗 Related Issue

Follows #18830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)