### PR TITLE
🐛 fix(goal): point a running goal's trace key at the object that exists

### DIFF
--- a/apps/server/src/modules/GoalTracing/S3GoalTraceStore.ts
+++ b/apps/server/src/modules/GoalTracing/S3GoalTraceStore.ts
@@ -24,6 +24,14 @@ export const buildGoalTraceKey = (goalId: string): string =>
   `${TRACE_PREFIX}/${goalId}${TRAJECTORY_SUFFIX}`;
 
 /**
+ * Where an in-progress trajectory lives. A long-horizon goal is a partial for
+ * nearly all of its life, so this is the object a reader wants most of the
+ * time — the finalized key only exists once the goal is terminal.
+ */
+export const buildGoalTracePartialKey = (goalId: string): string =>
+  `${TRACE_PREFIX}/_partial/${goalId}${TRAJECTORY_SUFFIX}`;
+
+/**
  * S3-backed goal trajectories.
  *
  * One object per goal, accumulated through a partial exactly like an operation
@@ -43,7 +51,7 @@ export class S3GoalTraceStore implements IGoalTraceStore {
   }
 
   private partialKey(goalId: string): string {
-    return `${TRACE_PREFIX}/_partial/${goalId}${TRAJECTORY_SUFFIX}`;
+    return buildGoalTracePartialKey(goalId);
   }
 
   private async encode(value: unknown): Promise<Buffer> {

--- a/apps/server/src/modules/GoalTracing/index.ts
+++ b/apps/server/src/modules/GoalTracing/index.ts
@@ -1,1 +1,1 @@
-export { buildGoalTraceKey, S3GoalTraceStore } from './S3GoalTraceStore';
+export { buildGoalTraceKey, buildGoalTracePartialKey, S3GoalTraceStore } from './S3GoalTraceStore';

--- a/apps/server/src/services/goal/advanceGoal.test.ts
+++ b/apps/server/src/services/goal/advanceGoal.test.ts
@@ -201,7 +201,10 @@ describe('advanceGoal trajectory recording', () => {
         finalStatus: null,
         goalId: 'goal-1',
         ticksTotal: 1,
-        traceS3Key: 'goal-traces/goal-1.json.zst',
+        // The partial, because that is the object that exists while the goal
+        // runs. Pointing at the finalized key here made `hasTrace` a lie and
+        // had the server sign a URL that 404s until the goal was over.
+        traceS3Key: 'goal-traces/_partial/goal-1.json.zst',
         // The column name, not the rollup's. Pinned so the mapping in
         // `writeObservationRow` cannot drift silently.
         workOperations: 1,
@@ -222,6 +225,13 @@ describe('advanceGoal trajectory recording', () => {
 
     expect(state.saved).toMatchObject({ completionReason: 'achieved', totalAdvances: 1 });
     expect(state.partial).toBeUndefined();
+    // And the row follows the object: the partial is gone, so the key moves.
+    expect(mocks.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        finalStatus: 'achieved',
+        traceS3Key: 'goal-traces/goal-1.json.zst',
+      }),
+    );
   });
 
   it('leaves the trajectory open for a goal that is merely parked', async () => {

--- a/apps/server/src/services/goal/goalTraceRecorder.ts
+++ b/apps/server/src/services/goal/goalTraceRecorder.ts
@@ -12,7 +12,7 @@ import { sql } from 'drizzle-orm';
 
 import { GoalTraceModel } from '@/database/models/goalTrace';
 import type { LobeChatDatabase } from '@/database/type';
-import { buildGoalTraceKey } from '@/server/modules/GoalTracing';
+import { buildGoalTraceKey, buildGoalTracePartialKey } from '@/server/modules/GoalTracing';
 
 import type { GoalTickObservation } from './traceObservation';
 import { createDefaultGoalTraceStore } from './traceStore';
@@ -136,7 +136,13 @@ export class GoalAdvanceRecorder {
       startedAt: new Date(rollup.startedAt),
       ticksByBranch: rollup.ticksByBranch,
       ticksTotal: rollup.ticksTotal,
-      traceS3Key: buildGoalTraceKey(this.goalId),
+      // Whichever object exists *now*. Writing the finalized key from the
+      // first advance made `hasTrace` a lie for every running goal and had the
+      // server sign a URL that 404s — so a goal could not be inspected until it
+      // was over, which is the opposite of the intent.
+      traceS3Key: trajectory.completionReason
+        ? buildGoalTraceKey(this.goalId)
+        : buildGoalTracePartialKey(this.goalId),
       workOperations: rollup.operationsTotal,
       // Columns kept as shipped. The node kind is now `task`, but renaming
       // three columns on a live table buys nothing the reporting names above

--- a/packages/agent-tracing/src/goal/__tests__/loadTrajectory.test.ts
+++ b/packages/agent-tracing/src/goal/__tests__/loadTrajectory.test.ts
@@ -80,6 +80,43 @@ describe('loadGoalTrajectory', () => {
     expect(resolveDownloadUrl).toHaveBeenCalledWith('goal_missing');
   });
 
+  it('re-fetches an unfinished goal instead of serving a stale cached copy', async () => {
+    // A running goal is a moving object; a cache hit would pin the reader to
+    // whatever it looked like the first time it was inspected.
+    const cacheDir = path.join(rootDir, '.goal-tracing', '_remote');
+    await fs.mkdir(cacheDir, { recursive: true });
+    await fs.writeFile(
+      path.join(cacheDir, 'goal_running.json'),
+      JSON.stringify({ ...trajectory('goal_running'), advances: [] }),
+      'utf8',
+    );
+    const resolveDownloadUrl = vi.fn().mockResolvedValue(null);
+
+    await loadGoalTrajectory('goal_running', { allowDownload: true, resolveDownloadUrl, rootDir });
+
+    expect(resolveDownloadUrl).toHaveBeenCalledWith('goal_running');
+  });
+
+  it('serves a finished goal from cache without asking the server again', async () => {
+    const cacheDir = path.join(rootDir, '.goal-tracing', '_remote');
+    await fs.mkdir(cacheDir, { recursive: true });
+    await fs.writeFile(
+      path.join(cacheDir, 'goal_done.json'),
+      JSON.stringify({ ...trajectory('goal_done'), completionReason: 'achieved' }),
+      'utf8',
+    );
+    const resolveDownloadUrl = vi.fn();
+
+    const loaded = await loadGoalTrajectory('goal_done', {
+      allowDownload: true,
+      resolveDownloadUrl,
+      rootDir,
+    });
+
+    expect(loaded?.completionReason).toBe('achieved');
+    expect(resolveDownloadUrl).not.toHaveBeenCalled();
+  });
+
   it('reads a trajectory straight off a json path', async () => {
     const filePath = path.join(rootDir, 'exported.json');
     await fs.writeFile(filePath, JSON.stringify(trajectory('goal_3')), 'utf8');

--- a/packages/agent-tracing/src/goal/store/loadTrajectory.ts
+++ b/packages/agent-tracing/src/goal/store/loadTrajectory.ts
@@ -51,8 +51,10 @@ export async function loadGoalTrajectory(
   if (local) return local;
 
   const remote = new RemoteGoalTraceStore(rootDir);
+  // Cached copies are only written for finished goals, but an older cache may
+  // predate that rule, so an unfinished one is re-fetched rather than served.
   const cached = await remote.getCached(target);
-  if (cached) return cached;
+  if (cached?.completionReason) return cached;
 
   if (!allowDownload) return undefined;
 

--- a/packages/agent-tracing/src/goal/store/remote-store.ts
+++ b/packages/agent-tracing/src/goal/store/remote-store.ts
@@ -58,9 +58,14 @@ export class RemoteGoalTraceStore {
     const decoded = isZstdFrame(body) ? await decompressZstd(body) : body;
     const trajectory = JSON.parse(decoded.toString('utf8')) as GoalTrajectory;
 
-    await fs.mkdir(this.cacheDir, { recursive: true });
-    await fs.writeFile(this.cachePath(goalId), JSON.stringify(trajectory, null, 2), 'utf8');
-    console.error(`✓ Cached to: ${DEFAULT_DIR}/${REMOTE_DIR}/${goalId}.json`);
+    // Only a finished goal is safe to cache. A running one is a snapshot of a
+    // moving object, and caching it would pin the reader to whatever the goal
+    // happened to look like the first time it was inspected.
+    if (trajectory.completionReason) {
+      await fs.mkdir(this.cacheDir, { recursive: true });
+      await fs.writeFile(this.cachePath(goalId), JSON.stringify(trajectory, null, 2), 'utf8');
+      console.error(`✓ Cached to: ${DEFAULT_DIR}/${REMOTE_DIR}/${goalId}.json`);
+    }
 
     return trajectory;
   }


### PR DESCRIPTION
## Summary

`writeObservationRow` wrote the **finalized** S3 key on every advance, but while a goal is running only the **partial** object exists. Three consequences, all shipped in #18801:

- `hasTrace` read `yes` for every in-flight goal — a lie
- `agentTrace.getGoalTrajectoryUrl` signed a URL for an object that isn't there
- a goal could not be inspected from the server until it was over

That last one is the opposite of what the recorder was deliberately written around: *"an unfinished long-horizon goal is the normal thing to inspect, not an error."*

## How it surfaced

Only by running it. The first real production goal listed correctly and then failed to download:

```
$ lh trace goal list --server
GOAL               STATUS   TRACE  ADVANCES  TRIGGERS
goal_PrUIwfSnU9TH  running  yes    1         create=1

$ lh trace goal inspect goal_PrUIwfSnU9TH
↓ Downloading trajectory: goal_PrUIwfSnU9TH
[ERROR] Failed to fetch goal trajectory: 404 Not Found
```

Unit tests could not have caught it: they drive an in-memory store where both keys are the same map. The bug lives in the gap between what the row claims and what object storage holds.

## The fix

The key follows the object — partial while running, finalized once the goal is terminal, which is exactly when `finalizeGoalTrace` deletes the partial. Derived from `completionReason` rather than a separate flag, so the row cannot disagree with the trajectory it was built from.

The client cache had the mirror-image bug: caching an in-flight trajectory pins the reader to whatever the goal looked like the first time it was inspected. Only finished goals are cached now, and a cached partial written before this rule is re-fetched rather than served.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Regression coverage on both halves: the row asserts `goal-traces/_partial/goal-1.json.zst` while running and `goal-traces/goal-1.json.zst` after finalize (the previous assertion pinned the buggy behaviour), and `loadGoalTrajectory` asserts an unfinished cached copy is re-fetched while a finished one is served.

41 tests in `packages/agent-tracing/src/goal`, 15 in `advanceGoal`.

#### 🔗 Related Issue

Follows #18801.