### PR TITLE
🐛 fix: preserve group history when transferring agents across scopes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Packages
     env:
-      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
+      PACKAGES: '@lobechat/business-server @lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
 
     steps:
       - name: Checkout

--- a/apps/server/src/routers/lambda/agent.ts
+++ b/apps/server/src/routers/lambda/agent.ts
@@ -1159,8 +1159,11 @@ export const agentRouter = router({
       }
 
       // Heavy history goes through an async backfill — kick the driver now
-      // that the transfer transaction has committed.
+      // that the transfer transaction has committed. Deferred group-history
+      // remaps are their own jobs and need the same kick, or they stay
+      // pending and keep the moved agent's delete/re-transfer guards up.
       if (result.transferJobId) startAgentTransferJob(ctx.serverDB, result.transferJobId);
+      for (const remapJobId of result.remapJobIds) startAgentTransferJob(ctx.serverDB, remapJobId);
 
       if (ctx.workspaceId) {
         await new ResourcePermissionModel(ctx.serverDB, ctx.workspaceId).removeAll(
@@ -1333,9 +1336,12 @@ export const agentRouter = router({
         throw error;
       }
 
-      // The whole batch shares one backfill job; kick it post-commit.
+      // The whole batch shares one backfill job (and one deferred-remap job
+      // list); kick them post-commit.
       const batchTransferJobId = results[0]?.transferJobId;
       if (batchTransferJobId) startAgentTransferJob(ctx.serverDB, batchTransferJobId);
+      for (const remapJobId of results[0]?.remapJobIds ?? [])
+        startAgentTransferJob(ctx.serverDB, remapJobId);
 
       if (ctx.workspaceId) {
         const sourcePermissionModel = new ResourcePermissionModel(ctx.serverDB, ctx.workspaceId);

--- a/packages/business-server/package.json
+++ b/packages/business-server/package.json
@@ -5,11 +5,18 @@
   "exports": {
     "./*": "./src/*.ts"
   },
+  "scripts": {
+    "test": "vitest",
+    "test:coverage": "vitest --coverage --silent='passed-only'"
+  },
   "dependencies": {
     "@lobechat/agent-gateway-client": "workspace:*",
     "@lobechat/database": "workspace:*",
     "@lobechat/model-runtime": "workspace:*",
     "@lobechat/trpc": "workspace:*",
     "@lobechat/types": "workspace:*"
+  },
+  "devDependencies": {
+    "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/packages/business-server/src/agent-transfer/jobRunner.test.ts
+++ b/packages/business-server/src/agent-transfer/jobRunner.test.ts
@@ -78,6 +78,27 @@ describe('startAgentTransferJob scheduling', () => {
     expect(started).toEqual(['j1', 'j2', 'j3', 'queued']);
   });
 
+  it('promotes a queued job to the front when a user prioritizes it', async () => {
+    const { startAgentTransferJob } = await loadRunner();
+
+    for (const id of ['j1', 'j2', 'j3', 'q1', 'q2']) startAgentTransferJob(db, id);
+    expect(started).toEqual(['j1', 'j2', 'j3']);
+
+    // A user opened a topic of q2 — it must jump ahead of q1, and the
+    // duplicate suppression must still hold (one drain, not two).
+    startAgentTransferJob(db, 'q2', { promote: true });
+
+    await settle('j1', 'ok');
+    expect(started).toEqual(['j1', 'j2', 'j3', 'q2']);
+
+    await settle('j2', 'ok');
+    expect(started).toEqual(['j1', 'j2', 'j3', 'q2', 'q1']);
+
+    await settle('j3', 'ok');
+    await settle('q1', 'ok');
+    await settle('q2', 'ok');
+  });
+
   it('releases a failing drain’s slot immediately and requeues it after the delay', async () => {
     const { startAgentTransferJob } = await loadRunner();
 

--- a/packages/business-server/src/agent-transfer/jobRunner.test.ts
+++ b/packages/business-server/src/agent-transfer/jobRunner.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Controller = { reject: (error: Error) => void; resolve: () => void };
+
+/** One controller per in-flight drain, FIFO per job id. */
+const controllers = new Map<string, Controller[]>();
+const started: string[] = [];
+
+vi.mock('@lobechat/database', () => ({
+  AgentTransferJobModel: {},
+  drainAgentHistoryJob: (_db: unknown, jobId: string) => {
+    started.push(jobId);
+    return new Promise<void>((resolve, reject) => {
+      const list = controllers.get(jobId) ?? [];
+      list.push({ reject, resolve });
+      controllers.set(jobId, list);
+    });
+  },
+}));
+
+const db = {} as never;
+
+/** Fresh module per test — the runner keeps its queue in module state. */
+const loadRunner = async () => {
+  vi.resetModules();
+  return import('./jobRunner');
+};
+
+const settle = async (jobId: string, outcome: 'ok' | 'fail') => {
+  const controller = controllers.get(jobId)?.shift();
+  if (!controller) throw new Error(`no active drain for ${jobId}`);
+  if (outcome === 'ok') controller.resolve();
+  else controller.reject(new Error('boom'));
+  // Flush the runner's continuation without advancing the retry delay.
+  await vi.advanceTimersByTimeAsync(0);
+};
+
+beforeEach(() => {
+  controllers.clear();
+  started.length = 0;
+  vi.useFakeTimers();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('startAgentTransferJob scheduling', () => {
+  it('caps concurrent drains and starts queued jobs as slots free up', async () => {
+    const { startAgentTransferJob } = await loadRunner();
+
+    for (const id of ['j1', 'j2', 'j3', 'j4', 'j5']) startAgentTransferJob(db, id);
+    // Only the cap's worth of drains actually run; the rest wait in FIFO.
+    expect(started).toEqual(['j1', 'j2', 'j3']);
+
+    await settle('j1', 'ok');
+    expect(started).toEqual(['j1', 'j2', 'j3', 'j4']);
+
+    await settle('j2', 'ok');
+    expect(started).toEqual(['j1', 'j2', 'j3', 'j4', 'j5']);
+  });
+
+  it('deduplicates repeated starts for active AND queued jobs', async () => {
+    const { startAgentTransferJob } = await loadRunner();
+
+    for (const id of ['j1', 'j2', 'j3', 'queued']) startAgentTransferJob(db, id);
+    // Re-starting an actively draining job and a still-queued one must both no-op.
+    startAgentTransferJob(db, 'j1');
+    startAgentTransferJob(db, 'queued');
+
+    await settle('j1', 'ok');
+    await settle('j2', 'ok');
+    await settle('j3', 'ok');
+    await settle('queued', 'ok');
+    expect(started).toEqual(['j1', 'j2', 'j3', 'queued']);
+  });
+
+  it('releases a failing drain’s slot immediately and requeues it after the delay', async () => {
+    const { startAgentTransferJob } = await loadRunner();
+
+    for (const id of ['a', 'b', 'c', 'd']) startAgentTransferJob(db, id);
+    expect(started).toEqual(['a', 'b', 'c']);
+
+    // The failure frees the slot at once — 'd' starts without waiting for the
+    // retry delay, so persistent failures can never pin every slot.
+    await settle('a', 'fail');
+    expect(started).toEqual(['a', 'b', 'c', 'd']);
+
+    // While the failed job waits out its delay it stays deduped.
+    startAgentTransferJob(db, 'a');
+    await vi.advanceTimersByTimeAsync(5000);
+    // Requeued behind a full house: it must wait for a slot, not preempt one.
+    expect(started.filter((id) => id === 'a')).toHaveLength(1);
+
+    await settle('b', 'ok');
+    expect(started.filter((id) => id === 'a')).toHaveLength(2);
+
+    await settle('a', 'ok');
+    await settle('c', 'ok');
+    await settle('d', 'ok');
+    expect(started).toEqual(['a', 'b', 'c', 'd', 'a']);
+  });
+});

--- a/packages/business-server/src/agent-transfer/jobRunner.ts
+++ b/packages/business-server/src/agent-transfer/jobRunner.ts
@@ -25,7 +25,19 @@ import {
 
 const RETRY_DELAY_MS = 5000;
 
+/**
+ * Global drain-concurrency bound. A single call site can hand this runner a
+ * burst of jobs — one deferred group-history remap per group, or every
+ * pending job at boot — and each drain is a loop of index-heavy message
+ * UPDATE transactions; running them all at once would saturate PostgreSQL.
+ * Jobs beyond the bound wait in FIFO order and start as slots free up.
+ */
+const MAX_CONCURRENT_DRAINS = 3;
+
+/** Every job this runner owns right now: actively draining OR queued. */
 const running = new Set<string>();
+const waiting: { db: LobeChatDatabase; jobId: string }[] = [];
+let activeDrains = 0;
 
 const drainWithRetry = async (db: LobeChatDatabase, jobId: string): Promise<void> => {
   try {
@@ -40,13 +52,23 @@ const drainWithRetry = async (db: LobeChatDatabase, jobId: string): Promise<void
   }
 };
 
+const pumpDrains = (): void => {
+  while (activeDrains < MAX_CONCURRENT_DRAINS && waiting.length > 0) {
+    const next = waiting.shift()!;
+    activeDrains += 1;
+    void drainWithRetry(next.db, next.jobId).finally(() => {
+      activeDrains -= 1;
+      running.delete(next.jobId);
+      pumpDrains();
+    });
+  }
+};
+
 export const startAgentTransferJob = (db: LobeChatDatabase, jobId: string): void => {
   if (running.has(jobId)) return;
   running.add(jobId);
-
-  void drainWithRetry(db, jobId).finally(() => {
-    running.delete(jobId);
-  });
+  waiting.push({ db, jobId });
+  pumpDrains();
 };
 
 export const prioritizeAgentTransferTopic = async (

--- a/packages/business-server/src/agent-transfer/jobRunner.ts
+++ b/packages/business-server/src/agent-transfer/jobRunner.ts
@@ -75,10 +75,29 @@ const pumpDrains = (): void => {
   }
 };
 
-export const startAgentTransferJob = (db: LobeChatDatabase, jobId: string): void => {
-  if (running.has(jobId)) return;
+export const startAgentTransferJob = (
+  db: LobeChatDatabase,
+  jobId: string,
+  options: {
+    /**
+     * Jump the FIFO: a user is waiting on this job (topic prioritization),
+     * so a queued instance moves to the front instead of sitting behind a
+     * boot-recovery backlog of full migrations. An actively draining job is
+     * left alone; duplicate suppression holds either way.
+     */
+    promote?: boolean;
+  } = {},
+): void => {
+  if (running.has(jobId)) {
+    if (options.promote) {
+      const queuedIndex = waiting.findIndex((entry) => entry.jobId === jobId);
+      if (queuedIndex > 0) waiting.unshift(...waiting.splice(queuedIndex, 1));
+    }
+    return;
+  }
   running.add(jobId);
-  waiting.push({ db, jobId });
+  if (options.promote) waiting.unshift({ db, jobId });
+  else waiting.push({ db, jobId });
   pumpDrains();
 };
 
@@ -90,7 +109,7 @@ export const prioritizeAgentTransferTopic = async (
   if (!flagged) return false;
 
   const pending = await AgentTransferJobModel.findPendingJobForTopic(db, topicId);
-  if (pending) startAgentTransferJob(db, pending.jobId);
+  if (pending) startAgentTransferJob(db, pending.jobId, { promote: true });
   return true;
 };
 

--- a/packages/business-server/src/agent-transfer/jobRunner.ts
+++ b/packages/business-server/src/agent-transfer/jobRunner.ts
@@ -39,16 +39,16 @@ const running = new Set<string>();
 const waiting: { db: LobeChatDatabase; jobId: string }[] = [];
 let activeDrains = 0;
 
-const drainWithRetry = async (db: LobeChatDatabase, jobId: string): Promise<void> => {
+const drainOnce = async (db: LobeChatDatabase, jobId: string): Promise<boolean> => {
   try {
     // Type-dispatching drain: the same runner serves transfer and copy jobs.
     await drainAgentHistoryJob(db, jobId);
+    return true;
   } catch (error) {
     // Keep the job pending and retry forever — the job row stays visible as
     // "migrating" instead of silently dying, per the transfer design.
     console.error(`[agent-transfer] drain of ${jobId} failed, retrying:`, error);
-    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-    return drainWithRetry(db, jobId);
+    return false;
   }
 };
 
@@ -56,9 +56,20 @@ const pumpDrains = (): void => {
   while (activeDrains < MAX_CONCURRENT_DRAINS && waiting.length > 0) {
     const next = waiting.shift()!;
     activeDrains += 1;
-    void drainWithRetry(next.db, next.jobId).finally(() => {
+    void drainOnce(next.db, next.jobId).then((done) => {
       activeDrains -= 1;
-      running.delete(next.jobId);
+      if (done) {
+        running.delete(next.jobId);
+      } else {
+        // Yield the slot between retries: the job stays in `running` (so
+        // repeated start calls stay deduped) but re-queues after a delay,
+        // letting healthy jobs drain instead of a persistently failing one
+        // pinning a slot forever.
+        setTimeout(() => {
+          waiting.push(next);
+          pumpDrains();
+        }, RETRY_DELAY_MS);
+      }
       pumpDrains();
     });
   }

--- a/packages/business-server/vitest.config.mts
+++ b/packages/business-server/vitest.config.mts
@@ -1,0 +1,13 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths({ projects: ['../../tsconfig.json'] })],
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
+    environment: 'node',
+  },
+});

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -1934,6 +1934,15 @@ describe('AgentModel.transferAgents group history preservation', () => {
         topicId: `${groupId}-topic-plain`,
         userId,
       },
+      // Thread-anchored row (API-imported / legacy shape): threadId only —
+      // no topicId, no groupId. Reaches the group solely through the thread.
+      {
+        agentId,
+        id: `${groupId}-msg-thread-only`,
+        role: 'assistant',
+        threadId: `${groupId}-thr-grp`,
+        userId,
+      },
     ]);
   };
 
@@ -2030,10 +2039,11 @@ describe('AgentModel.transferAgents group history preservation', () => {
           'gh-group-msg-residual',
           'gh-group-msg-target',
           'gh-group-msg-topic-only',
+          'gh-group-msg-thread-only',
           'gh-group-msg-mixed',
         ]),
       );
-    expect(groupMessages).toHaveLength(5);
+    expect(groupMessages).toHaveLength(6);
     for (const message of groupMessages) {
       // Regression: the residual rewrite used to re-scope topicless group
       // messages to the target.
@@ -2068,9 +2078,10 @@ describe('AgentModel.transferAgents group history preservation', () => {
             'gh-group-msg-residual',
             'gh-group-msg-target',
             'gh-group-msg-topic-only',
+            'gh-group-msg-thread-only',
           ]),
         ),
-    ).resolves.toHaveLength(4);
+    ).resolves.toHaveLength(5);
     // The mixed row is gone — but through its TOPIC's lifecycle, not the
     // agent_id cascade this fix blocks: deleting the agent deletes its own
     // topics, and a message hosted on someone's topic lives and dies with it.
@@ -2186,13 +2197,14 @@ describe('AgentModel.transferAgents group history preservation', () => {
       'big-group-msg-residual',
       'big-group-msg-target',
       'big-group-msg-topic-only',
+      'big-group-msg-thread-only',
       'big-group-msg-foreign-topic',
     ];
     const pendingRows = await serverDB
       .select()
       .from(messages)
       .where(inArray(messages.id, messageIds));
-    expect(pendingRows).toHaveLength(5);
+    expect(pendingRows).toHaveLength(6);
     for (const message of pendingRows) {
       expect(message.userId).toBe(userId);
       expect(message.workspaceId).toBeNull();
@@ -2226,7 +2238,7 @@ describe('AgentModel.transferAgents group history preservation', () => {
       .select()
       .from(messages)
       .where(inArray(messages.id, messageIds));
-    expect(drainedRows).toHaveLength(5);
+    expect(drainedRows).toHaveLength(6);
     for (const message of drainedRows) {
       expect(message.userId).toBe(userId);
       expect(message.workspaceId).toBeNull();
@@ -2250,7 +2262,7 @@ describe('AgentModel.transferAgents group history preservation', () => {
             messageIds.filter((id) => id !== 'big-group-msg-foreign-topic'),
           ),
         ),
-    ).resolves.toHaveLength(4);
+    ).resolves.toHaveLength(5);
     await expect(
       serverDB.select().from(messages).where(eq(messages.id, 'big-group-msg-foreign-topic')),
     ).resolves.toHaveLength(0);

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -1945,8 +1945,25 @@ describe('AgentModel.transferAgents group history preservation', () => {
       title: 'History Agent',
     });
     await seedGroupHistory('gh-group', agent.id);
+    // A legal mixed row: group-anchored, but its topic is the AGENT's own
+    // (moving) topic. Step 7's topic rewrite must leave it in the group's
+    // scope even though the topic itself transfers.
+    await serverDB.insert(topics).values({ agentId: agent.id, id: 'gh-own-topic', userId });
+    await serverDB.insert(messages).values({
+      agentId: agent.id,
+      groupId: 'gh-group',
+      id: 'gh-group-msg-mixed',
+      role: 'assistant',
+      topicId: 'gh-own-topic',
+      userId,
+    });
 
     await model.transferAgent(agent.id, wsId2, targetUserId);
+
+    // The agent's own topic moved with it; the group-anchored row it hosted
+    // did not.
+    const [ownTopic] = await serverDB.select().from(topics).where(eq(topics.id, 'gh-own-topic'));
+    expect(ownTopic).toMatchObject({ userId: targetUserId, workspaceId: wsId2 });
 
     // The agent itself moved and left the roster.
     const moved = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
@@ -2012,9 +2029,10 @@ describe('AgentModel.transferAgents group history preservation', () => {
           'gh-group-msg-residual',
           'gh-group-msg-target',
           'gh-group-msg-topic-only',
+          'gh-group-msg-mixed',
         ]),
       );
-    expect(groupMessages).toHaveLength(4);
+    expect(groupMessages).toHaveLength(5);
     for (const message of groupMessages) {
       // Regression: the residual rewrite used to re-scope topicless group
       // messages to the target.
@@ -2052,6 +2070,12 @@ describe('AgentModel.transferAgents group history preservation', () => {
           ]),
         ),
     ).resolves.toHaveLength(4);
+    // The mixed row is gone — but through its TOPIC's lifecycle, not the
+    // agent_id cascade this fix blocks: deleting the agent deletes its own
+    // topics, and a message hosted on someone's topic lives and dies with it.
+    await expect(
+      serverDB.select().from(messages).where(eq(messages.id, 'gh-group-msg-mixed')),
+    ).resolves.toHaveLength(0);
   });
 
   it('creates no clone when the agent leaves groups without history', async () => {
@@ -2107,9 +2131,11 @@ describe('AgentModel.transferAgents group history preservation', () => {
     const agent = await model.create({ title: 'Chatty Member' });
     await seedGroupHistory('big-group', agent.id); // 4 message references > threshold 2
     // A group-anchored row whose topic_id is NOT one of the group's own
-    // topics (nothing enforces the pair): the per-topic drain can never
-    // reach it, only the group-anchored finalization remap can.
-    await serverDB.insert(topics).values({ id: 'foreign-topic', userId });
+    // topics (nothing enforces the pair): the remap job's per-topic drain can
+    // never reach it, only the group-anchored finalization remap can. The
+    // topic is the AGENT's own, so the deferred MAIN job also drains it —
+    // its topic rewrite must skip this group-anchored row.
+    await serverDB.insert(topics).values({ agentId: agent.id, id: 'foreign-topic', userId });
     await serverDB.insert(messages).values({
       agentId: agent.id,
       groupId: 'big-group',
@@ -2184,11 +2210,26 @@ describe('AgentModel.transferAgents group history preservation', () => {
       else expect(message.agentId).toBe(clone.id);
     }
 
-    // With the remap drained the delete goes through — and takes no history.
+    // With the remap drained the delete goes through — and takes no history
+    // via agent_id. (The foreign-topic row does disappear, but through its
+    // TOPIC's lifecycle: the topic belongs to the deleted agent and cascades
+    // with it, taking its hosted messages along — pre-existing semantics,
+    // not the group-history cascade this fix blocks.)
     await targetModel.delete(agent.id);
     await expect(
-      serverDB.select().from(messages).where(inArray(messages.id, messageIds)),
-    ).resolves.toHaveLength(5);
+      serverDB
+        .select()
+        .from(messages)
+        .where(
+          inArray(
+            messages.id,
+            messageIds.filter((id) => id !== 'big-group-msg-foreign-topic'),
+          ),
+        ),
+    ).resolves.toHaveLength(4);
+    await expect(
+      serverDB.select().from(messages).where(eq(messages.id, 'big-group-msg-foreign-topic')),
+    ).resolves.toHaveLength(0);
   });
 
   it('records the transfer target as a protected scope on a deferred remap job', async () => {

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -7,6 +7,7 @@ import {
   agentBotProviders,
   agentCronJobs,
   agentDocuments,
+  agentHistoryJobs,
   agents,
   agentsFiles,
   agentsKnowledgeBases,
@@ -42,6 +43,7 @@ import {
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { AgentModel } from '../agent';
+import { AGENT_TRANSFER_IN_PROGRESS, AgentTransferJobModel } from '../agentTransferJob';
 import { ExpertiseModel } from '../expertise';
 import {
   TOPIC_COMMENT_TOPIC_NOT_FOUND,
@@ -67,7 +69,12 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  delete process.env.AGENT_TRANSFER_SYNC_MESSAGE_THRESHOLD;
   await serverDB.delete(users);
+  // Jobs deliberately carry no FK onto users, so they survive the cascade —
+  // clean them up explicitly or they leak into later files on the shared
+  // server test DB.
+  await serverDB.delete(agentHistoryJobs);
 });
 
 describe('AgentModel.transferAgent', () => {
@@ -1933,6 +1940,7 @@ describe('AgentModel.transferAgents group history preservation', () => {
     const model = new AgentModel(serverDB, userId);
     const agent = await model.create({
       avatar: 'https://example.com/a.png',
+      name: 'Herodotus',
       systemRole: 'The historian',
       title: 'History Agent',
     });
@@ -1956,6 +1964,9 @@ describe('AgentModel.transferAgents group history preservation', () => {
     const clone = clones[0];
     expect(clone).toMatchObject({
       avatar: 'https://example.com/a.png',
+      // `agentDisplayName` prefers `name` — a clone missing it would render
+      // the role/title instead of the original speaker.
+      name: 'Herodotus',
       systemRole: 'The historian',
       title: 'History Agent',
       workspaceId: null,
@@ -2083,6 +2094,83 @@ describe('AgentModel.transferAgents group history preservation', () => {
       cloneIdByGroup.set(groupId, message.agentId!);
     }
     expect(cloneIdByGroup.get('multi-a')).not.toBe(cloneIdByGroup.get('multi-b'));
+  });
+
+  it('defers a large group-history remap to a remap-only job and keeps scope untouched', async () => {
+    process.env.AGENT_TRANSFER_SYNC_MESSAGE_THRESHOLD = '2';
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Chatty Member' });
+    await seedGroupHistory('big-group', agent.id); // 4 message references > threshold 2
+
+    await model.transferAgents([agent.id], wsId2, targetUserId);
+
+    // The clone is minted and topics/threads are remapped inline either way.
+    const clones = await serverDB
+      .select()
+      .from(agents)
+      .where(and(eq(agents.userId, userId), eq(agents.virtual, true)));
+    expect(clones).toHaveLength(1);
+    const clone = clones[0];
+    const [attrTopic] = await serverDB
+      .select()
+      .from(topics)
+      .where(eq(topics.id, 'big-group-topic-attr'));
+    expect(attrTopic.agentId).toBe(clone.id);
+
+    // Message rows are untouched so far: still in the group's scope, still
+    // pointing at the moved agent, waiting for the drain.
+    const messageIds = [
+      'big-group-msg-topic',
+      'big-group-msg-residual',
+      'big-group-msg-target',
+      'big-group-msg-topic-only',
+    ];
+    const pendingRows = await serverDB
+      .select()
+      .from(messages)
+      .where(inArray(messages.id, messageIds));
+    expect(pendingRows).toHaveLength(4);
+    for (const message of pendingRows) {
+      expect(message.userId).toBe(userId);
+      expect(message.workspaceId).toBeNull();
+      if (message.id === 'big-group-msg-target') expect(message.targetId).toBe(agent.id);
+      else expect(message.agentId).toBe(agent.id);
+    }
+
+    // A remap-only job was recorded, and while it is pending the moved agent
+    // cannot be deleted — the cascade hazard the tombstone exists to stop.
+    const jobs = await serverDB.query.agentHistoryJobs.findMany();
+    const remapJobs = jobs.filter((job) => job.payload?.remapOnly);
+    expect(remapJobs).toHaveLength(1);
+    expect(remapJobs[0].payload?.agentIdRemap).toEqual([
+      { newAgentId: clone.id, sourceAgentId: agent.id },
+    ]);
+    const targetModel = new AgentModel(serverDB, targetUserId, wsId2);
+    await expect(targetModel.delete(agent.id)).rejects.toThrow(AGENT_TRANSFER_IN_PROGRESS);
+
+    // Drain every pending job (the low threshold defers the main scope
+    // rewrite too); the remap lands, the scope does not move.
+    for (const job of jobs) {
+      let done = false;
+      while (!done) ({ done } = await AgentTransferJobModel.processNextTopic(serverDB, job.id));
+    }
+    const drainedRows = await serverDB
+      .select()
+      .from(messages)
+      .where(inArray(messages.id, messageIds));
+    expect(drainedRows).toHaveLength(4);
+    for (const message of drainedRows) {
+      expect(message.userId).toBe(userId);
+      expect(message.workspaceId).toBeNull();
+      if (message.id === 'big-group-msg-target') expect(message.targetId).toBe(clone.id);
+      else expect(message.agentId).toBe(clone.id);
+    }
+
+    // With the remap drained the delete goes through — and takes no history.
+    await targetModel.delete(agent.id);
+    await expect(
+      serverDB.select().from(messages).where(inArray(messages.id, messageIds)),
+    ).resolves.toHaveLength(4);
   });
 
   it('discovers a mention that references the agent only via topic-anchored target_id', async () => {

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -2015,6 +2015,9 @@ describe('AgentModel.transferAgents group history preservation', () => {
     expect(clone.systemRole).toBeNull();
     expect(clone.plugins).toBeNull();
     expect(clone.agencyConfig).toBeNull();
+    // And no slug: the schema default would otherwise mint one and make this
+    // internal row addressable through slug lookups.
+    expect(clone.slug).toBeNull();
     expect(clone.slug).not.toBe(moved?.slug);
     await expect(
       serverDB.select().from(chatGroupsAgents).where(eq(chatGroupsAgents.agentId, clone.id)),

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -2106,6 +2106,18 @@ describe('AgentModel.transferAgents group history preservation', () => {
     const model = new AgentModel(serverDB, userId);
     const agent = await model.create({ title: 'Chatty Member' });
     await seedGroupHistory('big-group', agent.id); // 4 message references > threshold 2
+    // A group-anchored row whose topic_id is NOT one of the group's own
+    // topics (nothing enforces the pair): the per-topic drain can never
+    // reach it, only the group-anchored finalization remap can.
+    await serverDB.insert(topics).values({ id: 'foreign-topic', userId });
+    await serverDB.insert(messages).values({
+      agentId: agent.id,
+      groupId: 'big-group',
+      id: 'big-group-msg-foreign-topic',
+      role: 'assistant',
+      topicId: 'foreign-topic',
+      userId,
+    });
 
     await model.transferAgents([agent.id], wsId2, targetUserId);
 
@@ -2129,12 +2141,13 @@ describe('AgentModel.transferAgents group history preservation', () => {
       'big-group-msg-residual',
       'big-group-msg-target',
       'big-group-msg-topic-only',
+      'big-group-msg-foreign-topic',
     ];
     const pendingRows = await serverDB
       .select()
       .from(messages)
       .where(inArray(messages.id, messageIds));
-    expect(pendingRows).toHaveLength(4);
+    expect(pendingRows).toHaveLength(5);
     for (const message of pendingRows) {
       expect(message.userId).toBe(userId);
       expect(message.workspaceId).toBeNull();
@@ -2163,7 +2176,7 @@ describe('AgentModel.transferAgents group history preservation', () => {
       .select()
       .from(messages)
       .where(inArray(messages.id, messageIds));
-    expect(drainedRows).toHaveLength(4);
+    expect(drainedRows).toHaveLength(5);
     for (const message of drainedRows) {
       expect(message.userId).toBe(userId);
       expect(message.workspaceId).toBeNull();
@@ -2175,7 +2188,7 @@ describe('AgentModel.transferAgents group history preservation', () => {
     await targetModel.delete(agent.id);
     await expect(
       serverDB.select().from(messages).where(inArray(messages.id, messageIds)),
-    ).resolves.toHaveLength(4);
+    ).resolves.toHaveLength(5);
   });
 
   it('records the transfer target as a protected scope on a deferred remap job', async () => {

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -2173,6 +2173,43 @@ describe('AgentModel.transferAgents group history preservation', () => {
     ).resolves.toHaveLength(4);
   });
 
+  it('records the transfer target as a protected scope on a deferred remap job', async () => {
+    process.env.AGENT_TRANSFER_SYNC_MESSAGE_THRESHOLD = '2';
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Mention Magnet' });
+    await serverDB.insert(chatGroups).values({ id: 'pin-group', userId });
+    await serverDB
+      .insert(chatGroupsAgents)
+      .values({ agentId: agent.id, chatGroupId: 'pin-group', userId });
+    // Only target_id mentions: the group-history remap exceeds the threshold
+    // while the main transfer (zero agent_id messages, zero own topics) stays
+    // on the fast path — so the remap job is the ONLY thing standing between
+    // the moved agent and a target-scope owner delete.
+    await serverDB.insert(messages).values(
+      [1, 2, 3].map((n) => ({
+        groupId: 'pin-group',
+        id: `pin-msg-${n}`,
+        role: 'user' as const,
+        targetId: agent.id,
+        userId,
+      })),
+    );
+
+    const [result] = await model.transferAgents([agent.id], wsId2, targetUserId);
+    expect(result.transferJobId).toBeNull();
+    expect(result.remapJobIds).toHaveLength(1);
+
+    // The moved agent's NEW scope is a protected scope of the remap job:
+    // deleting its owner or workspace mid-drain would cascade the agent and
+    // with it every group row the remap has not rescued yet.
+    await expect(
+      AgentTransferJobModel.hasPendingJobTouchingUser(serverDB, targetUserId),
+    ).resolves.toBe(true);
+    await expect(
+      AgentTransferJobModel.hasPendingJobTouchingWorkspace(serverDB, wsId2),
+    ).resolves.toBe(true);
+  });
+
   it('discovers a mention that references the agent only via topic-anchored target_id', async () => {
     const model = new AgentModel(serverDB, userId);
     const agent = await model.create({ title: 'Mentioned Only' });

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -1959,14 +1959,26 @@ describe('AgentModel.transferAgents group history preservation', () => {
     // (moving) topic. Step 7's topic rewrite must leave it in the group's
     // scope even though the topic itself transfers.
     await serverDB.insert(topics).values({ agentId: agent.id, id: 'gh-own-topic', userId });
-    await serverDB.insert(messages).values({
-      agentId: agent.id,
-      groupId: 'gh-group',
-      id: 'gh-group-msg-mixed',
-      role: 'assistant',
-      topicId: 'gh-own-topic',
-      userId,
-    });
+    await serverDB.insert(messages).values([
+      {
+        agentId: agent.id,
+        groupId: 'gh-group',
+        id: 'gh-group-msg-mixed',
+        role: 'assistant',
+        topicId: 'gh-own-topic',
+        userId,
+      },
+      // Same mismatch through the THREAD anchor: no group_id of its own, a
+      // moving (agent-owned) topic, but a stationary group's thread.
+      {
+        agentId: agent.id,
+        id: 'gh-group-msg-thread-mixed',
+        role: 'assistant',
+        threadId: 'gh-group-thr-grp',
+        topicId: 'gh-own-topic',
+        userId,
+      },
+    ]);
 
     await model.transferAgent(agent.id, wsId2, targetUserId);
 
@@ -2041,9 +2053,10 @@ describe('AgentModel.transferAgents group history preservation', () => {
           'gh-group-msg-topic-only',
           'gh-group-msg-thread-only',
           'gh-group-msg-mixed',
+          'gh-group-msg-thread-mixed',
         ]),
       );
-    expect(groupMessages).toHaveLength(6);
+    expect(groupMessages).toHaveLength(7);
     for (const message of groupMessages) {
       // Regression: the residual rewrite used to re-scope topicless group
       // messages to the target.
@@ -2082,11 +2095,14 @@ describe('AgentModel.transferAgents group history preservation', () => {
           ]),
         ),
     ).resolves.toHaveLength(5);
-    // The mixed row is gone — but through its TOPIC's lifecycle, not the
+    // The mixed rows are gone — but through their TOPIC's lifecycle, not the
     // agent_id cascade this fix blocks: deleting the agent deletes its own
     // topics, and a message hosted on someone's topic lives and dies with it.
     await expect(
-      serverDB.select().from(messages).where(eq(messages.id, 'gh-group-msg-mixed')),
+      serverDB
+        .select()
+        .from(messages)
+        .where(inArray(messages.id, ['gh-group-msg-mixed', 'gh-group-msg-thread-mixed'])),
     ).resolves.toHaveLength(0);
   });
 

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -2332,6 +2332,44 @@ describe('AgentModel.transferAgents group history preservation', () => {
     ).resolves.toBe(true);
   });
 
+  it('discovers a mention reachable only through a thread on a group topic', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Thread Mentioned' });
+    await serverDB.insert(chatGroups).values({ id: 'thr-mention-group', userId });
+    await serverDB
+      .insert(chatGroupsAgents)
+      .values({ agentId: agent.id, chatGroupId: 'thr-mention-group', userId });
+    await serverDB
+      .insert(topics)
+      .values({ groupId: 'thr-mention-group', id: 'thr-mention-topic', userId });
+    // The thread carries NO group_id of its own — it reaches the group only
+    // through its topic; the message reaches it only through the thread.
+    await serverDB.insert(threads).values({
+      id: 'thr-mention-thread',
+      topicId: 'thr-mention-topic',
+      type: 'continuation',
+      userId,
+    });
+    await serverDB.insert(messages).values({
+      id: 'thr-mention-msg',
+      role: 'user',
+      targetId: agent.id,
+      threadId: 'thr-mention-thread',
+      userId,
+    });
+
+    await model.transferAgent(agent.id, wsId2, targetUserId);
+
+    const [message] = await serverDB
+      .select()
+      .from(messages)
+      .where(eq(messages.id, 'thr-mention-msg'));
+    expect(message.targetId).not.toBe(agent.id);
+    expect(message.userId).toBe(userId);
+    const [clone] = await serverDB.select().from(agents).where(eq(agents.id, message.targetId!));
+    expect(clone).toMatchObject({ userId, virtual: true, workspaceId: null });
+  });
+
   it('discovers a mention that references the agent only via topic-anchored target_id', async () => {
     const model = new AgentModel(serverDB, userId);
     const agent = await model.create({ title: 'Mentioned Only' });

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -2256,6 +2256,33 @@ describe('AgentModel.transferAgents group history preservation', () => {
     ).resolves.toHaveLength(0);
   });
 
+  it('spends one shared sync budget across all groups instead of per group', async () => {
+    process.env.AGENT_TRANSFER_SYNC_MESSAGE_THRESHOLD = '5';
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Spread Member' });
+    await seedGroupHistory('budget-a', agent.id); // 4 message references each
+    await seedGroupHistory('budget-b', agent.id);
+
+    await model.transferAgents([agent.id], wsId2, targetUserId);
+
+    // 4 + 4 > 5: only one group fits the SHARED budget, the other defers —
+    // per-group budgeting would have run both inline (~8 rewrites > 5).
+    const jobs = await serverDB.query.agentHistoryJobs.findMany();
+    expect(jobs.filter((job) => job.payload?.remapOnly)).toHaveLength(1);
+
+    const [aMessage] = await serverDB
+      .select()
+      .from(messages)
+      .where(eq(messages.id, 'budget-a-msg-topic'));
+    const [bMessage] = await serverDB
+      .select()
+      .from(messages)
+      .where(eq(messages.id, 'budget-b-msg-topic'));
+    // Exactly one group was remapped inline; the deferred one still points
+    // at the moved agent until its job drains.
+    expect([aMessage, bMessage].filter((row) => row.agentId !== agent.id)).toHaveLength(1);
+  });
+
   it('records the transfer target as a protected scope on a deferred remap job', async () => {
     process.env.AGENT_TRANSFER_SYNC_MESSAGE_THRESHOLD = '2';
     const model = new AgentModel(serverDB, userId);

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -2055,7 +2055,7 @@ describe('AgentModel.transferAgents group history preservation', () => {
     expect(leftBehind).toHaveLength(0);
   });
 
-  it('reuses one clone across every group in the same scope', async () => {
+  it('mints one clone per group so a later handover can split their fates', async () => {
     const model = new AgentModel(serverDB, userId);
     const agent = await model.create({ title: 'Busy Member' });
     await seedGroupHistory('multi-a', agent.id);
@@ -2063,19 +2063,53 @@ describe('AgentModel.transferAgents group history preservation', () => {
 
     await model.transferAgent(agent.id, wsId2, targetUserId);
 
+    // Per group, not per scope: `transferGroupOwnership` re-homes a group's
+    // tombstones with the group, which must not drag another group's
+    // preserved history to the new owner.
     const clones = await serverDB
       .select()
       .from(agents)
       .where(and(eq(agents.userId, userId), eq(agents.virtual, true)));
-    expect(clones).toHaveLength(1);
+    expect(clones).toHaveLength(2);
+    const cloneIds = new Set(clones.map((clone) => clone.id));
 
+    const cloneIdByGroup = new Map<string, string>();
     for (const groupId of ['multi-a', 'multi-b']) {
       const [message] = await serverDB
         .select()
         .from(messages)
         .where(eq(messages.id, `${groupId}-msg-topic`));
-      expect(message.agentId).toBe(clones[0].id);
+      expect(cloneIds.has(message.agentId!)).toBe(true);
+      cloneIdByGroup.set(groupId, message.agentId!);
     }
+    expect(cloneIdByGroup.get('multi-a')).not.toBe(cloneIdByGroup.get('multi-b'));
+  });
+
+  it('discovers a mention that references the agent only via topic-anchored target_id', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Mentioned Only' });
+    await serverDB.insert(chatGroups).values({ id: 'mention-group', userId });
+    await serverDB
+      .insert(chatGroupsAgents)
+      .values({ agentId: agent.id, chatGroupId: 'mention-group', userId });
+    await serverDB.insert(topics).values({ groupId: 'mention-group', id: 'mention-topic', userId });
+    // The ONLY reference to the agent: a user message carrying just topicId +
+    // targetId — no agent_id anywhere, no direct group_id. The candidate set
+    // must reach this group through the roster row.
+    await serverDB.insert(messages).values({
+      id: 'mention-msg',
+      role: 'user',
+      targetId: agent.id,
+      topicId: 'mention-topic',
+      userId,
+    });
+
+    await model.transferAgent(agent.id, wsId2, targetUserId);
+
+    const [message] = await serverDB.select().from(messages).where(eq(messages.id, 'mention-msg'));
+    expect(message.targetId).not.toBe(agent.id);
+    const [clone] = await serverDB.select().from(agents).where(eq(agents.id, message.targetId!));
+    expect(clone).toMatchObject({ userId, virtual: true, workspaceId: null });
   });
 
   it('round-trips without stacking tombstones', async () => {

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -1967,10 +1967,15 @@ describe('AgentModel.transferAgents group history preservation', () => {
       // `agentDisplayName` prefers `name` — a clone missing it would render
       // the role/title instead of the original speaker.
       name: 'Herodotus',
-      systemRole: 'The historian',
       title: 'History Agent',
       workspaceId: null,
     });
+    // Display-only: nothing operational crosses into the tombstone — its
+    // owner may be someone the source agent's owner never shared
+    // configuration with.
+    expect(clone.systemRole).toBeNull();
+    expect(clone.plugins).toBeNull();
+    expect(clone.agencyConfig).toBeNull();
     expect(clone.slug).not.toBe(moved?.slug);
     await expect(
       serverDB.select().from(chatGroupsAgents).where(eq(chatGroupsAgents.agentId, clone.id)),

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -1867,5 +1867,288 @@ describe('AgentModel.transferAgents (batch)', () => {
 
     await expect(model.transferHasForeignRows([mine.id])).resolves.toBe(false);
     await expect(model.transferHasForeignRows([mine.id, foreign.id])).resolves.toBe(true);
+  });
+});
+
+describe('AgentModel.transferAgents group history preservation', () => {
+  /**
+   * Fixture: a personal-scope group with the given agent as a referenced
+   * member, holding a group topic, a thread and messages (topic'd + topicless)
+   * all attributed to the agent.
+   */
+  const seedGroupHistory = async (groupId: string, agentId: string) => {
+    await serverDB.insert(chatGroups).values({ id: groupId, title: `Group ${groupId}`, userId });
+    await serverDB.insert(chatGroupsAgents).values({ agentId, chatGroupId: groupId, userId });
+    await serverDB.insert(topics).values([
+      // Group topic attributed to the member agent
+      { agentId, groupId, id: `${groupId}-topic-attr`, userId },
+      // Group topic with no agent attribution
+      { groupId, id: `${groupId}-topic-plain`, userId },
+    ]);
+    await serverDB.insert(threads).values([
+      // Thread carrying only the group anchor
+      {
+        agentId,
+        groupId,
+        id: `${groupId}-thr-grp`,
+        topicId: `${groupId}-topic-plain`,
+        type: 'continuation',
+        userId,
+      },
+      // Thread carrying only the topic anchor into a group topic
+      {
+        agentId,
+        id: `${groupId}-thr-top`,
+        topicId: `${groupId}-topic-plain`,
+        type: 'continuation',
+        userId,
+      },
+    ]);
+    await serverDB.insert(messages).values([
+      // Topic'd group message spoken by the agent
+      {
+        agentId,
+        groupId,
+        id: `${groupId}-msg-topic`,
+        role: 'assistant',
+        topicId: `${groupId}-topic-plain`,
+        userId,
+      },
+      // Topicless group residue spoken by the agent
+      { agentId, groupId, id: `${groupId}-msg-residual`, role: 'assistant', userId },
+      // Message addressed TO the agent (target_id soft reference)
+      { groupId, id: `${groupId}-msg-target`, role: 'user', targetId: agentId, userId },
+      // Topic-anchored row without its own group_id
+      {
+        agentId,
+        id: `${groupId}-msg-topic-only`,
+        role: 'assistant',
+        topicId: `${groupId}-topic-plain`,
+        userId,
+      },
+    ]);
+  };
+
+  it('leaves a tombstone clone so group history survives the transfer AND a later delete', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({
+      avatar: 'https://example.com/a.png',
+      systemRole: 'The historian',
+      title: 'History Agent',
+    });
+    await seedGroupHistory('gh-group', agent.id);
+
+    await model.transferAgent(agent.id, wsId2, targetUserId);
+
+    // The agent itself moved and left the roster.
+    const moved = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+    expect(moved).toMatchObject({ userId: targetUserId, workspaceId: wsId2 });
+    await expect(
+      serverDB.select().from(chatGroupsAgents).where(eq(chatGroupsAgents.agentId, agent.id)),
+    ).resolves.toHaveLength(0);
+
+    // Exactly one tombstone clone, in the GROUP's scope, virtual and rosterless.
+    const clones = await serverDB
+      .select()
+      .from(agents)
+      .where(and(eq(agents.userId, userId), eq(agents.virtual, true)));
+    expect(clones).toHaveLength(1);
+    const clone = clones[0];
+    expect(clone).toMatchObject({
+      avatar: 'https://example.com/a.png',
+      systemRole: 'The historian',
+      title: 'History Agent',
+      workspaceId: null,
+    });
+    expect(clone.slug).not.toBe(moved?.slug);
+    await expect(
+      serverDB.select().from(chatGroupsAgents).where(eq(chatGroupsAgents.agentId, clone.id)),
+    ).resolves.toHaveLength(0);
+
+    // Every group row stayed in the source scope and now points at the clone.
+    const groupTopics = await serverDB.select().from(topics).where(eq(topics.groupId, 'gh-group'));
+    expect(groupTopics).toHaveLength(2);
+    for (const topic of groupTopics) {
+      expect(topic.userId).toBe(userId);
+      expect(topic.workspaceId).toBeNull();
+      expect(topic.agentId === null || topic.agentId === clone.id).toBe(true);
+    }
+
+    const groupThreads = await serverDB
+      .select()
+      .from(threads)
+      .where(inArray(threads.id, ['gh-group-thr-grp', 'gh-group-thr-top']));
+    expect(groupThreads).toHaveLength(2);
+    for (const thread of groupThreads) {
+      expect(thread.agentId).toBe(clone.id);
+      // Regression: step 8 used to drag agent-linked group threads into the
+      // target scope.
+      expect(thread.userId).toBe(userId);
+      expect(thread.workspaceId).toBeNull();
+    }
+
+    const groupMessages = await serverDB
+      .select()
+      .from(messages)
+      .where(
+        inArray(messages.id, [
+          'gh-group-msg-topic',
+          'gh-group-msg-residual',
+          'gh-group-msg-target',
+          'gh-group-msg-topic-only',
+        ]),
+      );
+    expect(groupMessages).toHaveLength(4);
+    for (const message of groupMessages) {
+      // Regression: the residual rewrite used to re-scope topicless group
+      // messages to the target.
+      expect(message.userId).toBe(userId);
+      expect(message.workspaceId).toBeNull();
+      if (message.id === 'gh-group-msg-target') {
+        expect(message.targetId).toBe(clone.id);
+      } else {
+        expect(message.agentId).toBe(clone.id);
+      }
+    }
+
+    // The cascade regression itself: deleting the moved agent in its new
+    // scope must not erase the old group's history.
+    await serverDB.delete(agents).where(eq(agents.id, agent.id));
+    await expect(
+      serverDB.select().from(topics).where(eq(topics.groupId, 'gh-group')),
+    ).resolves.toHaveLength(2);
+    await expect(
+      serverDB
+        .select()
+        .from(threads)
+        .where(inArray(threads.id, ['gh-group-thr-grp', 'gh-group-thr-top'])),
+    ).resolves.toHaveLength(2);
+    await expect(
+      serverDB
+        .select()
+        .from(messages)
+        .where(
+          inArray(messages.id, [
+            'gh-group-msg-topic',
+            'gh-group-msg-residual',
+            'gh-group-msg-target',
+            'gh-group-msg-topic-only',
+          ]),
+        ),
+    ).resolves.toHaveLength(4);
+  });
+
+  it('creates no clone when the agent leaves groups without history', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Quiet Member' });
+    await serverDB.insert(chatGroups).values({ id: 'quiet-group', userId });
+    await serverDB
+      .insert(chatGroupsAgents)
+      .values({ agentId: agent.id, chatGroupId: 'quiet-group', userId });
+
+    await model.transferAgent(agent.id, wsId1, userId);
+
+    const leftBehind = await serverDB
+      .select()
+      .from(agents)
+      .where(and(eq(agents.userId, userId), isNull(agents.workspaceId)));
+    expect(leftBehind).toHaveLength(0);
+  });
+
+  it('reuses one clone across every group in the same scope', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Busy Member' });
+    await seedGroupHistory('multi-a', agent.id);
+    await seedGroupHistory('multi-b', agent.id);
+
+    await model.transferAgent(agent.id, wsId2, targetUserId);
+
+    const clones = await serverDB
+      .select()
+      .from(agents)
+      .where(and(eq(agents.userId, userId), eq(agents.virtual, true)));
+    expect(clones).toHaveLength(1);
+
+    for (const groupId of ['multi-a', 'multi-b']) {
+      const [message] = await serverDB
+        .select()
+        .from(messages)
+        .where(eq(messages.id, `${groupId}-msg-topic`));
+      expect(message.agentId).toBe(clones[0].id);
+    }
+  });
+
+  it('round-trips without stacking tombstones', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Traveler' });
+    await seedGroupHistory('rt-group', agent.id);
+
+    await model.transferAgent(agent.id, wsId2, targetUserId);
+    const back = new AgentModel(serverDB, targetUserId, wsId2);
+    await back.transferAgent(agent.id, null, userId);
+
+    // The first leg remapped every group reference, so the return leg finds
+    // nothing to preserve and mints no second clone.
+    const clones = await serverDB
+      .select()
+      .from(agents)
+      .where(and(eq(agents.userId, userId), eq(agents.virtual, true)));
+    expect(clones).toHaveLength(1);
+
+    const [message] = await serverDB
+      .select()
+      .from(messages)
+      .where(eq(messages.id, 'rt-group-msg-topic'));
+    expect(message.agentId).toBe(clones[0].id);
+    expect(message.userId).toBe(userId);
+  });
+
+  it('clones into each group scope for cross-scope memberships', async () => {
+    const model = new AgentModel(serverDB, userId, wsId1);
+    const agent = await model.create({ title: 'Shared Agent', visibility: 'public' });
+
+    // A workspace group in wsId1 and a personal group of targetUserId both
+    // hold history from this agent.
+    await serverDB.insert(chatGroups).values([
+      { id: 'xs-ws-group', userId, workspaceId: wsId1 },
+      { id: 'xs-personal-group', userId: targetUserId },
+    ]);
+    await serverDB.insert(messages).values([
+      {
+        agentId: agent.id,
+        groupId: 'xs-ws-group',
+        id: 'xs-msg-ws',
+        role: 'assistant',
+        userId,
+        workspaceId: wsId1,
+      },
+      {
+        agentId: agent.id,
+        groupId: 'xs-personal-group',
+        id: 'xs-msg-personal',
+        role: 'assistant',
+        userId: targetUserId,
+      },
+    ]);
+
+    await model.transferAgent(agent.id, wsId2, targetUserId);
+
+    const [wsMessage] = await serverDB.select().from(messages).where(eq(messages.id, 'xs-msg-ws'));
+    const [personalMessage] = await serverDB
+      .select()
+      .from(messages)
+      .where(eq(messages.id, 'xs-msg-personal'));
+
+    expect(wsMessage.agentId).not.toBe(agent.id);
+    expect(personalMessage.agentId).not.toBe(agent.id);
+    expect(wsMessage.agentId).not.toBe(personalMessage.agentId);
+
+    const [wsClone] = await serverDB.select().from(agents).where(eq(agents.id, wsMessage.agentId!));
+    expect(wsClone).toMatchObject({ virtual: true, workspaceId: wsId1 });
+    const [personalClone] = await serverDB
+      .select()
+      .from(agents)
+      .where(eq(agents.id, personalMessage.agentId!));
+    expect(personalClone).toMatchObject({ userId: targetUserId, virtual: true, workspaceId: null });
   });
 });

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -44,6 +44,7 @@ import {
 import type { LobeChatDatabase } from '../../type';
 import { AgentModel } from '../agent';
 import { AGENT_TRANSFER_IN_PROGRESS, AgentTransferJobModel } from '../agentTransferJob';
+import { ChatGroupModel } from '../chatGroup';
 import { ExpertiseModel } from '../expertise';
 import {
   TOPIC_COMMENT_TOPIC_NOT_FOUND,
@@ -2100,6 +2101,17 @@ describe('AgentModel.transferAgents group history preservation', () => {
     const agent = await model.create({ title: 'Busy Member' });
     await seedGroupHistory('multi-a', agent.id);
     await seedGroupHistory('multi-b', agent.id);
+    // A schema-valid mismatched anchor: group_id names multi-b while the
+    // topic belongs to multi-a. The DIRECT group anchor must win — the row's
+    // history belongs to multi-b regardless of which group remaps first.
+    await serverDB.insert(messages).values({
+      agentId: agent.id,
+      groupId: 'multi-b',
+      id: 'cross-anchor-msg',
+      role: 'assistant',
+      topicId: 'multi-a-topic-plain',
+      userId,
+    });
 
     await model.transferAgent(agent.id, wsId2, targetUserId);
 
@@ -2123,6 +2135,13 @@ describe('AgentModel.transferAgents group history preservation', () => {
       cloneIdByGroup.set(groupId, message.agentId!);
     }
     expect(cloneIdByGroup.get('multi-a')).not.toBe(cloneIdByGroup.get('multi-b'));
+
+    // The mismatched-anchor row followed its group_id, not its topic.
+    const [crossAnchor] = await serverDB
+      .select()
+      .from(messages)
+      .where(eq(messages.id, 'cross-anchor-msg'));
+    expect(crossAnchor.agentId).toBe(cloneIdByGroup.get('multi-b'));
   });
 
   it('defers a large group-history remap to a remap-only job and keeps scope untouched', async () => {
@@ -2191,6 +2210,11 @@ describe('AgentModel.transferAgents group history preservation', () => {
     ]);
     const targetModel = new AgentModel(serverDB, targetUserId, wsId2);
     await expect(targetModel.delete(agent.id)).rejects.toThrow(AGENT_TRANSFER_IN_PROGRESS);
+
+    // Deleting the GROUP mid-drain is blocked too: the drain addresses the
+    // residue by group id, which the delete would SET-NULL away.
+    const groupModel = new ChatGroupModel(serverDB, userId);
+    await expect(groupModel.delete('big-group')).rejects.toThrow(AGENT_TRANSFER_IN_PROGRESS);
 
     // Drain every pending job (the low threshold defers the main scope
     // rewrite too); the remap lands, the scope does not move.

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -1072,9 +1072,15 @@ describe('ChatGroupModel', () => {
         .insert(agentsTable)
         .values({ title: 'Residue Mention', userId, virtual: true })
         .returning();
-      await serverDB
-        .insert(topics)
-        .values({ agentId: orphan.id, groupId: 'tomb-group', id: 'tomb-topic', userId });
+      const [mismatchMentioned] = await serverDB
+        .insert(agentsTable)
+        .values({ title: 'Mismatch Mention', userId, virtual: true })
+        .returning();
+      await serverDB.insert(topics).values([
+        { agentId: orphan.id, groupId: 'tomb-group', id: 'tomb-topic', userId },
+        // A topic OUTSIDE the deleted group — it does not cascade.
+        { id: 'tomb-outside-topic', userId },
+      ]);
       await serverDB.insert(messages).values([
         // Cascades with its topic → the orphan loses its last reference.
         {
@@ -1103,6 +1109,17 @@ describe('ChatGroupModel', () => {
           targetId: mentioned.id,
           userId,
         },
+        // Mismatched anchor: group-anchored, but hosted on a topic OUTSIDE
+        // the group. The topic does not cascade, so this mention survives —
+        // its tombstone must survive with it.
+        {
+          groupId: 'tomb-group',
+          id: 'tomb-msg-mismatch-mention',
+          role: 'user',
+          targetId: mismatchMentioned.id,
+          topicId: 'tomb-outside-topic',
+          userId,
+        },
       ]);
 
       await chatGroupModel.delete('tomb-group');
@@ -1110,19 +1127,28 @@ describe('ChatGroupModel', () => {
       const survivors = await serverDB
         .select({ id: agentsTable.id })
         .from(agentsTable)
-        .where(inArray(agentsTable.id, [orphan.id, speaker.id, mentioned.id]));
+        .where(
+          inArray(agentsTable.id, [orphan.id, speaker.id, mentioned.id, mismatchMentioned.id]),
+        );
       const survivorIds = survivors.map((row) => row.id);
       expect(survivorIds).not.toContain(orphan.id);
       expect(survivorIds).toContain(speaker.id);
       expect(survivorIds).toContain(mentioned.id);
+      expect(survivorIds).toContain(mismatchMentioned.id);
 
       // The surviving residue rows themselves are intact.
       await expect(
         serverDB
           .select()
           .from(messages)
-          .where(inArray(messages.id, ['tomb-msg-residual', 'tomb-msg-mention'])),
-      ).resolves.toHaveLength(2);
+          .where(
+            inArray(messages.id, [
+              'tomb-msg-residual',
+              'tomb-msg-mention',
+              'tomb-msg-mismatch-mention',
+            ]),
+          ),
+      ).resolves.toHaveLength(3);
     });
 
     it('should delete chat group', async () => {

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -12,6 +12,8 @@ import {
   agents as agentsTable,
   chatGroups,
   chatGroupsAgents,
+  messages,
+  topics,
   users,
   workspaces,
 } from '../../schemas';
@@ -1055,6 +1057,74 @@ describe('ChatGroupModel', () => {
   });
 
   describe('delete', () => {
+    it('reclaims orphaned history tombstones but keeps ones surviving rows still need', async () => {
+      await serverDB.insert(chatGroups).values({ id: 'tomb-group', title: 'T', userId });
+      // Rosterless virtual history agents (the tombstone shape).
+      const [orphan] = await serverDB
+        .insert(agentsTable)
+        .values({ title: 'Orphan Tombstone', userId, virtual: true })
+        .returning();
+      const [speaker] = await serverDB
+        .insert(agentsTable)
+        .values({ title: 'Residue Speaker', userId, virtual: true })
+        .returning();
+      const [mentioned] = await serverDB
+        .insert(agentsTable)
+        .values({ title: 'Residue Mention', userId, virtual: true })
+        .returning();
+      await serverDB
+        .insert(topics)
+        .values({ agentId: orphan.id, groupId: 'tomb-group', id: 'tomb-topic', userId });
+      await serverDB.insert(messages).values([
+        // Cascades with its topic → the orphan loses its last reference.
+        {
+          agentId: orphan.id,
+          groupId: 'tomb-group',
+          id: 'tomb-msg-topic',
+          role: 'assistant',
+          topicId: 'tomb-topic',
+          userId,
+        },
+        // Topicless residue SURVIVES the delete (group_id goes SET NULL) —
+        // its speaker must keep resolving.
+        {
+          agentId: speaker.id,
+          groupId: 'tomb-group',
+          id: 'tomb-msg-residual',
+          role: 'assistant',
+          userId,
+        },
+        // Topicless residue that only MENTIONS its agent via the FK-less
+        // target_id — must survive too.
+        {
+          groupId: 'tomb-group',
+          id: 'tomb-msg-mention',
+          role: 'user',
+          targetId: mentioned.id,
+          userId,
+        },
+      ]);
+
+      await chatGroupModel.delete('tomb-group');
+
+      const survivors = await serverDB
+        .select({ id: agentsTable.id })
+        .from(agentsTable)
+        .where(inArray(agentsTable.id, [orphan.id, speaker.id, mentioned.id]));
+      const survivorIds = survivors.map((row) => row.id);
+      expect(survivorIds).not.toContain(orphan.id);
+      expect(survivorIds).toContain(speaker.id);
+      expect(survivorIds).toContain(mentioned.id);
+
+      // The surviving residue rows themselves are intact.
+      await expect(
+        serverDB
+          .select()
+          .from(messages)
+          .where(inArray(messages.id, ['tomb-msg-residual', 'tomb-msg-mention'])),
+      ).resolves.toHaveLength(2);
+    });
+
     it('should delete chat group', async () => {
       // Create test group
       await serverDB.insert(chatGroups).values({

--- a/packages/database/src/models/__tests__/chatGroupTransferOwnership.test.ts
+++ b/packages/database/src/models/__tests__/chatGroupTransferOwnership.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -111,6 +112,64 @@ describe('ChatGroupModel.transferGroupOwnership', () => {
 
     const [standalone] = await serverDB.select().from(agents).where(eq(agents.id, referenced.id));
     expect(standalone.userId).toBe(teammateId);
+  });
+
+  it('re-homes rosterless history tombstones so deleting the former owner keeps group history', async () => {
+    const { group } = await seedGroupWithRoster();
+    // A history tombstone: virtual, owned by the outgoing owner, referenced
+    // only by group content — never in the roster.
+    const [tombstone] = await serverDB
+      .insert(agents)
+      .values({ title: 'Moved Away', userId: ownerId, virtual: true, workspaceId: wsId })
+      .returning();
+    // A builtin agent (reserved slug) referenced in history must stay with
+    // its owner.
+    const [builtinLike] = await serverDB
+      .insert(agents)
+      .values({
+        slug: Object.values(BUILTIN_AGENT_SLUGS)[0],
+        title: 'Builtin',
+        userId: ownerId,
+        virtual: true,
+        workspaceId: wsId,
+      })
+      .returning();
+    await serverDB.insert(topics).values([
+      {
+        agentId: tombstone.id,
+        groupId: group.id,
+        id: 'hist-topic',
+        userId: teammateId,
+        workspaceId: wsId,
+      },
+      {
+        agentId: builtinLike.id,
+        groupId: group.id,
+        id: 'hist-topic-builtin',
+        userId: teammateId,
+        workspaceId: wsId,
+      },
+    ]);
+
+    await handover({ fromUserId: ownerId, groupId: group.id, toUserId: recipientId });
+
+    const [rehomed] = await serverDB.select().from(agents).where(eq(agents.id, tombstone.id));
+    expect(rehomed.userId).toBe(recipientId);
+    const [slugged] = await serverDB.select().from(agents).where(eq(agents.id, builtinLike.id));
+    expect(slugged.userId).toBe(ownerId);
+
+    // The cascade regression: deleting the former owner must not erase the
+    // history the tombstone preserves for the transferred group. (The
+    // workspace itself moves off the leaver first — otherwise the whole
+    // workspace cascades and proves nothing.)
+    await serverDB
+      .update(workspaces)
+      .set({ primaryOwnerId: recipientId })
+      .where(eq(workspaces.id, wsId));
+    await serverDB.delete(users).where(eq(users.id, ownerId));
+    await expect(
+      serverDB.select().from(topics).where(eq(topics.id, 'hist-topic')),
+    ).resolves.toHaveLength(1);
   });
 
   it('keeps everyone’s group conversations untouched', async () => {

--- a/packages/database/src/models/__tests__/chatGroupTransferOwnership.test.ts
+++ b/packages/database/src/models/__tests__/chatGroupTransferOwnership.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
 import {
+  agentHistoryJobs,
   agents,
   agentsKnowledgeBases,
   chatGroups,
@@ -80,6 +81,10 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await serverDB.delete(users);
+  // Jobs deliberately carry no FK onto users, so they survive the cascade —
+  // clean them up explicitly or they leak into later files on the shared
+  // server test DB.
+  await serverDB.delete(agentHistoryJobs);
 });
 
 describe('ChatGroupModel.transferGroupOwnership', () => {

--- a/packages/database/src/models/__tests__/chatGroupTransferOwnership.test.ts
+++ b/packages/database/src/models/__tests__/chatGroupTransferOwnership.test.ts
@@ -11,6 +11,8 @@ import {
   chatGroups,
   chatGroupsAgents,
   knowledgeBases,
+  messages,
+  threads,
   topics,
   users,
   workspaces,
@@ -139,6 +141,12 @@ describe('ChatGroupModel.transferGroupOwnership', () => {
         workspaceId: wsId,
       })
       .returning();
+    // A second tombstone referenced ONLY by a thread-anchored message
+    // (threadId set, topicId and groupId both null on the message).
+    const [threadTombstone] = await serverDB
+      .insert(agents)
+      .values({ title: 'Thread Referenced', userId: ownerId, virtual: true, workspaceId: wsId })
+      .returning();
     await serverDB.insert(topics).values([
       {
         agentId: tombstone.id,
@@ -155,11 +163,32 @@ describe('ChatGroupModel.transferGroupOwnership', () => {
         workspaceId: wsId,
       },
     ]);
+    await serverDB.insert(threads).values({
+      groupId: group.id,
+      id: 'hist-thread',
+      topicId: 'hist-topic',
+      type: 'continuation',
+      userId: teammateId,
+      workspaceId: wsId,
+    });
+    await serverDB.insert(messages).values({
+      agentId: threadTombstone.id,
+      id: 'hist-thread-msg',
+      role: 'assistant',
+      threadId: 'hist-thread',
+      userId: teammateId,
+      workspaceId: wsId,
+    });
 
     await handover({ fromUserId: ownerId, groupId: group.id, toUserId: recipientId });
 
     const [rehomed] = await serverDB.select().from(agents).where(eq(agents.id, tombstone.id));
     expect(rehomed.userId).toBe(recipientId);
+    const [threadRehomed] = await serverDB
+      .select()
+      .from(agents)
+      .where(eq(agents.id, threadTombstone.id));
+    expect(threadRehomed.userId).toBe(recipientId);
     const [slugged] = await serverDB.select().from(agents).where(eq(agents.id, builtinLike.id));
     expect(slugged.userId).toBe(ownerId);
 
@@ -174,6 +203,9 @@ describe('ChatGroupModel.transferGroupOwnership', () => {
     await serverDB.delete(users).where(eq(users.id, ownerId));
     await expect(
       serverDB.select().from(topics).where(eq(topics.id, 'hist-topic')),
+    ).resolves.toHaveLength(1);
+    await expect(
+      serverDB.select().from(messages).where(eq(messages.id, 'hist-thread-msg')),
     ).resolves.toHaveLength(1);
   });
 

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2063,6 +2063,7 @@ export class AgentModel {
     trx: Transaction,
     agentIds: string[],
     agentById: Map<string, AgentItem>,
+    transferTarget: { userId: string; workspaceId: string | null },
   ): Promise<string[]> => {
     // (group, agent) pairs holding history. The direct arms anchor on the
     // rows' own group_id; the join arms catch rows that carry only a topicId
@@ -2244,7 +2245,6 @@ export class AgentModel {
           .select({ id: topics.id, updatedAt: topics.updatedAt })
           .from(topics)
           .where(eq(topics.groupId, group.id));
-        const groupScope = { userId: group.userId, workspaceId: group.workspaceId };
         const remapJobId = await AgentTransferJobModel.createJob(trx, {
           // Junction coverage on the moved agents: blocks a re-transfer
           // (step 1a's pending-job guard) and — via the remap payload — a
@@ -2258,8 +2258,14 @@ export class AgentModel {
           // residual REMAP anchors on `groupIds` above.
           residualAgentIds: [],
           sessionIds: [],
-          source: groupScope,
-          target: groupScope,
+          // The scope pair exists for the OWNER-DELETE guards, and both ends
+          // are load-bearing: the group's scope owns the rows being remapped,
+          // and the transfer's target scope owns the moved agent — deleting
+          // either owner/workspace mid-drain would cascade rows the remap
+          // has not rescued yet. The drain itself never rewrites scope for a
+          // remap-only job, so `target` is not a destination here.
+          source: { userId: group.userId, workspaceId: group.workspaceId },
+          target: transferTarget,
           topics: groupTopics.map((topic) => ({ activityAt: topic.updatedAt, id: topic.id })),
         });
         remapJobIds.push(remapJobId);
@@ -2504,7 +2510,10 @@ export class AgentModel {
       // repointing the group rows first also keeps those moves from dragging
       // group history into the target scope (threads matched by `agent_id` in
       // step 8, topicless group messages in step 7's residual rewrite).
-      const remapJobIds = await this.preserveGroupHistoryForTransfer(trx, agentIds, agentById);
+      const remapJobIds = await this.preserveGroupHistoryForTransfer(trx, agentIds, agentById, {
+        userId: targetUserId,
+        workspaceId: targetWorkspaceId,
+      });
 
       // 6. Update topics (linked via sessionId or agentId)
       const topicCondition =

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -95,6 +95,7 @@ import {
   AgentTransferJobModel,
   getAgentTransferSyncMessageThreshold,
   remapMessageAgentIdsForGroups,
+  remapMessageAgentIdsForGroupThreads,
   remapMessageAgentIdsForGroupTopics,
   rewriteMessageScopeForTopics,
   rewriteResidualMessageScope,
@@ -2091,6 +2092,20 @@ export class AgentModel {
         .from(messages)
         .innerJoin(topics, eq(messages.topicId, topics.id))
         .where(and(inArray(messages.agentId, agentIds), isNotNull(topics.groupId)))),
+      // Rows that reach the group only through a THREAD (API-imported /
+      // legacy shapes: threadId set, topicId and groupId both null) — either
+      // a group-anchored thread, or a thread hosted on a group topic.
+      ...(await trx
+        .selectDistinct({ agentId: messages.agentId, groupId: threads.groupId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .where(and(inArray(messages.agentId, agentIds), isNotNull(threads.groupId)))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.agentId, groupId: topics.groupId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(and(inArray(messages.agentId, agentIds), isNotNull(topics.groupId)))),
     ];
 
     // `messages.target_id` (no FK) rides the same pairs — it cannot cascade
@@ -2129,6 +2144,14 @@ export class AgentModel {
         .innerJoin(topics, eq(messages.topicId, topics.id))
         .where(
           and(inArray(topics.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
+        )),
+      // Thread-anchored mentions, same fencing via threads.group_id.
+      ...(await trx
+        .selectDistinct({ agentId: messages.targetId, groupId: threads.groupId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .where(
+          and(inArray(threads.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
         )),
     );
 
@@ -2213,9 +2236,22 @@ export class AgentModel {
       // recorded as a remap-only backfill job (drained topic-by-topic, scope
       // untouched); until it drains, the guards on the covered agents block
       // re-transfers and deletes, so the cascade hazard cannot fire early.
+      const groupThreadSubquery = trx
+        .select({ id: threads.id })
+        .from(threads)
+        .where(
+          or(
+            eq(threads.groupId, group.id),
+            inArray(
+              threads.topicId,
+              trx.select({ id: topics.id }).from(topics).where(eq(topics.groupId, group.id)),
+            ),
+          ),
+        );
       const remapAnchor = or(
         eq(messages.groupId, group.id),
         inArray(messages.topicId, groupTopicSubquery),
+        inArray(messages.threadId, groupThreadSubquery),
       );
       const [{ affectedGroupMessages }] = await trx
         .select({ affectedGroupMessages: count() })
@@ -2242,6 +2278,7 @@ export class AgentModel {
         // is idempotent.
         await remapMessageAgentIdsForGroups(trx, [group.id], remapPairs);
         await remapMessageAgentIdsForGroupTopics(trx, [group.id], remapPairs);
+        await remapMessageAgentIdsForGroupThreads(trx, [group.id], remapPairs);
       } else {
         // The topic list is only materialized on this rare path — it feeds
         // the job's drain queue, and `createJob` chunks the inserts.

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2107,7 +2107,7 @@ export class AgentModel {
     if (candidateGroupIds.length === 0) return;
 
     const candidateTopics = await trx
-      .select({ groupId: topics.groupId, id: topics.id })
+      .select({ groupId: topics.groupId, id: topics.id, updatedAt: topics.updatedAt })
       .from(topics)
       .where(inArray(topics.groupId, candidateGroupIds));
     const topicGroupById = new Map(candidateTopics.map((topic) => [topic.id, topic.groupId]));
@@ -2155,12 +2155,12 @@ export class AgentModel {
       .from(chatGroups)
       .where(inArray(chatGroups.id, [...agentIdsByGroup.keys()]));
 
-    const topicIdsByGroup = new Map<string, string[]>();
+    const topicsByGroup = new Map<string, { id: string; updatedAt: Date }[]>();
     for (const topic of candidateTopics) {
       if (!topic.groupId) continue;
-      const list = topicIdsByGroup.get(topic.groupId) ?? [];
-      list.push(topic.id);
-      topicIdsByGroup.set(topic.groupId, list);
+      const list = topicsByGroup.get(topic.groupId) ?? [];
+      list.push({ id: topic.id, updatedAt: topic.updatedAt });
+      topicsByGroup.set(topic.groupId, list);
     }
 
     for (const group of groupRows) {
@@ -2189,12 +2189,15 @@ export class AgentModel {
         sourceAgentId,
       }));
 
-      const groupTopicIds = topicIdsByGroup.get(group.id) ?? [];
+      const groupTopics = topicsByGroup.get(group.id) ?? [];
+      const groupTopicIds = groupTopics.map((topic) => topic.id);
 
       // One statement per pair, exactly like the group transfer's remap loop —
       // the pair count is the number of moved agents with history here, i.e. a
       // handful. `updatedAt` is pinned so `$onUpdate` does not stamp a scope
-      // repair as fresh activity.
+      // repair as fresh activity. Topics and threads are always remapped
+      // inline (their counts are small and steps 6/8 below would otherwise
+      // drag them into the target scope).
       for (const { newAgentId, sourceAgentId } of remapPairs) {
         await trx
           .update(topics)
@@ -2214,12 +2217,57 @@ export class AgentModel {
         }
       }
 
-      // Both anchors on purpose: `group_id` covers topicless residue and rows
-      // whose topic is gone; the topic anchor covers rows that carry only a
-      // topicId into a group topic. Overlap is harmless — the remap is
-      // idempotent.
-      await remapMessageAgentIdsForGroups(trx, [group.id], remapPairs);
-      await remapMessageAgentIdsForTopics(trx, groupTopicIds, remapPairs);
+      // Message remap rides the same fast/slow contract as step 7's scope
+      // rewrite: rewriting a message row maintains every message index, so a
+      // group holding a HUGE history from these agents must not be rewritten
+      // inside this foreground transaction. Above the threshold the remap is
+      // recorded as a remap-only backfill job (drained topic-by-topic, scope
+      // untouched); until it drains, the guards on the covered agents block
+      // re-transfers and deletes, so the cascade hazard cannot fire early.
+      const remapAnchor =
+        groupTopicIds.length > 0
+          ? or(eq(messages.groupId, group.id), inArray(messages.topicId, groupTopicIds))
+          : eq(messages.groupId, group.id);
+      const [{ affectedGroupMessages }] = await trx
+        .select({ affectedGroupMessages: count() })
+        .from(messages)
+        .where(
+          and(
+            remapAnchor,
+            or(
+              inArray(messages.agentId, cloneSourceIds),
+              inArray(messages.targetId, cloneSourceIds),
+            ),
+          ),
+        );
+
+      if (affectedGroupMessages <= getAgentTransferSyncMessageThreshold()) {
+        // Both anchors on purpose: `group_id` covers topicless residue and
+        // rows whose topic is gone; the topic anchor covers rows that carry
+        // only a topicId into a group topic. Overlap is harmless — the remap
+        // is idempotent.
+        await remapMessageAgentIdsForGroups(trx, [group.id], remapPairs);
+        await remapMessageAgentIdsForTopics(trx, groupTopicIds, remapPairs);
+      } else {
+        const groupScope = { userId: group.userId, workspaceId: group.workspaceId };
+        await AgentTransferJobModel.createJob(trx, {
+          // Junction coverage on the moved agents: blocks a re-transfer
+          // (step 1a's pending-job guard) and — via the remap payload — a
+          // delete of the moved agent (`hasPendingRemapForSourceAgents`)
+          // until the group's rows stop pointing at it.
+          agentIds: cloneSourceIds,
+          agentIdRemap: remapPairs,
+          groupIds: [group.id],
+          remapOnly: true,
+          // No residual scope rewrite happens for a remap-only job; the
+          // residual REMAP anchors on `groupIds` above.
+          residualAgentIds: [],
+          sessionIds: [],
+          source: groupScope,
+          target: groupScope,
+          topics: groupTopics.map((topic) => ({ activityAt: topic.updatedAt, id: topic.id })),
+        });
+      }
     }
   };
 

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -67,7 +67,7 @@ import {
   collectBoundDeviceIds,
   sanitizeAgencyConfigsForWorkspace,
 } from '../utils/agencyConfigDevices';
-import { buildAgentCopyValues } from '../utils/agentClone';
+import { buildAgentTombstoneValues } from '../utils/agentClone';
 import {
   rehomeAgentConnectorsForRecipient,
   rehomeAgentConnectorsForScopeTransfer,
@@ -2152,22 +2152,20 @@ export class AgentModel {
     const remapJobIds: string[] = [];
     for (const group of groupRows) {
       const cloneSourceIds = [...agentIdsByGroup.get(group.id)!];
+      // Display-only field set on purpose: the tombstone exists to render
+      // past speakers, and its owner may be someone the source agent's owner
+      // never shared configuration with. `virtual: true` (baked into the
+      // builder) hides it from every list and member picker.
       const clones = await trx
         .insert(agents)
         .values(
-          cloneSourceIds.map((sourceId) => ({
-            ...buildAgentCopyValues(
+          cloneSourceIds.map((sourceId) =>
+            buildAgentTombstoneValues(
               agentById.get(sourceId),
               { userId: group.userId, workspaceId: group.workspaceId },
               'Agent',
             ),
-            // Same overrides, same rationale as the group transfer's clone
-            // site: the tombstone exists for this history and nothing else —
-            // `virtual: true` hides it from every list and member picker, and
-            // a pin is the source owner's sidebar choice, not the group's.
-            pinned: false,
-            virtual: true,
-          })),
+          ),
         )
         .returning({ id: agents.id });
 

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2145,13 +2145,23 @@ export class AgentModel {
         .where(
           and(inArray(topics.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
         )),
-      // Thread-anchored mentions, same fencing via threads.group_id.
+      // Thread-anchored mentions, same fencing via threads.group_id — and
+      // via the thread's group TOPIC for threads that carry no group_id of
+      // their own.
       ...(await trx
         .selectDistinct({ agentId: messages.targetId, groupId: threads.groupId })
         .from(messages)
         .innerJoin(threads, eq(messages.threadId, threads.id))
         .where(
           and(inArray(threads.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
+        )),
+      ...(await trx
+        .selectDistinct({ agentId: messages.targetId, groupId: topics.groupId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(
+          and(inArray(topics.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
         )),
     );
 

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2045,11 +2045,13 @@ export class AgentModel {
    * `topics/threads/messages.agent_id` (+ the FK-less `messages.target_id`)
    * from the moved agent onto its clone.
    *
-   * The clone is scoped per group scope, not per group: every group in one
-   * scope can resolve the same tombstone, and cross-scope groups (a workspace
-   * group referencing a personal agent) each get one that THEIR readers can
-   * load. Agents with no group history insert nothing — the common case costs
-   * six index-only probes.
+   * The clone is scoped per group, in the group's own scope: cross-scope
+   * groups (a workspace group referencing a personal agent) each get one that
+   * THEIR readers can load, and a later same-workspace ownership handover
+   * (`ChatGroupModel.transferGroupOwnership`) can re-home one group's
+   * tombstones without pulling another group's history along. Agents with no
+   * group history insert nothing — the common case costs a handful of
+   * index-only probes.
    */
   private preserveGroupHistoryForTransfer = async (
     trx: Transaction,
@@ -2058,9 +2060,7 @@ export class AgentModel {
   ): Promise<void> => {
     // (group, agent) pairs holding history. The direct arms anchor on the
     // rows' own group_id; the join arms catch rows that carry only a topicId
-    // into a group topic. `messages.target_id` (no FK) rides the same pairs —
-    // it cannot cascade anything, but left stale it would attribute @mentions
-    // to an agent the scope cannot see.
+    // into a group topic. Every arm probes an agent_id index.
     const pairSources: { agentId: string | null; groupId: string | null }[] = [
       ...(await trx
         .selectDistinct({ agentId: topics.agentId, groupId: topics.groupId })
@@ -2084,11 +2084,59 @@ export class AgentModel {
         .from(messages)
         .innerJoin(topics, eq(messages.topicId, topics.id))
         .where(and(inArray(messages.agentId, agentIds), isNotNull(topics.groupId)))),
+    ];
+
+    // `messages.target_id` (no FK) rides the same pairs — it cannot cascade
+    // anything, but left stale it would attribute @mentions to an agent the
+    // scope cannot see. Unlike the arms above it has no index, so the scan is
+    // fenced to candidate groups reachable through indexed paths: every group
+    // the arms already surfaced plus the agents' current roster rows. A
+    // target-only reference outside both (the agent left the group without
+    // ever leaving an indexed trace behind) stays put — acceptable for a soft
+    // reference that cannot cascade anything.
+    const rosterGroupRows = await trx
+      .selectDistinct({ groupId: chatGroupsAgents.chatGroupId })
+      .from(chatGroupsAgents)
+      .where(inArray(chatGroupsAgents.agentId, agentIds));
+    const candidateGroupIds = [
+      ...new Set([
+        ...pairSources.map((pair) => pair.groupId),
+        ...rosterGroupRows.map((row) => row.groupId),
+      ]),
+    ].filter((id): id is string => Boolean(id));
+    if (candidateGroupIds.length === 0) return;
+
+    const candidateTopics = await trx
+      .select({ groupId: topics.groupId, id: topics.id })
+      .from(topics)
+      .where(inArray(topics.groupId, candidateGroupIds));
+    const topicGroupById = new Map(candidateTopics.map((topic) => [topic.id, topic.groupId]));
+
+    pairSources.push(
       ...(await trx
         .selectDistinct({ agentId: messages.targetId, groupId: messages.groupId })
         .from(messages)
-        .where(and(inArray(messages.targetId, agentIds), isNotNull(messages.groupId)))),
-    ];
+        .where(
+          and(inArray(messages.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
+        )),
+    );
+    if (candidateTopics.length > 0) {
+      const targetRows = await trx
+        .selectDistinct({ agentId: messages.targetId, topicId: messages.topicId })
+        .from(messages)
+        .where(
+          and(
+            inArray(messages.topicId, [...topicGroupById.keys()]),
+            inArray(messages.targetId, agentIds),
+          ),
+        );
+      pairSources.push(
+        ...targetRows.map((row) => ({
+          agentId: row.agentId,
+          groupId: (row.topicId && topicGroupById.get(row.topicId)) || null,
+        })),
+      );
+    }
 
     const agentIdsByGroup = new Map<string, Set<string>>();
     for (const { agentId, groupId } of pairSources) {
@@ -2107,32 +2155,23 @@ export class AgentModel {
       .from(chatGroups)
       .where(inArray(chatGroups.id, [...agentIdsByGroup.keys()]));
 
-    const scopes = new Map<
-      string,
-      { agentIds: Set<string>; groupIds: string[]; userId: string; workspaceId: string | null }
-    >();
-    for (const group of groupRows) {
-      const key = `${group.userId}\0${group.workspaceId ?? ''}`;
-      const scope = scopes.get(key) ?? {
-        agentIds: new Set<string>(),
-        groupIds: [],
-        userId: group.userId,
-        workspaceId: group.workspaceId,
-      };
-      scope.groupIds.push(group.id);
-      for (const agentId of agentIdsByGroup.get(group.id)!) scope.agentIds.add(agentId);
-      scopes.set(key, scope);
+    const topicIdsByGroup = new Map<string, string[]>();
+    for (const topic of candidateTopics) {
+      if (!topic.groupId) continue;
+      const list = topicIdsByGroup.get(topic.groupId) ?? [];
+      list.push(topic.id);
+      topicIdsByGroup.set(topic.groupId, list);
     }
 
-    for (const scope of scopes.values()) {
-      const cloneSourceIds = [...scope.agentIds];
+    for (const group of groupRows) {
+      const cloneSourceIds = [...agentIdsByGroup.get(group.id)!];
       const clones = await trx
         .insert(agents)
         .values(
           cloneSourceIds.map((sourceId) => ({
             ...buildAgentCopyValues(
               agentById.get(sourceId),
-              { userId: scope.userId, workspaceId: scope.workspaceId },
+              { userId: group.userId, workspaceId: group.workspaceId },
               'Agent',
             ),
             // Same overrides, same rationale as the group transfer's clone
@@ -2150,12 +2189,7 @@ export class AgentModel {
         sourceAgentId,
       }));
 
-      const groupTopicIds = (
-        await trx
-          .select({ id: topics.id })
-          .from(topics)
-          .where(inArray(topics.groupId, scope.groupIds))
-      ).map((row) => row.id);
+      const groupTopicIds = topicIdsByGroup.get(group.id) ?? [];
 
       // One statement per pair, exactly like the group transfer's remap loop —
       // the pair count is the number of moved agents with history here, i.e. a
@@ -2165,11 +2199,11 @@ export class AgentModel {
         await trx
           .update(topics)
           .set({ agentId: newAgentId, updatedAt: topics.updatedAt })
-          .where(and(inArray(topics.groupId, scope.groupIds), eq(topics.agentId, sourceAgentId)));
+          .where(and(eq(topics.groupId, group.id), eq(topics.agentId, sourceAgentId)));
         await trx
           .update(threads)
           .set({ agentId: newAgentId, updatedAt: threads.updatedAt })
-          .where(and(inArray(threads.groupId, scope.groupIds), eq(threads.agentId, sourceAgentId)));
+          .where(and(eq(threads.groupId, group.id), eq(threads.agentId, sourceAgentId)));
         if (groupTopicIds.length > 0) {
           await trx
             .update(threads)
@@ -2184,7 +2218,7 @@ export class AgentModel {
       // whose topic is gone; the topic anchor covers rows that carry only a
       // topicId into a group topic. Overlap is harmless — the remap is
       // idempotent.
-      await remapMessageAgentIdsForGroups(trx, scope.groupIds, remapPairs);
+      await remapMessageAgentIdsForGroups(trx, [group.id], remapPairs);
       await remapMessageAgentIdsForTopics(trx, groupTopicIds, remapPairs);
     }
   };

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -95,7 +95,7 @@ import {
   AgentTransferJobModel,
   getAgentTransferSyncMessageThreshold,
   remapMessageAgentIdsForGroups,
-  remapMessageAgentIdsForTopics,
+  remapMessageAgentIdsForGroupTopics,
   rewriteMessageScopeForTopics,
   rewriteResidualMessageScope,
 } from './agentTransferJob';
@@ -2053,11 +2053,17 @@ export class AgentModel {
    * group history insert nothing — the common case costs a handful of
    * index-only probes.
    */
+  /**
+   * Returns the ids of any remap-only backfill jobs it recorded (one per
+   * group whose history exceeded the sync threshold). They are created inside
+   * the transfer transaction but the drain runs OUTSIDE it — the caller must
+   * kick each one post-commit, exactly like the main `transferJobId`.
+   */
   private preserveGroupHistoryForTransfer = async (
     trx: Transaction,
     agentIds: string[],
     agentById: Map<string, AgentItem>,
-  ): Promise<void> => {
+  ): Promise<string[]> => {
     // (group, agent) pairs holding history. The direct arms anchor on the
     // rows' own group_id; the join arms catch rows that carry only a topicId
     // into a group topic. Every arm probes an agent_id index.
@@ -2104,13 +2110,7 @@ export class AgentModel {
         ...rosterGroupRows.map((row) => row.groupId),
       ]),
     ].filter((id): id is string => Boolean(id));
-    if (candidateGroupIds.length === 0) return;
-
-    const candidateTopics = await trx
-      .select({ groupId: topics.groupId, id: topics.id, updatedAt: topics.updatedAt })
-      .from(topics)
-      .where(inArray(topics.groupId, candidateGroupIds));
-    const topicGroupById = new Map(candidateTopics.map((topic) => [topic.id, topic.groupId]));
+    if (candidateGroupIds.length === 0) return [];
 
     pairSources.push(
       ...(await trx
@@ -2119,24 +2119,17 @@ export class AgentModel {
         .where(
           and(inArray(messages.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
         )),
-    );
-    if (candidateTopics.length > 0) {
-      const targetRows = await trx
-        .selectDistinct({ agentId: messages.targetId, topicId: messages.topicId })
+      // Topic-anchored mentions: driven from the topics side (group_id index)
+      // through messages.topic_id — never by the unindexed target_id, and
+      // never by expanding a group's topic list into bind parameters.
+      ...(await trx
+        .selectDistinct({ agentId: messages.targetId, groupId: topics.groupId })
         .from(messages)
+        .innerJoin(topics, eq(messages.topicId, topics.id))
         .where(
-          and(
-            inArray(messages.topicId, [...topicGroupById.keys()]),
-            inArray(messages.targetId, agentIds),
-          ),
-        );
-      pairSources.push(
-        ...targetRows.map((row) => ({
-          agentId: row.agentId,
-          groupId: (row.topicId && topicGroupById.get(row.topicId)) || null,
-        })),
-      );
-    }
+          and(inArray(topics.groupId, candidateGroupIds), inArray(messages.targetId, agentIds)),
+        )),
+    );
 
     const agentIdsByGroup = new Map<string, Set<string>>();
     for (const { agentId, groupId } of pairSources) {
@@ -2145,7 +2138,7 @@ export class AgentModel {
       set.add(agentId);
       agentIdsByGroup.set(groupId, set);
     }
-    if (agentIdsByGroup.size === 0) return;
+    if (agentIdsByGroup.size === 0) return [];
 
     // The FK guarantees every referenced group row still exists (topics /
     // threads cascade with their group; messages.group_id is SET NULL), so
@@ -2155,14 +2148,7 @@ export class AgentModel {
       .from(chatGroups)
       .where(inArray(chatGroups.id, [...agentIdsByGroup.keys()]));
 
-    const topicsByGroup = new Map<string, { id: string; updatedAt: Date }[]>();
-    for (const topic of candidateTopics) {
-      if (!topic.groupId) continue;
-      const list = topicsByGroup.get(topic.groupId) ?? [];
-      list.push({ id: topic.id, updatedAt: topic.updatedAt });
-      topicsByGroup.set(topic.groupId, list);
-    }
-
+    const remapJobIds: string[] = [];
     for (const group of groupRows) {
       const cloneSourceIds = [...agentIdsByGroup.get(group.id)!];
       const clones = await trx
@@ -2189,8 +2175,13 @@ export class AgentModel {
         sourceAgentId,
       }));
 
-      const groupTopics = topicsByGroup.get(group.id) ?? [];
-      const groupTopicIds = groupTopics.map((topic) => topic.id);
+      // The group's topics enter every probe below as a subquery, never as an
+      // expanded id list — a long-lived group can hold more topics than
+      // PostgreSQL's bind-parameter limit allows in an `IN (...)` list.
+      const groupTopicSubquery = trx
+        .select({ id: topics.id })
+        .from(topics)
+        .where(eq(topics.groupId, group.id));
 
       // One statement per pair, exactly like the group transfer's remap loop —
       // the pair count is the number of moved agents with history here, i.e. a
@@ -2207,14 +2198,12 @@ export class AgentModel {
           .update(threads)
           .set({ agentId: newAgentId, updatedAt: threads.updatedAt })
           .where(and(eq(threads.groupId, group.id), eq(threads.agentId, sourceAgentId)));
-        if (groupTopicIds.length > 0) {
-          await trx
-            .update(threads)
-            .set({ agentId: newAgentId, updatedAt: threads.updatedAt })
-            .where(
-              and(inArray(threads.topicId, groupTopicIds), eq(threads.agentId, sourceAgentId)),
-            );
-        }
+        await trx
+          .update(threads)
+          .set({ agentId: newAgentId, updatedAt: threads.updatedAt })
+          .where(
+            and(inArray(threads.topicId, groupTopicSubquery), eq(threads.agentId, sourceAgentId)),
+          );
       }
 
       // Message remap rides the same fast/slow contract as step 7's scope
@@ -2224,10 +2213,10 @@ export class AgentModel {
       // recorded as a remap-only backfill job (drained topic-by-topic, scope
       // untouched); until it drains, the guards on the covered agents block
       // re-transfers and deletes, so the cascade hazard cannot fire early.
-      const remapAnchor =
-        groupTopicIds.length > 0
-          ? or(eq(messages.groupId, group.id), inArray(messages.topicId, groupTopicIds))
-          : eq(messages.groupId, group.id);
+      const remapAnchor = or(
+        eq(messages.groupId, group.id),
+        inArray(messages.topicId, groupTopicSubquery),
+      );
       const [{ affectedGroupMessages }] = await trx
         .select({ affectedGroupMessages: count() })
         .from(messages)
@@ -2247,10 +2236,16 @@ export class AgentModel {
         // only a topicId into a group topic. Overlap is harmless — the remap
         // is idempotent.
         await remapMessageAgentIdsForGroups(trx, [group.id], remapPairs);
-        await remapMessageAgentIdsForTopics(trx, groupTopicIds, remapPairs);
+        await remapMessageAgentIdsForGroupTopics(trx, [group.id], remapPairs);
       } else {
+        // The topic list is only materialized on this rare path — it feeds
+        // the job's drain queue, and `createJob` chunks the inserts.
+        const groupTopics = await trx
+          .select({ id: topics.id, updatedAt: topics.updatedAt })
+          .from(topics)
+          .where(eq(topics.groupId, group.id));
         const groupScope = { userId: group.userId, workspaceId: group.workspaceId };
-        await AgentTransferJobModel.createJob(trx, {
+        const remapJobId = await AgentTransferJobModel.createJob(trx, {
           // Junction coverage on the moved agents: blocks a re-transfer
           // (step 1a's pending-job guard) and — via the remap payload — a
           // delete of the moved agent (`hasPendingRemapForSourceAgents`)
@@ -2267,8 +2262,11 @@ export class AgentModel {
           target: groupScope,
           topics: groupTopics.map((topic) => ({ activityAt: topic.updatedAt, id: topic.id })),
         });
+        remapJobIds.push(remapJobId);
       }
     }
+
+    return remapJobIds;
   };
 
   transferAgent = async (
@@ -2277,7 +2275,12 @@ export class AgentModel {
     targetUserId: string,
     targetVisibility?: 'private' | 'public',
     options: { rejectForeignTopicCommentAuthors?: boolean } = {},
-  ): Promise<{ agentId: string; slug: string | null; transferJobId: string | null }> => {
+  ): Promise<{
+    agentId: string;
+    remapJobIds: string[];
+    slug: string | null;
+    transferJobId: string | null;
+  }> => {
     const [result] = await this.transferAgents(
       [agentId],
       targetWorkspaceId,
@@ -2300,7 +2303,9 @@ export class AgentModel {
     targetUserId: string,
     targetVisibility?: 'private' | 'public',
     options: { rejectForeignTopicCommentAuthors?: boolean } = {},
-  ): Promise<{ agentId: string; slug: string | null; transferJobId: string | null }[]> => {
+  ): Promise<
+    { agentId: string; remapJobIds: string[]; slug: string | null; transferJobId: string | null }[]
+  > => {
     if (agentIds.length === 0) return [];
 
     return this.db.transaction(async (trx) => {
@@ -2499,7 +2504,7 @@ export class AgentModel {
       // repointing the group rows first also keeps those moves from dragging
       // group history into the target scope (threads matched by `agent_id` in
       // step 8, topicless group messages in step 7's residual rewrite).
-      await this.preserveGroupHistoryForTransfer(trx, agentIds, agentById);
+      const remapJobIds = await this.preserveGroupHistoryForTransfer(trx, agentIds, agentById);
 
       // 6. Update topics (linked via sessionId or agentId)
       const topicCondition =
@@ -2789,6 +2794,9 @@ export class AgentModel {
 
       return agentIds.map((id) => ({
         agentId: id,
+        // Shared by the whole batch, like `transferJobId`: the caller must
+        // kick every one post-commit or the deferred remaps never drain.
+        remapJobIds,
         slug: resolvedSlugs.get(id) ?? agentById.get(id)?.slug ?? null,
         transferJobId,
       }));

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -16,6 +16,7 @@ import {
   gt,
   ilike,
   inArray,
+  isNotNull,
   isNull,
   like,
   ne,
@@ -66,6 +67,7 @@ import {
   collectBoundDeviceIds,
   sanitizeAgencyConfigsForWorkspace,
 } from '../utils/agencyConfigDevices';
+import { buildAgentCopyValues } from '../utils/agentClone';
 import {
   rehomeAgentConnectorsForRecipient,
   rehomeAgentConnectorsForScopeTransfer,
@@ -89,8 +91,11 @@ import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 import { AGENT_COPY_IN_PROGRESS, AgentCopyJobModel } from './agentCopyJob';
 import {
   AGENT_TRANSFER_IN_PROGRESS,
+  type AgentIdRemapPair,
   AgentTransferJobModel,
   getAgentTransferSyncMessageThreshold,
+  remapMessageAgentIdsForGroups,
+  remapMessageAgentIdsForTopics,
   rewriteMessageScopeForTopics,
   rewriteResidualMessageScope,
 } from './agentTransferJob';
@@ -2031,6 +2036,159 @@ export class AgentModel {
     );
   };
 
+  /**
+   * The tombstone half of step 5c in {@link transferAgents} — see the call
+   * site for the why. Finds every chat group the moved agents left history in
+   * (NOT limited to current roster rows: a reference left over from an
+   * earlier membership is just as much a cascade hazard), inserts one virtual
+   * clone per (agent × group scope) in the GROUPS' scope, and repoints
+   * `topics/threads/messages.agent_id` (+ the FK-less `messages.target_id`)
+   * from the moved agent onto its clone.
+   *
+   * The clone is scoped per group scope, not per group: every group in one
+   * scope can resolve the same tombstone, and cross-scope groups (a workspace
+   * group referencing a personal agent) each get one that THEIR readers can
+   * load. Agents with no group history insert nothing — the common case costs
+   * six index-only probes.
+   */
+  private preserveGroupHistoryForTransfer = async (
+    trx: Transaction,
+    agentIds: string[],
+    agentById: Map<string, AgentItem>,
+  ): Promise<void> => {
+    // (group, agent) pairs holding history. The direct arms anchor on the
+    // rows' own group_id; the join arms catch rows that carry only a topicId
+    // into a group topic. `messages.target_id` (no FK) rides the same pairs —
+    // it cannot cascade anything, but left stale it would attribute @mentions
+    // to an agent the scope cannot see.
+    const pairSources: { agentId: string | null; groupId: string | null }[] = [
+      ...(await trx
+        .selectDistinct({ agentId: topics.agentId, groupId: topics.groupId })
+        .from(topics)
+        .where(and(inArray(topics.agentId, agentIds), isNotNull(topics.groupId)))),
+      ...(await trx
+        .selectDistinct({ agentId: threads.agentId, groupId: threads.groupId })
+        .from(threads)
+        .where(and(inArray(threads.agentId, agentIds), isNotNull(threads.groupId)))),
+      ...(await trx
+        .selectDistinct({ agentId: threads.agentId, groupId: topics.groupId })
+        .from(threads)
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(and(inArray(threads.agentId, agentIds), isNotNull(topics.groupId)))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.agentId, groupId: messages.groupId })
+        .from(messages)
+        .where(and(inArray(messages.agentId, agentIds), isNotNull(messages.groupId)))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.agentId, groupId: topics.groupId })
+        .from(messages)
+        .innerJoin(topics, eq(messages.topicId, topics.id))
+        .where(and(inArray(messages.agentId, agentIds), isNotNull(topics.groupId)))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.targetId, groupId: messages.groupId })
+        .from(messages)
+        .where(and(inArray(messages.targetId, agentIds), isNotNull(messages.groupId)))),
+    ];
+
+    const agentIdsByGroup = new Map<string, Set<string>>();
+    for (const { agentId, groupId } of pairSources) {
+      if (!agentId || !groupId) continue;
+      const set = agentIdsByGroup.get(groupId) ?? new Set<string>();
+      set.add(agentId);
+      agentIdsByGroup.set(groupId, set);
+    }
+    if (agentIdsByGroup.size === 0) return;
+
+    // The FK guarantees every referenced group row still exists (topics /
+    // threads cascade with their group; messages.group_id is SET NULL), so
+    // this read is total over the pairs above.
+    const groupRows = await trx
+      .select({ id: chatGroups.id, userId: chatGroups.userId, workspaceId: chatGroups.workspaceId })
+      .from(chatGroups)
+      .where(inArray(chatGroups.id, [...agentIdsByGroup.keys()]));
+
+    const scopes = new Map<
+      string,
+      { agentIds: Set<string>; groupIds: string[]; userId: string; workspaceId: string | null }
+    >();
+    for (const group of groupRows) {
+      const key = `${group.userId}\0${group.workspaceId ?? ''}`;
+      const scope = scopes.get(key) ?? {
+        agentIds: new Set<string>(),
+        groupIds: [],
+        userId: group.userId,
+        workspaceId: group.workspaceId,
+      };
+      scope.groupIds.push(group.id);
+      for (const agentId of agentIdsByGroup.get(group.id)!) scope.agentIds.add(agentId);
+      scopes.set(key, scope);
+    }
+
+    for (const scope of scopes.values()) {
+      const cloneSourceIds = [...scope.agentIds];
+      const clones = await trx
+        .insert(agents)
+        .values(
+          cloneSourceIds.map((sourceId) => ({
+            ...buildAgentCopyValues(
+              agentById.get(sourceId),
+              { userId: scope.userId, workspaceId: scope.workspaceId },
+              'Agent',
+            ),
+            // Same overrides, same rationale as the group transfer's clone
+            // site: the tombstone exists for this history and nothing else —
+            // `virtual: true` hides it from every list and member picker, and
+            // a pin is the source owner's sidebar choice, not the group's.
+            pinned: false,
+            virtual: true,
+          })),
+        )
+        .returning({ id: agents.id });
+
+      const remapPairs: AgentIdRemapPair[] = cloneSourceIds.map((sourceAgentId, index) => ({
+        newAgentId: clones[index].id,
+        sourceAgentId,
+      }));
+
+      const groupTopicIds = (
+        await trx
+          .select({ id: topics.id })
+          .from(topics)
+          .where(inArray(topics.groupId, scope.groupIds))
+      ).map((row) => row.id);
+
+      // One statement per pair, exactly like the group transfer's remap loop —
+      // the pair count is the number of moved agents with history here, i.e. a
+      // handful. `updatedAt` is pinned so `$onUpdate` does not stamp a scope
+      // repair as fresh activity.
+      for (const { newAgentId, sourceAgentId } of remapPairs) {
+        await trx
+          .update(topics)
+          .set({ agentId: newAgentId, updatedAt: topics.updatedAt })
+          .where(and(inArray(topics.groupId, scope.groupIds), eq(topics.agentId, sourceAgentId)));
+        await trx
+          .update(threads)
+          .set({ agentId: newAgentId, updatedAt: threads.updatedAt })
+          .where(and(inArray(threads.groupId, scope.groupIds), eq(threads.agentId, sourceAgentId)));
+        if (groupTopicIds.length > 0) {
+          await trx
+            .update(threads)
+            .set({ agentId: newAgentId, updatedAt: threads.updatedAt })
+            .where(
+              and(inArray(threads.topicId, groupTopicIds), eq(threads.agentId, sourceAgentId)),
+            );
+        }
+      }
+
+      // Both anchors on purpose: `group_id` covers topicless residue and rows
+      // whose topic is gone; the topic anchor covers rows that carry only a
+      // topicId into a group topic. Overlap is harmless — the remap is
+      // idempotent.
+      await remapMessageAgentIdsForGroups(trx, scope.groupIds, remapPairs);
+      await remapMessageAgentIdsForTopics(trx, groupTopicIds, remapPairs);
+    }
+  };
+
   transferAgent = async (
     agentId: string,
     targetWorkspaceId: string | null,
@@ -2241,6 +2399,25 @@ export class AgentModel {
       await trx
         .delete(agentLabelAssignments)
         .where(inArray(agentLabelAssignments.agentId, agentIds));
+
+      // 5c. Preserve the history these agents leave behind in chat groups.
+      // Step 15 drops the roster rows, but the groups' topics / threads /
+      // messages keep `agent_id` pointing at the moved agents — and all three
+      // FKs are ON DELETE CASCADE, so deleting the agent later in its NEW
+      // scope would silently erase the old groups' history across scopes.
+      //
+      // Mirror of the group transfer's referenced-member clone
+      // (`AgentGroupRepository.transferToWorkspace`): whoever is the SUBJECT
+      // of a move is kept whole, and the side left behind gets a clone. Here
+      // the subject is the agent, so the clone — virtual, rosterless,
+      // invisible to every list — stays with the groups as a history
+      // tombstone in THEIR scope.
+      //
+      // Runs BEFORE the topic / thread / message moves below on purpose:
+      // repointing the group rows first also keeps those moves from dragging
+      // group history into the target scope (threads matched by `agent_id` in
+      // step 8, topicless group messages in step 7's residual rewrite).
+      await this.preserveGroupHistoryForTransfer(trx, agentIds, agentById);
 
       // 6. Update topics (linked via sessionId or agentId)
       const topicCondition =

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2150,6 +2150,7 @@ export class AgentModel {
       .where(inArray(chatGroups.id, [...agentIdsByGroup.keys()]));
 
     const remapJobIds: string[] = [];
+    let remainingSyncBudget = getAgentTransferSyncMessageThreshold();
     for (const group of groupRows) {
       const cloneSourceIds = [...agentIdsByGroup.get(group.id)!];
       // Display-only field set on purpose: the tombstone exists to render
@@ -2229,7 +2230,12 @@ export class AgentModel {
           ),
         );
 
-      if (affectedGroupMessages <= getAgentTransferSyncMessageThreshold()) {
+      if (affectedGroupMessages <= remainingSyncBudget) {
+        // The budget is shared across ALL groups in this transfer — an agent
+        // in twenty groups of 999 messages each must not rewrite ~20k rows
+        // in this foreground transaction just because each group alone sits
+        // under the threshold.
+        remainingSyncBudget -= affectedGroupMessages;
         // Both anchors on purpose: `group_id` covers topicless residue and
         // rows whose topic is gone; the topic anchor covers rows that carry
         // only a topicId into a group topic. Overlap is harmless — the remap

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2801,11 +2801,14 @@ export class AgentModel {
       // everything reaching here is a `referenced` link the caller confirmed.
       await trx.delete(chatGroupsAgents).where(inArray(chatGroupsAgents.agentId, agentIds));
 
-      return agentIds.map((id) => ({
+      return agentIds.map((id, index) => ({
         agentId: id,
-        // Shared by the whole batch, like `transferJobId`: the caller must
-        // kick every one post-commit or the deferred remaps never drain.
-        remapJobIds,
+        // Shared by the whole batch, like `transferJobId`, and carried only
+        // on the first element (the routers read it from there) — repeating
+        // a possibly long job list per agent would just multiply the
+        // response. The caller must kick every one post-commit or the
+        // deferred remaps never drain.
+        remapJobIds: index === 0 ? remapJobIds : [],
         slug: resolvedSlugs.get(id) ?? agentById.get(id)?.slug ?? null,
         transferJobId,
       }));

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -2575,7 +2575,13 @@ export class AgentModel {
       const targetScope = { userId: targetUserId, workspaceId: targetWorkspaceId };
       let transferJobId: string | null = null;
       if (affectedMessages <= getAgentTransferSyncMessageThreshold()) {
-        await rewriteMessageScopeForTopics(trx, movedTopicIds, targetScope);
+        // `excludeGroupRows`: a row pairing a group_id with a moved (agent-
+        // owned) topic was already repointed at its group's tombstone in step
+        // 5c and belongs to the group's scope — the topic rewrite must not
+        // drag it into the target.
+        await rewriteMessageScopeForTopics(trx, movedTopicIds, targetScope, {
+          excludeGroupRows: true,
+        });
         await rewriteResidualMessageScope(trx, { agentIds, sessionIds }, targetScope);
       } else {
         transferJobId = await AgentTransferJobModel.createJob(trx, {

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -14,6 +14,7 @@ import {
   messagesFiles,
   messageTranslates,
   messageTTS,
+  topics,
 } from '../schemas';
 import type { LobeChatDatabase, Transaction } from '../type';
 
@@ -225,6 +226,25 @@ export const remapMessageAgentIdsForGroups = async (
   if (groupIds.length === 0) return;
 
   await remapMessageAgentIds(executor, inArray(messages.groupId, groupIds), pairs);
+};
+
+/**
+ * {@link remapMessageAgentIds} over the messages of every topic the given
+ * groups hold, via a subquery — a long-lived group can hold more topics than
+ * PostgreSQL's bind-parameter limit allows in an `IN (...)` list.
+ */
+export const remapMessageAgentIdsForGroupTopics = async (
+  executor: Executor,
+  groupIds: string[],
+  pairs: AgentIdRemapPair[],
+): Promise<void> => {
+  if (groupIds.length === 0) return;
+
+  await remapMessageAgentIds(
+    executor,
+    sql`${messages.topicId} IN (SELECT ${topics.id} FROM ${topics} WHERE ${inArray(topics.groupId, groupIds)})`,
+    pairs,
+  );
 };
 
 /**

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -217,10 +217,26 @@ export const remapMessageAgentIdsForTopics = async (
   executor: Executor,
   topicIds: string[],
   pairs: AgentIdRemapPair[],
+  options: {
+    /**
+     * Skip rows whose `group_id` names a group OUTSIDE this list (rows with a
+     * NULL group_id always remap). A schema-valid row can pair group H with a
+     * topic of group G; its history belongs to H (the direct anchor wins), so
+     * G's topic-anchored remap must not claim it first — the remaps are not
+     * idempotent across different clones.
+     */
+    restrictToGroupIdsOrNull?: string[];
+  } = {},
 ): Promise<void> => {
   if (topicIds.length === 0) return;
 
-  await remapMessageAgentIds(executor, inArray(messages.topicId, topicIds), pairs);
+  const base = inArray(messages.topicId, topicIds);
+  const restrict = options.restrictToGroupIdsOrNull;
+  const condition = restrict
+    ? and(base, or(isNull(messages.groupId), inArray(messages.groupId, restrict)))!
+    : base;
+
+  await remapMessageAgentIds(executor, condition, pairs);
 };
 
 /**
@@ -254,9 +270,12 @@ export const remapMessageAgentIdsForGroupTopics = async (
 ): Promise<void> => {
   if (groupIds.length === 0) return;
 
+  // The group-id guard mirrors `restrictToGroupIdsOrNull` on the topic
+  // variant: a row anchored to a DIFFERENT group via its own group_id belongs
+  // to that group's remap, not this topic-derived one.
   await remapMessageAgentIds(
     executor,
-    sql`${messages.topicId} IN (SELECT ${topics.id} FROM ${topics} WHERE ${inArray(topics.groupId, groupIds)})`,
+    sql`${messages.topicId} IN (SELECT ${topics.id} FROM ${topics} WHERE ${inArray(topics.groupId, groupIds)}) AND (${messages.groupId} IS NULL OR ${inArray(messages.groupId, groupIds)})`,
     pairs,
   );
 };
@@ -803,7 +822,16 @@ export class AgentTransferJobModel {
           excludeGroupRows: job.groupIds.length === 0,
         });
       }
-      if (agentIdRemap) await remapMessageAgentIdsForTopics(trx, [next.topicId], agentIdRemap);
+      if (agentIdRemap) {
+        // A remap-only drain restricts to its own groups' rows — a row whose
+        // group_id names another group belongs to THAT group's remap.
+        await remapMessageAgentIdsForTopics(
+          trx,
+          [next.topicId],
+          agentIdRemap,
+          remapOnly ? { restrictToGroupIdsOrNull: job.groupIds } : {},
+        );
+      }
       await trx
         .delete(agentHistoryJobTopics)
         .where(

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -48,6 +48,20 @@ type Executor = Pick<LobeChatDatabase, 'execute'> | Transaction;
  * anchor column, so the child always follows whatever set of parent messages
  * the caller's condition selects.
  */
+/**
+ * True when the row does NOT reach a group through its thread — the thread is
+ * absent, carries no group_id, and is not hosted on a group topic. Shared by
+ * every agent-transfer rewrite that must leave group history where it is: a
+ * row anchored to a stationary group's thread belongs to the group's scope
+ * even when its own group_id is null.
+ */
+const notGroupThreadAnchored = () => sql`NOT EXISTS (
+  SELECT 1 FROM ${threads}
+  WHERE ${threads.id} = ${messages.threadId}
+    AND (${threads.groupId} IS NOT NULL
+      OR EXISTS (SELECT 1 FROM ${topics} WHERE ${topics.id} = ${threads.topicId} AND ${topics.groupId} IS NOT NULL))
+)`;
+
 const MESSAGE_CHILD_ANCHORS = [
   { anchor: messagePlugins.id, table: messagePlugins },
   { anchor: messageTranslates.id, table: messageTranslates },
@@ -77,12 +91,13 @@ export const rewriteMessageScopeForTopics = async (
   target: AgentTransferTargetScope,
   options: {
     /**
-     * Skip rows that carry a `group_id`. An AGENT transfer must set this: a
-     * legal row can pair a group_id with a topic_id owned by the moved agent,
-     * and while the group-history preservation step repoints its agent_id at
-     * the tombstone, it belongs to the GROUP's scope and must not follow the
-     * topic into the transfer target. A GROUP transfer keeps such rows — the
-     * group is the thing moving.
+     * Skip rows that carry a `group_id` OR reach a stationary group through
+     * their thread. An AGENT transfer must set this: a legal row can pair a
+     * group anchor with a topic_id owned by the moved agent, and while the
+     * group-history preservation step repoints its agent_id at the tombstone,
+     * it belongs to the GROUP's scope and must not follow the topic into the
+     * transfer target. A GROUP transfer keeps such rows — the group is the
+     * thing moving.
      */
     excludeGroupRows?: boolean;
   } = {},
@@ -91,7 +106,7 @@ export const rewriteMessageScopeForTopics = async (
 
   const inTopicsAlone = inArray(messages.topicId, topicIds);
   const inTopics = options.excludeGroupRows
-    ? and(inTopicsAlone, isNull(messages.groupId))!
+    ? and(inTopicsAlone, isNull(messages.groupId), notGroupThreadAnchored())!
     : inTopicsAlone;
 
   await executor.execute(sql`
@@ -133,12 +148,6 @@ export const rewriteResidualMessageScope = async (
   // both shapes. Without this, an agent transfer whose group-history remap is
   // still pending (deferred to a remap-only job) would drag the group's
   // topicless residue into the target scope.
-  const notGroupThreadAnchored = sql`NOT EXISTS (
-    SELECT 1 FROM ${threads}
-    WHERE ${threads.id} = ${messages.threadId}
-      AND (${threads.groupId} IS NOT NULL
-        OR EXISTS (SELECT 1 FROM ${topics} WHERE ${topics.id} = ${threads.topicId} AND ${topics.groupId} IS NOT NULL))
-  )`;
   const scopeArms: SQL[] = [];
   if (linkage.sessionIds.length > 0)
     scopeArms.push(inArray(messages.sessionId, linkage.sessionIds));
@@ -149,7 +158,7 @@ export const rewriteResidualMessageScope = async (
       and(
         scopeArms.length === 1 ? scopeArms[0] : or(...scopeArms),
         isNull(messages.groupId),
-        notGroupThreadAnchored,
+        notGroupThreadAnchored(),
       )!,
     );
   if (linkage.groupIds && linkage.groupIds.length > 0)

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -14,6 +14,7 @@ import {
   messagesFiles,
   messageTranslates,
   messageTTS,
+  threads,
   topics,
 } from '../schemas';
 import type { LobeChatDatabase, Transaction } from '../type';
@@ -126,11 +127,18 @@ export const rewriteResidualMessageScope = async (
   linkage: { agentIds: string[]; groupIds?: string[]; sessionIds: string[] },
   target: AgentTransferTargetScope,
 ): Promise<void> => {
-  // A row that carries a group_id belongs to that group's scope and moves
-  // only when its group is the thing being transferred — the session / agent
-  // arms therefore exclude group rows. Without this, an agent transfer whose
-  // group-history remap is still pending (deferred to a remap-only job) would
-  // drag the group's topicless residue into the target scope.
+  // A row that carries a group_id — or reaches a group only through its
+  // thread — belongs to that group's scope and moves only when its group is
+  // the thing being transferred: the session / agent arms therefore exclude
+  // both shapes. Without this, an agent transfer whose group-history remap is
+  // still pending (deferred to a remap-only job) would drag the group's
+  // topicless residue into the target scope.
+  const notGroupThreadAnchored = sql`NOT EXISTS (
+    SELECT 1 FROM ${threads}
+    WHERE ${threads.id} = ${messages.threadId}
+      AND (${threads.groupId} IS NOT NULL
+        OR EXISTS (SELECT 1 FROM ${topics} WHERE ${topics.id} = ${threads.topicId} AND ${topics.groupId} IS NOT NULL))
+  )`;
   const scopeArms: SQL[] = [];
   if (linkage.sessionIds.length > 0)
     scopeArms.push(inArray(messages.sessionId, linkage.sessionIds));
@@ -138,7 +146,11 @@ export const rewriteResidualMessageScope = async (
   const arms: SQL[] = [];
   if (scopeArms.length > 0)
     arms.push(
-      and(scopeArms.length === 1 ? scopeArms[0] : or(...scopeArms), isNull(messages.groupId))!,
+      and(
+        scopeArms.length === 1 ? scopeArms[0] : or(...scopeArms),
+        isNull(messages.groupId),
+        notGroupThreadAnchored,
+      )!,
     );
   if (linkage.groupIds && linkage.groupIds.length > 0)
     arms.push(inArray(messages.groupId, linkage.groupIds));
@@ -276,6 +288,30 @@ export const remapMessageAgentIdsForGroupTopics = async (
   await remapMessageAgentIds(
     executor,
     sql`${messages.topicId} IN (SELECT ${topics.id} FROM ${topics} WHERE ${inArray(topics.groupId, groupIds)}) AND (${messages.groupId} IS NULL OR ${inArray(messages.groupId, groupIds)})`,
+    pairs,
+  );
+};
+
+/**
+ * {@link remapMessageAgentIds} over rows anchored to the given groups only
+ * through a THREAD (API-imported / legacy shapes: threadId set, topicId and
+ * groupId both null) — a group-anchored thread, or one hosted on a group
+ * topic. The direct-group precedence guard matches the topic variant.
+ */
+export const remapMessageAgentIdsForGroupThreads = async (
+  executor: Executor,
+  groupIds: string[],
+  pairs: AgentIdRemapPair[],
+): Promise<void> => {
+  if (groupIds.length === 0) return;
+
+  await remapMessageAgentIds(
+    executor,
+    sql`${messages.threadId} IN (
+      SELECT ${threads.id} FROM ${threads}
+      WHERE ${inArray(threads.groupId, groupIds)}
+         OR ${threads.topicId} IN (SELECT ${topics.id} FROM ${topics} WHERE ${inArray(topics.groupId, groupIds)})
+    ) AND (${messages.groupId} IS NULL OR ${inArray(messages.groupId, groupIds)})`,
     pairs,
   );
 };
@@ -797,6 +833,9 @@ export class AgentTransferJobModel {
             // such rows via the same group-anchored remap; by finalization
             // the bulk is already remapped, so this touches only leftovers.
             await remapMessageAgentIdsForGroups(trx, job.groupIds, agentIdRemap);
+            // Thread-anchored rows (threadId only) sit outside the per-topic
+            // queue too — same finalization sweep as the synchronous branch.
+            await remapMessageAgentIdsForGroupThreads(trx, job.groupIds, agentIdRemap);
           } else {
             await remapResidualMessageAgentIds(trx, job.groupIds, agentIdRemap);
           }

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -74,10 +74,24 @@ export const rewriteMessageScopeForTopics = async (
   executor: Executor,
   topicIds: string[],
   target: AgentTransferTargetScope,
+  options: {
+    /**
+     * Skip rows that carry a `group_id`. An AGENT transfer must set this: a
+     * legal row can pair a group_id with a topic_id owned by the moved agent,
+     * and while the group-history preservation step repoints its agent_id at
+     * the tombstone, it belongs to the GROUP's scope and must not follow the
+     * topic into the transfer target. A GROUP transfer keeps such rows — the
+     * group is the thing moving.
+     */
+    excludeGroupRows?: boolean;
+  } = {},
 ): Promise<void> => {
   if (topicIds.length === 0) return;
 
-  const inTopics = inArray(messages.topicId, topicIds);
+  const inTopicsAlone = inArray(messages.topicId, topicIds);
+  const inTopics = options.excludeGroupRows
+    ? and(inTopicsAlone, isNull(messages.groupId))!
+    : inTopicsAlone;
 
   await executor.execute(sql`
     UPDATE ${messages}
@@ -781,7 +795,14 @@ export class AgentTransferJobModel {
         return { done: true };
       }
 
-      if (!remapOnly) await rewriteMessageScopeForTopics(trx, [next.topicId], target);
+      // An agent-transfer job (no groupIds) must leave group-anchored rows in
+      // their group's scope — mirror of the synchronous branch. A group
+      // transfer's job moves them on purpose.
+      if (!remapOnly) {
+        await rewriteMessageScopeForTopics(trx, [next.topicId], target, {
+          excludeGroupRows: job.groupIds.length === 0,
+        });
+      }
       if (agentIdRemap) await remapMessageAgentIdsForTopics(trx, [next.topicId], agentIdRemap);
       await trx
         .delete(agentHistoryJobTopics)

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -198,6 +198,25 @@ export const remapMessageAgentIdsForTopics = async (
 };
 
 /**
+ * {@link remapMessageAgentIds} over EVERYTHING the given groups hold — topic'd
+ * rows and topicless residue alike, anchored on `messages.group_id`.
+ *
+ * The group transfer cannot use this (its fast/slow split needs the per-topic
+ * form so the drain can batch); it exists for the AGENT transfer, where the
+ * groups stay put and their whole history is repointed in one synchronous
+ * stroke before the agent leaves.
+ */
+export const remapMessageAgentIdsForGroups = async (
+  executor: Executor,
+  groupIds: string[],
+  pairs: AgentIdRemapPair[],
+): Promise<void> => {
+  if (groupIds.length === 0) return;
+
+  await remapMessageAgentIds(executor, inArray(messages.groupId, groupIds), pairs);
+};
+
+/**
  * {@link remapMessageAgentIds} over the topicless residue of the given groups —
  * the same rows `rewriteResidualMessageScope` picks up on its group arm.
  */

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -111,9 +111,20 @@ export const rewriteResidualMessageScope = async (
   linkage: { agentIds: string[]; groupIds?: string[]; sessionIds: string[] },
   target: AgentTransferTargetScope,
 ): Promise<void> => {
+  // A row that carries a group_id belongs to that group's scope and moves
+  // only when its group is the thing being transferred — the session / agent
+  // arms therefore exclude group rows. Without this, an agent transfer whose
+  // group-history remap is still pending (deferred to a remap-only job) would
+  // drag the group's topicless residue into the target scope.
+  const scopeArms: SQL[] = [];
+  if (linkage.sessionIds.length > 0)
+    scopeArms.push(inArray(messages.sessionId, linkage.sessionIds));
+  if (linkage.agentIds.length > 0) scopeArms.push(inArray(messages.agentId, linkage.agentIds));
   const arms: SQL[] = [];
-  if (linkage.sessionIds.length > 0) arms.push(inArray(messages.sessionId, linkage.sessionIds));
-  if (linkage.agentIds.length > 0) arms.push(inArray(messages.agentId, linkage.agentIds));
+  if (scopeArms.length > 0)
+    arms.push(
+      and(scopeArms.length === 1 ? scopeArms[0] : or(...scopeArms), isNull(messages.groupId))!,
+    );
   if (linkage.groupIds && linkage.groupIds.length > 0)
     arms.push(inArray(messages.groupId, linkage.groupIds));
   if (arms.length === 0) return;
@@ -285,6 +296,13 @@ export interface CreateAgentTransferJobParams {
    * group transfer move strictly more than a small one: exactly the fast/slow
    * drift this framework exists to avoid.
    */
+  /**
+   * Remap-without-moving: the drain applies `agentIdRemap` to the job's
+   * topics and residual but skips every scope rewrite. An agent transfer uses
+   * this to defer a LARGE group-history remap — the group's rows stay exactly
+   * where they are, only their `agent_id` / `target_id` change.
+   */
+  remapOnly?: boolean;
   residualAgentIds?: string[];
   sessionIds: string[];
   source: AgentTransferTargetScope;
@@ -322,11 +340,17 @@ export class AgentTransferJobModel {
         // the junction below is the coverage set. They differ for a group job.
         agentIds: params.residualAgentIds ?? params.agentIds,
         groupIds: params.groupIds ?? [],
-        // `payload` is the generic per-job slot; the remap only exists for
-        // group transfers, so it stays out of the columns.
+        // `payload` is the generic per-job slot; the remap fields only exist
+        // for group transfers and deferred group-history remaps, so they stay
+        // out of the columns.
         payload:
-          params.agentIdRemap && params.agentIdRemap.length > 0
-            ? { agentIdRemap: params.agentIdRemap }
+          (params.agentIdRemap && params.agentIdRemap.length > 0) || params.remapOnly
+            ? {
+                ...(params.agentIdRemap && params.agentIdRemap.length > 0
+                  ? { agentIdRemap: params.agentIdRemap }
+                  : {}),
+                ...(params.remapOnly ? { remapOnly: true } : {}),
+              }
             : undefined,
         sessionIds: params.sessionIds,
         sourceUserId: params.source.userId,
@@ -681,6 +705,9 @@ export class AgentTransferJobModel {
       // contract as the scope rewrite itself: the synchronous branch does this
       // inline, so the drain must do it on exactly the same rows.
       const agentIdRemap = job.payload?.agentIdRemap;
+      // A remap-only job never moves anything: the rows belong to a group
+      // that stayed put, and only who they point at changes.
+      const remapOnly = job.payload?.remapOnly === true;
 
       const [next] = await trx
         .select({ topicId: agentHistoryJobTopics.topicId })
@@ -690,11 +717,13 @@ export class AgentTransferJobModel {
         .limit(1);
 
       if (!next) {
-        await rewriteResidualMessageScope(
-          trx,
-          { agentIds: job.agentIds, groupIds: job.groupIds, sessionIds: job.sessionIds },
-          target,
-        );
+        if (!remapOnly) {
+          await rewriteResidualMessageScope(
+            trx,
+            { agentIds: job.agentIds, groupIds: job.groupIds, sessionIds: job.sessionIds },
+            target,
+          );
+        }
         if (agentIdRemap) await remapResidualMessageAgentIds(trx, job.groupIds, agentIdRemap);
         await trx
           .update(agentHistoryJobs)
@@ -709,7 +738,7 @@ export class AgentTransferJobModel {
         return { done: true };
       }
 
-      await rewriteMessageScopeForTopics(trx, [next.topicId], target);
+      if (!remapOnly) await rewriteMessageScopeForTopics(trx, [next.topicId], target);
       if (agentIdRemap) await remapMessageAgentIdsForTopics(trx, [next.topicId], agentIdRemap);
       await trx
         .delete(agentHistoryJobTopics)

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -289,7 +289,10 @@ export const remapResidualMessageAgentIds = async (
  * cancelled Stripe and wiped the billing rows.
  */
 const isPendingTransfer = () =>
-  and(eq(agentHistoryJobs.status, 'pending'), eq(agentHistoryJobs.type, 'transfer'));
+  and(
+    eq(agentHistoryJobs.status, 'pending'),
+    inArray(agentHistoryJobs.type, ['transfer', 'remap']),
+  );
 
 export interface CreateAgentTransferJobParams {
   /**
@@ -378,6 +381,10 @@ export class AgentTransferJobModel {
         targetUserId: params.target.userId,
         targetWorkspaceId: params.target.workspaceId,
         totalTopics: params.topics.length,
+        // Distinct type so a worker predating remap-only jobs refuses them
+        // instead of scope-rewriting a stationary group's history — see the
+        // schema comment on `type`.
+        ...(params.remapOnly ? { type: 'remap' as const } : {}),
       })
       .returning({ id: agentHistoryJobs.id });
 
@@ -461,7 +468,7 @@ export class AgentTransferJobModel {
       .where(
         and(
           eq(agentHistoryJobs.status, 'pending'),
-          eq(agentHistoryJobs.type, 'transfer'),
+          inArray(agentHistoryJobs.type, ['transfer', 'remap']),
           // COALESCE covers both a NULL payload (the common case for a plain
           // agent transfer) and a payload that carries no remap.
           sql`EXISTS (
@@ -717,7 +724,9 @@ export class AgentTransferJobModel {
       // transfer logic over a `copy` job would rewrite the scope of its target
       // topics and drop their queue rows, reporting success against history it
       // never duplicated (see the `type` column's schema comment).
-      if (!job || job.type !== 'transfer' || job.status === 'completed') return { done: true };
+      if (!job || (job.type !== 'transfer' && job.type !== 'remap') || job.status === 'completed') {
+        return { done: true };
+      }
 
       const target = { userId: job.targetUserId, workspaceId: job.targetWorkspaceId };
       // A group transfer that left referenced members behind also has to move
@@ -726,8 +735,10 @@ export class AgentTransferJobModel {
       // inline, so the drain must do it on exactly the same rows.
       const agentIdRemap = job.payload?.agentIdRemap;
       // A remap-only job never moves anything: the rows belong to a group
-      // that stayed put, and only who they point at changes.
-      const remapOnly = job.payload?.remapOnly === true;
+      // that stayed put, and only who they point at changes. The `type`
+      // discriminator is authoritative; the payload flag is kept as a
+      // self-describing mirror.
+      const remapOnly = job.type === 'remap' || job.payload?.remapOnly === true;
 
       const [next] = await trx
         .select({ topicId: agentHistoryJobTopics.topicId })
@@ -744,7 +755,19 @@ export class AgentTransferJobModel {
             target,
           );
         }
-        if (agentIdRemap) await remapResidualMessageAgentIds(trx, job.groupIds, agentIdRemap);
+        if (agentIdRemap) {
+          if (remapOnly) {
+            // The full group anchor, not just the topicless residual: a row
+            // can carry `group_id` alongside a topic_id that is NOT one of
+            // the group's own topics (nothing enforces the pair), so the
+            // per-topic drain never reaches it. The synchronous branch covers
+            // such rows via the same group-anchored remap; by finalization
+            // the bulk is already remapped, so this touches only leftovers.
+            await remapMessageAgentIdsForGroups(trx, job.groupIds, agentIdRemap);
+          } else {
+            await remapResidualMessageAgentIds(trx, job.groupIds, agentIdRemap);
+          }
+        }
         await trx
           .update(agentHistoryJobs)
           .set({ completedAt: new Date(), status: 'completed' })
@@ -752,7 +775,7 @@ export class AgentTransferJobModel {
             and(
               eq(agentHistoryJobs.id, jobId),
               eq(agentHistoryJobs.status, 'pending'),
-              eq(agentHistoryJobs.type, 'transfer'),
+              inArray(agentHistoryJobs.type, ['transfer', 'remap']),
             ),
           );
         return { done: true };

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -892,10 +892,11 @@ export class ChatGroupModel {
 
   /**
    * Tombstone candidates still mentioned (via the FK-less `target_id`) by
-   * topicless residue rows — the one message shape that SURVIVES a group
-   * delete (`group_id` goes SET NULL while topic'd rows cascade with their
-   * topics). Computed BEFORE the delete so the group anchor's index is still
-   * usable; `target_id` itself has no index.
+   * message rows that SURVIVE the group delete: topicless residue
+   * (`group_id` goes SET NULL) and rows whose topic lives OUTSIDE the
+   * deleted groups (a schema-valid mismatched anchor — such a topic does not
+   * cascade, so neither does its message). Computed BEFORE the delete so the
+   * group anchor's index is still usable; `target_id` itself has no index.
    */
   private findTargetMentionedSurvivorIds = async (
     executor: LobeChatDatabase,
@@ -910,8 +911,16 @@ export class ChatGroupModel {
       .where(
         and(
           inArray(messages.groupId, groupIds),
-          isNull(messages.topicId),
           inArray(messages.targetId, candidateIds),
+          or(
+            isNull(messages.topicId),
+            notExists(
+              executor
+                .select({ id: topics.id })
+                .from(topics)
+                .where(and(eq(topics.id, messages.topicId), inArray(topics.groupId, groupIds))),
+            ),
+          ),
         ),
       );
     return new Set(rows.map((row) => row.targetId).filter((id): id is string => Boolean(id)));

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -777,6 +777,147 @@ export class ChatGroupModel {
   };
 
   /**
+   * Agents referenced by the given groups' content (topics / threads /
+   * messages, including the FK-less `messages.target_id`) that are NOT on any
+   * of the groups' rosters — the shape of the history tombstones
+   * `AgentModel.preserveGroupHistoryForTransfer` parks in a group's scope.
+   *
+   * Every probe rides a group_id / topic_id index; topic-anchored rows join
+   * through `topics` instead of expanding a topic list into bind parameters
+   * (a long-lived group can hold more topics than the parameter limit
+   * allows). Shared by the ownership handover (re-homes them) and the group
+   * deletes (reclaims the ones the cascade orphans).
+   */
+  private findRosterlessHistoryAgentIds = async (
+    executor: LobeChatDatabase,
+    groupIds: string[],
+  ): Promise<string[]> => {
+    if (groupIds.length === 0) return [];
+
+    const historyRefRows = [
+      ...(await executor
+        .selectDistinct({ agentId: topics.agentId })
+        .from(topics)
+        .where(inArray(topics.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: threads.agentId })
+        .from(threads)
+        .where(inArray(threads.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.agentId })
+        .from(messages)
+        .where(inArray(messages.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.targetId })
+        .from(messages)
+        .where(inArray(messages.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: threads.agentId })
+        .from(threads)
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(inArray(topics.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.agentId })
+        .from(messages)
+        .innerJoin(topics, eq(messages.topicId, topics.id))
+        .where(inArray(topics.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.targetId })
+        .from(messages)
+        .innerJoin(topics, eq(messages.topicId, topics.id))
+        .where(inArray(topics.groupId, groupIds))),
+    ];
+    const rosterRows = await executor
+      .selectDistinct({ agentId: chatGroupsAgents.agentId })
+      .from(chatGroupsAgents)
+      .where(inArray(chatGroupsAgents.chatGroupId, groupIds));
+    const rosterIdSet = new Set(rosterRows.map((row) => row.agentId));
+
+    return [...new Set(historyRefRows.map((row) => row.agentId))].filter(
+      (id): id is string => Boolean(id) && !rosterIdSet.has(id!),
+    );
+  };
+
+  /**
+   * After a group delete, reclaim the history tombstones the cascade
+   * orphaned. Runs on the pre-delete candidate set and deletes only rows that
+   * are now referenced by NOTHING: still virtual and non-builtin, on no
+   * roster, in no project, and with zero surviving topic / thread / message
+   * `agent_id` references (all indexed probes). A topicless residue row keeps
+   * its message after the group delete (`messages.group_id` goes SET NULL),
+   * so its speaker's tombstone naturally survives these checks; the FK-less
+   * `messages.target_id` has no index, so the CALLER pre-computes which
+   * candidates surviving residue rows still mention and withholds them.
+   */
+  private deleteOrphanedHistoryTombstones = async (
+    executor: LobeChatDatabase,
+    candidateIds: string[],
+  ): Promise<void> => {
+    if (candidateIds.length === 0) return;
+
+    await executor
+      .delete(agents)
+      .where(
+        and(
+          inArray(agents.id, candidateIds),
+          eq(agents.virtual, true),
+          or(isNull(agents.slug), notInArray(agents.slug, RESERVED_BUILTIN_AGENT_SLUGS)),
+          notExists(
+            executor
+              .select({ id: chatGroupsAgents.agentId })
+              .from(chatGroupsAgents)
+              .where(eq(chatGroupsAgents.agentId, agents.id)),
+          ),
+          notExists(
+            executor
+              .select({ id: projectAgents.agentId })
+              .from(projectAgents)
+              .where(eq(projectAgents.agentId, agents.id)),
+          ),
+          notExists(
+            executor.select({ id: topics.id }).from(topics).where(eq(topics.agentId, agents.id)),
+          ),
+          notExists(
+            executor.select({ id: threads.id }).from(threads).where(eq(threads.agentId, agents.id)),
+          ),
+          notExists(
+            executor
+              .select({ id: messages.id })
+              .from(messages)
+              .where(eq(messages.agentId, agents.id)),
+          ),
+        ),
+      );
+  };
+
+  /**
+   * Tombstone candidates still mentioned (via the FK-less `target_id`) by
+   * topicless residue rows — the one message shape that SURVIVES a group
+   * delete (`group_id` goes SET NULL while topic'd rows cascade with their
+   * topics). Computed BEFORE the delete so the group anchor's index is still
+   * usable; `target_id` itself has no index.
+   */
+  private findTargetMentionedSurvivorIds = async (
+    executor: LobeChatDatabase,
+    groupIds: string[],
+    candidateIds: string[],
+  ): Promise<Set<string>> => {
+    if (groupIds.length === 0 || candidateIds.length === 0) return new Set();
+
+    const rows = await executor
+      .selectDistinct({ targetId: messages.targetId })
+      .from(messages)
+      .where(
+        and(
+          inArray(messages.groupId, groupIds),
+          isNull(messages.topicId),
+          inArray(messages.targetId, candidateIds),
+        ),
+      );
+    return new Set(rows.map((row) => row.targetId).filter((id): id is string => Boolean(id)));
+  };
+
+  /**
    * Builtin agents (Inbox, the agent builders, …) are provisioned per user and
    * are `virtual` like a group's own members, so `owned` on a malformed
    * junction row would be enough to take one down with a group. Their reserved
@@ -814,8 +955,16 @@ export class ChatGroupModel {
   async delete(id: string): Promise<{ deletedOwnedAgentIds: string[]; group: ChatGroupItem }> {
     return this.db.transaction(async (trx) => {
       // Collect BEFORE the delete: the junction rows cascade away with the
-      // group, taking the only record of which agents were group-owned.
+      // group, taking the only record of which agents were group-owned — and
+      // the group anchor is the only indexed way to find its rosterless
+      // history tombstones.
       const ownedAgentIds = await this.findOwnedMemberAgentIds(trx, [id]);
+      const tombstoneCandidateIds = await this.findRosterlessHistoryAgentIds(trx, [id]);
+      const mentionedSurvivorIds = await this.findTargetMentionedSurvivorIds(
+        trx,
+        [id],
+        tombstoneCandidateIds,
+      );
 
       const [result] = await trx
         .delete(chatGroups)
@@ -829,6 +978,10 @@ export class ChatGroupModel {
       // Same transaction as the group delete: a cleanup that can be interrupted
       // between the two statements is a leak with extra steps.
       const deletedOwnedAgentIds = await this.deleteOwnedMemberAgents(trx, ownedAgentIds);
+      await this.deleteOrphanedHistoryTombstones(
+        trx,
+        tombstoneCandidateIds.filter((agentId) => !mentionedSurvivorIds.has(agentId)),
+      );
 
       return { deletedOwnedAgentIds, group: result };
     });
@@ -841,14 +994,22 @@ export class ChatGroupModel {
         .from(chatGroups)
         .where(this.ownership());
 
-      const ownedAgentIds = await this.findOwnedMemberAgentIds(
+      const ids = groupIds.map((group) => group.id);
+      const ownedAgentIds = await this.findOwnedMemberAgentIds(trx, ids);
+      const tombstoneCandidateIds = await this.findRosterlessHistoryAgentIds(trx, ids);
+      const mentionedSurvivorIds = await this.findTargetMentionedSurvivorIds(
         trx,
-        groupIds.map((group) => group.id),
+        ids,
+        tombstoneCandidateIds,
       );
 
       await trx.delete(chatGroups).where(this.ownership());
 
       await this.deleteOwnedMemberAgents(trx, ownedAgentIds);
+      await this.deleteOrphanedHistoryTombstones(
+        trx,
+        tombstoneCandidateIds.filter((agentId) => !mentionedSurvivorIds.has(agentId)),
+      );
     });
   }
 
@@ -976,48 +1137,8 @@ export class ChatGroupModel {
     // member-derived re-homing below cannot see them. Left behind, deleting
     // the previous owner would cascade through `agents.user_id` and erase the
     // very history they preserve. Discover them from the group's content
-    // references (every probe rides a group_id / topic_id index) and hand
-    // them over with the group.
-    // Topic-anchored rows join through `topics` (group_id index) instead of
-    // expanding the group's topic list into bind parameters — a long-lived
-    // group can hold more topics than the parameter limit allows.
-    const historyRefRows = [
-      ...(await trx
-        .selectDistinct({ agentId: topics.agentId })
-        .from(topics)
-        .where(eq(topics.groupId, groupId))),
-      ...(await trx
-        .selectDistinct({ agentId: threads.agentId })
-        .from(threads)
-        .where(eq(threads.groupId, groupId))),
-      ...(await trx
-        .selectDistinct({ agentId: messages.agentId })
-        .from(messages)
-        .where(eq(messages.groupId, groupId))),
-      ...(await trx
-        .selectDistinct({ agentId: messages.targetId })
-        .from(messages)
-        .where(eq(messages.groupId, groupId))),
-      ...(await trx
-        .selectDistinct({ agentId: threads.agentId })
-        .from(threads)
-        .innerJoin(topics, eq(threads.topicId, topics.id))
-        .where(eq(topics.groupId, groupId))),
-      ...(await trx
-        .selectDistinct({ agentId: messages.agentId })
-        .from(messages)
-        .innerJoin(topics, eq(messages.topicId, topics.id))
-        .where(eq(topics.groupId, groupId))),
-      ...(await trx
-        .selectDistinct({ agentId: messages.targetId })
-        .from(messages)
-        .innerJoin(topics, eq(messages.topicId, topics.id))
-        .where(eq(topics.groupId, groupId))),
-    ];
-    const rosterIdSet = new Set(agentIds);
-    const historyAgentIds = [...new Set(historyRefRows.map((row) => row.agentId))].filter(
-      (id): id is string => Boolean(id) && !rosterIdSet.has(id!),
-    );
+    // references and hand them over with the group.
+    const historyAgentIds = await this.findRosterlessHistoryAgentIds(trx, [groupId]);
     if (historyAgentIds.length > 0) {
       // Only tombstones re-home: virtual, owned by the outgoing owner, and
       // serving nothing but history — not a builtin (reserved slug), not on

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -826,6 +826,31 @@ export class ChatGroupModel {
         .from(messages)
         .innerJoin(topics, eq(messages.topicId, topics.id))
         .where(inArray(topics.groupId, groupIds))),
+      // Thread-anchored rows (threadId only — no topicId, no groupId), both
+      // through a group-anchored thread and through a thread hosted on a
+      // group topic.
+      ...(await executor
+        .selectDistinct({ agentId: messages.agentId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .where(inArray(threads.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.targetId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .where(inArray(threads.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.agentId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(inArray(topics.groupId, groupIds))),
+      ...(await executor
+        .selectDistinct({ agentId: messages.targetId })
+        .from(messages)
+        .innerJoin(threads, eq(messages.threadId, threads.id))
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(inArray(topics.groupId, groupIds))),
     ];
     const rosterRows = await executor
       .selectDistinct({ agentId: chatGroupsAgents.agentId })

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -1,6 +1,18 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
 import { TRPCError } from '@trpc/server';
-import { and, asc, desc, eq, inArray, isNull, ne, notInArray, or, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  ne,
+  notExists,
+  notInArray,
+  or,
+  sql,
+} from 'drizzle-orm';
 
 import type {
   ChatGroupAgentItem,
@@ -14,10 +26,13 @@ import {
   agents,
   chatGroups,
   chatGroupsAgents,
+  messages,
   projectAgents,
   projects,
   sessionGroups,
   tasks,
+  threads,
+  topics,
 } from '../schemas';
 import type { LobeChatDatabase, Transaction } from '../type';
 import { sanitizeAgencyConfigsForWorkspace } from '../utils/agencyConfigDevices';
@@ -953,6 +968,88 @@ export class ChatGroupModel {
       .update(chatGroupsAgents)
       .set({ userId: toUserId })
       .where(eq(chatGroupsAgents.chatGroupId, groupId));
+
+    // History tombstones — the rosterless virtual clones that
+    // `AgentModel.preserveGroupHistoryForTransfer` parks in the group's scope
+    // so a transferred-then-deleted member keeps resolving — belong to the
+    // group's owner but never appear in `chat_groups_agents`, so the
+    // member-derived re-homing below cannot see them. Left behind, deleting
+    // the previous owner would cascade through `agents.user_id` and erase the
+    // very history they preserve. Discover them from the group's content
+    // references (every probe rides a group_id / topic_id index) and hand
+    // them over with the group.
+    const groupTopicIds = (
+      await trx.select({ id: topics.id }).from(topics).where(eq(topics.groupId, groupId))
+    ).map((row) => row.id);
+    const historyRefRows = [
+      ...(await trx
+        .selectDistinct({ agentId: topics.agentId })
+        .from(topics)
+        .where(eq(topics.groupId, groupId))),
+      ...(await trx
+        .selectDistinct({ agentId: threads.agentId })
+        .from(threads)
+        .where(eq(threads.groupId, groupId))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.agentId })
+        .from(messages)
+        .where(eq(messages.groupId, groupId))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.targetId })
+        .from(messages)
+        .where(eq(messages.groupId, groupId))),
+    ];
+    if (groupTopicIds.length > 0) {
+      historyRefRows.push(
+        ...(await trx
+          .selectDistinct({ agentId: threads.agentId })
+          .from(threads)
+          .where(inArray(threads.topicId, groupTopicIds))),
+        ...(await trx
+          .selectDistinct({ agentId: messages.agentId })
+          .from(messages)
+          .where(inArray(messages.topicId, groupTopicIds))),
+        ...(await trx
+          .selectDistinct({ agentId: messages.targetId })
+          .from(messages)
+          .where(inArray(messages.topicId, groupTopicIds))),
+      );
+    }
+    const rosterIdSet = new Set(agentIds);
+    const historyAgentIds = [...new Set(historyRefRows.map((row) => row.agentId))].filter(
+      (id): id is string => Boolean(id) && !rosterIdSet.has(id!),
+    );
+    if (historyAgentIds.length > 0) {
+      // Only tombstones re-home: virtual, owned by the outgoing owner, and
+      // serving nothing but history — not a builtin (reserved slug), not on
+      // any group's roster, not attached to a project. A standalone agent
+      // that once spoke here and left still belongs to ITS owner, and a
+      // virtual agent serving another group or a project must stay with that
+      // surface — an ownership handover of the group must not steal either.
+      await trx
+        .update(agents)
+        .set({ clientId: null, updatedAt: agents.updatedAt, userId: toUserId })
+        .where(
+          and(
+            inArray(agents.id, historyAgentIds),
+            eq(agents.userId, fromUserId),
+            eq(agents.virtual, true),
+            or(isNull(agents.slug), notInArray(agents.slug, RESERVED_BUILTIN_AGENT_SLUGS)),
+            notExists(
+              trx
+                .select({ id: chatGroupsAgents.agentId })
+                .from(chatGroupsAgents)
+                .where(eq(chatGroupsAgents.agentId, agents.id)),
+            ),
+            notExists(
+              trx
+                .select({ id: projectAgents.agentId })
+                .from(projectAgents)
+                .where(eq(projectAgents.agentId, agents.id)),
+            ),
+          ),
+        );
+    }
 
     if (ownedAgentIds.length > 0) {
       // Re-home device bindings on the owned agents (supervisor + generated

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -978,9 +978,9 @@ export class ChatGroupModel {
     // very history they preserve. Discover them from the group's content
     // references (every probe rides a group_id / topic_id index) and hand
     // them over with the group.
-    const groupTopicIds = (
-      await trx.select({ id: topics.id }).from(topics).where(eq(topics.groupId, groupId))
-    ).map((row) => row.id);
+    // Topic-anchored rows join through `topics` (group_id index) instead of
+    // expanding the group's topic list into bind parameters — a long-lived
+    // group can hold more topics than the parameter limit allows.
     const historyRefRows = [
       ...(await trx
         .selectDistinct({ agentId: topics.agentId })
@@ -998,23 +998,22 @@ export class ChatGroupModel {
         .selectDistinct({ agentId: messages.targetId })
         .from(messages)
         .where(eq(messages.groupId, groupId))),
+      ...(await trx
+        .selectDistinct({ agentId: threads.agentId })
+        .from(threads)
+        .innerJoin(topics, eq(threads.topicId, topics.id))
+        .where(eq(topics.groupId, groupId))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.agentId })
+        .from(messages)
+        .innerJoin(topics, eq(messages.topicId, topics.id))
+        .where(eq(topics.groupId, groupId))),
+      ...(await trx
+        .selectDistinct({ agentId: messages.targetId })
+        .from(messages)
+        .innerJoin(topics, eq(messages.topicId, topics.id))
+        .where(eq(topics.groupId, groupId))),
     ];
-    if (groupTopicIds.length > 0) {
-      historyRefRows.push(
-        ...(await trx
-          .selectDistinct({ agentId: threads.agentId })
-          .from(threads)
-          .where(inArray(threads.topicId, groupTopicIds))),
-        ...(await trx
-          .selectDistinct({ agentId: messages.agentId })
-          .from(messages)
-          .where(inArray(messages.topicId, groupTopicIds))),
-        ...(await trx
-          .selectDistinct({ agentId: messages.targetId })
-          .from(messages)
-          .where(inArray(messages.topicId, groupTopicIds))),
-      );
-    }
     const rosterIdSet = new Set(agentIds);
     const historyAgentIds = [...new Set(historyRefRows.map((row) => row.agentId))].filter(
       (id): id is string => Boolean(id) && !rosterIdSet.has(id!),

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -954,6 +954,15 @@ export class ChatGroupModel {
    */
   async delete(id: string): Promise<{ deletedOwnedAgentIds: string[]; group: ChatGroupItem }> {
     return this.db.transaction(async (trx) => {
+      // A pending backfill (a deferred group-history remap included) still
+      // addresses this group's rows by group id; deleting the group now would
+      // cascade the job's queue rows and SET-NULL `messages.group_id`, so the
+      // drain could never find — let alone rescue — the residue, and it would
+      // later cascade away with the moved agent. Delete only once drained.
+      if (await AgentTransferJobModel.hasPendingJobForGroups(trx, [id])) {
+        throw new Error(AGENT_TRANSFER_IN_PROGRESS);
+      }
+
       // Collect BEFORE the delete: the junction rows cascade away with the
       // group, taking the only record of which agents were group-owned — and
       // the group anchor is the only indexed way to find its rosterless
@@ -995,6 +1004,12 @@ export class ChatGroupModel {
         .where(this.ownership());
 
       const ids = groupIds.map((group) => group.id);
+      // Same pending-backfill guard as the single delete: a deferred remap
+      // addresses rows by group id and cannot rescue them once the delete
+      // SET-NULLs `messages.group_id`.
+      if (await AgentTransferJobModel.hasPendingJobForGroups(trx, ids)) {
+        throw new Error(AGENT_TRANSFER_IN_PROGRESS);
+      }
       const ownedAgentIds = await this.findOwnedMemberAgentIds(trx, ids);
       const tombstoneCandidateIds = await this.findRosterlessHistoryAgentIds(trx, ids);
       const mentionedSurvivorIds = await this.findTargetMentionedSurvivorIds(

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -40,6 +40,7 @@ import {
   topics,
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { buildAgentCopyValues } from '../../utils/agentClone';
 import { insertInBatches, splitCrossBatchSelfReferences } from '../../utils/batchInsert';
 import { COPIED_TOPIC_USAGE_RESET } from '../../utils/copiedTranscript';
 import { copyMessagesInDatabase, type IdPair } from '../../utils/copyMessagesInDatabase';
@@ -158,30 +159,13 @@ export class AgentGroupRepository {
     targetUserId: string,
     fallbackTitle: string,
     targetVisibility?: 'private' | 'public',
-  ): NewAgent => ({
-    agencyConfig: source?.agencyConfig,
-    avatar: source?.avatar,
-    backgroundColor: source?.backgroundColor,
-    chatConfig: source?.chatConfig,
-    description: source?.description,
-    editorData: source?.editorData,
-    fewShots: source?.fewShots,
-    model: source?.model,
-    openingMessage: source?.openingMessage,
-    openingQuestions: source?.openingQuestions,
-    params: source?.params,
-    pinned: source?.pinned,
-    plugins: source?.plugins,
-    provider: source?.provider,
-    systemRole: source?.systemRole,
-    tags: source?.tags,
-    title: source?.title || fallbackTitle,
-    tts: source?.tts,
-    userId: targetUserId,
-    virtual: source?.virtual ?? true,
-    ...(targetWorkspaceId && targetVisibility ? { visibility: targetVisibility } : {}),
-    workspaceId: targetWorkspaceId,
-  });
+  ): NewAgent =>
+    buildAgentCopyValues(
+      source,
+      { userId: targetUserId, workspaceId: targetWorkspaceId },
+      fallbackTitle,
+      targetVisibility,
+    );
 
   /**
    * Duplicate a group's conversations into the freshly created target group,

--- a/packages/database/src/schemas/agentHistoryJob.ts
+++ b/packages/database/src/schemas/agentHistoryJob.ts
@@ -42,6 +42,13 @@ export interface AgentHistoryJobPayload {
    * of the single-agent remap.
    */
   group?: { newGroupId: string; sourceGroupId: string };
+  /**
+   * `transfer` jobs only: the job's topics stay in their CURRENT scope — the
+   * drain applies `agentIdRemap` but skips every scope rewrite. Used when an
+   * agent transfer defers a large group-history remap: the group is not
+   * moving, only who its rows point at changes.
+   */
+  remapOnly?: boolean;
 }
 
 /** `copy` queue-row payload. */

--- a/packages/database/src/schemas/agentHistoryJob.ts
+++ b/packages/database/src/schemas/agentHistoryJob.ts
@@ -109,7 +109,13 @@ export const agentHistoryJobs = pgTable(
      * that runs transfer logic over a `copy` job would delete its queue rows
      * and report success against untouched history.
      */
-    type: text('type', { enum: ['transfer', 'copy'] })
+    // `remap` is a deliberate discriminator, not just a payload flag: a
+    // worker predating it routes the job into a `processNextTopic` whose
+    // type check refuses it outright, so a mixed-version rollout can never
+    // run a remap-only job's topics through the unconditional scope rewrites
+    // (which would move a stationary group's history into the transfer's
+    // target scope). The TS enum adds no DB constraint — no migration.
+    type: text('type', { enum: ['transfer', 'copy', 'remap'] })
       .notNull()
       .default('transfer'),
 

--- a/packages/database/src/utils/agentClone.ts
+++ b/packages/database/src/utils/agentClone.ts
@@ -24,6 +24,10 @@ export const buildAgentCopyValues = (
   editorData: source?.editorData,
   fewShots: source?.fewShots,
   model: source?.model,
+  // `agentDisplayName` prefers `name` over `title` for author attribution —
+  // dropping it would make preserved history render the role instead of the
+  // original speaker.
+  name: source?.name,
   openingMessage: source?.openingMessage,
   openingQuestions: source?.openingQuestions,
   params: source?.params,

--- a/packages/database/src/utils/agentClone.ts
+++ b/packages/database/src/utils/agentClone.ts
@@ -1,10 +1,10 @@
 import type { AgentItem, NewAgent } from '../schemas';
 
 /**
- * The field-copy core shared by every agent clone site: the group transfer's
- * referenced-member clone, the group copy, and the agent transfer's history
- * tombstone. One list, or the sites drift apart on which config a clone
- * carries.
+ * The field-copy core for clone sites that need a WORKING replacement agent:
+ * the group transfer's referenced-member clone and the group copy. (The agent
+ * transfer's history tombstone deliberately does NOT use this — see
+ * {@link buildAgentTombstoneValues}.)
  *
  * Deliberately never copies `slug` (the schema default mints a fresh random
  * one — a clone must not steal the source's identity) or `clientId` (device
@@ -41,5 +41,29 @@ export const buildAgentCopyValues = (
   userId: target.userId,
   virtual: source?.virtual ?? true,
   ...(target.workspaceId && targetVisibility ? { visibility: targetVisibility } : {}),
+  workspaceId: target.workspaceId,
+});
+
+/**
+ * The history tombstone's field set: ONLY what rendering a past speaker needs
+ * (`agentDisplayName` + avatar treatment). Nothing operational is copied — a
+ * tombstone lands in the GROUP's scope, which may belong to someone the
+ * source agent's owner never shared configuration with, and a rosterless
+ * clone sits outside the parent-group permission cap; copying `systemRole` /
+ * `plugins` / `params` / `agencyConfig` would hand the tombstone's owner a
+ * readable snapshot of configuration `getAgentConfigById` would otherwise
+ * redact.
+ */
+export const buildAgentTombstoneValues = (
+  source: AgentItem | undefined,
+  target: { userId: string; workspaceId: string | null },
+  fallbackTitle: string,
+): NewAgent => ({
+  avatar: source?.avatar,
+  backgroundColor: source?.backgroundColor,
+  name: source?.name,
+  title: source?.title || fallbackTitle,
+  userId: target.userId,
+  virtual: true,
   workspaceId: target.workspaceId,
 });

--- a/packages/database/src/utils/agentClone.ts
+++ b/packages/database/src/utils/agentClone.ts
@@ -62,6 +62,9 @@ export const buildAgentTombstoneValues = (
   avatar: source?.avatar,
   backgroundColor: source?.backgroundColor,
   name: source?.name,
+  // Explicit null, or the schema's `$defaultFn` mints a random slug and this
+  // display-only internal row becomes addressable through slug lookups.
+  slug: null,
   title: source?.title || fallbackTitle,
   userId: target.userId,
   virtual: true,

--- a/packages/database/src/utils/agentClone.ts
+++ b/packages/database/src/utils/agentClone.ts
@@ -1,0 +1,41 @@
+import type { AgentItem, NewAgent } from '../schemas';
+
+/**
+ * The field-copy core shared by every agent clone site: the group transfer's
+ * referenced-member clone, the group copy, and the agent transfer's history
+ * tombstone. One list, or the sites drift apart on which config a clone
+ * carries.
+ *
+ * Deliberately never copies `slug` (the schema default mints a fresh random
+ * one — a clone must not steal the source's identity) or `clientId` (device
+ * sync identity is not clonable).
+ */
+export const buildAgentCopyValues = (
+  source: AgentItem | undefined,
+  target: { userId: string; workspaceId: string | null },
+  fallbackTitle: string,
+  targetVisibility?: 'private' | 'public',
+): NewAgent => ({
+  agencyConfig: source?.agencyConfig,
+  avatar: source?.avatar,
+  backgroundColor: source?.backgroundColor,
+  chatConfig: source?.chatConfig,
+  description: source?.description,
+  editorData: source?.editorData,
+  fewShots: source?.fewShots,
+  model: source?.model,
+  openingMessage: source?.openingMessage,
+  openingQuestions: source?.openingQuestions,
+  params: source?.params,
+  pinned: source?.pinned,
+  plugins: source?.plugins,
+  provider: source?.provider,
+  systemRole: source?.systemRole,
+  tags: source?.tags,
+  title: source?.title || fallbackTitle,
+  tts: source?.tts,
+  userId: target.userId,
+  virtual: source?.virtual ?? true,
+  ...(target.workspaceId && targetVisibility ? { visibility: targetVisibility } : {}),
+  workspaceId: target.workspaceId,
+});


### PR DESCRIPTION
When `AgentModel.transferAgents` moves an agent to another scope, chat groups the agent belonged to keep their topics/threads/messages pointing at the moved agent row. Since `messages/topics/threads.agent_id` are all `ON DELETE CASCADE`, deleting the agent later in its new scope silently cascade-deletes the original group's history. Some group rows were also incorrectly carried over: group threads (step 8) and topic-less group messages (step 7 residual rewrite) followed the agent into the target scope.

This PR mirrors the existing referenced-member clone pattern from group transfer, in the opposite direction: before the transfer touches group rows, we create a virtual tombstone clone in **the group's scope** for every agent that has group history, then remap `topics/threads/messages.agent_id` (and the `messages.target_id` soft reference) to the clone.

- `preserveGroupHistoryForTransfer` (new step 5c in `transferAgents`): collects `(groupId, agentId)` reference pairs across topics/threads/messages (direct `group_id`, via group topics, and `target_id`), groups target groups by scope, inserts one clone per (scope, source agent), and remaps all references inside the transaction.
- Tombstone clones are `virtual: true`, unpinned, slug-less — they never show up in agent lists (filtered by `buildQueryAgentsWhere`) and only exist so history keeps rendering the original speaker.
- Extracted the shared clone field builder into `utils/agentClone.ts`; `AgentGroupRepo.buildCopiedAgent` now delegates to it (no behavior change) so the two clone sites can't drift.
- Added `remapMessageAgentIdsForGroups` beside the existing topic-scoped remap helper.
- Because the remap runs before steps 6–8, group threads and topic-less group messages now stay in the group's scope instead of being dragged into the target scope.

#### Key Decisions / Non-goals

- The "moving an agent takes it out of its chat groups" semantics are unchanged — this only stops the group's history from being lost or migrated.
- The slow path (async transfer job above the row-count threshold) needs no changes: the remap completes before the job is enqueued, so job batches never see group-referenced rows.
- Round-trip transfers don't stack tombstones: a second transfer of the same agent reuses the remapped references, and clones are per (scope, source agent), reused across groups in the same scope.
- No schema changes; no snapshot columns — speaker rendering keeps resolving via `useAgentMeta(agentId)`.

#### Test

- [x] Tested locally
- [x] Added/updated tests

New `AgentModel.transferAgents group history preservation` suite (5 tests): history survives transfer + delete, no clone without history, clone reuse across groups in one scope, round-trip doesn't stack tombstones, per-scope clones. With the fix reverted, 4 of 5 fail (cascade-delete reproduction included). Also verified end-to-end via a real personal→workspace transfer + delete in a dev runtime.