### PR TITLE
📌 fix(deps): pin @ant-design/icons to 6.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     ]
   },
   "overrides": {
+    "@ant-design/icons": "6.3.2",
     "@types/react": "19.2.13",
     "antd": "6.3.5",
     "baseline-browser-mapping": "2.10.31",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
   },
   "dependencies": {
     "@aiden0z/pptx-renderer": "^1.2.4",
-    "@ant-design/icons": "^6.3.2",
+    "@ant-design/icons": "6.3.2",
     "@anthropic-ai/sdk": "^0.73.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.2.0",


### PR DESCRIPTION
### What & Why

\`@ant-design/icons@6.3.3\` (published 2026-08-31 06:53 UTC) ships a new \`MetaFilled\` icon that imports \`@ant-design/icons-svg/es/asn/MetaFilled\` — a file that does not exist in the latest published \`@ant-design/icons-svg\` (4.5.0, from June). The root dependency is the caret range \`^6.3.2\`, so every fresh install since the release resolves the broken version and the SPA build dies:

```
Error: [vite]: Rolldown failed to resolve import "@ant-design/icons-svg/es/asn/MetaFilled"
from ".../@ant-design/icons/es/icons/MetaFilled.js"
```

This is currently failing **Test Web App** and **Vercel** on every PR (first observed on #18921, whose CI installed at 06:57 — four minutes after the release). Local environments with an older install still build fine, which is why it looks like a phantom failure.

Pin the override to the last good \`6.3.2\` until upstream publishes a matching \`icons-svg\`; the pin can be dropped once \`@ant-design/icons\` ships a fixed release.

#### Test

- Local build with 6.3.2 installed passes (\`bun run build:spa:raw\` exit 0); 6.3.3's \`MetaFilled.js\` import target verified missing from \`@ant-design/icons-svg@4.5.0\`.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed