### PR TITLE
♻️ refactor(settings): merge font size into the Font section

### DIFF
--- a/src/features/Settings/appearance/features/Font/ChatPreview.tsx
+++ b/src/features/Settings/appearance/features/Font/ChatPreview.tsx
@@ -1,5 +1,5 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
-import { type MarkdownProps } from '@lobehub/ui';
+import type { MarkdownProps } from '@lobehub/ui';
 import { Center, Markdown } from '@lobehub/ui';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/Settings/appearance/features/Font/FontSize.tsx
+++ b/src/features/Settings/appearance/features/Font/FontSize.tsx
@@ -15,31 +15,28 @@ interface FontSizeControlProps {
 
 export const FontSizeControl = memo<FontSizeControlProps>(({ onChange, value }) => {
   const { t } = useTranslation('setting');
-  const options = useMemo(
-    () =>
-      Array.from({ length: 7 }, (_, index) => {
-        const size = index + 12;
+  const options = useMemo(() => {
+    const marks: Record<number, string> = {
+      12: 'A',
+      14: t('settingChatAppearance.fontSize.marks.normal'),
+      18: 'A',
+    };
 
-        return {
-          ariaLabel: `${size}px`,
-          label:
-            size === 12
-              ? 'A'
-              : size === 14
-                ? t('settingChatAppearance.fontSize.marks.normal')
-                : size === 18
-                  ? 'A'
-                  : ' ',
-          style: {
-            fontSize: size === 14 ? 14 : size,
-            overflowWrap: 'normal' as const,
-            whiteSpace: 'nowrap' as const,
-          },
-          value: size,
-        };
-      }),
-    [t],
-  );
+    return Array.from({ length: 7 }, (_, index) => {
+      const size = index + 12;
+
+      return {
+        ariaLabel: `${size}px`,
+        label: marks[size] ?? ' ',
+        style: {
+          fontSize: size,
+          overflowWrap: 'normal' as const,
+          whiteSpace: 'nowrap' as const,
+        },
+        value: size,
+      };
+    });
+  }, [t]);
 
   return (
     <Flexbox gap={16} width={'100%'}>

--- a/src/features/Settings/appearance/features/Font/FontSize.tsx
+++ b/src/features/Settings/appearance/features/Font/FontSize.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import DiscreteSlider from '@/components/DiscreteSlider';
+
+import ChatPreview from './ChatPreview';
+
+interface FontSizeControlProps {
+  onChange: (value: number) => void;
+  value: number;
+}
+
+export const FontSizeControl = memo<FontSizeControlProps>(({ onChange, value }) => {
+  const { t } = useTranslation('setting');
+  const options = useMemo(
+    () =>
+      Array.from({ length: 7 }, (_, index) => {
+        const size = index + 12;
+
+        return {
+          ariaLabel: `${size}px`,
+          label:
+            size === 12
+              ? 'A'
+              : size === 14
+                ? t('settingChatAppearance.fontSize.marks.normal')
+                : size === 18
+                  ? 'A'
+                  : ' ',
+          style: {
+            fontSize: size === 14 ? 14 : size,
+            overflowWrap: 'normal' as const,
+            whiteSpace: 'nowrap' as const,
+          },
+          value: size,
+        };
+      }),
+    [t],
+  );
+
+  return (
+    <Flexbox gap={16} width={'100%'}>
+      <DiscreteSlider options={options} value={value} onChange={onChange} />
+      <ChatPreview fontSize={value} />
+    </Flexbox>
+  );
+});

--- a/src/features/Settings/appearance/features/Font/index.tsx
+++ b/src/features/Settings/appearance/features/Font/index.tsx
@@ -2,7 +2,7 @@
 
 import { isDesktop } from '@lobechat/const';
 import type { FormGroupItemType } from '@lobehub/ui';
-import { Form } from '@lobehub/ui';
+import { Form, Skeleton } from '@lobehub/ui';
 import { Select } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +12,17 @@ import { FORM_STYLE } from '@/const/layoutTokens';
 import { SettingsSearchAnchor } from '@/features/SettingsSearch/anchor';
 import { useSaveState } from '@/hooks/useSaveState';
 import { useUserStore } from '@/store/user';
-import { preferenceSelectors } from '@/store/user/selectors';
+import { preferenceSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { APPLICATION_DEFAULT_FONT, useSystemFontOptions } from '../useSystemFontOptions';
+import { FontSizeControl } from './FontSize';
+
+const wrapperCol = {
+  style: {
+    maxWidth: '100%',
+    width: '100%',
+  },
+};
 
 const FontSettings = memo(() => {
   const { t } = useTranslation('setting');
@@ -22,76 +30,106 @@ const FontSettings = memo(() => {
     preferenceSelectors.fontFamily(s),
     preferenceSelectors.terminalFontFamily(s),
   ]);
+  const fontSize = useUserStore(userGeneralSettingsSelectors.fontSize);
   const updatePreference = useUserStore((s) => s.updatePreference);
+  const setSettings = useUserStore((s) => s.setSettings);
+  const isUserStateInit = useUserStore((s) => s.isUserStateInit);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
 
   const interfaceFonts = useSystemFontOptions({
     defaultLabel: t('settingAppearance.font.fontFamily.default'),
+    enabled: isDesktop,
     unavailableLabel: (font) => t('settingAppearance.font.fontFamily.unavailable', { font }),
     value: fontFamily,
   });
   const monospaceFonts = useSystemFontOptions({
     defaultLabel: t('settingAppearance.font.monospace.default'),
+    enabled: isDesktop,
     monospaceOnly: true,
     unavailableLabel: (font) => t('settingAppearance.font.monospace.unavailable', { font }),
     value: monospaceFontFamily,
   });
 
+  if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
+
   const font: FormGroupItemType = {
     children: [
+      ...(isDesktop
+        ? [
+            {
+              children: (
+                <Select
+                  showSearch
+                  aria-label={t('settingAppearance.font.fontFamily.title')}
+                  loading={interfaceFonts.isLoading}
+                  options={interfaceFonts.options}
+                  style={{ width: 320 }}
+                  value={fontFamily || APPLICATION_DEFAULT_FONT}
+                  onChange={(value: string) =>
+                    save(() =>
+                      updatePreference({
+                        fontFamily: value === APPLICATION_DEFAULT_FONT ? '' : value,
+                      }),
+                    )
+                  }
+                />
+              ),
+              desc: interfaceFonts.hasLoadError
+                ? t('settingAppearance.font.fontFamily.loadError')
+                : t('settingAppearance.font.fontFamily.desc'),
+              label: (
+                <SettingsSearchAnchor id={'appearance-font-family'}>
+                  {t('settingAppearance.font.fontFamily.title')}
+                </SettingsSearchAnchor>
+              ),
+              minWidth: undefined,
+            },
+            {
+              children: (
+                <Select
+                  showSearch
+                  aria-label={t('settingAppearance.font.monospace.title')}
+                  loading={monospaceFonts.isLoading}
+                  options={monospaceFonts.options}
+                  style={{ width: 320 }}
+                  value={monospaceFontFamily || APPLICATION_DEFAULT_FONT}
+                  onChange={(value: string) =>
+                    save(() =>
+                      updatePreference({
+                        terminalFontFamily: value === APPLICATION_DEFAULT_FONT ? '' : value,
+                      }),
+                    )
+                  }
+                />
+              ),
+              desc: monospaceFonts.hasLoadError
+                ? t('settingAppearance.font.monospace.loadError')
+                : t('settingAppearance.font.monospace.desc'),
+              label: (
+                <SettingsSearchAnchor id={'appearance-monospace-font'}>
+                  {t('settingAppearance.font.monospace.title')}
+                </SettingsSearchAnchor>
+              ),
+              minWidth: undefined,
+            },
+          ]
+        : []),
       {
         children: (
-          <Select
-            showSearch
-            aria-label={t('settingAppearance.font.fontFamily.title')}
-            loading={interfaceFonts.isLoading}
-            options={interfaceFonts.options}
-            style={{ width: 320 }}
-            value={fontFamily || APPLICATION_DEFAULT_FONT}
-            onChange={(value: string) =>
-              save(() =>
-                updatePreference({ fontFamily: value === APPLICATION_DEFAULT_FONT ? '' : value }),
-              )
-            }
+          <FontSizeControl
+            value={fontSize}
+            onChange={(value) => save(() => setSettings({ general: { fontSize: value } }))}
           />
         ),
-        desc: interfaceFonts.hasLoadError
-          ? t('settingAppearance.font.fontFamily.loadError')
-          : t('settingAppearance.font.fontFamily.desc'),
+        desc: t('settingChatAppearance.fontSize.desc'),
         label: (
-          <SettingsSearchAnchor id={'appearance-font-family'}>
-            {t('settingAppearance.font.fontFamily.title')}
+          <SettingsSearchAnchor id={'appearance-font-size'}>
+            {t('settingChatAppearance.fontSize.title')}
           </SettingsSearchAnchor>
         ),
-        minWidth: undefined,
-      },
-      {
-        children: (
-          <Select
-            showSearch
-            aria-label={t('settingAppearance.font.monospace.title')}
-            loading={monospaceFonts.isLoading}
-            options={monospaceFonts.options}
-            style={{ width: 320 }}
-            value={monospaceFontFamily || APPLICATION_DEFAULT_FONT}
-            onChange={(value: string) =>
-              save(() =>
-                updatePreference({
-                  terminalFontFamily: value === APPLICATION_DEFAULT_FONT ? '' : value,
-                }),
-              )
-            }
-          />
-        ),
-        desc: monospaceFonts.hasLoadError
-          ? t('settingAppearance.font.monospace.loadError')
-          : t('settingAppearance.font.monospace.desc'),
-        label: (
-          <SettingsSearchAnchor id={'appearance-monospace-font'}>
-            {t('settingAppearance.font.monospace.title')}
-          </SettingsSearchAnchor>
-        ),
-        minWidth: undefined,
+        layout: 'vertical',
+        minWidth: '100%',
+        wrapperCol,
       },
     ],
     extra: <AutoSaveHint lastUpdatedTime={lastSavedAt} saveStatus={saveStatus} onRetry={retry} />,
@@ -109,10 +147,4 @@ const FontSettings = memo(() => {
   );
 });
 
-const Font = () => {
-  if (!isDesktop) return null;
-
-  return <FontSettings />;
-};
-
-export default Font;
+export default FontSettings;

--- a/src/features/Settings/appearance/features/useSystemFontOptions.test.ts
+++ b/src/features/Settings/appearance/features/useSystemFontOptions.test.ts
@@ -75,4 +75,13 @@ describe('useSystemFontOptions', () => {
 
     expect(result.current.options).toEqual([{ label: 'default', value: APPLICATION_DEFAULT_FONT }]);
   });
+
+  it('does not load system fonts when disabled', () => {
+    const { result } = renderHook(() => useSystemFontOptions({ ...params, enabled: false }));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.options).toEqual([{ label: 'default', value: APPLICATION_DEFAULT_FONT }]);
+    expect(electronSystemService.getSystemFonts).not.toHaveBeenCalled();
+    expect(electronSystemService.getSystemMonospaceFonts).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/Settings/appearance/features/useSystemFontOptions.ts
+++ b/src/features/Settings/appearance/features/useSystemFontOptions.ts
@@ -7,6 +7,7 @@ export const APPLICATION_DEFAULT_FONT = '__application_default__';
 
 interface UseSystemFontOptionsParams {
   defaultLabel: string;
+  enabled?: boolean;
   monospaceOnly?: boolean;
   unavailableLabel: (font: string) => string;
   value?: string;
@@ -14,16 +15,23 @@ interface UseSystemFontOptionsParams {
 
 export const useSystemFontOptions = ({
   defaultLabel,
+  enabled = true,
   monospaceOnly,
   unavailableLabel,
   value,
 }: UseSystemFontOptionsParams) => {
   const [systemFonts, setSystemFonts] = useState<SystemFont[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(enabled);
   const [hasLoadError, setHasLoadError] = useState(false);
 
   useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+
     let active = true;
+    setIsLoading(true);
 
     const load = monospaceOnly
       ? electronSystemService.getSystemMonospaceFonts()
@@ -49,7 +57,7 @@ export const useSystemFontOptions = ({
     return () => {
       active = false;
     };
-  }, [monospaceOnly]);
+  }, [enabled, monospaceOnly]);
 
   const options = useMemo(() => {
     const fontOptions = [...systemFonts];

--- a/src/features/Settings/chat-appearance/features/ChatAppearance/index.tsx
+++ b/src/features/Settings/chat-appearance/features/ChatAppearance/index.tsx
@@ -1,19 +1,16 @@
 'use client';
 
 import { Flexbox, FormGroup, highlighterThemes, mermaidThemes, Skeleton } from '@lobehub/ui';
-import { InputNumber, Select, Switch, Tabs } from '@lobehub/ui/base-ui';
+import { Select, Switch, Tabs } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
-import { memo, useMemo, useState } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import DiscreteSlider from '@/components/DiscreteSlider';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
-import { SettingsSearchAnchor } from '@/features/SettingsSearch/anchor';
 import { useSaveState } from '@/hooks/useSaveState';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 
-import ChatPreview from './ChatPreview';
 import ChatTransitionPreview from './ChatTransitionPreview';
 import HighlighterPreview from './HighlighterPreview';
 import LinkIconPreview from './LinkIconPreview';
@@ -25,27 +22,6 @@ const ChatAppearance = memo(() => {
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
   const [savingKey, setSavingKey] = useState<string>();
-  const fontSizeOptions = useMemo(
-    () =>
-      Array.from({ length: 7 }, (_, index) => {
-        const value = index + 12;
-
-        return {
-          ariaLabel: `${value}px`,
-          label:
-            value === 12
-              ? 'A'
-              : value === 14
-                ? t('settingChatAppearance.fontSize.marks.normal')
-                : value === 18
-                  ? 'A'
-                  : ' ',
-          style: { fontSize: value === 14 ? 14 : value },
-          value,
-        };
-      }),
-    [t],
-  );
 
   if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
 
@@ -128,42 +104,6 @@ const ChatAppearance = memo(() => {
         }
       >
         <LinkIconPreview />
-      </FormGroup>
-
-      <FormGroup
-        collapsible={false}
-        gap={16}
-        variant={'filled'}
-        extra={
-          <Flexbox horizontal align={'center'} gap={8}>
-            {renderSaveHint('fontSize')}
-            <Flexbox horizontal align={'center'} gap={12} style={{ width: 240 }}>
-              <DiscreteSlider
-                options={fontSizeOptions}
-                style={{ flex: 1 }}
-                value={general.fontSize}
-                onChange={(value) => handleChange('fontSize', value)}
-              />
-              <InputNumber
-                max={18}
-                min={12}
-                step={1}
-                style={{ width: 56 }}
-                value={general.fontSize}
-                onChange={(value) => {
-                  if (value !== null) handleChange('fontSize', value);
-                }}
-              />
-            </Flexbox>
-          </Flexbox>
-        }
-        title={
-          <SettingsSearchAnchor id={'appearance-font-size'}>
-            {t('settingChatAppearance.fontSize.title')}
-          </SettingsSearchAnchor>
-        }
-      >
-        <ChatPreview fontSize={general.fontSize} />
       </FormGroup>
 
       <FormGroup

--- a/src/features/SettingsSearch/items.ts
+++ b/src/features/SettingsSearch/items.ts
@@ -326,13 +326,6 @@ export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
     tab: SettingsTabs.Appearance,
   },
   {
-    anchor: 'appearance-font-size',
-    descKey: 'settingChatAppearance.fontSize.desc',
-    keywords: ['font', 'size', 'text'],
-    labelKey: 'settingChatAppearance.fontSize.title',
-    tab: SettingsTabs.Appearance,
-  },
-  {
     anchor: 'appearance-app-tray',
     keywords: ['tray', 'menu bar', 'menubar'],
     labelKey: 'settingAppearance.appTray.title',
@@ -354,6 +347,13 @@ export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
     labelKey: 'settingAppearance.font.monospace.title',
     tab: SettingsTabs.Appearance,
     visible: (ctx) => ctx.isDesktop,
+  },
+  {
+    anchor: 'appearance-font-size',
+    descKey: 'settingChatAppearance.fontSize.desc',
+    keywords: ['font', 'size', 'text'],
+    labelKey: 'settingChatAppearance.fontSize.title',
+    tab: SettingsTabs.Appearance,
   },
   // System Tools
   {


### PR DESCRIPTION
<!-- Brief and heads-up -->

Move chat font size out of its own Chat Appearance card and into the Font section, so typeface and size live in one group.

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| Font Size was a standalone Chat Appearance card, with the slider cramped in the header extra (the "Standard" mark wrapped, and a numeric stepper clipped two-digit values). | Font Size is a row in the Font group. The slider is full-width with a live preview underneath. The numeric stepper is gone. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

How to test:

1. Open **Settings → Appearance**.
2. Confirm there is no standalone **Font Size** card under Chat Appearance.
3. Confirm **Font Size** is inside the **Font** group, with a full-width A / Standard / A slider and a message preview.
4. Drag the slider and click the marks; the preview font size updates and autosave still runs.
5. Search settings for "font size" and confirm it jumps to `#appearance-font-size`.
6. On desktop, Interface Font and Monospace Font remain in the same Font group above Font Size.

#### 🔗 Related Issue

N/A