### PR TITLE
🐛 fix(cli): link `lh goal create` at the goal it just created

### DIFF
--- a/apps/cli/src/commands/goal.test.ts
+++ b/apps/cli/src/commands/goal.test.ts
@@ -6,6 +6,7 @@ import { registerGoalCommand } from './goal';
 const { mockClient } = vi.hoisted(() => ({
   mockClient: {
     goal: {
+      create: { mutate: vi.fn() },
       graph: { query: vi.fn() },
       tick: { mutate: vi.fn() },
     },
@@ -13,6 +14,13 @@ const { mockClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: vi.fn().mockResolvedValue(mockClient) }));
+// Building the app URL otherwise resolves a workspace and a server, which needs
+// a real login; the link's shape is what this file is asserting, not its host.
+vi.mock('./task/url', () => ({
+  resolveAppUrlBuilder: vi
+    .fn()
+    .mockResolvedValue((pathname: string) => `https://app.lobehub.com${pathname}`),
+}));
 const createProgram = () => {
   const program = new Command();
   program.exitOverride();
@@ -151,5 +159,38 @@ describe('goal show command', () => {
     });
 
     expect(await render()).toContain('task_8A1DyvjIc7PL');
+  });
+});
+
+describe('goal create command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('links to the created goal rather than to /goal/undefined', async () => {
+    // `goal.create` returns the whole graph snapshot, so the id lives on its
+    // goal. Reading `data.id` printed a link nobody could follow, and the CLI
+    // cannot resolve the router's types to catch it.
+    mockClient.goal.create.mutate.mockResolvedValue({
+      data: {
+        decisions: [],
+        edges: [],
+        events: [],
+        goal: { id: 'goal_PrUIwfSnU9TH', requirement: null, status: 'planning', title: 'Fix bugs' },
+        nodes: [],
+        workVersions: [],
+      },
+    });
+
+    await createProgram().parseAsync(['node', 'test', 'goal', 'create', 'Fix bugs']);
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map(([value]) => (value === undefined ? '' : String(value)))
+      .join('\n');
+
+    expect(output).toContain('https://app.lobehub.com/goal/goal_PrUIwfSnU9TH');
+    expect(output).not.toContain('/goal/undefined');
   });
 });

--- a/apps/cli/src/commands/goal.ts
+++ b/apps/cli/src/commands/goal.ts
@@ -122,7 +122,10 @@ export function registerGoalCommand(program: Command) {
         title,
         work: options.work,
       });
-      const url = buildUrl(`/goal/${encodeURIComponent(result.data.id)}`);
+      // `goal.create` returns the whole graph snapshot, so the id is on its
+      // goal — `result.data.id` is undefined, and the CLI cannot resolve the
+      // router's types to catch that, which is how it reached a printed URL.
+      const url = buildUrl(`/goal/${encodeURIComponent(result.data.goal.id)}`);
       if (options.json !== undefined) return outputJson({ ...result.data, url }, options.json);
       printGraph(result.data);
       console.log(`${pc.bold('goal')}: ${url}`);


### PR DESCRIPTION
## Summary

`goal.create` returns the whole graph snapshot, so the id lives on its `goal`. Reading `result.data.id` printed a link nobody could follow:

```
$ lh goal create "修复最近 3 天的 bug issue" --agent agt_...
修复最近 3 天的 bug issue goal_PrUIwfSnU9TH [planning]
...
goal: https://app.lobehub.com/goal/undefined
```

The id was right there — `printGraph(result.data)` on the very next line renders it from `graph.goal.id`.

## Same blind spot as #18912

Worth stating, because this is the second one in a week and they share a cause. The CLI cannot resolve the TRPC router's types, so `result.data` widens to `any` and reading a field that does not exist compiles clean. On top of that, `apps/cli` is outside **both** guards:

- the root `tsconfig.json` `include` covers `src`, `packages`, `tests`, `apps/server` — not `apps/cli`
- CI's `PACKAGES` matrix in `test.yml` does not list `@lobehub/cli`

So neither the type checker nor CI would have caught either bug. Closing that gap is a build-config change worth its own PR; this one just fixes the link and pins it with a test.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Drives `lh goal create` end to end against a mocked `goal.create` and asserts the printed link. Verified as a regression test: reverting to `result.data.id` fails it on `/goal/undefined`.

Note for anyone running these locally — `apps/cli` is not in the pnpm workspace, so a root `pnpm install` unlinks its `node_modules` and the suite then fails with `process.exit(1)` from the real auth path. `cd apps/cli && pnpm install` restores it.

#### 🔗 Related Issue

Follows #18912.