### PR TITLE
🐛 fix(model-runtime): resolve and forward pricingOptions on the OpenAI path and surface pricing issues

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
+import { loadModels } from '@lobechat/business-model-bank/model-config';
 import { ModelProvider } from 'model-bank';
+import aihubmixModels from 'model-bank/aihubmix';
 import OpenAI from 'openai';
 import type { Stream } from 'openai/streaming';
 import type { Mock } from 'vitest';
@@ -110,6 +112,311 @@ afterEach(() => {
 });
 
 describe('LobeOpenAICompatibleFactory', () => {
+  describe('getPricingOptions hook', () => {
+    it('should resolve pricing options from the transformed chat request payload', async () => {
+      const create = vi.fn().mockRejectedValue(new Error('stop after hook'));
+      const getPricingOptions = vi.fn(() => ({ lookupParams: { ttl: '1h' } }));
+      const Runtime = createOpenAICompatibleRuntime({
+        baseURL: 'https://api.test.com/v1',
+        chatCompletion: { getPricingOptions },
+        customClient: {
+          createClient: () => ({ chat: { completions: { create } } }) as unknown as OpenAI,
+        },
+        provider: 'test-provider',
+      });
+      const runtime = new Runtime({ apiKey: 'test' });
+
+      await runtime
+        .chat({ messages: [{ content: 'hi', role: 'user' }], model: 'test-model', stream: true })
+        .catch(() => {});
+
+      expect(getPricingOptions).toHaveBeenCalledTimes(1);
+      // The second argument must be the final provider request: stream_options
+      // only exists on the transmitted payload, never on the intermediate one.
+      expect(getPricingOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'test-model' }),
+        expect.objectContaining({
+          model: 'test-model',
+          stream_options: { include_usage: true },
+        }),
+      );
+    });
+
+    it('should resolve pricing options on the custom stream client branch', async () => {
+      const createChatCompletionStream = vi.fn(() => {
+        throw new Error('stop after hook');
+      });
+      const getPricingOptions = vi.fn(() => ({ lookupParams: { ttl: '1h' } }));
+      const Runtime = createOpenAICompatibleRuntime({
+        baseURL: 'https://api.test.com/v1',
+        chatCompletion: { getPricingOptions },
+        customClient: {
+          createChatCompletionStream: createChatCompletionStream as any,
+          createClient: () => ({ chat: { completions: { create: vi.fn() } } }) as unknown as OpenAI,
+        },
+        provider: 'test-provider',
+      });
+      const runtime = new Runtime({
+        apiKey: 'test',
+        modelIdMapping: { 'logical-model': 'upstream-model' },
+      });
+
+      await runtime
+        .chat({ messages: [{ content: 'hi', role: 'user' }], model: 'logical-model', stream: true })
+        .catch(() => {});
+
+      expect(getPricingOptions).toHaveBeenCalledTimes(1);
+      // The mapped upstream id only exists on the final provider request.
+      expect(getPricingOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'logical-model' }),
+        expect.objectContaining({ model: 'upstream-model' }),
+      );
+    });
+
+    it('should price lookup units through the hook on the custom stream client', async () => {
+      const usageChunk = {
+        choices: [],
+        created: 1_785_670_001,
+        id: 'chatcmpl_custom_hook',
+        model: 'claude-opus-4-6',
+        object: 'chat.completion.chunk',
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 1_000_000,
+          prompt_tokens_details: { cache_write_tokens: 1_000_000, cached_tokens: 0 },
+          total_tokens: 1_000_010,
+        },
+      };
+      const createChatCompletionStream = vi.fn(
+        () =>
+          ({
+            async *[Symbol.asyncIterator]() {
+              yield usageChunk;
+            },
+          }) as any,
+      );
+      const Runtime = createOpenAICompatibleRuntime({
+        baseURL: 'https://api.test.com/v1',
+        chatCompletion: { getPricingOptions: () => ({ lookupParams: { ttl: '1h' } }) },
+        customClient: {
+          createChatCompletionStream: createChatCompletionStream as any,
+          createClient: () => ({ chat: { completions: { create: vi.fn() } } }) as unknown as OpenAI,
+        },
+        provider: 'aihubmix',
+      });
+      const runtime = new Runtime({ apiKey: 'test' });
+      const cards = aihubmixModels.map((m) => ({ ...m, providerId: 'aihubmix' }));
+      vi.mocked(loadModels).mockResolvedValue(cards as any);
+      try {
+        const response = await runtime.chat({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'claude-opus-4-6',
+          stream: true,
+        });
+        const text = await response.text();
+        const costs = [...text.matchAll(/"cost":([\d.]+)/g)].map((m) => Number(m[1]));
+        // 1M cache-write tokens at the 1h lookup rate ($10/M) dominate the cost.
+        expect(Math.max(...costs, 0)).toBeGreaterThan(9);
+      } finally {
+        vi.mocked(loadModels).mockResolvedValue([]);
+      }
+    });
+
+    it('should resolve pricing options for the Responses API flow', async () => {
+      const rawStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            response: { id: 'resp_hook', model: 'test-model', status: 'in_progress', usage: null },
+            sequence_number: 0,
+            type: 'response.created',
+          };
+        },
+      };
+      const create = vi.fn(() => ({
+        withResponse: vi.fn().mockResolvedValue({
+          data: rawStream,
+          request_id: 'req_hook',
+          response: new Response('', { headers: {}, status: 200 }),
+        }),
+      }));
+      const getPricingOptions = vi.fn(() => ({ lookupParams: { ttl: '1h' } }));
+      const Runtime = createOpenAICompatibleRuntime({
+        baseURL: 'https://api.test.com/v1',
+        chatCompletion: { getPricingOptions, useResponse: true },
+        customClient: {
+          createClient: () => ({ responses: { create } }) as unknown as OpenAI,
+        },
+        provider: 'test-provider',
+      });
+      const runtime = new Runtime({ apiKey: 'test' });
+
+      const response = await runtime.chat({
+        messages: [{ content: 'hi', role: 'user' }],
+        model: 'test-model',
+        stream: true,
+      });
+      await response.text().catch(() => {});
+
+      expect(getPricingOptions).toHaveBeenCalledTimes(1);
+      // `store` is only set on the prepared Responses request, never on the
+      // LobeHub payload.
+      expect(getPricingOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'test-model' }),
+        expect.objectContaining({ model: 'test-model', store: false }),
+      );
+    });
+
+    it('should price lookup units through the forwarded options end to end', async () => {
+      const usageChunk = {
+        choices: [],
+        created: 1_785_670_001,
+        id: 'chatcmpl_hook',
+        model: 'claude-opus-4-6',
+        object: 'chat.completion.chunk',
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 1_000_000,
+          prompt_tokens_details: { cache_write_tokens: 1_000_000, cached_tokens: 0 },
+          total_tokens: 1_000_010,
+        },
+      };
+      const runChat = async (withHook: boolean) => {
+        const rawStream = {
+          async *[Symbol.asyncIterator]() {
+            yield usageChunk;
+          },
+        };
+        const create = vi.fn(() => ({
+          withResponse: vi.fn().mockResolvedValue({
+            data: rawStream,
+            request_id: 'req_hook_e2e',
+            response: new Response('', { headers: {}, status: 200 }),
+          }),
+        }));
+        const Runtime = createOpenAICompatibleRuntime({
+          baseURL: 'https://api.test.com/v1',
+          chatCompletion: withHook
+            ? { getPricingOptions: () => ({ lookupParams: { ttl: '1h' } }) }
+            : {},
+          customClient: {
+            createClient: () => ({ chat: { completions: { create } } }) as unknown as OpenAI,
+          },
+          provider: 'aihubmix',
+        });
+        const runtime = new Runtime({ apiKey: 'test' });
+        const response = await runtime.chat({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'claude-opus-4-6',
+          stream: true,
+        });
+        const text = await response.text();
+        const costs = [...text.matchAll(/"cost":([\d.]+)/g)].map((m) => Number(m[1]));
+        return Math.max(...costs, 0);
+      };
+
+      // The file-level mock pins loadModels to []; feed it the real aihubmix
+      // cards so getModelPricing can resolve the lookup-priced claude card.
+      const cards = aihubmixModels.map((m) => ({ ...m, providerId: 'aihubmix' }));
+      vi.mocked(loadModels).mockResolvedValue(cards as any);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      let costWithoutHook: number;
+      let costWithHook: number;
+      try {
+        costWithoutHook = await runChat(false);
+        costWithHook = await runChat(true);
+      } finally {
+        warn.mockRestore();
+        vi.mocked(loadModels).mockResolvedValue([]);
+      }
+
+      // The aihubmix claude-opus-4-6 card prices cache writes via a ttl-keyed
+      // lookup, so the 1M write tokens only bill when the hook supplies the ttl.
+      expect(costWithoutHook).toBeGreaterThan(0); // output tokens still priced
+      expect(costWithHook).toBeGreaterThan(costWithoutHook);
+    });
+
+    it('should price lookup units through the forwarded options on the Responses flow', async () => {
+      const runChat = async (withHook: boolean) => {
+        const rawEvents = [
+          {
+            response: {
+              id: 'resp_hook_e2e',
+              model: 'claude-opus-4-6',
+              status: 'in_progress',
+              usage: null,
+            },
+            sequence_number: 0,
+            type: 'response.created',
+          },
+          {
+            response: {
+              id: 'resp_hook_e2e',
+              model: 'claude-opus-4-6',
+              output: [],
+              status: 'completed',
+              usage: {
+                input_tokens: 1_000_000,
+                input_tokens_details: { cache_write_tokens: 1_000_000, cached_tokens: 0 },
+                output_tokens: 10,
+                output_tokens_details: { reasoning_tokens: 0 },
+                total_tokens: 1_000_010,
+              },
+            },
+            sequence_number: 1,
+            type: 'response.completed',
+          },
+        ] as unknown as OpenAI.Responses.ResponseStreamEvent[];
+        const rawStream = {
+          async *[Symbol.asyncIterator]() {
+            for (const event of rawEvents) yield event;
+          },
+        };
+        const create = vi.fn(() => ({
+          withResponse: vi.fn().mockResolvedValue({
+            data: rawStream,
+            request_id: 'req_hook_responses',
+            response: new Response('', { headers: {}, status: 200 }),
+          }),
+        }));
+        const Runtime = createOpenAICompatibleRuntime({
+          baseURL: 'https://api.test.com/v1',
+          chatCompletion: withHook
+            ? { getPricingOptions: () => ({ lookupParams: { ttl: '1h' } }), useResponse: true }
+            : { useResponse: true },
+          customClient: {
+            createClient: () => ({ responses: { create } }) as unknown as OpenAI,
+          },
+          provider: 'aihubmix',
+        });
+        const runtime = new Runtime({ apiKey: 'test' });
+        const response = await runtime.chat({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'claude-opus-4-6',
+          stream: true,
+        });
+        const text = await response.text();
+        const costs = [...text.matchAll(/"cost":([\d.]+)/g)].map((m) => Number(m[1]));
+        return Math.max(...costs, 0);
+      };
+
+      const cards = aihubmixModels.map((m) => ({ ...m, providerId: 'aihubmix' }));
+      vi.mocked(loadModels).mockResolvedValue(cards as any);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      let costWithoutHook: number;
+      let costWithHook: number;
+      try {
+        costWithoutHook = await runChat(false);
+        costWithHook = await runChat(true);
+      } finally {
+        warn.mockRestore();
+        vi.mocked(loadModels).mockResolvedValue([]);
+      }
+
+      expect(costWithoutHook).toBeGreaterThan(0);
+      expect(costWithHook).toBeGreaterThan(costWithoutHook);
+    });
+  });
+
   // Polyfill File for Node environment used in image tests
   if (typeof File === 'undefined') {
     // @ts-ignore

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -75,6 +75,7 @@ import type { OpenAIStreamOptions } from '../streams';
 import { OpenAIResponsesStream, OpenAIStream } from '../streams';
 import { type ChatPayloadForTransformStream, readableFromAsyncIterable } from '../streams/protocol';
 import { convertOpenAIResponseUsage, convertOpenAIUsage } from '../usageConverters/openai';
+import { type ComputeChatCostOptions } from '../usageConverters/utils/computeChatCost';
 import { createOpenAICompatibleImage } from './createImage';
 import { createOpenAICompatibleVideo, pollOpenAICompatibleVideoStatus } from './createVideo';
 import { transformResponseAPIToStream, transformResponseToStream } from './nonStreamToStream';
@@ -217,6 +218,17 @@ export interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = 
     excludeUsage?: boolean;
     forceImageBase64?: boolean;
     forceVideoBase64?: boolean;
+    /**
+     * Resolve pricing lookup options (e.g. ttl, thinkingMode) consumed by the
+     * usage cost computation for lookup-priced units. Receives the LobeHub
+     * payload and the transformed provider request (chat-completions params or
+     * Responses params). Mirrors anthropicCompatibleFactory's hook of the
+     * same name.
+     */
+    getPricingOptions?: (
+      payload: ChatStreamPayload,
+      requestPayload: unknown,
+    ) => Promise<ComputeChatCostOptions | undefined> | ComputeChatCostOptions | undefined;
     handleError?: (
       error: any,
       options: ConstructorOptions<T>,
@@ -739,17 +751,18 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           | Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;
         let providerResponseDiagnostics;
 
+        const streamPayload: ChatPayloadForTransformStream = {
+          apiMode: 'chat_completions',
+          includeUsageRequested,
+          model: payload.model,
+          pricing: await getModelPricing(payload.model, this.id, options?.pricingContext),
+          provider: this.id,
+          thoughtSignatureScope,
+        };
         const streamOptions: OpenAIStreamOptions = {
           bizErrorTypeTransformer: chatCompletion?.handleStreamBizErrorType,
           callbacks: options?.callback,
-          payload: {
-            apiMode: 'chat_completions',
-            includeUsageRequested,
-            model: payload.model,
-            pricing: await getModelPricing(payload.model, this.id, options?.pricingContext),
-            provider: this.id,
-            thoughtSignatureScope,
-          },
+          payload: streamPayload,
         };
 
         if (customClient?.createChatCompletionStream) {
@@ -771,6 +784,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             }),
           };
           const requestPayload = this.withMappedRequestModel(customRequestPayload, payload.model);
+          streamPayload.pricingOptions = await chatCompletion?.getPricingOptions?.(
+            payload,
+            requestPayload,
+          );
           providerResponseDiagnostics = initializeOpenAIDiagnostics({
             apiMode: 'chat_completions',
             diagnostics: options?.diagnostics,
@@ -802,6 +819,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             stream_options: includeUsageRequested ? { include_usage: true } : undefined,
           };
           const requestPayload = this.withMappedRequestModel(finalPayload, payload.model);
+          streamPayload.pricingOptions = await chatCompletion?.getPricingOptions?.(
+            payload,
+            requestPayload,
+          );
 
           log('sending chat completion request with %d messages', messages.length);
 
@@ -1639,6 +1660,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         response: responseWithMetadata.response,
       });
 
+      const pricingOptions = await chatCompletion?.getPricingOptions?.(payload, requestPayload);
       const streamOptions: OpenAIStreamOptions = {
         bizErrorTypeTransformer: chatCompletion?.handleStreamBizErrorType,
         callbacks: options?.callback,
@@ -1646,6 +1668,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           apiMode: 'responses',
           model: usageModel,
           pricing: await getModelPricing(usageModel, this.id, options?.pricingContext),
+          pricingOptions,
           provider: this.id,
           reasoningSignatureScope,
         },

--- a/packages/model-runtime/src/core/usageConverters/anthropic.ts
+++ b/packages/model-runtime/src/core/usageConverters/anthropic.ts
@@ -66,7 +66,13 @@ export const convertAnthropicUsage = (
     }
     case 'message_delta': {
       const usage = mergeDeltaUsage(streamContextUsage, messageEvent.usage);
-      return usage && withUsageCost(usage, payload?.pricing, payload?.pricingOptions);
+      return (
+        usage &&
+        withUsageCost(usage, payload?.pricing, payload?.pricingOptions, {
+          model: payload?.model,
+          provider: payload?.provider,
+        })
+      );
     }
     default: {
       return streamContextUsage;

--- a/packages/model-runtime/src/core/usageConverters/openai.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.test.ts
@@ -1,6 +1,6 @@
 import type { Pricing } from 'model-bank';
 import type OpenAI from 'openai';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { convertOpenAIImageUsage, convertOpenAIResponseUsage, convertOpenAIUsage } from './openai';
 
@@ -193,6 +193,66 @@ describe('convertUsage', () => {
       inputWriteCacheTokens: 200_000,
     });
     expect(mixedResult.cost).toBeCloseTo(0.78, 10);
+  });
+
+  it('should forward pricingOptions so lookup-priced units can resolve', () => {
+    const pricing: Pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 2, '5m': 1.25 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    };
+
+    const usage = {
+      prompt_tokens: 1_000_000,
+      prompt_tokens_details: {
+        cache_write_tokens: 1_000_000,
+        cached_tokens: 0,
+      },
+      completion_tokens: 0,
+      total_tokens: 1_000_000,
+    } as OpenAI.Completions.CompletionUsage;
+
+    // 1M cache-write tokens at the 1h rate. Without the forwarded options the
+    // lookup cannot resolve its key and the write unit contributes $0.
+    const result = convertOpenAIUsage(usage, {
+      pricing,
+      pricingOptions: { lookupParams: { ttl: '1h' } },
+    });
+    expect(result.cost).toBeCloseTo(2, 10);
+  });
+
+  it('should attach model and provider to pricing warnings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const pricing: Pricing = {
+      units: [
+        {
+          lookup: { prices: { '1h': 2 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    };
+    const usage = {
+      completion_tokens: 0,
+      prompt_tokens: 1_000_000,
+      prompt_tokens_details: { cache_write_tokens: 1_000_000, cached_tokens: 0 },
+      total_tokens: 1_000_000,
+    } as OpenAI.Completions.CompletionUsage;
+
+    convertOpenAIUsage(usage, { model: 'gpt-x', pricing, provider: 'test-openai' });
+
+    const serialized = String(warn.mock.calls[0][1]);
+    expect(serialized).toContain('"model":"gpt-x"');
+    expect(serialized).toContain('"provider":"test-openai"');
+    warn.mockRestore();
   });
 
   it('should preserve zero cache miss tokens for fully cached completion usage', () => {
@@ -582,6 +642,40 @@ describe('convertUsage', () => {
       totalTokens: 4796,
     });
     expect(result.cost).toBeGreaterThan(0);
+  });
+
+  it('should forward pricingOptions so lookup-priced units can resolve', () => {
+    const pricing: Pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 2, '5m': 1.25 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    };
+
+    const responseUsage = {
+      input_tokens: 1_000_000,
+      input_tokens_details: {
+        cache_write_tokens: 1_000_000,
+        cached_tokens: 0,
+      },
+      output_tokens: 0,
+      output_tokens_details: {
+        reasoning_tokens: 0,
+      },
+      total_tokens: 1_000_000,
+    } as OpenAI.Responses.ResponseUsage;
+
+    const result = convertOpenAIResponseUsage(responseUsage, {
+      pricing,
+      pricingOptions: { lookupParams: { ttl: '1h' } },
+    });
+    expect(result.cost).toBeCloseTo(2, 10);
   });
 
   it('should map GPT-5.6+ cache_write_tokens for ResponseUsage and bill cache write', () => {

--- a/packages/model-runtime/src/core/usageConverters/openai.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.ts
@@ -135,7 +135,10 @@ export const convertOpenAIUsage = (
 
   log('convertOpenAIUsage data(completion-api): %O', finalData);
 
-  return withUsageCost(finalData as ModelUsage, payload?.pricing);
+  return withUsageCost(finalData as ModelUsage, payload?.pricing, payload?.pricingOptions, {
+    model: payload?.model,
+    provider: payload?.provider,
+  });
 };
 
 export const convertOpenAIResponseUsage = (
@@ -201,7 +204,11 @@ export const convertOpenAIResponseUsage = (
 
   log('convertOpenAIResponseUsage data(response-api): %O', finalData);
 
-  return withUsageCost(finalData as ModelUsage, payload?.pricing); // Cast because we've built it to match
+  // Cast because we've built it to match
+  return withUsageCost(finalData as ModelUsage, payload?.pricing, payload?.pricingOptions, {
+    model: payload?.model,
+    provider: payload?.provider,
+  });
 };
 
 export const convertOpenAIImageUsage = (

--- a/packages/model-runtime/src/core/usageConverters/utils/withUsageCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/withUsageCost.test.ts
@@ -1,0 +1,197 @@
+import type { ModelUsage } from '@lobechat/types';
+import type { Pricing } from 'model-bank';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { withUsageCost } from './withUsageCost';
+
+const fixedPricing: Pricing = {
+  units: [
+    { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+    { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+  ],
+};
+
+const lookupPricing: Pricing = {
+  units: [
+    {
+      lookup: { prices: { '1h': 2, '5m': 1.25 }, pricingParams: ['ttl'] },
+      name: 'textInput_cacheWrite',
+      strategy: 'lookup',
+      unit: 'millionTokens',
+    },
+  ],
+};
+
+const textUsage: ModelUsage = {
+  inputCacheMissTokens: 1_000_000,
+  totalInputTokens: 1_000_000,
+  totalOutputTokens: 0,
+  totalTokens: 1_000_000,
+};
+
+const writeUsage: ModelUsage = {
+  inputWriteCacheTokens: 1_000_000,
+  totalInputTokens: 1_000_000,
+  totalTokens: 1_000_000,
+};
+
+describe('withUsageCost', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the usage untouched when pricing is absent', () => {
+    expect(withUsageCost(textUsage)).toBe(textUsage);
+  });
+
+  it('attaches the computed cost and stays silent when every unit resolves', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = withUsageCost(textUsage, fixedPricing);
+
+    expect(result.cost).toBeCloseTo(1, 10);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when pricing resolution produced issues instead of silently pricing $0', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // No options supplied, so the ttl lookup cannot resolve its key.
+    const result = withUsageCost(writeUsage, lookupPricing);
+
+    expect(result.cost).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const serialized = String(warn.mock.calls[0][1]);
+    expect(serialized).toContain('Missing lookup params');
+    expect(serialized).toContain('textInput_cacheWrite');
+  });
+
+  it('includes the caller identity in the warning payload', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const pricing: Pricing = {
+      units: [
+        {
+          lookup: { prices: { '1h': 2 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    };
+
+    withUsageCost(writeUsage, pricing, undefined, { model: 'm-1', provider: 'p-1' });
+
+    const serialized = String(warn.mock.calls[0][1]);
+    expect(serialized).toContain('"model":"m-1"');
+    expect(serialized).toContain('"provider":"p-1"');
+  });
+
+  it('warns once per pricing card for a repeating failure', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const inputLookupPricing: Pricing = {
+      units: [
+        {
+          lookup: { prices: { high: 3, low: 1 }, pricingParams: ['thinkingMode'] },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    };
+
+    withUsageCost(textUsage, inputLookupPricing);
+    withUsageCost(textUsage, inputLookupPricing);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns separately for distinct pricing cards with the same failure shape', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const makePricing = (): Pricing => ({
+      units: [
+        {
+          lookup: { prices: { high: 3, low: 1 }, pricingParams: ['thinkingMode'] },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    });
+
+    withUsageCost(textUsage, makePricing());
+    withUsageCost(textUsage, makePricing());
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-warns only the new issue when a later call adds one (A then A+B)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const twoLookupPricing: Pricing = {
+      units: [
+        {
+          lookup: { prices: { high: 3, low: 1 }, pricingParams: ['thinkingMode'] },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { high: 6, low: 2 }, pricingParams: ['thinkingMode'] },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    };
+
+    // First call only exercises the input unit (issue A)...
+    withUsageCost(
+      { inputCacheMissTokens: 1_000_000, totalInputTokens: 1_000_000 },
+      twoLookupPricing,
+    );
+    // ...the second adds output tokens (issues A+B) and must warn only about B.
+    withUsageCost(
+      {
+        inputCacheMissTokens: 1_000_000,
+        outputTextTokens: 1_000_000,
+        totalInputTokens: 1_000_000,
+        totalOutputTokens: 1_000_000,
+      },
+      twoLookupPricing,
+    );
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    const second = String(warn.mock.calls[1][1]);
+    expect(second).toContain('textOutput');
+    expect(second).not.toContain('"textInput"');
+  });
+
+  it('caps the number of distinct warnings per pricing card', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cappedPricing: Pricing = {
+      units: [
+        {
+          lookup: { prices: { '1h': 2 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    };
+
+    // Each invalid ttl value produces a distinct failure reason.
+    for (let i = 0; i < 40; i++) {
+      withUsageCost(writeUsage, cappedPricing, { lookupParams: { ttl: 'bad-' + i } });
+    }
+
+    expect(warn).toHaveBeenCalledTimes(32);
+  });
+
+  it('does not warn when the lookup resolves through options', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = withUsageCost(writeUsage, lookupPricing, { lookupParams: { ttl: '5m' } });
+
+    expect(result.cost).toBeCloseTo(1.25, 10);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/model-runtime/src/core/usageConverters/utils/withUsageCost.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/withUsageCost.ts
@@ -4,15 +4,55 @@ import type { Pricing } from 'model-bank';
 import type { ComputeChatCostOptions } from './computeChatCost';
 import { computeChatCost } from './computeChatCost';
 
+const MAX_WARNED_ISSUES_PER_PRICING = 32;
+const warnedIssuesByPricing = new WeakMap<Pricing, Set<string>>();
+
+interface UsageCostContext {
+  model?: string;
+  provider?: string;
+}
+
 export const withUsageCost = (
   usage: ModelUsage,
   pricing?: Pricing,
   options?: ComputeChatCostOptions,
+  /** Identity attached to pricing warnings so a failing card can be located. */
+  context?: UsageCostContext,
 ): ModelUsage => {
   if (!pricing) return usage;
 
   const pricingResult = computeChatCost(pricing, usage, options);
   if (!pricingResult) return usage;
+
+  if (pricingResult.issues.length > 0) {
+    // Every unit that fails to resolve contributes 0 to `totalCost`, which is
+    // indistinguishable from "free" once stored - surface the failure instead
+    // of persisting a silently understated cost (see #16991 for the data side).
+    // Warn each distinct failure once per pricing card: some cards fail
+    // structurally on every call, and repeating the warning per message would
+    // only bury it. Keyed by the pricing object so distinct cards sharing a
+    // failure shape each warn once (WeakMap entries release with the card);
+    // the per-card set is capped because failure reasons can embed
+    // caller-supplied lookup values.
+    let warned = warnedIssuesByPricing.get(pricing);
+    if (!warned) {
+      warned = new Set();
+      warnedIssuesByPricing.set(pricing, warned);
+    }
+    const capacity = MAX_WARNED_ISSUES_PER_PRICING - warned.size;
+    if (capacity > 0) {
+      const freshIssues = pricingResult.issues
+        .filter((issue) => !warned.has(issue.unit.name + ':' + issue.reason))
+        .slice(0, capacity);
+      if (freshIssues.length > 0) {
+        for (const issue of freshIssues) warned.add(issue.unit.name + ':' + issue.reason);
+        console.warn(
+          '[withUsageCost] pricing issues, cost may be understated:',
+          JSON.stringify({ context, issues: freshIssues }),
+        );
+      }
+    }
+  }
 
   return { ...usage, cost: pricingResult.totalCost };
 };


### PR DESCRIPTION
## Problem

When a model's pricing declares `strategy: 'lookup'`, the OpenAI-compatible path prices that unit at $0, silently. Two causes stack: `openaiCompatibleFactory` has no `getPricingOptions` hook — the Anthropic factory resolves lookup params per request — and both OpenAI usage converters dropped the payload's `pricingOptions` on the way into `withUsageCost`, so even a supplied value never reached pricing. `withUsageCost` then discards `computeChatCost`'s `issues[]`, so "could not price this unit" is indistinguishable from "free" and the understated total is stored as a normal-looking `cost`.

#16991 came from this mechanism (gpt-5.5/5.4/5.4-pro at $0; on my deployment 5,690 rows recorded ~$645 as $0). Still armed: model-bank carries **222 lookup-priced units across 13 provider catalogs** at this revision.

## Fix

- Add the `getPricingOptions` hook to `openaiCompatibleFactory` (same shape as the Anthropic factory's), invoked with the final provider request on all three flows — default chat, custom stream client, Responses — and forward its result through the stream payloads into the converters.
- `console.warn` in `withUsageCost`, each distinct failure once per pricing card (WeakMap keyed by the pricing object, per-card set capped at 32 because reasons can embed caller-supplied lookup values): some cards fail structurally on every call, so a per-message warning would bury itself. It carries `{ model, provider }` so the failing card can be located.

## Scope

- Card data untouched. Range-key lookups (`'[0, 0.128]'`-style, e.g. qwen) resolve only if a caller passes that literal string, which no runtime does; those cards need the #16991 treatment per provider, and the warn names each as it fails.
- No built-in provider implements the hook yet, so the shipped behaviour change is the warn. `generateObject`, embeddings and the image converter are not plumbed for `pricingOptions` either; the warn fires there too.

#### Test

`openaiCompatibleFactory/index.test.ts` +6: the hook receives the final request on all three flows, and end-to-end a ttl-lookup cache-write card prices only when the hook supplies `ttl`. `openai.test.ts` +3 and `anthropic.test.ts` +1: each converter forwards `pricingOptions`, and the warning carries model/provider. New `withUsageCost.test.ts` +9: attach, silence on a clean resolve, warn on missing params, per-card dedupe and cap, cross-card independence, A→A+B warning only about the new issue, resolution through options, caller identity in the payload.

Re-verified on this head (canary `add06349cd` merged in): the five affected `model-runtime` suites are 165/165 (Node 24.11.1 / pnpm 12.4.1), `prettier -c` and `eslint` clean, `tsgo --noEmit` 0 diagnostics on both the merge base and this head. Seven planted defects: six fail an assertion — dropping OpenAI completion `pricingOptions`, dropping its caller context, dropping Anthropic `pricingOptions`, never warning, warning every time, dropping identity from the warning — and a comment-only control survives. The seventh, removing the `capacity > 0` fast path, is behaviourally equivalent because the following `slice(0, capacity)` already bounds the set. Not exercised: a real provider request — the factory's own test doubles drive the hook.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Acceptance: No published report (no LobeHub Cloud account). Completed verification and its limits are documented under Test.

#### 🔗 Related Issue

Related to #16991 — that PR fixed the affected cards' data; this one fixes the mechanism that zeroed them.
