### PR TITLE
🔒️ fix(agent): authorize SSE stream subscriptions

### DIFF
--- a/src/app/(backend)/api/agent/stream/__tests__/route.test.ts
+++ b/src/app/(backend)/api/agent/stream/__tests__/route.test.ts
@@ -119,6 +119,28 @@ describe('/api/agent/stream route', () => {
       expect(mockStreamEventManager.getStreamHistory).not.toHaveBeenCalled();
     });
 
+    it('should return 404 when an API key belongs to a different workspace', async () => {
+      mockCreateLambdaContext.mockResolvedValue({
+        apiKeyScopes: null,
+        userId: OWNER_USER_ID,
+        workspaceId: 'workspace-1',
+      });
+      mockAgentStateManager.getOperationMetadata.mockResolvedValue({
+        userId: OWNER_USER_ID,
+        workspaceId: 'workspace-2',
+      });
+
+      const request = new NextRequest(
+        'https://test.com/api/agent/stream?operationId=test-operation',
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe('operation_not_found');
+      expect(mockStreamEventManager.getStreamHistory).not.toHaveBeenCalled();
+    });
+
     it('should return 404 for a share-visitor operation even when the caller is the visitor', async () => {
       mockCreateLambdaContext.mockResolvedValue({ userId: 'visitor-user' });
       mockAgentStateManager.getOperationMetadata.mockResolvedValue({
@@ -734,7 +756,7 @@ data: {"type":"stream_end","timestamp":300,"operationId":"test-operation","data"
         },
       );
 
-      const response = await GET(request);
+      await GET(request);
 
       expect(capturedCallback).toBeDefined();
       expect(capturedSignal).toBeDefined();

--- a/src/app/(backend)/api/agent/stream/route.ts
+++ b/src/app/(backend)/api/agent/stream/route.ts
@@ -34,7 +34,11 @@ export async function GET(request: NextRequest) {
   // Resolve the caller the same way the lambda tRPC context does (Better Auth
   // session cookie, `Oidc-Auth` JWT, or `X-API-Key`) so the CLI's existing
   // `getAgentStreamAuthInfo` headers keep working unchanged.
-  const { userId: callerUserId } = await createLambdaContext(request);
+  const {
+    apiKeyScopes,
+    userId: callerUserId,
+    workspaceId: callerWorkspaceId,
+  } = await createLambdaContext(request);
 
   if (!callerUserId) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -62,6 +66,15 @@ export async function GET(request: NextRequest) {
   // 404 rather than 403 so an unauthorized caller cannot distinguish "not mine"
   // from "does not exist".
   if (metadata.userId !== callerUserId) {
+    return NextResponse.json({ error: 'operation_not_found' }, { status: 404 });
+  }
+
+  // API keys are capability-bound to their own workspace. Do not let a key read
+  // another workspace's operation merely because both belong to the same user.
+  if (
+    apiKeyScopes !== undefined &&
+    (metadata.workspaceId ?? null) !== (callerWorkspaceId ?? null)
+  ) {
     return NextResponse.json({ error: 'operation_not_found' }, { status: 404 });
   }
 


### PR DESCRIPTION
## Summary

- enforce the authenticated API key workspace against Agent Runtime ownership metadata before opening `/api/agent/stream`
- return the existing indistinguishable `operation_not_found` response for cross-workspace attempts
- preserve the runtime-metadata authorization and share-visitor SSE denial introduced by the latest `canary`
- add regression coverage for a same-user API key attempting to read an operation from another workspace

## Context

The original authentication work in this PR was superseded by the Agent Share implementation on `canary`, which uses runtime ownership metadata and safely supports operations whose initial `agent_operations` write failed. After rebasing, this PR contains only the remaining API-key workspace isolation fix.

## Test plan

- focused lint check: clean
- `pnpm exec vitest run --silent=passed-only src/app/(backend)/api/agent/stream/__tests__/route.test.ts`: 29 passed
