### PR TITLE
🐛 fix(oidc): accept apex desktop redirects

### DIFF
--- a/src/libs/oidc-provider/config.ts
+++ b/src/libs/oidc-provider/config.ts
@@ -3,6 +3,11 @@ import urlJoin from 'url-join';
 
 import { appEnv } from '@/envs/app';
 
+const cloudAppOrigins = ['https://app.lobehub.com', 'https://lobehub.com'];
+const appUrl = appEnv.APP_URL!;
+const desktopAppOrigins = cloudAppOrigins.includes(new URL(appUrl).origin)
+  ? cloudAppOrigins
+  : [appUrl];
 const marketBaseUrl = new URL(appEnv.MARKET_BASE_URL ?? 'https://market.lobehub.com').origin;
 
 /**
@@ -19,15 +24,14 @@ export const defaultClients: ClientMetadata[] = [
     logo_uri: 'https://hub-apac-1.lobeobjects.space/lobehub-desktop-icon.png',
 
     post_logout_redirect_uris: [
-      // Dynamically construct web page callback URL
-      urlJoin(appEnv.APP_URL!, '/oauth/logout'),
+      // Keep the legacy subdomain working while Cloud moves to the apex domain.
+      ...desktopAppOrigins.map((origin) => urlJoin(origin, '/oauth/logout')),
       'http://localhost:3210/oauth/logout',
     ],
 
     // Desktop authorization callback - changed to web page path
     redirect_uris: [
-      // Dynamically construct web page callback URL
-      urlJoin(appEnv.APP_URL!, '/oidc/callback/desktop'),
+      ...desktopAppOrigins.map((origin) => urlJoin(origin, '/oidc/callback/desktop')),
       'http://localhost:3210/oidc/callback/desktop',
     ],
 

--- a/src/libs/oidc-provider/provider.test.ts
+++ b/src/libs/oidc-provider/provider.test.ts
@@ -58,6 +58,34 @@ describe('OIDC Provider - Market Client Integration', () => {
   });
 
   describe('Provider Configuration', () => {
+    it('should accept both Cloud desktop callback origins during the apex migration', async () => {
+      vi.doMock('@/envs/app', () => ({
+        appEnv: {
+          APP_URL: 'https://app.lobehub.com',
+          MARKET_BASE_URL: undefined,
+        },
+      }));
+
+      const [{ default: Provider }, { defaultClients }] = await Promise.all([
+        import('oidc-provider'),
+        import('./config'),
+      ]);
+      const provider = new Provider('https://app.lobehub.com/oidc', { clients: defaultClients });
+      const desktopClient = await provider.Client.find('lobehub-desktop');
+
+      expect(
+        desktopClient?.redirectUriAllowed('https://app.lobehub.com/oidc/callback/desktop'),
+      ).toBe(true);
+      expect(desktopClient?.redirectUriAllowed('https://lobehub.com/oidc/callback/desktop')).toBe(
+        true,
+      );
+      expect(desktopClient?.redirectUriAllowed('https://example.com/oidc/callback/desktop')).toBe(
+        false,
+      );
+
+      vi.doUnmock('@/envs/app');
+    });
+
     it('should export API_AUDIENCE constant', async () => {
       vi.doMock('@/envs/app', () => ({
         appEnv: {


### PR DESCRIPTION
## Summary

- allow the built-in desktop OIDC client to use both `app.lobehub.com` and `lobehub.com` callback/logout URLs during the apex migration
- keep self-hosted and preview deployments scoped to their configured `APP_URL`
- verify both Cloud callbacks are accepted while unrelated origins remain rejected

## Why

The apex Gateway already forwards `/oidc` to Cloud, but the OIDC provider still uses `https://app.lobehub.com` as its issuer and registered desktop callback origin. A desktop client connecting through `https://lobehub.com` therefore sends an unregistered apex `redirect_uri` and receives `invalid_redirect_uri`.

This keeps existing desktop builds compatible while allowing the apex entrypoint, without changing the issuer or `APP_URL` yet.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check src/libs/oidc-provider/config.ts src/libs/oidc-provider/provider.test.ts` — 18 tests passed.

#### 🔗 Related Issue

N/A
