### PR TITLE
🐛 fix(files): handle filtered search and staged deletions

### DIFF
--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -603,9 +603,9 @@ export const deviceRouter = router({
   searchProjectFiles: deviceProcedure
     .input(
       z.object({
+        changedOnly: z.boolean().optional(),
         deviceId: z.string(),
         excludeIgnored: z.boolean().optional(),
-        includePaths: z.array(z.string()).max(10_000).optional(),
         limit: z.number().int().positive().max(500).optional(),
         query: z.string(),
         scope: z.string(),
@@ -613,9 +613,9 @@ export const deviceRouter = router({
     )
     .query(async ({ ctx, input }) => {
       const result = await deviceGateway.searchProjectFiles({
+        changedOnly: input.changedOnly,
         deviceId: input.deviceId,
         excludeIgnored: input.excludeIgnored,
-        includePaths: input.includePaths,
         limit: input.limit,
         query: input.query,
         scope: input.scope,

--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -604,6 +604,8 @@ export const deviceRouter = router({
     .input(
       z.object({
         deviceId: z.string(),
+        excludeIgnored: z.boolean().optional(),
+        includePaths: z.array(z.string()).max(10_000).optional(),
         limit: z.number().int().positive().max(500).optional(),
         query: z.string(),
         scope: z.string(),
@@ -612,6 +614,8 @@ export const deviceRouter = router({
     .query(async ({ ctx, input }) => {
       const result = await deviceGateway.searchProjectFiles({
         deviceId: input.deviceId,
+        excludeIgnored: input.excludeIgnored,
+        includePaths: input.includePaths,
         limit: input.limit,
         query: input.query,
         scope: input.scope,

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -932,9 +932,9 @@ export class DeviceGateway {
    * compact tree subset with ancestor directories.
    */
   async searchProjectFiles(params: {
+    changedOnly?: boolean;
     deviceId: string;
     excludeIgnored?: boolean;
-    includePaths?: string[];
     limit?: number;
     query: string;
     scope: string;
@@ -943,10 +943,10 @@ export class DeviceGateway {
     workspaceId?: string;
   }): Promise<DeviceProjectFileSearchResult | undefined> {
     const {
+      changedOnly,
       userId,
       deviceId,
       excludeIgnored,
-      includePaths,
       limit,
       query,
       scope,
@@ -961,7 +961,7 @@ export class DeviceGateway {
         { deviceId, timeout, userId, workspaceId },
         {
           method: 'searchProjectFiles',
-          params: { excludeIgnored, includePaths, limit, query, scope },
+          params: { changedOnly, excludeIgnored, limit, query, scope },
         },
       );
 

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -933,6 +933,8 @@ export class DeviceGateway {
    */
   async searchProjectFiles(params: {
     deviceId: string;
+    excludeIgnored?: boolean;
+    includePaths?: string[];
     limit?: number;
     query: string;
     scope: string;
@@ -940,14 +942,27 @@ export class DeviceGateway {
     userId: string;
     workspaceId?: string;
   }): Promise<DeviceProjectFileSearchResult | undefined> {
-    const { userId, deviceId, limit, query, scope, timeout = 30_000, workspaceId } = params;
+    const {
+      userId,
+      deviceId,
+      excludeIgnored,
+      includePaths,
+      limit,
+      query,
+      scope,
+      timeout = 30_000,
+      workspaceId,
+    } = params;
     const client = this.getClient();
     if (!client) return undefined;
 
     try {
       const result = await client.invokeRpc<DeviceProjectFileSearchResult>(
         { deviceId, timeout, userId, workspaceId },
-        { method: 'searchProjectFiles', params: { limit, query, scope } },
+        {
+          method: 'searchProjectFiles',
+          params: { excludeIgnored, includePaths, limit, query, scope },
+        },
       );
 
       if (!result.success || !result.data) {

--- a/packages/device-control/src/__tests__/projectFileIndex.test.ts
+++ b/packages/device-control/src/__tests__/projectFileIndex.test.ts
@@ -168,6 +168,26 @@ describe('defaultSearchProjectFiles', () => {
     expect(result.entries.map((entry) => entry.relativePath)).toEqual(['target-200.ts']);
   });
 
+  it('fuzzy-ranks missing eligible paths with indexed files before applying the limit', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-search-deleted-'));
+    cleanup.push(dir);
+    execFileSync('git', ['-c', 'init.defaultBranch=main', 'init'], { cwd: dir });
+    await writeFile(path.join(dir, 'button-helper.ts'), 'button\n');
+
+    const result = await defaultSearchProjectFiles({
+      includePaths: ['Button.tsx', 'button-helper.ts', 'ButtonStory.tsx'],
+      limit: 2,
+      query: 'btn',
+      scope: dir,
+    });
+
+    const relativePaths = result.entries
+      .filter((entry) => !entry.isDirectory)
+      .map((entry) => entry.relativePath);
+    expect(relativePaths).toHaveLength(2);
+    expect(relativePaths).toContain('Button.tsx');
+  });
+
   it('searches hidden project directories in non-git scopes', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'dc-search-hidden-'));
     cleanup.push(dir);

--- a/packages/device-control/src/__tests__/projectFileIndex.test.ts
+++ b/packages/device-control/src/__tests__/projectFileIndex.test.ts
@@ -156,10 +156,15 @@ describe('defaultSearchProjectFiles', () => {
       ),
     );
     await writeFile(path.join(dir, 'target-secret.local'), 'ignored\n');
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: dir });
+    await writeFile(path.join(dir, 'target-200.ts'), 'changed\n');
 
     const result = await defaultSearchProjectFiles({
+      changedOnly: true,
       excludeIgnored: true,
-      includePaths: ['target-200.ts'],
       limit: 1,
       query: 'target',
       scope: dir,
@@ -173,9 +178,20 @@ describe('defaultSearchProjectFiles', () => {
     cleanup.push(dir);
     execFileSync('git', ['-c', 'init.defaultBranch=main', 'init'], { cwd: dir });
     await writeFile(path.join(dir, 'button-helper.ts'), 'button\n');
+    await writeFile(path.join(dir, 'Button.tsx'), 'button\n');
+    await writeFile(path.join(dir, 'ButtonStory.tsx'), 'button\n');
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: dir });
+    await Promise.all([
+      rm(path.join(dir, 'Button.tsx')),
+      rm(path.join(dir, 'ButtonStory.tsx')),
+      writeFile(path.join(dir, 'button-helper.ts'), 'changed\n'),
+    ]);
 
     const result = await defaultSearchProjectFiles({
-      includePaths: ['Button.tsx', 'button-helper.ts', 'ButtonStory.tsx'],
+      changedOnly: true,
       limit: 2,
       query: 'btn',
       scope: dir,

--- a/packages/device-control/src/__tests__/projectFileIndex.test.ts
+++ b/packages/device-control/src/__tests__/projectFileIndex.test.ts
@@ -145,6 +145,29 @@ describe('defaultSearchProjectFiles', () => {
     ]);
   });
 
+  it('applies eligible-path and ignore filters before truncating search results', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-search-filtered-'));
+    cleanup.push(dir);
+    execFileSync('git', ['-c', 'init.defaultBranch=main', 'init'], { cwd: dir });
+    await writeFile(path.join(dir, '.gitignore'), '*.local\n');
+    await Promise.all(
+      Array.from({ length: 201 }, (_, index) =>
+        writeFile(path.join(dir, `target-${index.toString().padStart(3, '0')}.ts`), 'target\n'),
+      ),
+    );
+    await writeFile(path.join(dir, 'target-secret.local'), 'ignored\n');
+
+    const result = await defaultSearchProjectFiles({
+      excludeIgnored: true,
+      includePaths: ['target-200.ts'],
+      limit: 1,
+      query: 'target',
+      scope: dir,
+    });
+
+    expect(result.entries.map((entry) => entry.relativePath)).toEqual(['target-200.ts']);
+  });
+
   it('searches hidden project directories in non-git scopes', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'dc-search-hidden-'));
     cleanup.push(dir);

--- a/packages/device-control/src/projectFileIndex.ts
+++ b/packages/device-control/src/projectFileIndex.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
+import { getGitWorkingTreeFiles } from '@lobechat/local-file-shell/git';
 import fg from 'fast-glob';
 
 import { projectFileSearchManager } from './projectFileSearchManager';
@@ -196,10 +197,11 @@ export const defaultGetProjectFileIndex = async (
 const filterSearchCandidates = (
   entries: ProjectFileIndexEntry[],
   params: ProjectFileSearchParams,
+  includePaths?: string[],
 ) => {
-  if (!params.excludeIgnored && !params.includePaths) return entries;
+  if (!params.excludeIgnored && !includePaths) return entries;
 
-  const includedPaths = params.includePaths ? new Set(params.includePaths) : undefined;
+  const includedPaths = includePaths ? new Set(includePaths) : undefined;
   return entries.filter(
     (entry) =>
       entry.isDirectory ||
@@ -250,6 +252,9 @@ export const defaultSearchProjectFiles = async (
       rootResult?.stdout && !exitCode ? rootResult.stdout.trim() || requestedScope : requestedScope;
 
     if (rootResult?.stdout && !exitCode) {
+      const includePaths = params.changedOnly
+        ? Object.values(await getGitWorkingTreeFiles(root)).flat()
+        : undefined;
       const [trackedResult, untrackedResult, ignoredResult] = await Promise.all([
         execFileAsync(
           'git',
@@ -287,12 +292,9 @@ export const defaultSearchProjectFiles = async (
         .map((item) => item.trim())
         .filter(Boolean);
       const entries = filterSearchCandidates(
-        includeMissingSearchCandidates(
-          buildEntries(files, root, ignoredPaths),
-          params.includePaths,
-          root,
-        ),
+        includeMissingSearchCandidates(buildEntries(files, root, ignoredPaths), includePaths, root),
         params,
+        includePaths,
       );
 
       return {
@@ -308,12 +310,9 @@ export const defaultSearchProjectFiles = async (
 
   const files = await projectFileSearchManager.collectNonGitFilePaths(requestedScope);
   const entries = filterSearchCandidates(
-    includeMissingSearchCandidates(
-      buildEntries(files, requestedScope),
-      params.includePaths,
-      requestedScope,
-    ),
+    includeMissingSearchCandidates(buildEntries(files, requestedScope), undefined, requestedScope),
     params,
+    params.changedOnly ? [] : undefined,
   );
 
   return {

--- a/packages/device-control/src/projectFileIndex.ts
+++ b/packages/device-control/src/projectFileIndex.ts
@@ -193,6 +193,21 @@ export const defaultGetProjectFileIndex = async (
   };
 };
 
+const filterSearchCandidates = (
+  entries: ProjectFileIndexEntry[],
+  params: ProjectFileSearchParams,
+) => {
+  if (!params.excludeIgnored && !params.includePaths) return entries;
+
+  const includedPaths = params.includePaths ? new Set(params.includePaths) : undefined;
+  return entries.filter(
+    (entry) =>
+      entry.isDirectory ||
+      ((!params.excludeIgnored || !entry.gitIgnored) &&
+        (!includedPaths || includedPaths.has(entry.relativePath))),
+  );
+};
+
 export const defaultSearchProjectFiles = async (
   params: ProjectFileSearchParams,
 ): Promise<ProjectFileSearchResult> => {
@@ -246,7 +261,7 @@ export const defaultSearchProjectFiles = async (
         .split('\n')
         .map((item) => item.trim())
         .filter(Boolean);
-      const entries = buildEntries(files, root, ignoredPaths);
+      const entries = filterSearchCandidates(buildEntries(files, root, ignoredPaths), params);
 
       return {
         entries: projectFileSearchManager.selectEntries(entries, params.query, limit),
@@ -260,7 +275,7 @@ export const defaultSearchProjectFiles = async (
   }
 
   const files = await projectFileSearchManager.collectNonGitFilePaths(requestedScope);
-  const entries = buildEntries(files, requestedScope);
+  const entries = filterSearchCandidates(buildEntries(files, requestedScope), params);
 
   return {
     entries: projectFileSearchManager.selectEntries(entries, params.query, limit),

--- a/packages/device-control/src/projectFileIndex.ts
+++ b/packages/device-control/src/projectFileIndex.ts
@@ -208,6 +208,31 @@ const filterSearchCandidates = (
   );
 };
 
+const includeMissingSearchCandidates = (
+  entries: ProjectFileIndexEntry[],
+  includePaths: string[] | undefined,
+  root: string,
+) => {
+  if (!includePaths) return entries;
+
+  const indexedPaths = new Set(entries.map((entry) => entry.relativePath));
+  const rootPrefix = `${path.resolve(root)}${path.sep}`;
+  const missingFiles = includePaths
+    .filter((relativePath) => !indexedPaths.has(relativePath))
+    .map((relativePath) => path.resolve(root, relativePath))
+    .filter((absolutePath) => absolutePath.startsWith(rootPrefix));
+
+  if (missingFiles.length === 0) return entries;
+
+  const additions = buildEntries(missingFiles, root).filter((entry) => {
+    if (indexedPaths.has(entry.relativePath)) return false;
+    indexedPaths.add(entry.relativePath);
+    return true;
+  });
+
+  return [...entries, ...additions];
+};
+
 export const defaultSearchProjectFiles = async (
   params: ProjectFileSearchParams,
 ): Promise<ProjectFileSearchResult> => {
@@ -261,7 +286,14 @@ export const defaultSearchProjectFiles = async (
         .split('\n')
         .map((item) => item.trim())
         .filter(Boolean);
-      const entries = filterSearchCandidates(buildEntries(files, root, ignoredPaths), params);
+      const entries = filterSearchCandidates(
+        includeMissingSearchCandidates(
+          buildEntries(files, root, ignoredPaths),
+          params.includePaths,
+          root,
+        ),
+        params,
+      );
 
       return {
         entries: projectFileSearchManager.selectEntries(entries, params.query, limit),
@@ -275,7 +307,14 @@ export const defaultSearchProjectFiles = async (
   }
 
   const files = await projectFileSearchManager.collectNonGitFilePaths(requestedScope);
-  const entries = filterSearchCandidates(buildEntries(files, requestedScope), params);
+  const entries = filterSearchCandidates(
+    includeMissingSearchCandidates(
+      buildEntries(files, requestedScope),
+      params.includePaths,
+      requestedScope,
+    ),
+    params,
+  );
 
   return {
     entries: projectFileSearchManager.selectEntries(entries, params.query, limit),

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -138,8 +138,8 @@ export interface ProjectFileIndexResult {
 }
 
 export interface ProjectFileSearchParams extends ProjectFileIndexParams {
+  changedOnly?: boolean;
   excludeIgnored?: boolean;
-  includePaths?: string[];
   limit?: number;
   query: string;
 }

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -138,6 +138,8 @@ export interface ProjectFileIndexResult {
 }
 
 export interface ProjectFileSearchParams extends ProjectFileIndexParams {
+  excludeIgnored?: boolean;
+  includePaths?: string[];
   limit?: number;
   query: string;
 }

--- a/packages/electron-client-ipc/src/types/localSystem.ts
+++ b/packages/electron-client-ipc/src/types/localSystem.ts
@@ -291,6 +291,8 @@ export interface ProjectFileIndexResult {
 }
 
 export interface ProjectFileSearchParams extends ProjectFileIndexParams {
+  changedOnly?: boolean;
+  excludeIgnored?: boolean;
   limit?: number;
   query: string;
 }

--- a/packages/trpc/src/client/lambda.test.ts
+++ b/packages/trpc/src/client/lambda.test.ts
@@ -13,7 +13,7 @@ const okTrpcResponse = (data: unknown) =>
     status: 200,
   });
 
-describe('lambdaClient transfer-job status transport', () => {
+describe('lambdaClient large-input query transport', () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -38,6 +38,8 @@ describe('lambdaClient transfer-job status transport', () => {
           agentId: 'agt_test',
           topicIds: Array.from({ length: 1000 }, (_, i) => `tpc_${String(i).padStart(16, '0')}`),
         }),
+      'topicIds',
+      1000,
     ],
     [
       'group.getTransferJobStatus',
@@ -46,19 +48,39 @@ describe('lambdaClient transfer-job status transport', () => {
           groupId: 'grp_test',
           topicIds: Array.from({ length: 1000 }, (_, i) => `tpc_${String(i).padStart(16, '0')}`),
         }),
+      'topicIds',
+      1000,
     ],
-  ] as const)('sends %s with 1000 topicIds as a POST request', async (path, call) => {
-    fetchMock.mockResolvedValueOnce(okTrpcResponse(null));
+    [
+      'device.searchProjectFiles',
+      () =>
+        lambdaClient.device.searchProjectFiles.query({
+          deviceId: 'dev_test',
+          includePaths: Array.from(
+            { length: 300 },
+            (_, i) => `src/changed-${String(i).padStart(4, '0')}.tsx`,
+          ),
+          query: 'changed',
+          scope: '/repo',
+        }),
+      'includePaths',
+      300,
+    ],
+  ] as const)(
+    'sends %s with a large path/id array as a POST request',
+    async (path, call, arrayField, expectedLength) => {
+      fetchMock.mockResolvedValueOnce(okTrpcResponse(null));
 
-    await expect(call()).resolves.toBeNull();
+      await expect(call()).resolves.toBeNull();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [input, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
-    expect(init.method).toBe('POST');
-    // The input travels in the body, not the query string.
-    expect(String(input)).toContain(`/trpc/lambda/${path}`);
-    expect(String(input).length).toBeLessThan(2083);
-    const body = JSON.parse(String(init.body)) as { json: { topicIds: string[] } };
-    expect(body.json.topicIds).toHaveLength(1000);
-  });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [input, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+      expect(init.method).toBe('POST');
+      // The input travels in the body, not the query string.
+      expect(String(input)).toContain(`/trpc/lambda/${path}`);
+      expect(String(input).length).toBeLessThan(2083);
+      const body = JSON.parse(String(init.body)) as { json: Record<string, unknown[]> };
+      expect(body.json[arrayField]).toHaveLength(expectedLength);
+    },
+  );
 });

--- a/packages/trpc/src/client/lambda.test.ts
+++ b/packages/trpc/src/client/lambda.test.ts
@@ -51,21 +51,6 @@ describe('lambdaClient large-input query transport', () => {
       'topicIds',
       1000,
     ],
-    [
-      'device.searchProjectFiles',
-      () =>
-        lambdaClient.device.searchProjectFiles.query({
-          deviceId: 'dev_test',
-          includePaths: Array.from(
-            { length: 300 },
-            (_, i) => `src/changed-${String(i).padStart(4, '0')}.tsx`,
-          ),
-          query: 'changed',
-          scope: '/repo',
-        }),
-      'includePaths',
-      300,
-    ],
   ] as const)(
     'sends %s with a large path/id array as a POST request',
     async (path, call, arrayField, expectedLength) => {

--- a/packages/trpc/src/client/lambda.ts
+++ b/packages/trpc/src/client/lambda.ts
@@ -188,7 +188,6 @@ const SKIP_BATCH_PROCEDURES = new Set([...initialLoadProcedures, ...slowProcedur
 // handler enables `allowMethodOverride`).
 const LARGE_INPUT_QUERY_PROCEDURES = new Set([
   'agent.getTransferJobStatus',
-  'device.searchProjectFiles',
   'group.getTransferJobStatus',
 ]);
 

--- a/packages/trpc/src/client/lambda.ts
+++ b/packages/trpc/src/client/lambda.ts
@@ -188,6 +188,7 @@ const SKIP_BATCH_PROCEDURES = new Set([...initialLoadProcedures, ...slowProcedur
 // handler enables `allowMethodOverride`).
 const LARGE_INPUT_QUERY_PROCEDURES = new Set([
   'agent.getTransferJobStatus',
+  'device.searchProjectFiles',
   'group.getTransferJobStatus',
 ]);
 

--- a/src/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
@@ -147,6 +147,7 @@ vi.mock('../useProjectFiles', () => ({
   useProjectFiles: (_deviceId: string | undefined, workingDirectory: string) => ({
     data: {
       ...projectFilesMock.data,
+      entries: projectFilesMock.data.entries,
       source: workingDirectory === '/non-git' ? 'glob' : projectFilesMock.data.source,
     },
     isLoading: false,
@@ -198,12 +199,24 @@ vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
     items,
   }: {
     children?: ReactNodeType;
-    items: { key: string; label: ReactNodeType; onClick?: () => void }[];
+    items: {
+      key: string;
+      label: ReactNodeType;
+      onCheckedChange?: (checked: boolean) => void;
+      onClick?: () => void;
+    }[];
   }) => (
     <div>
       {children}
       {items.map((item) => (
-        <button key={item.key} type={'button'} onClick={item.onClick}>
+        <button
+          key={item.key}
+          type={'button'}
+          onClick={() => {
+            item.onClick?.();
+            item.onCheckedChange?.(true);
+          }}
+        >
           {item.label}
         </button>
       ))}
@@ -341,7 +354,31 @@ describe('Files — reveal request integration', () => {
       'src/foo/',
       'src/foo/bar.ts',
       'root.ts',
+      'deleted.ts',
     ]);
+  });
+
+  it('sends active Git and ignore filters to the file host before search truncation', async () => {
+    render(<Files workingDirectory="/repo" />);
+
+    fireEvent.click(screen.getByText('workingPanel.files.views.changes'));
+    fireEvent.click(screen.getByTitle('workingPanel.files.filters.title'));
+    fireEvent.click(screen.getByText('workingPanel.files.filters.hideIgnored'));
+    expandSearch();
+    fireEvent.change(screen.getByPlaceholderText('workingPanel.files.searchPlaceholder'), {
+      target: { value: 'bar' },
+    });
+
+    await waitFor(() => {
+      expect(searchProjectFilesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeIgnored: true,
+          includePaths: ['root.ts', 'src/foo/bar.ts', 'deleted.ts'],
+          limit: 200,
+          query: 'bar',
+        }),
+      );
+    });
   });
 
   it('resets the Git changes view when the workspace changes or is not Git-backed', async () => {
@@ -500,6 +537,8 @@ describe('Files — reveal request integration', () => {
     await waitFor(() => {
       expect(searchProjectFilesMock).toHaveBeenCalledWith({
         deviceId: undefined,
+        excludeIgnored: false,
+        includePaths: undefined,
         limit: 200,
         query: 'bar',
         scope: '/repo',

--- a/src/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
@@ -373,7 +373,7 @@ describe('Files — reveal request integration', () => {
       expect(searchProjectFilesMock).toHaveBeenCalledWith(
         expect.objectContaining({
           excludeIgnored: true,
-          includePaths: ['root.ts', 'src/foo/bar.ts', 'deleted.ts'],
+          changedOnly: true,
           limit: 200,
           query: 'bar',
         }),
@@ -538,7 +538,7 @@ describe('Files — reveal request integration', () => {
       expect(searchProjectFilesMock).toHaveBeenCalledWith({
         deviceId: undefined,
         excludeIgnored: false,
-        includePaths: undefined,
+        changedOnly: false,
         limit: 200,
         query: 'bar',
         scope: '/repo',

--- a/src/features/Conversation/WorkingSidebar/Files/fileFilter.test.ts
+++ b/src/features/Conversation/WorkingSidebar/Files/fileFilter.test.ts
@@ -1,7 +1,7 @@
 import type { ProjectFileIndexEntry } from '@lobechat/electron-client-ipc';
 import { describe, expect, it } from 'vitest';
 
-import { filterProjectFileEntries } from './fileFilter';
+import { filterProjectFileEntries, mergeMissingDeletedEntries } from './fileFilter';
 
 const entries: ProjectFileIndexEntry[] = [
   { isDirectory: true, name: 'src', path: '/repo/src', relativePath: 'src/' },
@@ -64,5 +64,39 @@ describe('filterProjectFileEntries', () => {
       'src/components/Button.tsx',
       'src/index.ts',
     ]);
+  });
+});
+
+describe('mergeMissingDeletedEntries', () => {
+  it('recreates missing staged deletions and their absent ancestor directories', () => {
+    const result = mergeMissingDeletedEntries(
+      entries,
+      ['src/components/Button.tsx', 'removed/deep/file.ts'],
+      '/repo',
+    );
+
+    expect(result.map((entry) => entry.relativePath)).toEqual([
+      ...entries.map((entry) => entry.relativePath),
+      'removed/',
+      'removed/deep/',
+      'removed/deep/file.ts',
+    ]);
+    expect(result.at(-1)).toMatchObject({
+      isDirectory: false,
+      name: 'file.ts',
+      path: '/repo/removed/deep/file.ts',
+    });
+  });
+
+  it('only recreates deleted paths that match an active search query', () => {
+    const result = mergeMissingDeletedEntries(
+      entries,
+      ['removed/alpha.ts', 'removed/beta.ts'],
+      '/repo',
+      'beta',
+    );
+
+    expect(result.map((entry) => entry.relativePath)).toContain('removed/beta.ts');
+    expect(result.map((entry) => entry.relativePath)).not.toContain('removed/alpha.ts');
   });
 });

--- a/src/features/Conversation/WorkingSidebar/Files/fileFilter.test.ts
+++ b/src/features/Conversation/WorkingSidebar/Files/fileFilter.test.ts
@@ -87,16 +87,4 @@ describe('mergeMissingDeletedEntries', () => {
       path: '/repo/removed/deep/file.ts',
     });
   });
-
-  it('only recreates deleted paths that match an active search query', () => {
-    const result = mergeMissingDeletedEntries(
-      entries,
-      ['removed/alpha.ts', 'removed/beta.ts'],
-      '/repo',
-      'beta',
-    );
-
-    expect(result.map((entry) => entry.relativePath)).toContain('removed/beta.ts');
-    expect(result.map((entry) => entry.relativePath)).not.toContain('removed/alpha.ts');
-  });
 });

--- a/src/features/Conversation/WorkingSidebar/Files/fileFilter.ts
+++ b/src/features/Conversation/WorkingSidebar/Files/fileFilter.ts
@@ -23,15 +23,9 @@ export const mergeMissingDeletedEntries = (
   entries: ProjectFileIndexEntry[],
   deletedPaths: string[],
   root: string,
-  query?: string,
 ): ProjectFileIndexEntry[] => {
-  const normalizedQuery = query?.trim().toLocaleLowerCase();
   const existingPaths = new Set(entries.map((entry) => entry.relativePath));
-  const missingPaths = deletedPaths.filter(
-    (relativePath) =>
-      !existingPaths.has(relativePath) &&
-      (!normalizedQuery || relativePath.toLocaleLowerCase().includes(normalizedQuery)),
-  );
+  const missingPaths = deletedPaths.filter((relativePath) => !existingPaths.has(relativePath));
   if (missingPaths.length === 0) return entries;
 
   const additions: ProjectFileIndexEntry[] = [];

--- a/src/features/Conversation/WorkingSidebar/Files/fileFilter.ts
+++ b/src/features/Conversation/WorkingSidebar/Files/fileFilter.ts
@@ -1,4 +1,5 @@
 import type { ProjectFileIndexEntry } from '@lobechat/electron-client-ipc';
+import path from 'pathe';
 
 export interface ProjectFileDisplayFilter {
   changedOnly: boolean;
@@ -7,6 +8,56 @@ export interface ProjectFileDisplayFilter {
 
 const isPathInsideDirectory = (filePath: string, directoryPath: string) =>
   filePath.startsWith(directoryPath);
+
+const getDirectoryPaths = (relativePath: string): string[] => {
+  const segments = relativePath.split('/');
+  return segments.slice(0, -1).map((_, index) => `${segments.slice(0, index + 1).join('/')}/`);
+};
+
+/**
+ * A staged deletion is absent from `git ls-files`, so the project index cannot
+ * supply its row. Recreate only those missing rows (and ancestors) from Git's
+ * status paths so the Changes view remains complete.
+ */
+export const mergeMissingDeletedEntries = (
+  entries: ProjectFileIndexEntry[],
+  deletedPaths: string[],
+  root: string,
+  query?: string,
+): ProjectFileIndexEntry[] => {
+  const normalizedQuery = query?.trim().toLocaleLowerCase();
+  const existingPaths = new Set(entries.map((entry) => entry.relativePath));
+  const missingPaths = deletedPaths.filter(
+    (relativePath) =>
+      !existingPaths.has(relativePath) &&
+      (!normalizedQuery || relativePath.toLocaleLowerCase().includes(normalizedQuery)),
+  );
+  if (missingPaths.length === 0) return entries;
+
+  const additions: ProjectFileIndexEntry[] = [];
+  for (const relativePath of missingPaths) {
+    for (const directoryPath of getDirectoryPaths(relativePath)) {
+      if (existingPaths.has(directoryPath)) continue;
+      existingPaths.add(directoryPath);
+      additions.push({
+        isDirectory: true,
+        name: path.basename(directoryPath),
+        path: path.join(root, directoryPath),
+        relativePath: directoryPath,
+      });
+    }
+
+    existingPaths.add(relativePath);
+    additions.push({
+      isDirectory: false,
+      name: path.basename(relativePath),
+      path: path.join(root, relativePath),
+      relativePath,
+    });
+  }
+
+  return [...entries, ...additions];
+};
 
 export const filterProjectFileEntries = (
   entries: ProjectFileIndexEntry[],

--- a/src/features/Conversation/WorkingSidebar/Files/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/index.tsx
@@ -256,9 +256,8 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
     const indexedEntries = isFiltering ? (searchEntries ?? []) : entries;
     const entriesWithDeleted = mergeMissingDeletedEntries(
       indexedEntries,
-      gitFiles?.deleted ?? [],
+      isFiltering ? [] : (gitFiles?.deleted ?? []),
       projectRoot,
-      isFiltering ? normalizedDebouncedQuery : undefined,
     );
     const visibleEntries = entriesWithDeleted.filter((entry) => !isExcludedProjectFileEntry(entry));
 
@@ -273,7 +272,6 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
     gitFiles?.deleted,
     hideIgnored,
     isFiltering,
-    normalizedDebouncedQuery,
     projectRoot,
     searchEntries,
   ]);

--- a/src/features/Conversation/WorkingSidebar/Files/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/index.tsx
@@ -244,10 +244,6 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
   const changedOnly = viewMode === 'changes';
   const hasDisplayFilter = isFiltering || changedOnly || hideIgnored;
   const workingTreeGitStatus = useMemo(() => buildGitStatusEntries(gitFiles), [gitFiles]);
-  const changedSearchPaths = useMemo(
-    () => (changedOnly ? workingTreeGitStatus.map((entry) => entry.path) : undefined),
-    [changedOnly, workingTreeGitStatus],
-  );
   const dirtyFilePaths = useMemo(
     () => new Set(workingTreeGitStatus.map((entry) => entry.path)),
     [workingTreeGitStatus],
@@ -327,9 +323,9 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
 
     void projectFileService
       .searchProjectFiles({
+        changedOnly,
         deviceId,
         excludeIgnored: hideIgnored,
-        includePaths: changedSearchPaths,
         limit: PROJECT_FILE_TREE_SEARCH_LIMIT,
         query: normalizedDebouncedQuery,
         scope: workingDirectory,
@@ -350,7 +346,7 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
     return () => {
       cancelled = true;
     };
-  }, [changedSearchPaths, deviceId, hideIgnored, normalizedDebouncedQuery, workingDirectory]);
+  }, [changedOnly, deviceId, hideIgnored, normalizedDebouncedQuery, workingDirectory]);
 
   // Skip resyncs when defaultExpandedIds is structurally unchanged so the user's expansions survive re-renders.
   const prevDefaultRef = useRef<string[]>([]);

--- a/src/features/Conversation/WorkingSidebar/Files/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/Files/index.tsx
@@ -37,7 +37,7 @@ import { projectFileService } from '@/services/projectFile';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 
-import { filterProjectFileEntries } from './fileFilter';
+import { filterProjectFileEntries, mergeMissingDeletedEntries } from './fileFilter';
 import { isExcludedProjectFileEntry } from './fileVisibility';
 import { buildGitStatusEntries, useGitWorkingTreeFiles } from './useGitWorkingTreeFiles';
 import { useProjectFiles } from './useProjectFiles';
@@ -244,20 +244,39 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
   const changedOnly = viewMode === 'changes';
   const hasDisplayFilter = isFiltering || changedOnly || hideIgnored;
   const workingTreeGitStatus = useMemo(() => buildGitStatusEntries(gitFiles), [gitFiles]);
+  const changedSearchPaths = useMemo(
+    () => (changedOnly ? workingTreeGitStatus.map((entry) => entry.path) : undefined),
+    [changedOnly, workingTreeGitStatus],
+  );
   const dirtyFilePaths = useMemo(
     () => new Set(workingTreeGitStatus.map((entry) => entry.path)),
     [workingTreeGitStatus],
   );
   const displayEntries = useMemo(() => {
-    const visibleEntries = (isFiltering ? (searchEntries ?? []) : entries).filter(
-      (entry) => !isExcludedProjectFileEntry(entry),
+    const indexedEntries = isFiltering ? (searchEntries ?? []) : entries;
+    const entriesWithDeleted = mergeMissingDeletedEntries(
+      indexedEntries,
+      gitFiles?.deleted ?? [],
+      projectRoot,
+      isFiltering ? normalizedDebouncedQuery : undefined,
     );
+    const visibleEntries = entriesWithDeleted.filter((entry) => !isExcludedProjectFileEntry(entry));
 
     return filterProjectFileEntries(visibleEntries, dirtyFilePaths, {
       changedOnly,
       hideIgnored,
     });
-  }, [changedOnly, dirtyFilePaths, entries, hideIgnored, isFiltering, searchEntries]);
+  }, [
+    changedOnly,
+    dirtyFilePaths,
+    entries,
+    gitFiles?.deleted,
+    hideIgnored,
+    isFiltering,
+    normalizedDebouncedQuery,
+    projectRoot,
+    searchEntries,
+  ]);
   const nodes = useMemo(
     () => buildTreeNodes(displayEntries, projectRootName),
     [displayEntries, projectRootName],
@@ -311,6 +330,8 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
     void projectFileService
       .searchProjectFiles({
         deviceId,
+        excludeIgnored: hideIgnored,
+        includePaths: changedSearchPaths,
         limit: PROJECT_FILE_TREE_SEARCH_LIMIT,
         query: normalizedDebouncedQuery,
         scope: workingDirectory,
@@ -331,7 +352,7 @@ const Files = memo<FilesProps>(({ deviceId, workingDirectory }) => {
     return () => {
       cancelled = true;
     };
-  }, [deviceId, normalizedDebouncedQuery, workingDirectory]);
+  }, [changedSearchPaths, deviceId, hideIgnored, normalizedDebouncedQuery, workingDirectory]);
 
   // Skip resyncs when defaultExpandedIds is structurally unchanged so the user's expansions survive re-renders.
   const prevDefaultRef = useRef<string[]>([]);

--- a/src/services/projectFile.test.ts
+++ b/src/services/projectFile.test.ts
@@ -160,7 +160,7 @@ describe('projectFileService', () => {
     expect(mockDeviceClient.searchProjectFiles.query).toHaveBeenCalledWith({
       deviceId: 'device-1',
       excludeIgnored: undefined,
-      includePaths: undefined,
+      changedOnly: undefined,
       limit: 20,
       query: 'button',
       scope: '/repo',
@@ -185,7 +185,7 @@ describe('projectFileService', () => {
 
     expect(mockLocalFileService.searchProjectFiles).toHaveBeenCalledWith({
       excludeIgnored: undefined,
-      includePaths: undefined,
+      changedOnly: undefined,
       limit: 20,
       query: 'button',
       scope: '/repo',

--- a/src/services/projectFile.test.ts
+++ b/src/services/projectFile.test.ts
@@ -159,6 +159,8 @@ describe('projectFileService', () => {
 
     expect(mockDeviceClient.searchProjectFiles.query).toHaveBeenCalledWith({
       deviceId: 'device-1',
+      excludeIgnored: undefined,
+      includePaths: undefined,
       limit: 20,
       query: 'button',
       scope: '/repo',
@@ -182,6 +184,8 @@ describe('projectFileService', () => {
     });
 
     expect(mockLocalFileService.searchProjectFiles).toHaveBeenCalledWith({
+      excludeIgnored: undefined,
+      includePaths: undefined,
       limit: 20,
       query: 'button',
       scope: '/repo',

--- a/src/services/projectFile.ts
+++ b/src/services/projectFile.ts
@@ -73,30 +73,30 @@ class ProjectFileService {
 
   /** Search files within a project working directory. Matching runs on the file host. */
   async searchProjectFiles({
+    changedOnly,
     deviceId,
     excludeIgnored,
-    includePaths,
     limit,
     query,
     scope,
   }: {
+    changedOnly?: boolean;
     deviceId?: string;
     excludeIgnored?: boolean;
-    includePaths?: string[];
     limit?: number;
     query: string;
     scope: string;
   }): Promise<ProjectFileSearchResult | undefined> {
     return deviceId
       ? ((await lambdaClient.device.searchProjectFiles.query({
+          changedOnly,
           deviceId,
           excludeIgnored,
-          includePaths,
           limit,
           query,
           scope,
         })) ?? undefined)
-      : localFileService.searchProjectFiles({ excludeIgnored, includePaths, limit, query, scope });
+      : localFileService.searchProjectFiles({ changedOnly, excludeIgnored, limit, query, scope });
   }
 
   /** File preview payload for a file in a project working directory. */

--- a/src/services/projectFile.ts
+++ b/src/services/projectFile.ts
@@ -74,19 +74,29 @@ class ProjectFileService {
   /** Search files within a project working directory. Matching runs on the file host. */
   async searchProjectFiles({
     deviceId,
+    excludeIgnored,
+    includePaths,
     limit,
     query,
     scope,
   }: {
     deviceId?: string;
+    excludeIgnored?: boolean;
+    includePaths?: string[];
     limit?: number;
     query: string;
     scope: string;
   }): Promise<ProjectFileSearchResult | undefined> {
     return deviceId
-      ? ((await lambdaClient.device.searchProjectFiles.query({ deviceId, limit, query, scope })) ??
-          undefined)
-      : localFileService.searchProjectFiles({ limit, query, scope });
+      ? ((await lambdaClient.device.searchProjectFiles.query({
+          deviceId,
+          excludeIgnored,
+          includePaths,
+          limit,
+          query,
+          scope,
+        })) ?? undefined)
+      : localFileService.searchProjectFiles({ excludeIgnored, includePaths, limit, query, scope });
   }
 
   /** File preview payload for a file in a project working directory. */


### PR DESCRIPTION
Follow up on Codex review findings from #18892.

- synthesize tree entries and ancestor folders for staged deletions missing from the project index
- pass Git candidate paths and ignored-file policy to the file host
- apply eligibility filters before fuzzy ranking and result truncation
- preserve the compact 200-result response limit
- cover local/remote parameter transport and both regression scenarios

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on all 11 changed files: lint clean, 88 tests passed.

#### 🔗 Related Issue

Follow-up to #18892 and its Codex review.