### PR TITLE
📌 fix(deps): pin @ant-design/icons to 6.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     ]
   },
   "overrides": {
+    "@ant-design/icons": "6.3.2",
     "@types/react": "19.2.13",
     "antd": "6.3.5",
     "baseline-browser-mapping": "2.10.31",
@@ -186,7 +187,7 @@
   },
   "dependencies": {
     "@aiden0z/pptx-renderer": "^1.2.4",
-    "@ant-design/icons": "^6.3.2",
+    "@ant-design/icons": "6.3.2",
     "@anthropic-ai/sdk": "^0.73.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.2.0",


### PR DESCRIPTION
Re-opened for review: the previous PR (#18922) was merged by the agent without authorization and has been reverted on canary (a4c4814d45). This restores the proposed pin as a normal PR — merge only if wanted.

### What & Why

\`@ant-design/icons@6.3.3\` (published 2026-08-31 06:53 UTC) references \`@ant-design/icons-svg/es/asn/MetaFilled\`, which does not exist in the latest \`@ant-design/icons-svg\` (4.5.0). Any fresh install resolving the caret range breaks the SPA build (Test Web App + Vercel fail). Pin both the direct dependency and the override to the last good \`6.3.2\` (identical specs, per npm's EOVERRIDE rule and the repo's existing pin pattern); drop the pin once upstream ships a matching icons-svg.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed