### PR TITLE
♻️ refactor(profile-editor): replace the deprecated Dropdown with DropdownMenu

### DIFF
--- a/src/features/ProfileEditor/AgentUserTools/AgentToolsSection.tsx
+++ b/src/features/ProfileEditor/AgentUserTools/AgentToolsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { upsertPluginMode } from '@lobechat/types';
-import { Dropdown, Flexbox, Icon } from '@lobehub/ui';
+import { DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { Button, confirmModal, Text } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { CopyIcon, PlugZapIcon, PlusIcon } from 'lucide-react';
@@ -89,16 +89,11 @@ const AgentToolsSection = memo<{ agentId: string; onStartCopy: () => void }>(
           {t('settingAgent.agentTools.tabAgent')} · {agentConnectors.length}
         </Text>
         <Flexbox horizontal align={'center'} gap={8} wrap={'wrap'}>
-          <Dropdown
-            disabled={!canEdit}
-            menu={{ items: addMenuItems }}
-            placement={'bottomLeft'}
-            trigger={['click']}
-          >
+          <DropdownMenu disabled={!canEdit} items={addMenuItems} placement={'bottomLeft'}>
             <Button icon={<Icon icon={PlusIcon} />} size={'small'} type={'text'}>
               {t('settingAgent.agentTools.add')}
             </Button>
-          </Dropdown>
+          </DropdownMenu>
 
           {agentConnectors.length === 0 && (
             <Text style={{ fontSize: 12 }} type={'secondary'}>


### PR DESCRIPTION
The last `Dropdown` call site in this repo. `Dropdown` is the antd-based wrapper in `@lobehub/ui` (already `@deprecated` in its source) and is being added to the `@lobehub/ui/eslint` restricted-imports list — see lobehub/lobe-ui#631.

`DropdownMenu` takes `items` directly rather than `menu={{ items }}`, defaults to a click trigger, and resolves `nativeButton` from the trigger's displayName, so `trigger={['click']}` and the items array need no changes.

`tsc --noEmit` reports nothing for this file. Commit hooks were skipped because this was built in a detached worktree without `node_modules`; prettier and eslint were run on the file in the main checkout.

https://claude.ai/code/session_01G8ngtJ1jDUaLknvZnrKbuf