### PR TITLE
✨ feat(notification): show executing agent avatar on scheduled task notifications

### DIFF
--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -319,6 +319,7 @@ export class TaskLifecycleService {
       //    heartbeat ticks stay silent to avoid flooding the inbox.
       if (currentTask?.automationMode === 'schedule' && params.runTrigger === 'schedule') {
         void notifyScheduledTaskCompleted({
+          agentId: currentTask.assigneeAgentId ?? undefined,
           lastAssistantContent,
           operationId: params.operationId,
           taskId,
@@ -490,6 +491,7 @@ export class TaskLifecycleService {
         (runTrigger === 'schedule' || pausedByFuse)
       ) {
         void notifyScheduledTaskFailed({
+          agentId: currentTask.assigneeAgentId ?? undefined,
           consecutiveFailures: scheduleConsecutiveFailures,
           errorCode,
           operationId: params.operationId,

--- a/packages/business-server/src/task/notifyScheduledTaskResult.ts
+++ b/packages/business-server/src/task/notifyScheduledTaskResult.ts
@@ -1,4 +1,6 @@
 export interface NotifyScheduledTaskCompletedParams {
+  /** Agent executing the task — lets inbox surfaces render its avatar. */
+  agentId?: string;
   /** Final assistant reply text of the tick — may be used to build a preview. */
   lastAssistantContent?: string;
   operationId: string;
@@ -12,6 +14,8 @@ export interface NotifyScheduledTaskCompletedParams {
 }
 
 export interface NotifyScheduledTaskFailedParams {
+  /** Agent executing the task — lets inbox surfaces render its avatar. */
+  agentId?: string;
   /** Consecutive automation-tick failures including this one (schedule fuse). */
   consecutiveFailures?: number;
   /** Structured terminal error type (e.g. `InsufficientBudgetForModel`). Never

--- a/packages/types/src/notification.ts
+++ b/packages/types/src/notification.ts
@@ -13,8 +13,22 @@ export interface NotificationActor {
   userId?: string;
 }
 
+/**
+ * The agent behind an agent-driven notification (e.g. a scheduled task tick).
+ * Snapshotted at send time so inbox surfaces can render the agent's avatar
+ * even when the agent isn't loaded client-side; live store data (looked up by
+ * `id`) takes precedence when available.
+ */
+export interface NotificationAgent {
+  avatar?: string;
+  backgroundColor?: string;
+  id: string;
+  name?: string;
+}
+
 export interface NotificationMetadata {
   actor?: NotificationActor;
+  agent?: NotificationAgent;
   /**
    * Link to the resource-transfer request this notification is about. Inbox
    * surfaces use it to pair the immutable row with the live request: while

--- a/src/features/HomeSidebar/Header/components/InboxModal/NotificationItem.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxModal/NotificationItem.tsx
@@ -11,14 +11,13 @@ import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ProductLogo } from '@/components/Branding';
-import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
 
 import { formatNotificationRelativeTime } from './formatNotificationRelativeTime';
-import { getNotificationAgentId } from './getNotificationAgentId';
 import { createNotificationDetailModal } from './NotificationDetailModal';
 import { toNotificationPreview } from './toNotificationPreview';
+import { useNotificationAgentMeta } from './useNotificationAgentMeta';
 
 const styles = createStaticStyles(({ css }) => ({
   unreadDot: css`
@@ -74,8 +73,7 @@ const NotificationItem = memo<NotificationItemProps>(
     const dateLocale = i18n.resolvedLanguage || i18n.language;
     const preview = useMemo(() => toNotificationPreview(content), [content]);
     const actor = metadata?.actor;
-    const agentId = useMemo(() => getNotificationAgentId(actionUrl), [actionUrl]);
-    const agent = useAgentDisplayMeta(agentId, { fallbackToDefault: false });
+    const agent = useNotificationAgentMeta(actionUrl, metadata);
 
     const handleMarkAsRead = useCallback(() => {
       if (!isRead) onMarkAsRead(id);

--- a/src/features/HomeSidebar/Header/components/InboxModal/useNotificationAgentMeta.test.ts
+++ b/src/features/HomeSidebar/Header/components/InboxModal/useNotificationAgentMeta.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useNotificationAgentMeta } from './useNotificationAgentMeta';
+
+const mocks = vi.hoisted(() => ({
+  useAgentDisplayMeta: vi.fn(),
+}));
+
+vi.mock('@/features/AgentTasks/shared/useAgentDisplayMeta', () => ({
+  useAgentDisplayMeta: mocks.useAgentDisplayMeta,
+}));
+
+describe('useNotificationAgentMeta', () => {
+  beforeEach(() => {
+    mocks.useAgentDisplayMeta.mockReset().mockReturnValue(undefined);
+  });
+
+  it('renders the metadata agent snapshot when the agent is not loaded client-side', () => {
+    // Scheduled-task rows deep-link to /task/:id, so the actionUrl carries no
+    // agent segment — before the metadata.agent snapshot this resolved to
+    // undefined and the row fell back to the product logo.
+    const { result } = renderHook(() =>
+      useNotificationAgentMeta('/task/tsk_1', {
+        agent: {
+          avatar: 'https://cdn.example/cron-bot.png',
+          backgroundColor: '#abcdef',
+          id: 'agt_1',
+          name: 'Cron Bot',
+        },
+      }),
+    );
+
+    expect(mocks.useAgentDisplayMeta).toHaveBeenCalledWith('agt_1', { fallbackToDefault: false });
+    expect(result.current).toEqual({
+      avatar: 'https://cdn.example/cron-bot.png',
+      backgroundColor: '#abcdef',
+      title: 'Cron Bot',
+    });
+  });
+
+  it('prefers live store meta over the send-time snapshot', () => {
+    const liveMeta = { avatar: '🤖', backgroundColor: '#fff', title: 'Renamed Bot' };
+    mocks.useAgentDisplayMeta.mockReturnValue(liveMeta);
+
+    const { result } = renderHook(() =>
+      useNotificationAgentMeta('/task/tsk_1', {
+        agent: { avatar: 'https://cdn.example/stale.png', id: 'agt_1' },
+      }),
+    );
+
+    expect(result.current).toEqual(liveMeta);
+  });
+
+  it('falls back to the default avatar when the snapshot has none', () => {
+    const { result } = renderHook(() =>
+      useNotificationAgentMeta('/task/tsk_1', { agent: { id: 'agt_1' } }),
+    );
+
+    expect(result.current?.avatar).toBeTruthy();
+  });
+
+  it('still resolves the agent from an /agent/:id actionUrl without a snapshot', () => {
+    renderHook(() => useNotificationAgentMeta('/agent/agt_2/chat', null));
+
+    expect(mocks.useAgentDisplayMeta).toHaveBeenCalledWith('agt_2', { fallbackToDefault: false });
+  });
+
+  it('returns undefined without any agent identity (product logo fallback)', () => {
+    const { result } = renderHook(() => useNotificationAgentMeta('/task/tsk_1', null));
+
+    expect(mocks.useAgentDisplayMeta).toHaveBeenCalledWith(undefined, { fallbackToDefault: false });
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/src/features/HomeSidebar/Header/components/InboxModal/useNotificationAgentMeta.ts
+++ b/src/features/HomeSidebar/Header/components/InboxModal/useNotificationAgentMeta.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_AVATAR } from '@lobechat/const';
+import type { NotificationMetadata } from '@lobechat/types';
+
+import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
+
+import { getNotificationAgentId } from './getNotificationAgentId';
+
+interface NotificationAgentDisplayMeta {
+  avatar: string;
+  backgroundColor?: string;
+  title?: string;
+}
+
+/**
+ * Resolve the agent to show on a notification row. Live store data wins (the
+ * agent may have been re-skinned since the row was written); the send-time
+ * `metadata.agent` snapshot covers agents the client never loaded, e.g.
+ * scheduled-task agents whose actionUrl (`/task/:id`) carries no agent segment.
+ */
+export const useNotificationAgentMeta = (
+  actionUrl: string | null | undefined,
+  metadata: NotificationMetadata | null | undefined,
+): NotificationAgentDisplayMeta | undefined => {
+  const snapshot = metadata?.agent;
+  const agentId = snapshot?.id ?? getNotificationAgentId(actionUrl);
+  const liveAgent = useAgentDisplayMeta(agentId, { fallbackToDefault: false });
+
+  if (liveAgent) return liveAgent;
+  if (!snapshot) return undefined;
+
+  return {
+    avatar: snapshot.avatar || DEFAULT_AVATAR,
+    backgroundColor: snapshot.backgroundColor,
+    title: snapshot.name,
+  };
+};


### PR DESCRIPTION
Scheduled-task rows in the notification inbox always rendered the LobeHub logo, because the row's avatar could only be resolved from an `/agent/:id` segment in `actionUrl` — and scheduled-task notifications deep-link to `/task/:id`.

| Before | After |
| ------ | ----- |
| Every scheduled-task notification shows the LobeHub logo | The row shows the executing agent's avatar (send-time snapshot when the agent isn't loaded client-side, live store data when it is); rows without agent metadata keep the logo fallback |

#### Description of Change

- `NotificationMetadata` gains an optional `agent` snapshot (`id` / `avatar` / `backgroundColor` / `name`), captured at send time so inbox surfaces can render the avatar even for agents the client never loaded.
- The scheduled-task notify slot params (`notifyScheduledTaskCompleted` / `notifyScheduledTaskFailed`) gain `agentId`, and the task lifecycle passes the task's `assigneeAgentId` at both call sites.
- New `useNotificationAgentMeta` hook resolves the row avatar: live store meta by id first (the agent may have been re-skinned since the row was written), then the `metadata.agent` snapshot, then the existing `/agent/:id` actionUrl parsing; `NotificationItem` falls back to the product logo only when all three miss.

The metadata field is additive and optional, so this merges safely on its own; the business-side notification writer needs a follow-up to look up the agent and stamp `metadata.agent` when creating the row — until then new rows keep the logo fallback.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`useNotificationAgentMeta.test.ts` covers the snapshot render, live-over-snapshot precedence, default-avatar fallback, actionUrl parsing, and the logo fallback. Verified end-to-end in a local full stack: seeded scheduled-task rows with/without `metadata.agent` render the agent avatar (snapshot 🧹, live 🤖 winning over a stale snapshot) while legacy rows keep the logo; swapping `NotificationItem` back to the base revision reproduces the all-logo before state.

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)