### PR TITLE
🐛 fix(openapi): relay Gemini parts through Responses

### DIFF
--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -706,6 +706,51 @@ describe('heterogeneous direct invocation protocol', () => {
     });
   });
 
+  it('encodes Gemini text and reasoning parts as Responses output', async () => {
+    const events = parseSseEvents(
+      await readText(
+        responsesSse(
+          protocolStream([
+            {
+              data: { content: 'thinking', inReasoning: true, partType: 'text' },
+              type: 'reasoning_part',
+            },
+            { data: { content: 'answer', partType: 'text' }, type: 'content_part' },
+            {
+              data: { content: 'base64-image', mimeType: 'image/png', partType: 'image' },
+              type: 'content_part',
+            },
+          ]),
+        ),
+      ),
+    );
+    const textDeltas = events
+      .filter(({ type }) => type === 'response.output_text.delta')
+      .map(({ data }) => data.delta);
+    const reasoningDeltas = events
+      .filter(({ type }) => type === 'response.reasoning_summary_text.delta')
+      .map(({ data }) => data.delta);
+    const completed = events.find(({ type }) => type === 'response.completed');
+
+    expect(textDeltas).toEqual(['answer']);
+    expect(reasoningDeltas).toEqual(['thinking']);
+    expect(completed?.data.response.output).toEqual([
+      {
+        id: expect.any(String),
+        status: 'completed',
+        summary: [{ text: 'thinking', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      {
+        content: [{ annotations: [], text: 'answer', type: 'output_text' }],
+        id: expect.any(String),
+        role: 'assistant',
+        status: 'completed',
+        type: 'message',
+      },
+    ]);
+  });
+
   it('encodes Responses incomplete and failed terminal lifecycle events', async () => {
     const incomplete = await readText(
       responsesSse(

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -738,8 +738,23 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
         },
         transform(event, controller) {
           if (finalized) return;
-          if (event.type === 'text' && typeof event.data === 'string' && event.data) {
-            outputText += event.data;
+          const part =
+            (event.type === 'content_part' || event.type === 'reasoning_part') &&
+            isRecord(event.data) &&
+            event.data.partType === 'text'
+              ? event.data
+              : undefined;
+          const content =
+            event.type === 'text' || event.type === 'reasoning'
+              ? typeof event.data === 'string'
+                ? event.data
+                : undefined
+              : typeof part?.content === 'string'
+                ? part.content
+                : undefined;
+          const isReasoning = event.type === 'reasoning' || event.type === 'reasoning_part';
+          if (content && !isReasoning) {
+            outputText += content;
             if (textOutputIndex === undefined) {
               textOutputIndex = nextOutputIndex++;
               controller.enqueue(
@@ -768,14 +783,14 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
             controller.enqueue(
               responseSse('response.output_text.delta', {
                 content_index: 0,
-                delta: event.data,
+                delta: content,
                 item_id: `msg_${responseId}`,
                 output_index: textOutputIndex,
                 type: 'response.output_text.delta',
               }),
             );
-          } else if (event.type === 'reasoning' && typeof event.data === 'string' && event.data) {
-            reasoningText += event.data;
+          } else if (content && isReasoning) {
+            reasoningText += content;
             if (reasoningOutputIndex === undefined) {
               reasoningItemId = event.id || `rs_${responseId}`;
               reasoningOutputIndex = nextOutputIndex++;
@@ -794,7 +809,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
             }
             controller.enqueue(
               responseSse('response.reasoning_summary_text.delta', {
-                delta: event.data,
+                delta: content,
                 item_id: reasoningItemId,
                 output_index: reasoningOutputIndex,
                 summary_index: 0,


### PR DESCRIPTION
Gemini 3 models emit textual output as `content_part` and `reasoning_part` protocol events. The heterogeneous OpenAI Responses encoder only consumed legacy `text` and `reasoning` events, so Grok Build, Pi, and TRAE received empty output and waited until timeout.

This change:

- maps textual `content_part` events to `response.output_text.delta`
- maps textual `reasoning_part` events to `response.reasoning_summary_text.delta`
- leaves non-text parts, such as generated images, out of the text response
- adds regression coverage using the actual Gemini part-event shapes

The issue was isolated by the heterogeneous-agent official-model matrix: Grok Build improved from 0/33 to 28/32 after earlier protocol fixes, while the same four Gemini models still produced empty responses across the OpenAI Responses-based agents.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check --lint --test packages/openapi/src/services/heterogeneous-direct.service.ts packages/openapi/src/services/heterogeneous-direct.service.test.ts
# ✓ 2 files · lint clean · tests 31 passed
```

Post-fix production matrix verification requires this server change to be deployed.

#### 🔗 Related Issue

Follow-up found while validating #18932.
