### PR TITLE
🐛 fix(chat): record the assistant turn under the topic-pinned model

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -314,6 +314,115 @@ describe('ConversationLifecycle actions', () => {
         });
       });
 
+      describe('effective model', () => {
+        const AGENT_MODEL = { model: 'agent-default-model', provider: 'agent-default-provider' };
+        const TOPIC_MODEL = { model: 'topic-pinned-model', provider: 'topic-pinned-provider' };
+        const OTHER_MODEL = { model: 'other-topic-model', provider: 'other-topic-provider' };
+
+        const seedTopic = (agentId: string, topic: Record<string, any>) => {
+          act(() => {
+            useChatStore.setState({
+              topicDataMap: {
+                [topicMapKey({ agentId })]: {
+                  currentPage: 0,
+                  hasMore: false,
+                  items: [topic as any],
+                  pageSize: 20,
+                  total: 1,
+                },
+              },
+            });
+          });
+        };
+
+        it('persists the assistant turn under the topic-pinned model, not the agent default', async () => {
+          setupMockSelectors({ agentConfig: AGENT_MODEL });
+          const { result } = renderHook(() => useChatStore());
+          const agentId = TEST_IDS.SESSION_ID;
+          const topicId = TEST_IDS.TOPIC_ID;
+          seedTopic(agentId, { id: topicId, title: 'pinned topic', ...TOPIC_MODEL });
+
+          const sendMessageInServerSpy = vi
+            .spyOn(aiChatService, 'sendMessageInServer')
+            .mockResolvedValue({ messages: [], topicId } as any);
+
+          await act(async () => {
+            await result.current.sendMessage({
+              context: { agentId, threadId: null, topicId },
+              message: TEST_CONTENT.USER_MESSAGE,
+            });
+          });
+
+          expect(sendMessageInServerSpy.mock.calls[0][0].newAssistantMessage).toEqual(
+            expect.objectContaining(TOPIC_MODEL),
+          );
+        });
+
+        it('falls back to the agent default when the topic pins no model', async () => {
+          setupMockSelectors({ agentConfig: AGENT_MODEL });
+          const { result } = renderHook(() => useChatStore());
+          const agentId = TEST_IDS.SESSION_ID;
+          const topicId = TEST_IDS.TOPIC_ID;
+          seedTopic(agentId, { id: topicId, title: 'legacy topic' });
+
+          const sendMessageInServerSpy = vi
+            .spyOn(aiChatService, 'sendMessageInServer')
+            .mockResolvedValue({ messages: [], topicId } as any);
+
+          await act(async () => {
+            await result.current.sendMessage({
+              context: { agentId, threadId: null, topicId },
+              message: TEST_CONTENT.USER_MESSAGE,
+            });
+          });
+
+          expect(sendMessageInServerSpy.mock.calls[0][0].newAssistantMessage).toEqual(
+            expect.objectContaining(AGENT_MODEL),
+          );
+        });
+
+        it("uses the run's own topic pin, not the globally active topic", async () => {
+          setupMockSelectors({ agentConfig: AGENT_MODEL });
+          const { result } = renderHook(() => useChatStore());
+          const agentId = TEST_IDS.SESSION_ID;
+          const topicId = TEST_IDS.TOPIC_ID;
+          const activeTopicId = 'another-topic-id';
+          act(() => {
+            useChatStore.setState({
+              activeAgentId: agentId,
+              activeTopicId,
+              topicDataMap: {
+                [topicMapKey({ agentId })]: {
+                  currentPage: 0,
+                  hasMore: false,
+                  items: [
+                    { id: topicId, title: 'the run topic', ...TOPIC_MODEL } as any,
+                    { id: activeTopicId, title: 'the focused topic', ...OTHER_MODEL } as any,
+                  ],
+                  pageSize: 20,
+                  total: 2,
+                },
+              },
+            });
+          });
+
+          const sendMessageInServerSpy = vi
+            .spyOn(aiChatService, 'sendMessageInServer')
+            .mockResolvedValue({ messages: [], topicId } as any);
+
+          await act(async () => {
+            await result.current.sendMessage({
+              context: { agentId, threadId: null, topicId },
+              message: TEST_CONTENT.USER_MESSAGE,
+            });
+          });
+
+          expect(sendMessageInServerSpy.mock.calls[0][0].newAssistantMessage).toEqual(
+            expect.objectContaining(TOPIC_MODEL),
+          );
+        });
+      });
+
       it('should not process AI when onlyAddUserMessage is true', async () => {
         const { result } = renderHook(() => useChatStore());
         const onMessageAccepted = vi.fn();

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -204,6 +204,29 @@ const throwIfSendAborted = (signal?: AbortSignal) => {
     : new DOMException('Message send was cancelled', 'AbortError');
 };
 
+/**
+ * The model an assistant turn should be recorded under: the topic's pinned model
+ * when the topic has one, otherwise the agent default.
+ *
+ * A topic records the model it was started with plus every switch made while it
+ * is active (top-level `topics.model`/`provider`), and the client runtime resolves
+ * the run from that pin (`internal_createAgentState`). Resolving the persisted row
+ * the same way keeps the record consistent with the request — the agent default
+ * on its own diverges from the pin as soon as the user switches model while a
+ * topic is active.
+ */
+const resolvePersistedTurnModel = (
+  agentId: string,
+  topicId: string | null | undefined,
+  chatState: ChatStore,
+): { model: string; provider?: string } => {
+  const topicModel = topicId ? topicSelectors.getTopicModelById(topicId)(chatState) : undefined;
+  if (topicModel) return topicModel;
+
+  const { model, provider } = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
+  return { model, provider };
+};
+
 const attachSendTimeMetadataToUserMessage = (
   messages: UIChatMessage[],
   userMessageId: string,
@@ -1824,9 +1847,9 @@ export class ConversationLifecycleActionImpl {
 
     try {
       throwIfSendAborted(signal);
-      const { model, provider } = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
 
       const topicId = operationContext.topicId;
+      const { model, provider } = resolvePersistedTurnModel(agentId, topicId, this.#get());
 
       // Persist selected skill/tool context into user message content so it survives across turns.
       // Deduplicate: skip skills/tools already @mentioned in earlier messages (via editorData).


### PR DESCRIPTION
## Problem

When a topic has a pinned model (set at creation, updated on every switch while active), the client runtime resolves the run from that pin, but the send path reads the agent default only. Once they diverge, the assistant row is persisted under a model the request never used: the input shows the pin, the footer shows the other model, the wrong value survives a reload, and per-model spend reports inherit it (`services/usage` groups by `messages.model`).

Repro (#18370): send in topic A on model A → start a new topic and pick model B → return to topic A and send: the run uses A, the reply is labelled B.

| Before | After |
| ------ | ----- |
| A reply in a topic pinned to `gpt-5.6-luna` is labelled `gpt-5.6-terra` (the agent default)<br><img width="1455" height="804" alt="screenshot-before" src="https://github.com/user-attachments/assets/026aa534-ba6f-410c-819a-b330ce5459ae" /> | The reply is labelled `gpt-5.6-luna`, the model the run used<br><img width="1456" height="806" alt="screenshot-after" src="https://github.com/user-attachments/assets/64f5ce9d-5b2d-4ca3-b187-0288305e0fe6" />|



## Root cause

- `conversationLifecycle.ts:sendMessage` builds `{ model, provider }` from `agentSelectors.getAgentConfigById` and passes it as `newAssistantMessage.model`, the value persisted to `messages.model`.
- The run resolves the topic pin first (`streamingExecutor.ts:internal_createAgentState`, `modelOverride ?? topicModel`), so record and request disagree.
- They drift apart in ordinary use, not in a race: `ActionBar/Model/index.tsx` does `if (activeTopicId) updateTopicModel(...) else selectModel(...)`, so a switch inside a topic moves only its pin and a switch on the new-topic screen moves only the agent default.
- The gateway path already resolves the pin before creating the row (`turnSetup.ts`, `pinnedModel`): a client-path-only asymmetry.

## Fix

`resolvePersistedTurnModel` (topic pin first, agent default otherwise) where the send path builds `newAssistantMessage`, so the row resolves from the same source as the run. Re-stamping from the runtime afterwards was rejected: the row exists before the run starts, so that adds a write per turn.

## Scope and non-goals

- The heterogeneous-CLI branch persists no model up front (the adapter backfills it); untouched.
- `executeCompression` (manual `/compact`) reads the agent default too and is left alone: it also runs for heterogeneous agents, whose topic pin is a CLI selector such as `{ model: 'default', provider: 'codex' }`, not an LLM coordinate.
- A switch landing between the row write and the run start can still split them; pre-existing and unchanged — this PR removes the divergence that happens on every send, not the one that needs a switch mid-flight.
- No change when a topic pins no model or no topic exists yet: both take the agent default.

#### Test

`conversationLifecycle.test.ts` +3: the persisted turn uses the topic pin; the agent default still applies when the topic pins nothing; the run's own topic wins over a different globally active topic. `vitest run src/store/chat/slices/agentRun/actions/__tests__ src/store/chat/slices/topic` → 691 pass / 15 files. Mutation gate: 7 planted defects killed (fix reverted, fallback removed, pin ignored two ways, each provider dropped, active topic read instead of the run's); a comment-only control survived.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Acceptance: No published report (no LobeHub Cloud account). Completed verification and its limits are documented under Test.

#### 🔗 Related Issue

Fixes #18370
