### PR TITLE
🐛 fix(connector): treat zero-tool sync as legacy migration failure

### DIFF
--- a/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.test.ts
+++ b/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.test.ts
@@ -407,6 +407,7 @@ describe('executeLegacyMigrationSave', () => {
     hasExistingConnector = vi.fn(() => false);
     syncConnectorTools = vi.fn(async () => {
       calls.push('syncConnectorTools');
+      return 1;
     });
     uninstallCustomPlugin = vi.fn(async () => {
       calls.push('uninstallCustomPlugin');
@@ -534,6 +535,100 @@ describe('executeLegacyMigrationSave', () => {
     expect(calls).toEqual(['createConnector', 'deleteConnector']);
     expect(deleteConnector).toHaveBeenCalledWith('new-conn-id');
     expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+  });
+
+  describe('zero-tool sync (#18857)', () => {
+    // Regression coverage for #18857: discovery can RESOLVE with an empty tool
+    // list instead of throwing. Before the fix this was treated as a
+    // successful migration: the fresh connector was marked connected with an
+    // empty catalog, shadowed the legacy plugin (connector-first routing in
+    // `mcp.ts`), and the legacy row was uninstalled — leaving the integration
+    // permanently broken ("Tool '<name>' is not available on this connector").
+    const legacyWithTools = (id = 'my-mcp', toolNames = ['pdf_creator']): LobeToolCustomPlugin =>
+      ({
+        customParams: { mcp: { type: 'http', url: 'https://mcp.example.com' } },
+        identifier: id,
+        manifest: {
+          api: toolNames.map((name) => ({ name })),
+          meta: { title: 'PDF Creator' },
+          version: '1.0.0',
+        },
+        type: 'customPlugin',
+      }) as LobeToolCustomPlugin;
+
+    it('aborts and rolls back the created connector when sync persists zero tools', async () => {
+      syncConnectorTools.mockResolvedValueOnce(0);
+      await expect(
+        executeLegacyMigrationSave(legacyWithTools(), legacyWithTools(), {
+          createConnector,
+          deleteConnector,
+          hasExistingConnector,
+          syncConnectorTools,
+          uninstallCustomPlugin,
+        }),
+      ).rejects.toThrow(/empty list/);
+      // Same atomic rollback as a thrown sync failure: the tool-less connector
+      // is deleted and the legacy plugin is preserved so it keeps working.
+      // (`mockResolvedValueOnce` replaces the default mock, so the sync call
+      // itself is not recorded in `calls`.)
+      expect(syncConnectorTools).toHaveBeenCalledTimes(1);
+      expect(calls).toEqual(['createConnector', 'deleteConnector']);
+      expect(deleteConnector).toHaveBeenCalledWith('new-conn-id');
+      expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+    });
+
+    it('does NOT delete a pre-existing connector on zero-tool sync, but still aborts', async () => {
+      // The upsert only UPDATED the pre-existing row — deleting it would
+      // destroy a working connector (same guard as the thrown-sync path).
+      hasExistingConnector.mockReturnValue(true);
+      syncConnectorTools.mockResolvedValueOnce(0);
+      await expect(
+        executeLegacyMigrationSave(legacyWithTools(), legacyWithTools(), {
+          createConnector,
+          deleteConnector,
+          hasExistingConnector,
+          syncConnectorTools,
+          uninstallCustomPlugin,
+        }),
+      ).rejects.toThrow(/empty list/);
+      expect(deleteConnector).not.toHaveBeenCalled();
+      expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+    });
+
+    it('still aborts when the rollback delete fails after a zero-tool sync', async () => {
+      syncConnectorTools.mockResolvedValueOnce(0);
+      deleteConnector.mockRejectedValueOnce(new Error('rollback network error'));
+      await expect(
+        executeLegacyMigrationSave(legacyWithTools(), legacyWithTools(), {
+          createConnector,
+          deleteConnector,
+          hasExistingConnector,
+          syncConnectorTools,
+          uninstallCustomPlugin,
+        }),
+      ).rejects.toThrow(/empty list/);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[connector-migration] rollback after failed sync failed',
+        expect.any(Error),
+      );
+      expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+    });
+
+    it('accepts a zero-tool sync when the legacy manifest declares no tools', async () => {
+      // No manifest / empty api list → nothing to compare against; an empty
+      // catalog is not proof of a broken migration, so the flow completes.
+      syncConnectorTools.mockResolvedValueOnce(0);
+      const result = await executeLegacyMigrationSave(legacy(), legacy(), {
+        createConnector,
+        deleteConnector,
+        hasExistingConnector,
+        syncConnectorTools,
+        uninstallCustomPlugin,
+      });
+      expect(result).toEqual({ connectorId: 'new-conn-id', ok: true });
+      expect(deleteConnector).not.toHaveBeenCalled();
+      expect(uninstallCustomPlugin).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('does NOT roll back on sync failure when a connector already existed (idempotent update)', async () => {

--- a/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts
+++ b/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts
@@ -148,6 +148,12 @@ export const buildConnectorPayloadFromLegacy = (legacy: LobeToolCustomPlugin): M
  *      when no connector exists). Rolling back returns us atomically to the
  *      pre-migration state — legacy row only — so the user can retry once the
  *      endpoint is healthy (create is rebuilt from the untouched legacy shape).
+ *
+ *      A sync that RESOLVES with zero tools while the legacy manifest declares
+ *      tools is treated the same as a thrown sync failure (#18857): the remote
+ *      server answered but discovery found nothing, so completing the
+ *      migration would leave an enabled, "connected" connector with an empty
+ *      catalog that shadows — and then deletes — the working legacy plugin.
  *   4. `uninstallCustomPlugin` — best-effort. A throw is logged but swallowed;
  *      the runtime's `connectorIdentifierSet` filter in
  *      `aiAgent/index.ts:1717` dedupes by identifier (connector wins), so a
@@ -165,7 +171,8 @@ export interface MigrationSaveDeps {
    * failure path we must NOT delete a row we merely updated — only one we created.
    */
   hasExistingConnector: (identifier: string) => boolean;
-  syncConnectorTools: (id: string) => Promise<void>;
+  /** Resolves with the number of tools the sync persisted into the catalog. */
+  syncConnectorTools: (id: string) => Promise<number>;
   uninstallCustomPlugin: (id: string) => Promise<void>;
 }
 
@@ -199,8 +206,21 @@ export const executeLegacyMigrationSave = async (
 
   const newConnectorId = await deps.createConnector(payload);
 
+  // Tools the legacy manifest declares. A sync that discovers fewer than this
+  // — specifically zero — means discovery failed silently (auth rejected the
+  // tools/list call, the endpoint answered with a non-MCP payload, …), not
+  // that the server genuinely exposes nothing (#18857).
+  const expectedToolCount = legacyPlugin.manifest?.api?.length ?? 0;
+
   try {
-    await deps.syncConnectorTools(newConnectorId);
+    const syncedToolCount = await deps.syncConnectorTools(newConnectorId);
+    if (expectedToolCount > 0 && syncedToolCount === 0) {
+      throw new Error(
+        `Tool discovery returned an empty list, but the legacy plugin declares ` +
+          `${expectedToolCount} tool(s). Migration aborted — the legacy plugin was kept ` +
+          `so it keeps working; please retry once the MCP server is reachable.`,
+      );
+    }
   } catch (syncError) {
     // Endpoint unreachable / manifest fetch failed. Roll the just-created
     // connector back so we don't leave a tool-less duplicate alongside the

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -164,16 +164,25 @@ export class ConnectorActionImpl {
     await this.#refreshConnectorLists();
   };
 
-  syncConnectorTools = async (id: string): Promise<void> => {
+  /**
+   * Returns the number of tools the sync persisted. Callers that promote a
+   * legacy plugin (see `executeLegacyMigrationSave`) need the count to detect
+   * a "successful" sync that discovered zero tools (#18857).
+   */
+  syncConnectorTools = async (id: string): Promise<number> => {
     this.#set(
       (s) => ({ connectorSyncing: { ...s.connectorSyncing, [id]: true } }),
       false,
       'syncConnectorTools/start',
     );
     try {
-      const syncedLocally = await this.#syncLocalConnectorTools(id);
-      if (!syncedLocally) await lambdaClient.connector.syncTools.mutate({ id });
+      const localToolCount = await this.#syncLocalConnectorTools(id);
+      const { toolCount } =
+        localToolCount === null
+          ? await lambdaClient.connector.syncTools.mutate({ id })
+          : { toolCount: localToolCount };
       await this.#refreshConnectorLists();
+      return toolCount;
     } finally {
       this.#set(
         (s) => ({ connectorSyncing: { ...s.connectorSyncing, [id]: false } }),
@@ -192,11 +201,12 @@ export class ConnectorActionImpl {
    * Electron main process, same path Test Connection uses) and reports them
    * through `syncToolsFromClientById`.
    *
-   * Returns false when the connector is server-reachable (public HTTP) or when
-   * not running in desktop — the caller falls back to the server-side sync.
+   * Returns the synced tool count, or `null` when the connector is
+   * server-reachable (public HTTP) or when not running in desktop — the caller
+   * falls back to the server-side sync.
    */
-  #syncLocalConnectorTools = async (id: string): Promise<boolean> => {
-    if (!isDesktop) return false;
+  #syncLocalConnectorTools = async (id: string): Promise<number | null> => {
+    if (!isDesktop) return null;
 
     // `getForEdit` returns the decrypted user-set credentials (bearer/apikey/
     // header) needed to connect locally. OAuth2 tokens are machine-managed and
@@ -205,7 +215,7 @@ export class ConnectorActionImpl {
     const detail = await lambdaClient.connector.getForEdit.query({ id });
     const isStdio = detail.mcpConnectionType === 'stdio';
     const isLocalHttp = !!detail.mcpServerUrl && isLocalOrPrivateUrl(detail.mcpServerUrl);
-    if (!isStdio && !isLocalHttp) return false;
+    if (!isStdio && !isLocalHttp) return null;
 
     let api: Array<{ description?: string; name: string; parameters?: Record<string, unknown> }>;
     if (isStdio) {
@@ -241,7 +251,7 @@ export class ConnectorActionImpl {
       api = manifest.api ?? [];
     }
 
-    await lambdaClient.connector.syncToolsFromClientById.mutate({
+    const { toolCount } = await lambdaClient.connector.syncToolsFromClientById.mutate({
       id,
       tools: api.map((a) => ({
         description: a.description,
@@ -249,7 +259,7 @@ export class ConnectorActionImpl {
         toolName: a.name,
       })),
     });
-    return true;
+    return toolCount;
   };
 
   disconnectConnector = async (id: string): Promise<void> => {


### PR DESCRIPTION
## What

Legacy custom-plugin migration no longer treats a **successful sync with zero discovered tools** as a completed migration.

Per #18857: when the Connector tool-discovery step returned an empty list without throwing, the migration flow still completed — the fresh connector was marked `connected` with an empty catalog, connector-first routing in `src/services/mcp.ts` shadowed the working legacy plugin, and the legacy row was uninstalled. From then on every call to the original tool failed with `Tool '<name>' is not available on this connector`, and reinstalling repeated the same broken path.

## Root cause

`executeLegacyMigrationSave` (src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts) only rolled back when `syncConnectorTools` **threw**. `syncConnectorToolsById` (apps/server/src/services/connector/sync.ts) resolves happily with `{ toolCount: 0 }` when `listRawTools` returns `[]` — it upserts an empty list and marks the connector `connected`. Prior PRs #16172 / #17083 guarded sync *exceptions*, not the "successful sync, zero tools" case.

## Fix

- `syncConnectorTools` (store action) now returns the persisted tool count (both the server-side `connector.syncTools` path and the desktop local `syncToolsFromClientById` path).
- The migration orchestrator compares it against the legacy manifest's declared APIs (`manifest.api`). When the manifest declares ≥1 tool but the sync persisted 0, it throws — reusing the existing atomic rollback: the just-created connector is deleted (only when this migration created it), the legacy plugin is left intact, and the modal surfaces an explicit error so the user can retry once the MCP server is healthy.
- A zero-tool sync is still accepted when the legacy manifest declares no tools (nothing to compare against — an empty catalog is not proof of a broken migration).

#### Test

Regression tests added in `legacyPluginMigration.test.ts` (`zero-tool sync (#18857)` describe block). Verified they **fail before the fix** (source files stashed) and **pass after**:

```
# before fix (fix stashed, tests kept):
Tests  3 failed | 1 passed | 33 skipped (37)
# after fix:
Test Files  1 passed (1)
Tests  37 passed (37)
```

`bun run check` on the changed files:

```
✓ 3 files · lint clean · tests 37 passed
✓ types clean   (bun run check --type)
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #18857
