### PR TITLE
📌 fix(deps): unpin @ant-design/icons now that 6.3.4 is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     ]
   },
   "overrides": {
-    "@ant-design/icons": "6.3.2",
     "@types/react": "19.2.13",
     "antd": "6.3.5",
     "baseline-browser-mapping": "2.10.31",
@@ -187,7 +186,7 @@
   },
   "dependencies": {
     "@aiden0z/pptx-renderer": "^1.2.4",
-    "@ant-design/icons": "6.3.2",
+    "@ant-design/icons": "^6.3.4",
     "@anthropic-ai/sdk": "^0.73.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.2.0",
@@ -591,7 +590,6 @@
       "workerd"
     ],
     "overrides": {
-      "@ant-design/icons": "6.3.2",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",


### PR DESCRIPTION
### What & Why

Upstream shipped \`@ant-design/icons@6.3.4\` (2026-08-31 09:51 UTC) together with \`@ant-design/icons-svg@4.6.0\`, fixing the missing \`es/asn/MetaFilled\` that broke every fresh install on 6.3.3 and forced the temporary pin (#18923).

- Drop the \`@ant-design/icons\` entry from both \`overrides\` and \`pnpm.overrides\`.
- Float the direct dependency as \`^6.3.4\` — starting the range at the fixed release, so a lagging registry mirror can never resolve the broken 6.3.3 again.

#### Test

Fresh local install resolves 6.3.4 + icons-svg 4.6.0, \`es/asn/MetaFilled.js\` exists, and \`bun run build:spa:raw\` passes (exit 0, built in 13.6s).

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed