### PR TITLE
🐛 fix(resource): fix sidebar file highlight, unify the /resource skeleton, move the scope switch to the header

### DIFF
--- a/src/components/Skeleton/ResourceHome.tsx
+++ b/src/components/Skeleton/ResourceHome.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+
+import SkeletonBar from './Bar';
+
+/**
+ * Shared by the route-level skeleton and the sections' own loading state, so
+ * the placeholder never swaps shape between chunk load and data load.
+ */
+export const RESOURCE_HOME_SECTIONS = {
+  files: { count: 4, itemHeight: 160, minItemWidth: 180 },
+  libraries: { count: 4, itemHeight: 52, minItemWidth: 200 },
+  pages: { count: 3, itemHeight: 64, minItemWidth: 240 },
+  works: { count: 3, itemHeight: 220, minItemWidth: 260 },
+} as const;
+
+interface SectionSkeletonProps {
+  count: number;
+  itemHeight: number;
+  minItemWidth: number;
+}
+
+export const ResourceSectionSkeleton = ({
+  count,
+  itemHeight,
+  minItemWidth,
+}: SectionSkeletonProps) => (
+  <div
+    style={{
+      display: 'grid',
+      gap: 12,
+      gridTemplateColumns: `repeat(auto-fill, minmax(${minItemWidth}px, 1fr))`,
+    }}
+  >
+    {Array.from({ length: count }).map((_, index) => (
+      <SkeletonBar height={itemHeight} key={index} radius={cssVar.borderRadiusLG} />
+    ))}
+  </div>
+);
+
+const styles = createStaticStyles(({ css }) => ({
+  content: css`
+    width: 100%;
+    max-width: 1080px;
+    margin-inline: auto;
+    padding-block: 32px 64px;
+    padding-inline: 32px;
+  `,
+  header: css`
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  scroll: css`
+    overflow: hidden;
+    flex: 1;
+  `,
+}));
+
+const Section = (props: SectionSkeletonProps) => (
+  <Flexbox gap={12}>
+    <SkeletonBar height={18} width={112} />
+    <ResourceSectionSkeleton {...props} />
+  </Flexbox>
+);
+
+const ResourceHomeSkeleton = () => (
+  <Flexbox aria-busy flex={1} height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }}>
+    <Flexbox
+      horizontal
+      align={'center'}
+      className={styles.header}
+      flex={'none'}
+      height={44}
+      justify={'space-between'}
+      paddingInline={16}
+    >
+      <SkeletonBar height={20} width={96} />
+      <SkeletonBar height={28} width={88} />
+    </Flexbox>
+    <div className={styles.scroll}>
+      <Flexbox className={styles.content} gap={40}>
+        <Section {...RESOURCE_HOME_SECTIONS.libraries} />
+        <Section {...RESOURCE_HOME_SECTIONS.works} />
+        <Section {...RESOURCE_HOME_SECTIONS.pages} />
+        <Section {...RESOURCE_HOME_SECTIONS.files} />
+      </Flexbox>
+    </div>
+  </Flexbox>
+);
+
+export default ResourceHomeSkeleton;

--- a/src/features/ResourceHome/Home/Libraries.tsx
+++ b/src/features/ResourceHome/Home/Libraries.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { Flexbox, Icon } from '@lobehub/ui';
-import { Skeleton } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { PlusIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import LibraryStatusIcon from '@/components/LibIcon/StatusIcon';
+import {
+  RESOURCE_HOME_SECTIONS,
+  ResourceSectionSkeleton,
+} from '@/components/Skeleton/ResourceHome';
 import { useCreateNewModal } from '@/features/LibraryModal';
 import { useResourceManagerStore } from '@/features/ResourceManager/store';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -124,11 +127,7 @@ const Libraries = memo(() => {
     <Flexbox gap={12}>
       <SectionTitle title={t('home.libraries')} />
       {isLoading ? (
-        <div className={styles.grid}>
-          {Array.from({ length: 4 }, (_, index) => (
-            <Skeleton.Node active key={index} style={{ height: 52, width: '100%' }} />
-          ))}
-        </div>
+        <ResourceSectionSkeleton {...RESOURCE_HOME_SECTIONS.libraries} />
       ) : (
         <div className={styles.grid}>
           {data?.slice(0, MAX_LIBRARIES).map((item) => (

--- a/src/features/ResourceHome/Home/RecentFiles.tsx
+++ b/src/features/ResourceHome/Home/RecentFiles.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { Skeleton } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import { memo } from 'react';
@@ -10,6 +9,10 @@ import { useTranslation } from 'react-i18next';
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import AsyncError from '@/components/AsyncError';
 import FileIcon from '@/components/FileIcon';
+import {
+  RESOURCE_HOME_SECTIONS,
+  ResourceSectionSkeleton,
+} from '@/components/Skeleton/ResourceHome';
 import { useResourceManagerStore } from '@/features/ResourceManager/store';
 import { getResourceQueryVisibility } from '@/features/ResourceManager/store/selectors';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -104,11 +107,7 @@ const RecentFiles = memo(() => {
       {error && !data?.length ? (
         <AsyncError error={error} variant={'inline'} onRetry={() => void mutate()} />
       ) : isLoading ? (
-        <div className={styles.grid}>
-          {Array.from({ length: 4 }, (_, index) => (
-            <Skeleton.Node active key={index} style={{ height: 160, width: '100%' }} />
-          ))}
-        </div>
+        <ResourceSectionSkeleton {...RESOURCE_HOME_SECTIONS.files} />
       ) : (
         <div className={styles.grid}>
           {data?.map((item) => {

--- a/src/features/ResourceHome/Home/RecentPages.tsx
+++ b/src/features/ResourceHome/Home/RecentPages.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Flexbox, Icon } from '@lobehub/ui';
-import { Skeleton } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import { FileTextIcon } from 'lucide-react';
@@ -10,6 +9,10 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import AsyncError from '@/components/AsyncError';
+import {
+  RESOURCE_HOME_SECTIONS,
+  ResourceSectionSkeleton,
+} from '@/components/Skeleton/ResourceHome';
 import { useResourceManagerStore } from '@/features/ResourceManager/store';
 import { getResourceQueryVisibility } from '@/features/ResourceManager/store/selectors';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -92,11 +95,7 @@ const RecentPages = memo(() => {
       {error && !data?.length ? (
         <AsyncError error={error} variant={'inline'} onRetry={() => void mutate()} />
       ) : isLoading ? (
-        <div className={styles.grid}>
-          {Array.from({ length: 3 }, (_, index) => (
-            <Skeleton.Node active key={index} style={{ height: 64, width: '100%' }} />
-          ))}
-        </div>
+        <ResourceSectionSkeleton {...RESOURCE_HOME_SECTIONS.pages} />
       ) : (
         <div className={styles.grid}>
           {data?.map((item) => {

--- a/src/features/ResourceHome/Home/RecentWorks.tsx
+++ b/src/features/ResourceHome/Home/RecentWorks.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { Skeleton } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AsyncError from '@/components/AsyncError';
+import {
+  RESOURCE_HOME_SECTIONS,
+  ResourceSectionSkeleton,
+} from '@/components/Skeleton/ResourceHome';
 import { useWorkspaceWorksInfinite } from '@/features/WorkGallery/hooks';
 import { useOpenWork } from '@/features/WorkGallery/useOpenWork';
 import WorkPreviewCard from '@/features/WorkGallery/WorkPreviewCard';
@@ -39,11 +42,7 @@ const RecentWorks = memo(() => {
       {error && recent.length === 0 ? (
         <AsyncError error={error} variant={'inline'} onRetry={reload} />
       ) : isLoadingInitial ? (
-        <div className={styles.grid}>
-          {Array.from({ length: 3 }, (_, index) => (
-            <Skeleton.Node active key={index} style={{ height: 220, width: '100%' }} />
-          ))}
-        </div>
+        <ResourceSectionSkeleton {...RESOURCE_HOME_SECTIONS.works} />
       ) : (
         <div className={styles.grid}>
           {recent.map((item) => (

--- a/src/features/ResourceHome/Layout/Header/index.tsx
+++ b/src/features/ResourceHome/Layout/Header/index.tsx
@@ -14,6 +14,7 @@ const Header = memo(() => {
   return (
     <>
       <SideBarHeaderLayout
+        right={<ResourceModeToggle />}
         breadcrumb={[
           {
             href: '/resource',
@@ -21,7 +22,6 @@ const Header = memo(() => {
           },
         ]}
       />
-      <ResourceModeToggle />
       <CategoryMenu />
     </>
   );

--- a/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNode.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNode.tsx
@@ -25,6 +25,7 @@ import { useTreeStore } from '@/store/tree';
 
 import { useFileItemClick } from '../Explorer/hooks/useFileItemClick';
 import { useFileItemDropdown } from '../Explorer/ItemDropdown/useFileItemDropdown';
+import { isHierarchyNodeActive } from './selection';
 import { styles } from './styles';
 
 interface HierarchyNodeProps {
@@ -49,7 +50,7 @@ export const HierarchyNode = memo<HierarchyNodeProps>(
     const [renamingValue, setRenamingValue] = useState(item.name);
     const inputRef = useRef<any>(null);
 
-    const { itemKey, isPage, emoji } = useMemo(() => {
+    const { isPage, emoji } = useMemo(() => {
       const lowerFileType = item.fileType?.toLowerCase();
       const lowerName = item.name?.toLowerCase();
       const isPDF = lowerFileType === 'pdf' || lowerName?.endsWith('.pdf');
@@ -69,9 +70,8 @@ export const HierarchyNode = memo<HierarchyNodeProps>(
       return {
         emoji: pageMatch ? item.metadata?.emoji : null,
         isPage: pageMatch,
-        itemKey: item.slug || item.id,
       };
-    }, [item.slug, item.id, item.fileType, item.sourceType, item.name, item.metadata?.emoji]);
+    }, [item.fileType, item.sourceType, item.name, item.metadata?.emoji]);
 
     const handleRenameStart = useCallback(() => {
       setIsRenaming(true);
@@ -200,7 +200,7 @@ export const HierarchyNode = memo<HierarchyNodeProps>(
     );
 
     if (item.isFolder) {
-      const isActive = selectedKey === itemKey;
+      const isActive = isHierarchyNodeActive(item, selectedKey);
 
       const handleToggle = () => {
         onToggle(item.id);
@@ -304,7 +304,7 @@ export const HierarchyNode = memo<HierarchyNodeProps>(
     }
 
     // Render as file
-    const isActive = selectedKey === itemKey;
+    const isActive = isHierarchyNodeActive(item, selectedKey);
     return (
       <Flexbox gap={2}>
         <Block

--- a/src/features/ResourceManager/components/LibraryHierarchy/index.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/index.tsx
@@ -18,6 +18,7 @@ import { useTreeStore } from '@/store/tree';
 import AddButton from '../Header/AddButton';
 import { KnowledgeBaseListProvider } from '../KnowledgeBaseListProvider';
 import { HierarchyNode } from './HierarchyNode';
+import { resolveHierarchySelectedKey } from './selection';
 import TreeSkeleton from './TreeSkeleton';
 
 interface VisibleNode {
@@ -79,7 +80,7 @@ const LibraryHierarchy = memo(() => {
     return result;
   }, [children, expanded]);
 
-  const selectedKey = currentFolderSlug ?? null;
+  const selectedKey = resolveHierarchySelectedKey({ currentFolderSlug, currentViewItemId });
 
   const hasData = visibleNodes.length > 0;
   // The root fetch is in flight with nothing cached yet.

--- a/src/features/ResourceManager/components/LibraryHierarchy/selection.test.ts
+++ b/src/features/ResourceManager/components/LibraryHierarchy/selection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { isHierarchyNodeActive, resolveHierarchySelectedKey } from './selection';
+
+describe('resolveHierarchySelectedKey', () => {
+  it('prefers the opened file over the current folder', () => {
+    expect(
+      resolveHierarchySelectedKey({ currentFolderSlug: 'folder-a', currentViewItemId: 'file_1' }),
+    ).toBe('file_1');
+  });
+
+  it('falls back to the current folder', () => {
+    expect(resolveHierarchySelectedKey({ currentFolderSlug: 'folder-a' })).toBe('folder-a');
+    expect(resolveHierarchySelectedKey({})).toBeNull();
+  });
+});
+
+describe('isHierarchyNodeActive', () => {
+  const file = { id: 'file_1', isFolder: false, slug: 'my-page' };
+  const folder = { id: 'folder_1', isFolder: true, slug: 'folder-a' };
+
+  it('marks the opened file active by id, not slug', () => {
+    expect(isHierarchyNodeActive(file, 'file_1')).toBe(true);
+    expect(isHierarchyNodeActive(file, 'my-page')).toBe(false);
+  });
+
+  it('marks the current folder active by slug with id fallback', () => {
+    expect(isHierarchyNodeActive(folder, 'folder-a')).toBe(true);
+    expect(isHierarchyNodeActive({ ...folder, slug: null }, 'folder_1')).toBe(true);
+  });
+
+  it('drops folder highlight once a file is opened', () => {
+    expect(isHierarchyNodeActive(folder, 'file_1')).toBe(false);
+    expect(isHierarchyNodeActive(file, null)).toBe(false);
+  });
+});

--- a/src/features/ResourceManager/components/LibraryHierarchy/selection.ts
+++ b/src/features/ResourceManager/components/LibraryHierarchy/selection.ts
@@ -1,0 +1,20 @@
+import type { TreeItem } from '@/store/tree';
+
+interface SelectionSource {
+  currentFolderSlug?: string | null;
+  currentViewItemId?: string | null;
+}
+
+export const resolveHierarchySelectedKey = ({
+  currentFolderSlug,
+  currentViewItemId,
+}: SelectionSource): string | null => currentViewItemId ?? currentFolderSlug ?? null;
+
+export const isHierarchyNodeActive = (
+  item: Pick<TreeItem, 'id' | 'isFolder' | 'slug'>,
+  selectedKey: string | null,
+): boolean => {
+  if (!selectedKey) return false;
+
+  return item.isFolder ? selectedKey === (item.slug || item.id) : selectedKey === item.id;
+};

--- a/src/features/ResourceManager/components/ResourceModeToggle/index.tsx
+++ b/src/features/ResourceManager/components/ResourceModeToggle/index.tsx
@@ -1,59 +1,15 @@
 'use client';
 
-import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
-import { createStaticStyles, cx } from 'antd-style';
-import { LockIcon, UsersIcon } from 'lucide-react';
-import { memo, useEffect } from 'react';
+import { type DropdownItem, DropdownMenu, Flexbox, Icon, type MenuInfo } from '@lobehub/ui';
+import { Button, Text } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
+import { CheckIcon, ChevronDownIcon, LockIcon, UsersIcon } from 'lucide-react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { useResourceManagerStore } from '@/features/ResourceManager/store';
 import type { ResourceListVisibilityFilter } from '@/features/ResourceManager/store/initialState';
-
-const styles = createStaticStyles(({ css, cssVar }) => {
-  return {
-    button: css`
-      cursor: pointer;
-
-      display: inline-flex;
-      flex: 1;
-      gap: 6px;
-      align-items: center;
-      justify-content: center;
-
-      padding-block: 6px;
-      padding-inline: 8px;
-      border: none;
-      border-radius: ${cssVar.borderRadius};
-
-      font-size: 13px;
-      font-weight: 500;
-      color: ${cssVar.colorTextSecondary};
-
-      background: transparent;
-
-      transition: background 0.15s;
-
-      &:hover {
-        background: ${cssVar.colorFillTertiary};
-      }
-    `,
-    buttonActive: css`
-      color: ${cssVar.colorText};
-      background: ${cssVar.colorBgElevated};
-      box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
-    `,
-    group: css`
-      display: inline-flex;
-
-      width: 100%;
-      padding: 3px;
-      border-radius: ${cssVar.borderRadiusLG};
-
-      background: ${cssVar.colorFillQuaternary};
-    `,
-  };
-});
 
 const OPTIONS: Array<{
   icon: typeof LockIcon;
@@ -76,7 +32,7 @@ const OPTIONS: Array<{
 ];
 
 /**
- * Sidebar-top dual toggle: `[🔒 Private] [👥 Workspace]`.
+ * Sidebar-header scope chip, mirroring the task list's visibility filter.
  *
  * Rendered only in team-workspace mode — personal mode has no notion of
  * visibility, so the toggle is meaningless there and is deliberately hidden.
@@ -90,6 +46,7 @@ const ResourceModeToggle = memo(() => {
   const [listVisibility, setListVisibility, hydrateListVisibility] = useResourceManagerStore(
     (s) => [s.listVisibility, s.setListVisibility, s.hydrateListVisibility],
   );
+  const [open, setOpen] = useState(false);
 
   const workspaceId = activeWorkspaceId ?? undefined;
 
@@ -101,35 +58,50 @@ const ResourceModeToggle = memo(() => {
     hydrateListVisibility(workspaceId);
   }, [workspaceId, hydrateListVisibility]);
 
+  const menuItems = useMemo<DropdownItem[]>(
+    () =>
+      OPTIONS.map((option) => {
+        const OptionIcon = option.icon;
+        return {
+          extra:
+            option.key === listVisibility ? (
+              <Icon color={cssVar.colorTextSecondary} icon={CheckIcon} size={14} />
+            ) : undefined,
+          icon: <Icon color={cssVar.colorTextSecondary} icon={OptionIcon} size={16} />,
+          key: option.key,
+          label: t(option.labelKey as never),
+          onClick: ({ domEvent }: MenuInfo) => {
+            domEvent.stopPropagation();
+            if (!workspaceId) return;
+            setListVisibility(option.key, workspaceId);
+          },
+        };
+      }),
+    [listVisibility, setListVisibility, t, workspaceId],
+  );
+
   if (!workspaceId) return null;
 
+  const current = OPTIONS.find((option) => option.key === listVisibility) ?? OPTIONS[0];
+  const currentLabel = t(current.labelKey as never);
+
   return (
-    <Flexbox paddingBlock={6} paddingInline={4}>
-      <div className={styles.group} role={'tablist'}>
-        {OPTIONS.map((option) => {
-          const isActive = listVisibility === option.key;
-          const OptionIcon = option.icon;
-          const label = t(option.labelKey as never);
-          return (
-            <Tooltip key={option.key} title={t(option.tooltipKey as never)}>
-              <button
-                aria-selected={isActive}
-                className={cx(styles.button, isActive && styles.buttonActive)}
-                role={'tab'}
-                type={'button'}
-                onClick={() => {
-                  if (isActive) return;
-                  setListVisibility(option.key, workspaceId);
-                }}
-              >
-                <Icon icon={OptionIcon} size={14} />
-                <span>{label}</span>
-              </button>
-            </Tooltip>
-          );
-        })}
-      </div>
-    </Flexbox>
+    <DropdownMenu items={menuItems} open={open} onOpenChange={setOpen}>
+      <Button
+        size={'small'}
+        style={{ paddingInline: 6 }}
+        title={`${t('resources.visibility.label')}: ${currentLabel}`}
+        type={'text'}
+      >
+        <Flexbox horizontal align={'center'} gap={4}>
+          <Icon color={cssVar.colorIcon} icon={current.icon} size={14} />
+          <Text ellipsis fontSize={12} style={{ maxWidth: 96 }} type={'secondary'}>
+            {currentLabel}
+          </Text>
+          <Icon color={cssVar.colorIcon} icon={ChevronDownIcon} size={12} />
+        </Flexbox>
+      </Button>
+    </DropdownMenu>
   );
 });
 

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -31,6 +31,7 @@ import ConversationSegmentSkeleton from '@/components/Skeleton/Conversation/Segm
 import GenerationSkeleton from '@/components/Skeleton/Generation';
 import HomeSkeleton from '@/components/Skeleton/Home';
 import MemorySkeleton from '@/components/Skeleton/Memory';
+import ResourceHomeSkeleton from '@/components/Skeleton/ResourceHome';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
 import { agentDocumentRouteMeta } from '@/features/AgentDocumentPage/routeMeta';
@@ -593,7 +594,11 @@ export const sharedMainAreaChildren: RouteObject[] = [
               { preloadId: 'resource' },
             ),
             handle: {
-              meta: routeMeta({ icon: LibraryBigIcon, titleKey: 'navigation.resources' }),
+              meta: routeMeta({
+                icon: LibraryBigIcon,
+                Skeleton: ResourceHomeSkeleton,
+                titleKey: 'navigation.resources',
+              }),
             },
             index: true,
           },

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -14,6 +14,7 @@ import GoalSkeleton from '@/components/Skeleton/Goal';
 import GoalDetailSkeleton from '@/components/Skeleton/GoalDetail';
 import MemorySkeleton from '@/components/Skeleton/Memory';
 import ProfileSkeleton, { GroupProfileRouteSkeleton } from '@/components/Skeleton/Profile';
+import ResourceHomeSkeleton from '@/components/Skeleton/ResourceHome';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import SettingsPageSkeleton from '@/components/Skeleton/Settings/Page';
 import TasksSkeleton from '@/components/Skeleton/Tasks';
@@ -382,6 +383,7 @@ describe('desktop router shared definition', () => {
       ['/settings/profile', SettingsPageSkeleton],
       ['/apps', AppsSkeleton],
       ['/memory', MemorySkeleton],
+      ['/resource', ResourceHomeSkeleton],
     ] as const) {
       const matches = matchRoutes(getRoutes(pathname), pathname);
       expect(


### PR DESCRIPTION
Three fixes on the resource surface, all found while walking the page.

### 1. The opened file was never highlighted in the library sidebar

The library sidebar derived its selected key from the folder slug only, while opening a file selects it through `?file=<id>` (store `currentViewItemId`). File rows therefore never matched and the parent folder kept the highlight. `currentViewItemId` was already read in `LibraryHierarchy` but never used — this wires it up:

- file rows match on `item.id` (the id carried in `?file=`), folder rows keep matching on slug with an id fallback
- an opened file takes precedence over the current folder, so only one row is highlighted at a time
- selection logic extracted to `selection.ts` so it is unit-testable

### 2. `/resource` showed two different skeletons in a row

The home route declared no skeleton of its own, so `resolveRouteSkeleton` fell back to the parent `resource` route's `createSurfaceSkeleton('list')` while the chunk loaded — then the page mounted and each section swapped in its own antd `Skeleton.Node` placeholders. Two shapes, two animations, for a single load.

- new `components/Skeleton/ResourceHome` mirrors the dashboard: header, centered 1080 column, four section grids
- it exports `RESOURCE_HOME_SECTIONS` + `ResourceSectionSkeleton`, which the four sections now use for their own loading state, so the placeholders cannot drift apart
- the home index route declares that skeleton; library routes keep the list surface

### 3. The private/workspace switch read as two more nav items

`ResourceModeToggle` was a hand-rolled full-width segmented (60 lines of CSS, and a `role="tablist"` that misdescribes a scope filter) sitting in the nav stack at the same width and height as the nav rows — so it fought the "Home" entry right below it. Translated labels also crowded the breadcrumb.

It is now a dropdown chip on the sidebar header row — icon + current scope + chevron, ellipsised at 96px — mirroring `TaskListVisibilityFilter`, the existing language for this same private/workspace concept.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`selection.test.ts` covers the selection rules (5 cases). `desktopRouter.sync.test.tsx` gains `/resource → ResourceHomeSkeleton`; dropping the route meta makes it fail on both Web and Electron. 42 router tests pass, lint clean. The three surfaces were walked in the desktop app against the online backend.

https://claude.ai/code/session_01BLpagoKGLmekbvufK25xnP