### PR TITLE
✨ feat: add llmman provider

### DIFF
--- a/apps/server/src/globalConfig/index.ts
+++ b/apps/server/src/globalConfig/index.ts
@@ -57,6 +57,9 @@ export const getServerGlobalConfig = async () => {
     kimicodingplan: {
       withDeploymentName: true,
     },
+    llmman: {
+      fetchOnClient: isDesktop ? false : undefined,
+    },
     lmstudio: {
       fetchOnClient: isDesktop ? false : undefined,
     },

--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -34,6 +34,7 @@
   "internlm.description": "An open-source organization focused on large-model research and tooling, providing an efficient, easy-to-use platform that makes cutting-edge models and algorithms accessible.",
   "jina.description": "Founded in 2020, Jina AI is a leading search AI company. Its search stack includes vector models, rerankers, and small language models to build reliable, high-quality generative and multimodal search apps.",
   "kimicodingplan.description": "Kimi Code from Moonshot AI provides access to Kimi models including K2.5 for coding tasks.",
+  "llmman.description": "llmman is a command-line tool for running and serving local models, distributed as OCI artifacts.",
   "lmstudio.description": "LM Studio is a desktop app for developing and experimenting with LLMs on your computer.",
   "lobehub.description": "LobeHub Cloud uses official APIs to access AI models and measures usage with Credits tied to model tokens.",
   "longcat.description": "LongCat is a series of generative AI large models independently developed by Meituan. It is designed to enhance internal enterprise productivity and enable innovative applications through an efficient computational architecture and strong multimodal capabilities.",

--- a/packages/business/config/src/llm.ts
+++ b/packages/business/config/src/llm.ts
@@ -13,6 +13,7 @@ const providerDefaults: Partial<
   [ModelProvider.DeepSeek]: { enabled: true },
   [ModelProvider.Google]: { enabled: true },
   [ModelProvider.LMStudio]: { fetchOnClient: true },
+  [ModelProvider.Llmman]: { fetchOnClient: true },
   [ModelProvider.Ollama]: { fetchOnClient: true },
   [ModelProvider.OpenAI]: { enabled: true },
   [ModelProvider.OpenCodeZen]: { enabledModels: enabledOpenCodeZenModels },

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -36,6 +36,7 @@ import { default as infiniai } from './infiniai';
 import { default as internlm } from './internlm';
 import { default as jina } from './jina';
 import { default as kimicodingplan } from './kimiCodingPlan';
+import { default as llmman } from './llmman';
 import { default as lmstudio } from './lmstudio';
 import { default as longcat } from './longcat';
 import { default as minimax } from './minimax';
@@ -146,6 +147,7 @@ const staticModelMap: ModelsMap = {
   internlm,
   jina,
   kimicodingplan,
+  llmman,
   lmstudio,
   longcat,
   minimax,
@@ -262,6 +264,7 @@ export { default as infiniai } from './infiniai';
 export { default as internlm } from './internlm';
 export { default as jina } from './jina';
 export { default as kimicodingplan } from './kimiCodingPlan';
+export { default as llmman } from './llmman';
 export { default as lmstudio } from './lmstudio';
 export { default as longcat } from './longcat';
 export { default as minimax } from './minimax';

--- a/packages/model-bank/src/aiModels/llmman.ts
+++ b/packages/model-bank/src/aiModels/llmman.ts
@@ -1,0 +1,7 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// Models are whatever the user has pulled locally, discovered from the running
+// server, so no static catalog is shipped here.
+const llmmanChatModels: AIChatModelCard[] = [];
+
+export default llmmanChatModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -35,6 +35,7 @@ export enum ModelProvider {
   Jina = 'jina',
   KimiCodingPlan = 'kimicodingplan',
   LMStudio = 'lmstudio',
+  Llmman = 'llmman',
   LobeHub = 'lobehub',
   LongCat = 'longcat',
   Minimax = 'minimax',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -36,6 +36,7 @@ import InfiniAIProvider from './infiniai';
 import InternLMProvider from './internlm';
 import JinaProvider from './jina';
 import KimiCodingPlanProvider from './kimiCodingPlan';
+import LlmmanProvider from './llmman';
 import LMStudioProvider from './lmstudio';
 import LobeHubProvider from './lobehub';
 import LongCatProvider from './longcat';
@@ -204,6 +205,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   VolcengineCodingPlanProvider,
   MinimaxProvider,
   MinimaxCodingPlanProvider,
+  LlmmanProvider,
   LMStudioProvider,
   InternLMProvider,
   HigressProvider,
@@ -280,6 +282,7 @@ export { default as InfiniAIProviderCard } from './infiniai';
 export { default as InternLMProviderCard } from './internlm';
 export { default as JinaProviderCard } from './jina';
 export { default as KimiCodingPlanProviderCard } from './kimiCodingPlan';
+export { default as LlmmanProviderCard } from './llmman';
 export { default as LMStudioProviderCard } from './lmstudio';
 export { default as LobeHubProviderCard } from './lobehub';
 export { default as LongCatProviderCard } from './longcat';

--- a/packages/model-bank/src/modelProviders/llmman.ts
+++ b/packages/model-bank/src/modelProviders/llmman.ts
@@ -1,0 +1,27 @@
+import type { ModelProviderCard } from '../types';
+
+// llmman serves an OpenAI-compatible API at /v1, alongside Ollama- and
+// Anthropic-compatible ones. Models are whatever the user has pulled locally,
+// so the model list is fetched from the running server.
+const Llmman: ModelProviderCard = {
+  chatModels: [],
+  description:
+    'llmman is a command-line tool for running and serving local models, distributed as OCI artifacts.',
+  id: 'llmman',
+  modelsUrl: 'https://github.com/llmmanorg/llmman',
+  name: 'llmman',
+  settings: {
+    defaultShowBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'http://127.0.0.1:17434/v1',
+    },
+    responseAnimation: {
+      speed: 2,
+      text: 'smooth',
+    },
+    showModelFetcher: true,
+  },
+  url: 'https://github.com/llmmanorg/llmman',
+};
+
+export default Llmman;

--- a/packages/model-runtime/src/providers/llmman/index.ts
+++ b/packages/model-runtime/src/providers/llmman/index.ts
@@ -1,0 +1,44 @@
+import type { ChatModelCard } from '@lobechat/types';
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export interface LlmmanModelCard {
+  id: string;
+}
+
+export const params = {
+  apiKey: 'placeholder-to-avoid-error',
+  baseURL: 'http://127.0.0.1:17434/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_LLMMAN_CHAT_COMPLETION === '1',
+  },
+  models: async ({ client }) => {
+    const { LOBE_DEFAULT_MODEL_LIST } = await import('model-bank');
+
+    const modelsPage = (await client.models.list()) as any;
+    const modelList: LlmmanModelCard[] = modelsPage.data;
+
+    return modelList
+      .map((model) => {
+        const knownModel = LOBE_DEFAULT_MODEL_LIST.find(
+          (m) => model.id.toLowerCase() === m.id.toLowerCase(),
+        );
+
+        return {
+          contextWindowTokens: knownModel?.contextWindowTokens ?? undefined,
+          displayName: knownModel?.displayName ?? undefined,
+          enabled: knownModel?.enabled || false,
+          functionCall: knownModel?.abilities?.functionCall || false,
+          id: model.id,
+          reasoning: knownModel?.abilities?.reasoning || false,
+          vision: knownModel?.abilities?.vision || false,
+        };
+      })
+      .filter(Boolean) as ChatModelCard[];
+  },
+  provider: ModelProvider.Llmman,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeLlmmanAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -33,6 +33,7 @@ import { LobeInfiniAI } from './providers/infiniai';
 import { LobeInternLMAI } from './providers/internlm';
 import { LobeJinaAI } from './providers/jina';
 import { LobeKimiCodingPlanAI } from './providers/kimiCodingPlan';
+import { LobeLlmmanAI } from './providers/llmman';
 import { LobeLMStudioAI } from './providers/lmstudio';
 import { LobeHubAI } from './providers/lobehub';
 import { LobeLongCatAI } from './providers/longcat';
@@ -118,6 +119,7 @@ export const providerRuntimeMap = {
   internlm: LobeInternLMAI,
   jina: LobeJinaAI,
   kimicodingplan: LobeKimiCodingPlanAI,
+  llmman: LobeLlmmanAI,
   lmstudio: LobeLMStudioAI,
   lobehub: LobeHubAI,
   longcat: LobeLongCatAI,

--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -48,7 +48,7 @@ const activeProviderConfig = (s: AIProviderStoreState) =>
 const isAiProviderConfigLoading = (id: string) => (s: AIProviderStoreState) =>
   !s.aiProviderDetailMap[id];
 
-const providerWhitelist = new Set(['ollama', 'lmstudio']);
+const providerWhitelist = new Set(['ollama', 'lmstudio', 'llmman']);
 
 const activeProviderKeyVaults = (s: AIProviderStoreState) => activeProviderConfig(s)?.keyVaults;
 


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] ✨ feat

## 🔀 变更说明 | Description of Change

Adds [llmman](https://github.com/llmmanorg/llmman), a command-line tool for running and serving local models distributed as OCI artifacts. It serves an OpenAI-compatible API at `/v1` on port 17434, alongside Ollama- and Anthropic-compatible ones, so the runtime is the OpenAI-compatible factory with a different default base URL — the same shape as the neighbouring local-runner provider.

Models are whatever the user has pulled locally, so no static catalog is shipped: `aiModels/llmman.ts` is empty and the model fetcher lists them from the running server. Added to the local-provider whitelist so it appears without credentials.

Only the `en-US` locale string is added by hand; the rest come from `npm run i18n`.

## 📝 补充信息 | Additional Information

**Testing:** `tsc --noEmit -p packages/model-bank/tsconfig.json` gives identical output before and after (9 lines, all npm config warnings plus a pre-existing missing `vitest/globals` type), verified against a stashed clean tree. Prettier couldn't run here — `@lobehub/lint` isn't installed in this environment — so formatting is matched by hand against the sibling provider files.

Not verified: no run against a live server, so model fetching is covered by inspection rather than execution.

> AI-assisted, reviewed before submitting.
