### PR TITLE
✨ feat(goal): plan the exploration structure before executing

### DIFF
--- a/apps/cli/src/commands/goal.ts
+++ b/apps/cli/src/commands/goal.ts
@@ -82,7 +82,11 @@ export function registerGoalCommand(program: Command) {
     .command('create <title>')
     .description('Create a standalone goal and seed its graph')
     .option('-r, --requirement <text>', 'Acceptance requirement')
-    .option('-w, --work <title...>', 'Initial work node titles')
+    .option(
+      '-i, --instruction <text>',
+      "The ask in the user's own words, shown on the problem node",
+    )
+    .option('-w, --work <title...>', 'Initial work node titles (omit to let the planner decompose)')
     .option('--agent <id>', 'Responsible agent ID')
     .option('--project <id>', 'Project ID')
     .option('--max-rounds <n>', 'Maximum goal rounds')
@@ -117,6 +121,7 @@ export function registerGoalCommand(program: Command) {
             : undefined,
         maxRounds: options.maxRounds ? Number.parseInt(options.maxRounds, 10) : undefined,
         maxTotalCost: options.maxCost ? Number.parseFloat(options.maxCost) : undefined,
+        problemDescription: options.instruction,
         projectId: options.project,
         requirement: options.requirement,
         title,

--- a/apps/server/src/routers/lambda/goal.ts
+++ b/apps/server/src/routers/lambda/goal.ts
@@ -114,6 +114,7 @@ export const goalRouter = router({
           .optional(),
         maxRounds: z.number().int().positive().optional(),
         maxTotalCost: z.number().positive().optional(),
+        problemDescription: z.string().optional(),
         projectId: z.string().optional(),
         requirement: z.string().optional(),
         title: z.string().min(1),

--- a/apps/server/src/services/goal/criteriaGenerator.ts
+++ b/apps/server/src/services/goal/criteriaGenerator.ts
@@ -3,8 +3,11 @@ import { isProgrammaticTestCheck } from '@lobechat/const/verify';
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import {
   chainGoalCriteriaDraft,
+  chainGoalDecompose,
   GOAL_CRITERIA_DRAFT_JSON_SCHEMA,
   GOAL_CRITERIA_DRAFT_PROMPT_VERSION,
+  GOAL_DECOMPOSE_JSON_SCHEMA,
+  GOAL_DECOMPOSE_PROMPT_VERSION,
   VERIFY_EVIDENCE_MODALITIES,
   VERIFY_EVIDENCE_SCOPES,
   VERIFY_EVIDENCE_TYPES,
@@ -64,6 +67,16 @@ export interface GoalPlanDraft {
   title: string;
 }
 
+const decompositionSchema = z.object({
+  problemStatement: z.string().min(1),
+  works: z
+    .array(z.object({ instruction: z.string().min(1), title: z.string().min(1).max(80) }))
+    .min(1)
+    .max(5),
+});
+
+export type GoalDecompositionDraft = z.infer<typeof decompositionSchema>;
+
 export class GoalCriteriaGeneratorService {
   constructor(
     private readonly db: LobeChatDatabase,
@@ -117,5 +130,39 @@ export class GoalCriteriaGeneratorService {
       .filter((criterion) => !isProgrammaticTestCheck(criterion.title, criterion.description));
 
     return { ...parsed.data, criteria };
+  }
+
+  /**
+   * Plan the opening exploration structure for a goal that has no work yet:
+   * the core question plus 1–5 independent directions. Returns undefined on
+   * any model/schema failure so the coordinator can fall back to a single
+   * work seeded from the raw requirement instead of stalling the goal.
+   */
+  async decompose(params: { requirement: string }): Promise<GoalDecompositionDraft | undefined> {
+    const modelConfig = await resolveGoalModelConfig(this.db, this.userId);
+    const ai = new AiGenerationService(this.db, this.userId, this.workspaceId);
+    const raw = await ai.generateObject(
+      {
+        ...chainGoalDecompose(params),
+        ...modelConfig,
+        schema: GOAL_DECOMPOSE_JSON_SCHEMA,
+        thinking: { type: 'disabled' },
+      },
+      {
+        metadata: { trigger: 'goal_decompose' },
+        tracing: {
+          promptVersion: GOAL_DECOMPOSE_PROMPT_VERSION,
+          scenario: TRACING_SCENARIOS.GoalDecompose,
+          schemaName: GOAL_DECOMPOSE_JSON_SCHEMA.name,
+        } satisfies TracingOptions,
+      },
+    );
+
+    const parsed = decompositionSchema.safeParse(raw);
+    if (!parsed.success) {
+      log('goal decomposition did not match schema: %O', parsed.error.flatten());
+      return undefined;
+    }
+    return parsed.data;
   }
 }

--- a/apps/server/src/services/goal/decideNextMove.test.ts
+++ b/apps/server/src/services/goal/decideNextMove.test.ts
@@ -202,8 +202,13 @@ describe('decideNextMove', () => {
   });
 
   describe('with no ready work', () => {
-    it('reports an empty graph and a fully blocked one differently', () => {
-      expect(decide(graph()).message).toContain('add a work node');
+    it('plans the decomposition for an empty graph, parks a fully blocked one', () => {
+      // A goal with no work has not been planned yet — that is the planner's
+      // cue, not a dead end.
+      expect(decide(graph())).toMatchObject({
+        branch: 'plan_decomposition',
+        outcome: 'advanced',
+      });
 
       const blocked = graph({
         edges: [

--- a/apps/server/src/services/goal/decideNextMove.ts
+++ b/apps/server/src/services/goal/decideNextMove.ts
@@ -180,19 +180,27 @@ const decideWithoutFrontier = (
 ): GoalMove => {
   const base = { candidates };
   const taskNodes = graph.nodes.filter((node) => node.kind === 'task');
-  const allWorkTerminal =
-    taskNodes.length > 0 && taskNodes.every((node) => TERMINAL_NODE_STATUSES.has(node.status));
+
+  // A goal with no work at all has not been planned yet — decompose it into
+  // explorable directions before anything runs, instead of parking it.
+  if (taskNodes.length === 0) {
+    return {
+      ...base,
+      branch: 'plan_decomposition',
+      message: 'Goal has no work yet; plan its exploration structure first',
+      outcome: 'advanced',
+    };
+  }
+
+  const allWorkTerminal = taskNodes.every((node) => TERMINAL_NODE_STATUSES.has(node.status));
 
   if (!allWorkTerminal) {
-    // Nothing here moves without a person: either there is no Work at all, or
-    // every remaining Work is blocked and nothing is running to unblock it.
+    // Nothing here moves without a person: every remaining Work is blocked and
+    // nothing is running to unblock it.
     return {
       ...base,
       branch: 'no_frontier',
-      message:
-        taskNodes.length === 0
-          ? 'No work frontier exists; add a work node'
-          : 'No work node is ready; resolve its dependencies first',
+      message: 'No work node is ready; resolve its dependencies first',
       outcome: 'no_progress',
     };
   }

--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -7,6 +7,7 @@ import { getTestDB } from '@/database/core/getTestDB';
 import { AcceptanceModel } from '@/database/models/acceptance';
 import { AgentOperationModel } from '@/database/models/agentOperation';
 import { GoalModel } from '@/database/models/goal';
+import { GoalGraphModel } from '@/database/models/goalGraph';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
 import {
@@ -28,6 +29,7 @@ import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime/AgentRunt
 
 import { TaskService } from '../task';
 import { TaskRunnerService } from '../taskRunner';
+import { GoalCriteriaGeneratorService } from './criteriaGenerator';
 import { GoalService } from './index';
 import type { GoalTickObservation } from './traceObservation';
 
@@ -214,12 +216,61 @@ describe('GoalService', () => {
     expect(await service.graph(graph.goal.id)).toBeDefined();
   });
 
-  it('parks a goal nothing can move so the sweep stops re-picking it', async () => {
-    // A goal with no Work can only report `no_progress`. Left `running` it is
-    // selected by every newest-first scan forever, and enough of them starve
-    // every other stalled goal out of the sweep's window.
+  it('plans the decomposition when a goal has no work yet', async () => {
+    vi.spyOn(GoalCriteriaGeneratorService.prototype, 'decompose').mockResolvedValue({
+      problemStatement: '核心问题的一句话陈述',
+      works: [
+        { instruction: '收集原始材料', title: '方向A:收集' },
+        { instruction: '分析并综合结论', title: '方向B:分析' },
+      ],
+    });
     const service = new GoalService(serverDB, userId);
-    const graph = await service.create({ title: 'Nothing to do' });
+    const graph = await service.create({
+      problemDescription: '用户的原话',
+      requirement: '完整需求与验收标准全文',
+      title: 'Complex ask',
+    });
+    // The seeded graph carries the user's own words, not the contract blob.
+    expect(graph.nodes.find((n) => n.kind === 'problem')?.description).toBe('用户的原话');
+    expect(graph.nodes.filter((n) => n.kind === 'task')).toHaveLength(0);
+
+    const result = await service.tick(graph.goal.id);
+
+    expect(result.outcome).toBe('advanced');
+    const after = await service.graph(graph.goal.id);
+    expect(after.nodes.filter((n) => n.kind === 'task').map((n) => n.title)).toEqual([
+      '方向A:收集',
+      '方向B:分析',
+    ]);
+    expect(after.nodes.find((n) => n.kind === 'problem')?.description).toBe('核心问题的一句话陈述');
+    expect(after.edges.filter((e) => e.kind === 'decomposes')).toHaveLength(2);
+  });
+
+  it('falls back to a single work when the planner fails, instead of stalling', async () => {
+    vi.spyOn(GoalCriteriaGeneratorService.prototype, 'decompose').mockRejectedValue(
+      new Error('model unavailable'),
+    );
+    const service = new GoalService(serverDB, userId);
+    const graph = await service.create({ problemDescription: '原话', title: 'Nothing to do' });
+
+    const result = await service.tick(graph.goal.id);
+
+    expect(result.outcome).toBe('advanced');
+    const tasks = (await service.graph(graph.goal.id)).nodes.filter((n) => n.kind === 'task');
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].description).toBe('原话');
+  });
+
+  it('parks a goal nothing can move so the sweep stops re-picking it', async () => {
+    // Every remaining Work is blocked and nothing runs to unblock it. Left
+    // `running` it is selected by every newest-first scan forever, and enough
+    // of them starve every other stalled goal out of the sweep's window.
+    const service = new GoalService(serverDB, userId);
+    const graph = await service.create({ title: 'Deadlocked', work: ['A', 'B'] });
+    const [a, b] = graph.nodes.filter((n) => n.kind === 'task');
+    const graphModel = new GoalGraphModel(serverDB, userId);
+    await graphModel.createEdge(graph.goal.id, a.id, b.id, 'depends_on');
+    await graphModel.createEdge(graph.goal.id, b.id, a.id, 'depends_on');
 
     const result = await service.tick(graph.goal.id);
 

--- a/apps/server/src/services/goal/index.ts
+++ b/apps/server/src/services/goal/index.ts
@@ -29,6 +29,7 @@ import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime/AgentRunt
 import { TaskService } from '../task';
 import { TaskRunnerService } from '../taskRunner';
 import { AcceptanceService } from '../verify/acceptanceService';
+import { GoalCriteriaGeneratorService } from './criteriaGenerator';
 import {
   decideNextMove,
   GOAL_ACCEPTANCE_TASK_TITLE,
@@ -64,10 +65,19 @@ export interface CreateGoalGraphInput {
   createdByAgentId?: string;
   maxRounds?: number;
   maxTotalCost?: number;
+  /**
+   * The user's ask in their own words, shown on the seeded problem node. The
+   * full `requirement` (with its acceptance boilerplate) stays on the goal row
+   * — copying it onto the node made every drill-down read like a contract.
+   */
+  problemDescription?: string;
   projectId?: string;
   requirement?: string;
   title: string;
-  /** Seed Work nodes, in dependency-free order. A plain string is title-only. */
+  /**
+   * Seed Work nodes, in dependency-free order. A plain string is title-only.
+   * When omitted, the coordinator plans the decomposition on first advance.
+   */
   work?: Array<CreateGoalWorkInput | string>;
 }
 
@@ -160,7 +170,7 @@ export class GoalService {
     try {
       const problem = await authorGraph.createNode(goal.id, {
         createdByAgentId: input.createdByAgentId,
-        description: input.requirement,
+        description: input.problemDescription ?? input.requirement,
         kind: 'problem',
         status: 'active',
         title: input.title,
@@ -411,6 +421,10 @@ export class GoalService {
 
       case 'terminal_acceptance': {
         return observe(await this.settleTerminalAcceptance(graph, move, effects));
+      }
+
+      case 'plan_decomposition': {
+        return observe(await this.planDecomposition(graph, effects));
       }
 
       case 'no_frontier': {
@@ -930,6 +944,51 @@ export class GoalService {
       .filter(Boolean)
       .join('\n\n');
 
+  /**
+   * Turn a goal with no work into an explorable structure: the LLM plans the
+   * core question plus 1–5 independent directions, each carrying only its own
+   * deliverable requirements. A planning failure degrades to one work seeded
+   * from the raw requirement — the goal must never stall on its planner.
+   */
+  private planDecomposition = async (graph: GoalGraphSnapshot, effects: GoalAdvanceEffect[]) => {
+    const goalId = graph.goal.id;
+    const problem = graph.nodes.find((node) => node.kind === 'problem');
+    const requirement = graph.goal.requirement ?? problem?.description ?? graph.goal.title;
+
+    const generator = new GoalCriteriaGeneratorService(this.db, this.userId, this.workspaceId);
+    const plan = await generator.decompose({ requirement }).catch(() => undefined);
+
+    const works = plan?.works ?? [
+      { instruction: problem?.description ?? requirement, title: graph.goal.title },
+    ];
+
+    if (plan && problem) {
+      // The node's description becomes the planner's own words for the core
+      // question — not the acceptance boilerplate the goal row keeps.
+      await this.coordinatorGraph.updateNodeDescription(goalId, problem.id, plan.problemStatement);
+    }
+
+    for (const work of works) {
+      const node = await this.coordinatorGraph.createNode(goalId, {
+        description: work.instruction,
+        kind: 'task',
+        title: work.title,
+      });
+      if (!node) continue;
+      if (problem)
+        await this.coordinatorGraph.createEdge(goalId, problem.id, node.id, 'decomposes');
+      effects.push({ nodeId: node.id, type: 'created_node', detail: work.title });
+    }
+
+    return {
+      goalId,
+      message: plan
+        ? `Planned ${works.length} exploration direction${works.length > 1 ? 's' : ''}`
+        : 'Planner unavailable; seeded a single work from the requirement',
+      outcome: 'advanced' as const,
+    };
+  };
+
   private buildTaskAcceptanceRequirement = (
     graph: GoalGraphSnapshot,
     title: string,
@@ -947,12 +1006,14 @@ export class GoalService {
         .join('\n\n');
     }
 
+    // The full goal requirement (with its numbered acceptance list) is NOT
+    // injected here: it belongs to the terminal acceptance task above, and
+    // pasting it into every Work made each task's acceptance read as the whole
+    // contract. A Work is judged on its own outcome only.
     return [
       `Verify only this Work: ${title}.`,
       description ? `Required Work outcome: ${description}` : undefined,
-      graph.goal.requirement
-        ? `Use this overall Goal requirement only to interpret requirements relevant to the current Work: ${graph.goal.requirement}`
-        : undefined,
+      `This Work is one direction of the Goal "${graph.goal.title}"; the full Goal contract is verified separately at the end.`,
       'Pass only when the current Work deliverable is complete and supported by concrete evidence. Ignore sibling and downstream Work deliverables; they are verified by their own Tasks.',
     ]
       .filter(Boolean)

--- a/apps/server/src/services/toolExecution/serverRuntimes/goal.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/goal.ts
@@ -51,9 +51,12 @@ export const goalRuntime: ServerRuntimeRegistration = {
             // passed as `maxRounds`, which counts runs across every Work in the
             // graph and would strand later tasks that have not run at all.
             maxTotalCost: args.maxTotalCost ?? undefined,
+            // No seed work: the coordinator plans the decomposition on first
+            // advance, so a complex ask becomes several explorable directions
+            // instead of one task that mirrors the whole request.
+            problemDescription: args.instruction,
             requirement: buildGoalRequirement(args.name, drafts, args.instruction),
             title: args.name,
-            work: [{ description: args.instruction, title: args.name }],
           });
           // The TRPC `goal.create` route queues this; calling the service
           // directly does not. Without it the "the server will pick it up"

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     ]
   },
   "overrides": {
-    "@ant-design/icons": "6.3.2",
     "@types/react": "19.2.13",
     "antd": "6.3.5",
     "baseline-browser-mapping": "2.10.31",
@@ -187,7 +186,7 @@
   },
   "dependencies": {
     "@aiden0z/pptx-renderer": "^1.2.4",
-    "@ant-design/icons": "6.3.2",
+    "@ant-design/icons": "^6.3.4",
     "@anthropic-ai/sdk": "^0.73.0",
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.2.0",
@@ -591,7 +590,6 @@
       "workerd"
     ],
     "overrides": {
-      "@ant-design/icons": "6.3.2",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",

--- a/packages/agent-tracing/src/goal/types.ts
+++ b/packages/agent-tracing/src/goal/types.ts
@@ -27,6 +27,8 @@ export type GoalTickBranch =
   | 'pending_decision'
   /** No work node is eligible: none exists, or all remaining ones are blocked. */
   | 'no_frontier'
+  /** The graph has no work yet — decompose the goal into explorable directions first. */
+  | 'plan_decomposition'
   /** Every work node finished; the goal-level acceptance contract is next. */
   | 'terminal_acceptance'
   /** The chosen work has no responsible task yet. */

--- a/packages/builtin-tool-goal/src/client/executor/index.ts
+++ b/packages/builtin-tool-goal/src/client/executor/index.ts
@@ -61,9 +61,11 @@ class GoalExecutor extends BaseExecutor<typeof GoalApiName> {
         // passed as `maxRounds`, which counts runs across every Work in the
         // graph and would strand later tasks that have not run at all.
         maxTotalCost: params.maxTotalCost ?? undefined,
+        // No seed work: the coordinator plans the decomposition on first
+        // advance, turning a complex ask into several explorable directions.
+        problemDescription: params.instruction,
         requirement: buildGoalRequirement(params.name, criteria, params.instruction),
         title: params.name,
-        work: [{ description: params.instruction, title: params.name }],
       });
 
       return await this.reportCreatedGoal(graph, criteria.length, params.name);

--- a/packages/const/src/llmGenerationTracing.ts
+++ b/packages/const/src/llmGenerationTracing.ts
@@ -15,6 +15,7 @@ export const TRACING_SCENARIOS = {
   ExpertiseTopicIngestion: 'expertise_topic_ingestion',
   FollowUp: 'follow_up',
   GoalCriteriaGen: 'goal_criteria_gen',
+  GoalDecompose: 'goal_decompose',
   HomeBrief: 'home_brief',
   InputCompletion: 'input_completion',
   MemoryExtract: 'memory_extract',

--- a/packages/database/src/models/goalGraph.ts
+++ b/packages/database/src/models/goalGraph.ts
@@ -320,6 +320,26 @@ export class GoalGraphModel {
       return node;
     });
 
+  /** Rewrite a node's description — e.g. the planner replacing the seeded requirement blob with its own problem statement. */
+  updateNodeDescription = async (goalId: string, nodeId: string, description: string) =>
+    this.db.transaction(async (tx) => {
+      if (!(await this.ownedGoal(goalId, tx))) return undefined;
+      const [node] = await tx
+        .update(goalNodes)
+        .set({ description, updatedAt: new Date() })
+        .where(and(eq(goalNodes.goalId, goalId), eq(goalNodes.id, nodeId)))
+        .returning();
+      if (!node) return undefined;
+      await this.appendEvent(tx, goalId, {
+        entityId: node.id,
+        entityType: 'node',
+        eventType: 'updated',
+        reason: 'Planner refined the description',
+        taskId: node.taskId ?? undefined,
+      });
+      return node;
+    });
+
   updateNodeStatus = async (
     goalId: string,
     nodeId: string,

--- a/packages/prompts/src/chains/goal.ts
+++ b/packages/prompts/src/chains/goal.ts
@@ -64,6 +64,69 @@ export const GOAL_CRITERIA_DRAFT_JSON_SCHEMA = {
   strict: true,
 };
 
+/** Bump when the goal decomposition planning prompt meaningfully changes. */
+export const GOAL_DECOMPOSE_PROMPT_VERSION = 'v1';
+
+export const GOAL_DECOMPOSE_JSON_SCHEMA = {
+  name: 'goal_decomposition',
+  schema: {
+    additionalProperties: false,
+    properties: {
+      problemStatement: { maxLength: 280, minLength: 1, type: 'string' },
+      works: {
+        items: {
+          additionalProperties: false,
+          properties: {
+            instruction: { minLength: 1, type: 'string' },
+            title: { maxLength: 80, minLength: 1, type: 'string' },
+          },
+          required: ['title', 'instruction'],
+          type: 'object',
+        },
+        maxItems: 5,
+        minItems: 1,
+        type: 'array',
+      },
+    },
+    required: ['problemStatement', 'works'],
+    type: 'object' as const,
+  },
+  strict: true,
+};
+
+interface GoalDecomposeInput {
+  requirement: string;
+}
+
+/**
+ * Plan the opening exploration structure of a goal graph: the core question it
+ * answers plus the independent work directions to pursue, before anything runs.
+ */
+export const chainGoalDecompose = ({
+  requirement,
+}: GoalDecomposeInput): {
+  messages: OpenAIChatMessage[];
+} => ({
+  messages: [
+    {
+      content: [
+        'You plan the opening exploration structure for a persistent autonomous goal.',
+        'Decompose the goal into the core question it must answer and the independent work directions that together answer it.',
+        'Guidelines:',
+        '- problemStatement is 1–2 sentences naming the core question or outcome of the goal, in your own words. Never copy the acceptance-criteria list into it.',
+        '- Return 1–5 works. A complex goal (analysis, research, multi-stage delivery) must be split into several directions that can be explored independently or in sequence — e.g. gather the raw material, analyze it from distinct angles, then synthesize. A genuinely small single-step goal may stay as one work.',
+        '- Each work.title names its direction concisely; titles must be distinct from each other and from the goal name.',
+        '- Each work.instruction is a complete, self-contained brief for an autonomous agent working on that direction only: what to do, the concrete deliverable, and how that deliverable will be judged. Include only the requirements relevant to this direction — never paste the full goal acceptance list into every work.',
+        '- Preserve every concrete URL, scope, constraint, and numeric threshold from the goal in whichever work it belongs to.',
+        '- Order works so that earlier ones produce what later ones consume.',
+        '- Write all fields in the language used by the goal.',
+      ].join('\n'),
+      role: 'system',
+    },
+    { content: `## Goal\n${requirement}`, role: 'user' },
+  ],
+});
+
 interface GoalCriteriaDraftInput {
   context?: string;
   goal: string;

--- a/src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx
+++ b/src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx
@@ -442,10 +442,12 @@ const CreateGoalContent = memo<CreateGoalContentProps>((props) => {
         // graph-wide round cap, which counts runs across every Work and would
         // strand the fourth task of a goal whose limit is three attempts.
         maxTotalCost: budget.maxTotalCost ?? undefined,
+        // No seed work: the coordinator plans the decomposition on first
+        // advance, turning a complex ask into several explorable directions.
+        problemDescription: instruction,
         projectId,
         requirement: buildGoalRequirement(title, reviewedCriteria, budget.requirement),
         title,
-        work: [{ description: instruction, title }],
       });
       // `goal.create` already queued an advance; this runs the same driver so
       // the goal is visibly moving by the time the modal closes even where the

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -62,6 +62,7 @@ const styles = createStaticStyles(({ css }) => ({
     display: flex;
     gap: 8px;
     align-items: center;
+    justify-content: flex-end;
 
     padding-block: 0 10px;
     padding-inline: 12px;
@@ -245,19 +246,6 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
         )}
         {isTask && (
           <div className={styles.metrics}>
-            {chip && (
-              <Flexbox horizontal align={'center'} gap={4} style={{ flex: 'none' }}>
-                <span className={styles.chipDot} style={{ background: chip.color }} />
-                <span className={styles.chipText} style={{ color: chip.color }}>
-                  {chip.text}
-                </span>
-              </Flexbox>
-            )}
-            {view.humanTouches.length > 0 && (
-              <Tooltip title={t('goalProcess.node.humanTouched')}>
-                <span className={styles.human}>@</span>
-              </Tooltip>
-            )}
             {/* Verifier is icon-only: with the state chip sharing this strip
                 the word no longer fits the card width, and the tooltip carries
                 the full meaning anyway. */}
@@ -295,7 +283,29 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
                 </span>
               </Tooltip>
             )}
-            {running && <RunningClock startedAt={view.startedAt} />}
+            {/* State lives on the strip's right edge (review: bottom-left felt
+                off); the clock rides along when the task is running. */}
+            <Flexbox
+              horizontal
+              align={'center'}
+              gap={10}
+              style={{ flex: 'none', marginInlineStart: 'auto' }}
+            >
+              {running && <RunningClock startedAt={view.startedAt} />}
+              {chip && (
+                <Flexbox horizontal align={'center'} gap={4} style={{ flex: 'none' }}>
+                  <span className={styles.chipDot} style={{ background: chip.color }} />
+                  <span className={styles.chipText} style={{ color: chip.color }}>
+                    {chip.text}
+                  </span>
+                </Flexbox>
+              )}
+              {view.humanTouches.length > 0 && (
+                <Tooltip title={t('goalProcess.node.humanTouched')}>
+                  <span className={styles.human}>@</span>
+                </Tooltip>
+              )}
+            </Flexbox>
           </div>
         )}
       </div>

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -58,6 +58,14 @@ const styles = createStaticStyles(({ css }) => ({
   dim: css`
     opacity: 0.45;
   `,
+  footer: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    padding-block: 0 10px;
+    padding-inline: 12px;
+  `,
   gate: css`
     border-color: ${cssVar.colorWarningBorder};
     background: ${cssVar.colorWarningBg};
@@ -210,15 +218,13 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
             <span className={styles.title}>{node.title}</span>
             {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
           </Flexbox>
-          {/* State and human participation sit inside the card, on the header's
-              trailing edge. Floating them on the card's outline collided with
-              the edges and arrowheads routed around it. */}
-          <Flexbox horizontal align={'center'} gap={6} style={{ flex: 'none' }}>
-            {view.humanTouches.length > 0 && (
-              <Tooltip title={t('goalProcess.node.humanTouched')}>
-                <span className={styles.human}>@</span>
-              </Tooltip>
-            )}
+        </div>
+        {/* State and human participation live on the card's bottom-left, so the
+            title row keeps its full width and every kind reads its status in
+            the same place. A task folds them into its metric strip; other kinds
+            get a light footer. */}
+        {!isTask && (chip || view.humanTouches.length > 0) && (
+          <div className={styles.footer}>
             {chip && (
               <Flexbox horizontal align={'center'} gap={4}>
                 <span className={styles.chipDot} style={{ background: chip.color }} />
@@ -227,10 +233,28 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
                 </span>
               </Flexbox>
             )}
-          </Flexbox>
-        </div>
+            {view.humanTouches.length > 0 && (
+              <Tooltip title={t('goalProcess.node.humanTouched')}>
+                <span className={styles.human}>@</span>
+              </Tooltip>
+            )}
+          </div>
+        )}
         {isTask && (
           <div className={styles.metrics}>
+            {chip && (
+              <Flexbox horizontal align={'center'} gap={4} style={{ flex: 'none' }}>
+                <span className={styles.chipDot} style={{ background: chip.color }} />
+                <span className={styles.chipText} style={{ color: chip.color }}>
+                  {chip.text}
+                </span>
+              </Flexbox>
+            )}
+            {view.humanTouches.length > 0 && (
+              <Tooltip title={t('goalProcess.node.humanTouched')}>
+                <span className={styles.human}>@</span>
+              </Tooltip>
+            )}
             {node.taskId ? (
               <Tooltip title={t('goalProcess.node.verifierTooltip')}>
                 <span className={styles.metric}>

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -160,7 +160,10 @@ const useStateChip = (data: GraphNodeData): { color: string; text: string } | nu
 
   if (isGate) return { color: cssVar.colorWarning, text: t('goalProcess.tag.needsDecision') };
   if (stale) return { color: cssVar.colorError, text: t('goalProcess.tag.lost') };
-  if (running) return { color: cssVar.colorInfo, text: t('goalProcess.node.running') };
+  // Same running color the whole task family uses (frontier glyphs, task
+  // rows) — a lone blue chip here read as a different state.
+  if (running)
+    return { color: TASK_STATUS_VISUALS.running.color, text: t('goalProcess.node.running') };
   if (node.kind === 'task' && node.status === 'resolved')
     return { color: cssVar.colorSuccess, text: t('goalProcess.node.done') };
   if (node.kind === 'task' && (node.status === 'retired' || node.status === 'rejected'))

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -3,11 +3,12 @@
 import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { FileBox, Repeat2, ShieldCheck } from 'lucide-react';
+import { FileBox, type LucideIcon, Repeat2, ShieldCheck } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { TASK_STATUS_VISUALS } from '@/components/ExecutionStatus';
+import RunningGlyph from '@/features/Home/components/RunningGlyph';
 
 import type { GoalNodeView } from '../goalGraphViewModel';
 import { KIND_COLOR, KIND_ICON } from '../shared';
@@ -42,12 +43,6 @@ const styles = createStaticStyles(({ css }) => ({
     transition:
       opacity 0.2s,
       border-color 0.15s;
-  `,
-  chipDot: css`
-    flex: none;
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
   `,
   chipText: css`
     font-size: 11px;
@@ -160,24 +155,49 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const useStateChip = (data: GraphNodeData): { color: string; text: string } | null => {
+interface StateChip {
+  color: string;
+  /** The task family's status glyph; running renders the animated ring instead. */
+  icon?: LucideIcon;
+  text: string;
+}
+
+const useStateChip = (data: GraphNodeData): StateChip | null => {
   const { t } = useTranslation('chat');
   const { isGate, running, stale, view } = data;
   const { node } = view;
 
-  if (isGate) return { color: cssVar.colorWarning, text: t('goalProcess.tag.needsDecision') };
-  if (stale) return { color: cssVar.colorError, text: t('goalProcess.tag.lost') };
-  // Same running color the whole task family uses (frontier glyphs, task
-  // rows) — a lone blue chip here read as a different state.
+  if (isGate)
+    return {
+      color: TASK_STATUS_VISUALS.paused.color,
+      icon: TASK_STATUS_VISUALS.paused.icon,
+      text: t('goalProcess.tag.needsDecision'),
+    };
+  if (stale)
+    return {
+      color: TASK_STATUS_VISUALS.failed.color,
+      icon: TASK_STATUS_VISUALS.failed.icon,
+      text: t('goalProcess.tag.lost'),
+    };
+  // Running renders the same animated ring the frontier and home surfaces use.
   if (running)
     return { color: TASK_STATUS_VISUALS.running.color, text: t('goalProcess.node.running') };
   if (node.kind === 'task' && node.status === 'resolved')
-    return { color: cssVar.colorSuccess, text: t('goalProcess.node.done') };
+    return {
+      color: TASK_STATUS_VISUALS.completed.color,
+      icon: TASK_STATUS_VISUALS.completed.icon,
+      text: t('goalProcess.node.done'),
+    };
   if (node.kind === 'task' && (node.status === 'retired' || node.status === 'rejected'))
-    return { color: cssVar.colorTextTertiary, text: t('goalProcess.tag.retired') };
+    return {
+      color: TASK_STATUS_VISUALS.canceled.color,
+      icon: TASK_STATUS_VISUALS.canceled.icon,
+      text: t('goalProcess.tag.retired'),
+    };
   if (node.kind === 'decision' && node.status === 'resolved')
     return {
       color: cssVar.colorTextTertiary,
+      icon: TASK_STATUS_VISUALS.completed.icon,
       text: view.humanTouches.length
         ? t('goalProcess.node.decidedByYou')
         : t('goalProcess.node.decidedByAgent'),
@@ -186,7 +206,8 @@ const useStateChip = (data: GraphNodeData): { color: string; text: string } | nu
   // so "not dispatched" no longer hides in the metric strip.
   if (node.kind === 'task')
     return {
-      color: cssVar.colorTextTertiary,
+      color: TASK_STATUS_VISUALS.backlog.color,
+      icon: TASK_STATUS_VISUALS.backlog.icon,
       text: node.taskId
         ? t(`goalProcess.nodeStatus.${node.status}` as const)
         : t('goalProcess.node.unassigned'),
@@ -235,8 +256,12 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
         {(chip || view.humanTouches.length > 0) && (
           <div className={styles.statusRow}>
             {chip && (
-              <Flexbox horizontal align={'center'} gap={4}>
-                <span className={styles.chipDot} style={{ background: chip.color }} />
+              <Flexbox horizontal align={'center'} gap={5}>
+                {chip.icon ? (
+                  <Icon color={chip.color} icon={chip.icon} size={13} />
+                ) : (
+                  <RunningGlyph size={13} />
+                )}
                 <span className={styles.chipText} style={{ color: chip.color }}>
                   {chip.text}
                 </span>

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -258,11 +258,13 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
                 <span className={styles.human}>@</span>
               </Tooltip>
             )}
+            {/* Verifier is icon-only: with the state chip sharing this strip
+                the word no longer fits the card width, and the tooltip carries
+                the full meaning anyway. */}
             {node.taskId ? (
               <Tooltip title={t('goalProcess.node.verifierTooltip')}>
                 <span className={styles.metric}>
                   <Icon icon={ShieldCheck} size={13} />
-                  {t('goalProcess.node.verifier')}
                 </span>
               </Tooltip>
             ) : (

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -58,14 +58,21 @@ const styles = createStaticStyles(({ css }) => ({
   dim: css`
     opacity: 0.45;
   `,
-  footer: css`
+  statusRow: css`
     display: flex;
-    gap: 8px;
+    gap: 10px;
     align-items: center;
-    justify-content: flex-end;
 
-    padding-block: 0 10px;
+    padding-block: 10px 0;
     padding-inline: 12px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-variant-numeric: tabular-nums;
+
+    /* The row owns the card's top padding; keep the head snug beneath it. */
+    & + div {
+      padding-block-start: 6px;
+    }
   `,
   gate: css`
     border-color: ${cssVar.colorWarningBorder};
@@ -182,7 +189,8 @@ const useStateChip = (data: GraphNodeData): { color: string; text: string } | nu
 const RunningClock = memo<{ startedAt?: Date }>(({ startedAt }) => {
   const elapsed = useElapsed(startedAt);
   if (!elapsed) return null;
-  return <span style={{ marginInlineStart: 'auto' }}>{elapsed}</span>;
+  // Sits right behind the state chip in the status row — no auto margin.
+  return <span style={{ fontSize: 11 }}>{elapsed}</span>;
 });
 
 RunningClock.displayName = 'GoalGraphRunningClock';
@@ -214,6 +222,26 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
           selected && styles.selected,
         )}
       >
+        {/* Status reads first: its own top row, left-aligned, with the running
+            clock riding right behind it (review: bottom placements read poorly). */}
+        {(chip || view.humanTouches.length > 0) && (
+          <div className={styles.statusRow}>
+            {chip && (
+              <Flexbox horizontal align={'center'} gap={4}>
+                <span className={styles.chipDot} style={{ background: chip.color }} />
+                <span className={styles.chipText} style={{ color: chip.color }}>
+                  {chip.text}
+                </span>
+              </Flexbox>
+            )}
+            {running && <RunningClock startedAt={view.startedAt} />}
+            {view.humanTouches.length > 0 && (
+              <Tooltip title={t('goalProcess.node.humanTouched')}>
+                <span className={styles.human}>@</span>
+              </Tooltip>
+            )}
+          </div>
+        )}
         <div className={styles.head}>
           <div className={styles.glyph} style={{ background: palette.soft, color: palette.line }}>
             <Icon icon={KIND_ICON[node.kind]} size={16} />
@@ -223,36 +251,13 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
             {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
           </Flexbox>
         </div>
-        {/* State and human participation live on the card's bottom-left, so the
-            title row keeps its full width and every kind reads its status in
-            the same place. A task folds them into its metric strip; other kinds
-            get a light footer. */}
-        {!isTask && (chip || view.humanTouches.length > 0) && (
-          <div className={styles.footer}>
-            {chip && (
-              <Flexbox horizontal align={'center'} gap={4}>
-                <span className={styles.chipDot} style={{ background: chip.color }} />
-                <span className={styles.chipText} style={{ color: chip.color }}>
-                  {chip.text}
-                </span>
-              </Flexbox>
-            )}
-            {view.humanTouches.length > 0 && (
-              <Tooltip title={t('goalProcess.node.humanTouched')}>
-                <span className={styles.human}>@</span>
-              </Tooltip>
-            )}
-          </div>
-        )}
         {isTask && (
           <div className={styles.metrics}>
-            {/* Verifier is icon-only: with the state chip sharing this strip
-                the word no longer fits the card width, and the tooltip carries
-                the full meaning anyway. */}
             {node.taskId ? (
               <Tooltip title={t('goalProcess.node.verifierTooltip')}>
                 <span className={styles.metric}>
                   <Icon icon={ShieldCheck} size={13} />
+                  {t('goalProcess.node.verifier')}
                 </span>
               </Tooltip>
             ) : (
@@ -283,29 +288,6 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
                 </span>
               </Tooltip>
             )}
-            {/* State lives on the strip's right edge (review: bottom-left felt
-                off); the clock rides along when the task is running. */}
-            <Flexbox
-              horizontal
-              align={'center'}
-              gap={10}
-              style={{ flex: 'none', marginInlineStart: 'auto' }}
-            >
-              {running && <RunningClock startedAt={view.startedAt} />}
-              {chip && (
-                <Flexbox horizontal align={'center'} gap={4} style={{ flex: 'none' }}>
-                  <span className={styles.chipDot} style={{ background: chip.color }} />
-                  <span className={styles.chipText} style={{ color: chip.color }}>
-                    {chip.text}
-                  </span>
-                </Flexbox>
-              )}
-              {view.humanTouches.length > 0 && (
-                <Tooltip title={t('goalProcess.node.humanTouched')}>
-                  <span className={styles.human}>@</span>
-                </Tooltip>
-              )}
-            </Flexbox>
           </div>
         )}
       </div>

--- a/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/GraphNode.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
-import { Text } from '@lobehub/ui/base-ui';
 import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { FileBox, Repeat2, ShieldCheck } from 'lucide-react';
@@ -183,6 +182,15 @@ const useStateChip = (data: GraphNodeData): { color: string; text: string } | nu
         ? t('goalProcess.node.decidedByYou')
         : t('goalProcess.node.decidedByAgent'),
     };
+  // Every task reads its state in the same top row — a queued one included,
+  // so "not dispatched" no longer hides in the metric strip.
+  if (node.kind === 'task')
+    return {
+      color: cssVar.colorTextTertiary,
+      text: node.taskId
+        ? t(`goalProcess.nodeStatus.${node.status}` as const)
+        : t('goalProcess.node.unassigned'),
+    };
   return null;
 };
 
@@ -253,24 +261,15 @@ const GraphNodeView = memo<NodeProps>(({ data }) => {
         </div>
         {isTask && (
           <div className={styles.metrics}>
-            {node.taskId ? (
+            {/* "Not dispatched" moved to the status row with every other
+                state; an unassigned task simply has no verifier metric yet. */}
+            {node.taskId && (
               <Tooltip title={t('goalProcess.node.verifierTooltip')}>
                 <span className={styles.metric}>
                   <Icon icon={ShieldCheck} size={13} />
                   {t('goalProcess.node.verifier')}
                 </span>
               </Tooltip>
-            ) : (
-              <span className={styles.metric}>
-                <Icon
-                  color={TASK_STATUS_VISUALS.backlog.color}
-                  icon={TASK_STATUS_VISUALS.backlog.icon}
-                  size={13}
-                />
-                <Text fontSize={11} type={'secondary'}>
-                  {t('goalProcess.node.unassigned')}
-                </Text>
-              </span>
             )}
             <Tooltip title={t('goalProcess.node.attemptsTooltip', { count: attempts })}>
               <span className={styles.metric}>

--- a/src/features/AgentGoals/ProcessControl/Graph/index.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/index.tsx
@@ -205,6 +205,18 @@ const Canvas = memo<GraphProps & { className: string; interactive: boolean; view
       return layoutGraph(nodes, edges);
     }, [graph, visibleIds]);
 
+    // Inline, the canvas hugs its content: a two-node graph in a fixed 560px
+    // frame is mostly empty margin, and `fitView` then shrinks the nodes to
+    // fill it. Sizing the frame from the layout keeps small graphs at natural
+    // node scale; 560px stays the ceiling so large graphs still zoom out.
+    const inlineHeight = useMemo(() => {
+      const boxes = Object.values(positions);
+      if (boxes.length === 0) return 216;
+      const top = Math.min(...boxes.map((box) => box.y));
+      const bottom = Math.max(...boxes.map((box) => box.y + box.height));
+      return Math.min(560, Math.max(216, bottom - top + 72));
+    }, [positions]);
+
     const flowNodes: FlowNode[] = useMemo(
       () =>
         graph.nodes
@@ -269,7 +281,7 @@ const Canvas = memo<GraphProps & { className: string; interactive: boolean; view
     }, [view, flowNodes.length, fitView]);
 
     return (
-      <div className={className}>
+      <div className={className} style={interactive ? undefined : { height: inlineHeight }}>
         {/* Inline, the map is a picture: it settles on `fitView` and stays
             there. Panning or zooming it inside a scrolling page moves the graph
             under the cursor while the page moves too, and leaves no way back to

--- a/src/services/goal.ts
+++ b/src/services/goal.ts
@@ -27,6 +27,8 @@ class GoalService {
     createdByAgentId?: string;
     maxRounds?: number;
     maxTotalCost?: number;
+    /** The user's ask in their own words — shown on the seeded problem node. */
+    problemDescription?: string;
     projectId?: string;
     requirement?: string;
     title: string;


### PR DESCRIPTION
### What & Why

Field feedback from the first live goal run on the new detail page surfaced five problems; the three structural ones share one root cause — goal creation was a mechanical copy of the raw ask into one problem + one task, with no planning step at all.

**Behavior (root cause):**

- **No decomposition before execution.** Creating a goal seeded exactly one problem node + one task mirroring the whole request and dispatched it immediately. A complex ask (e.g. "analyze 300 issues and rank pain points / product directions") ran as a single monolithic task. Now a goal starts with only its problem node; the coordinator's new \`plan_decomposition\` branch runs an LLM planning step on first advance (\`chainGoalDecompose\`, traced as \`goal_decompose\`) that produces the core problem statement plus 1–5 independent work directions, each with a self-contained brief. Planner failure degrades to the old single-work shape so a goal never stalls on its planner.
- **The question node carried the whole acceptance contract.** \`problem.description\` was the full requirement, numbered "Acceptance criteria — every one must be satisfied…" block included. Callers now pass the user's own words (\`problemDescription\`), and the planner replaces it with its 1–2 sentence problem statement.
- **Each task's acceptance objective embedded the entire goal requirement again** ("Use this overall Goal requirement only to interpret…"). Dropped: a Work is judged on its own outcome; the complete contract remains with the terminal acceptance task, which is the one place it belongs.

**Exploration map polish:**

- The inline canvas was a fixed 560px frame — a two-node graph rendered as a tiny cluster adrift in padding because \`fitView\` shrinks nodes to fill the frame. The frame now sizes to the layout bounds (560px stays the ceiling for large graphs), so small graphs render at natural node scale.
- The state chip (「进行中」 etc.) and the @ human marker move from the title row's top-right to the card's bottom-left — a task folds them into its metric strip, other kinds get a light footer, and titles keep their full width.

| Before | After |
| ------ | ----- |
| 1 problem + 1 mirror task, instant dispatch; contract text pasted into every node and every task's acceptance; giant empty graph frame; chip crowding the title | Planned multi-direction exploration on first advance; nodes carry their own words; per-Work acceptance only; content-sized map with bottom-left status |

#### Test

- \`plan_decomposition\` decision + planned/fallback execution paths covered in \`decideNextMove.test.ts\` / \`index.test.ts\` (planner mocked; fallback seeds one work from the requirement; deadlocked-graph parking retained via an explicit blocked fixture).
- Full working-tree check: 66 tests passed, lint + type-check clean.

- [x] Tested locally
- [x] Added/updated tests