### PR TITLE
🐛 fix(agent): propagate tool completion success to hooks

### DIFF
--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -9,6 +9,15 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { createGatewayEventHandler } from './gatewayEventHandler';
 
+const executorMocks = vi.hoisted(() => ({
+  onAfterCall: vi.fn(),
+}));
+
+vi.mock('@/store/tool/slices/builtin/executors', () => ({
+  getExecutor: vi.fn(() => ({ onAfterCall: executorMocks.onAfterCall })),
+  registerBuiltinToolExecutors: vi.fn(),
+}));
+
 const context = {
   agentId: 'agent-1',
   topicId: 'topic-1',
@@ -52,7 +61,56 @@ const flush = async () => {
 describe('createGatewayEventHandler', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    executorMocks.onAfterCall.mockReset();
     vi.spyOn(agentSignalBridge, 'emitClientAgentSignalSourceEvent').mockResolvedValue(undefined);
+  });
+
+  it('normalizes tool_end isSuccess for Codex worktree side-effect hooks', async () => {
+    vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'seed-msg',
+      context,
+      operationId: 'op-1',
+      runtimeType: 'hetero',
+    });
+
+    handler(
+      makeEvent('tool_end', {
+        isSuccess: true,
+        payload: {
+          toolCalling: {
+            apiName: 'command_execution',
+            arguments: JSON.stringify({
+              command:
+                'git worktree add -b feat/device-reconnect-button /repo-wt-device-reconnect abc123',
+            }),
+            id: 'command-1',
+            identifier: 'codex',
+            type: 'default',
+          },
+        },
+        result: { content: 'Preparing worktree (new branch feat/device-reconnect-button)' },
+        skipMessageFetch: true,
+        toolCallId: 'command-1',
+      } as any),
+    );
+    await flush();
+
+    expect(executorMocks.onAfterCall).toHaveBeenCalledWith({
+      apiName: 'command_execution',
+      identifier: 'codex',
+      params: {
+        command:
+          'git worktree add -b feat/device-reconnect-button /repo-wt-device-reconnect abc123',
+      },
+      result: {
+        content: 'Preparing worktree (new branch feat/device-reconnect-button)',
+        success: true,
+      },
+      toolCallId: 'command-1',
+      topicId: 'topic-1',
+    });
   });
 
   it('inserts the assistant shell locally when stream_start carries the message seed (new server)', async () => {

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -230,9 +230,15 @@ const dispatchOnAfterCall = async (
   const executor = getExecutor(identity.identifier);
   if (!executor?.onAfterCall) return;
 
+  const result = (data?.result ?? {}) as BuiltinToolResult;
+
   await executor.onAfterCall({
     ...identity,
-    result: (data?.result ?? {}) as BuiltinToolResult,
+    // Gateway/hetero tool_end events carry the terminal outcome beside
+    // `result`, while client-tool results already include `result.success`.
+    // Normalize both shapes so hook-only heterogeneous executors do not treat
+    // a successful shell command as failed and skip git/worktree side effects.
+    result: { ...result, success: result.success ?? data?.isSuccess },
     topicId,
   });
 };


### PR DESCRIPTION
Normalize the gateway-level `tool_end.isSuccess` flag into `result.success` before dispatching executor `onAfterCall` hooks. Without this, successful heterogeneous CLI shell commands were treated as failed, so Codex `git worktree add` side effects did not update the topic's active worktree metadata.

Adds a regression test covering the real Codex `command_execution` event shape and full `git worktree add -b <branch> <path> <sha>` command.

| Before | After |
| ------ | ----- |
| Successful Codex worktree commands skipped the side-effect hook | Successful commands propagate completion state and update worktree metadata |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts`

Result: lint clean, 28 tests passed.