### PR TITLE
🐛 fix(cli): restore the node glyph `lh goal show` lost when the kind was renamed

### DIFF
--- a/apps/cli/src/commands/goal.test.ts
+++ b/apps/cli/src/commands/goal.test.ts
@@ -6,6 +6,7 @@ import { registerGoalCommand } from './goal';
 const { mockClient } = vi.hoisted(() => ({
   mockClient: {
     goal: {
+      graph: { query: vi.fn() },
       tick: { mutate: vi.fn() },
     },
   },
@@ -75,5 +76,80 @@ describe('goal run command', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ pollCount: 3, waitedMs: 30 });
     expect(result[1]).toMatchObject({ outcome: 'achieved' });
+  });
+});
+
+describe('goal show command', () => {
+  const node = (kind: string, title: string) => ({
+    createdAt: new Date(0),
+    id: `${kind}-node-id`,
+    kind,
+    priority: 0,
+    status: 'waiting',
+    taskId: kind === 'task' ? 'task_8A1DyvjIc7PL' : null,
+    title,
+    updatedAt: new Date(0),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  const render = async () => {
+    await createProgram().parseAsync(['node', 'test', 'goal', 'show', 'goal-1']);
+    return (
+      vi
+        .mocked(console.log)
+        .mock.calls // `printGraph` calls `console.log()` bare for a blank line; stringifying that
+        // would manufacture the very word the assertion below is looking for.
+        .map(([value]) => (value === undefined ? '' : String(value)))
+        .join('\n')
+    );
+  };
+
+  it('renders a glyph for every node kind, including task', async () => {
+    // The glyph map was keyed on the old `work` kind after the rename, so every
+    // task row printed `undefined task` against a real goal. Typing the map
+    // proves each kind maps to *a* string; only rendering proves it maps to the
+    // right one.
+    mockClient.goal.graph.query.mockResolvedValue({
+      data: {
+        decisions: [],
+        edges: [],
+        events: [],
+        goal: { id: 'goal-1', requirement: null, status: 'review', title: 'Three quotes' },
+        nodes: [
+          node('problem', 'Collect three quotes'),
+          node('task', 'Ask vendor A'),
+          node('finding', 'Vendor A quoted 1200'),
+          node('decision', 'Retry or retire?'),
+        ],
+        workVersions: [],
+      },
+    });
+
+    const output = await render();
+
+    expect(output).toContain('▣ task');
+    expect(output).toContain('◇ problem');
+    expect(output).toContain('● finding');
+    expect(output).toContain('◆ decision');
+    expect(output).not.toContain('undefined');
+  });
+
+  it('still shows the responsible task id next to its node', async () => {
+    mockClient.goal.graph.query.mockResolvedValue({
+      data: {
+        decisions: [],
+        edges: [],
+        events: [],
+        goal: { id: 'goal-1', requirement: null, status: 'review', title: 'Three quotes' },
+        nodes: [node('task', 'Ask vendor A')],
+        workVersions: [],
+      },
+    });
+
+    expect(await render()).toContain('task_8A1DyvjIc7PL');
   });
 });

--- a/apps/cli/src/commands/goal.ts
+++ b/apps/cli/src/commands/goal.ts
@@ -1,4 +1,9 @@
-import type { GoalGraphDecision, GoalGraphSnapshot, GoalTickResult } from '@lobechat/types';
+import type {
+  GoalGraphDecision,
+  GoalGraphSnapshot,
+  GoalNodeKind,
+  GoalTickResult,
+} from '@lobechat/types';
 import type { Command } from 'commander';
 import pc from 'picocolors';
 
@@ -7,7 +12,15 @@ import { outputJson, printTable, truncate } from '../utils/format';
 import { log } from '../utils/logger';
 import { resolveAppUrlBuilder } from './task/url';
 
-const nodeIcon = { decision: '◆', finding: '●', problem: '◇', work: '▣' } as const;
+// Typed rather than inferred: an `as const` map is indexable by a widened
+// `any` node kind, which is how a renamed kind silently printed `undefined`
+// here after the type checker had signed off everywhere else.
+const nodeIcon: Record<GoalNodeKind, string> = {
+  decision: '◆',
+  finding: '●',
+  problem: '◇',
+  task: '▣',
+};
 const terminalOutcomes = new Set(['achieved', 'waiting_human', 'no_progress', 'failed']);
 
 interface GoalRunTickResult extends GoalTickResult {


### PR DESCRIPTION
## Summary

`goal_nodes.kind` moved from `work` to `task` in #18801, but `lh goal show`'s glyph map still keyed on `work`. Against a live goal every task row printed `undefined task`:

```
TYPE            STATUS   TITLE                              TASK
◇ problem       active   海光 BW150 三家报价                -
undefined task  waiting  海光 BW150 三家报价                task_8A1DyvjIc7PL
◆ decision      waiting  Choose how to recover failed work  -
```

## Why the type checker missed it

Worth stating, because the rename was otherwise type-driven — the compiler found every other site, including two record literals in the UI.

`nodeIcon` was an inferred `as const` object, and the root `tsconfig.json` `include` covers `src`, `packages`, `tests` and `apps/server` — **not `apps/cli`**. So nothing type-checks this file except the CLI's own standalone `tsc`, where unresolved workspace imports widen `node.kind` to `any`, and indexing an `as const` map with `any` is legal.

Typing it as `Record<GoalNodeKind, string>` closes that hole locally: reverting the key to `work` now produces errors in the CLI's own type-check. The wider gap — `apps/cli` being outside the root type-check — is left alone here; it is a build-config change that deserves its own PR.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`goal show` now has coverage that drives the command end to end and asserts the rendered cell, because the type proves only that every kind maps to *a* string — not that the map is keyed correctly, which is the whole of the bug. Verified as a regression test: reverting the key to `work` fails it with the exact output the live goal produced, `undefined task  waiting  Ask vendor A`.

Also verified against the real goal: `lh goal show goal_xifTwm60t0Zq` renders `▣ task` where it printed `undefined task`.

#### 🔗 Related Issue

Follows #18801.
