### PR TITLE
✨ feat: add Kimi Code tool inspectors and renders

### DIFF
--- a/packages/builtin-tools/src/kimiCode/index.test.ts
+++ b/packages/builtin-tools/src/kimiCode/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { countChangedLines, stripKimiLineNumbers } from './utils';
+
+describe('Kimi Code tool surface normalization', () => {
+  it('normalizes the numbered output emitted by Kimi Read', () => {
+    expect(stripKimiLineNumbers('1\talpha\n  2\tbeta\nplain')).toBe('alpha\nbeta\nplain');
+  });
+
+  it('derives edit stats from Kimi old_string and new_string arguments', () => {
+    expect(countChangedLines('old\nvalue', 'new')).toEqual({
+      linesAdded: 1,
+      linesDeleted: 2,
+    });
+    expect(countChangedLines('same', 'same')).toEqual({ linesAdded: 0, linesDeleted: 0 });
+  });
+});

--- a/packages/builtin-tools/src/kimiCode/index.tsx
+++ b/packages/builtin-tools/src/kimiCode/index.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import {
+  createEditLocalFileInspector,
+  createGlobLocalFilesInspector,
+  createGrepContentInspector,
+  createReadLocalFileInspector,
+  createRunCommandInspector,
+  createWriteLocalFileInspector,
+} from '@lobechat/shared-tool-ui/inspectors';
+import { RunCommandRender } from '@lobechat/shared-tool-ui/renders';
+import {
+  highlightTextStyles,
+  inspectorTextStyles,
+  shinyTextStyles,
+} from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspector, BuiltinInspectorProps, BuiltinRenderProps } from '@lobechat/types';
+import { CodeDiff, Highlighter, Markdown, Skeleton } from '@lobehub/ui';
+import { cx } from 'antd-style';
+import path from 'path-browserify-esm';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { countChangedLines, stripKimiLineNumbers } from './utils';
+
+const KimiCodeApiName = {
+  Agent: 'Agent',
+  Bash: 'Bash',
+  Edit: 'Edit',
+  FetchURL: 'FetchURL',
+  Glob: 'Glob',
+  Grep: 'Grep',
+  Read: 'Read',
+  Skill: 'Skill',
+  WebSearch: 'WebSearch',
+  Write: 'Write',
+} as const;
+
+interface KimiLabelArgs {
+  description?: string;
+  query?: string;
+  skill?: string;
+  url?: string;
+}
+
+interface KimiEditArgs {
+  new_string?: string;
+  old_string?: string;
+  path?: string;
+  replace_all?: boolean;
+}
+
+interface KimiFileArgs {
+  content?: string;
+  path?: string;
+}
+
+interface EditState {
+  linesAdded: number;
+  linesDeleted: number;
+  path: string;
+  replacements: number;
+}
+
+interface KimiLabelInspectorProps extends BuiltinInspectorProps<KimiLabelArgs> {
+  apiName: string;
+  field: keyof KimiLabelArgs;
+}
+
+const KimiLabelInspector = memo<KimiLabelInspectorProps>(
+  ({ apiName, args, field, isArgumentsStreaming, isLoading, partialArgs }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(apiName as never);
+    const value = args?.[field] || partialArgs?.[field] || '';
+
+    return (
+      <div
+        className={cx(
+          inspectorTextStyles.root,
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+        )}
+      >
+        <span>{label}</span>
+        {value && (
+          <>
+            <span>: </span>
+            <span className={highlightTextStyles.primary}>{value}</span>
+          </>
+        )}
+      </div>
+    );
+  },
+);
+KimiLabelInspector.displayName = 'KimiCodeLabelInspector';
+
+const createKimiLabelInspector = (apiName: string, field: keyof KimiLabelArgs) => {
+  const Inspector = memo<BuiltinInspectorProps<KimiLabelArgs>>((props) => (
+    <KimiLabelInspector {...props} apiName={apiName} field={field} />
+  ));
+  Inspector.displayName = `KimiCode${apiName}Inspector`;
+  return Inspector;
+};
+
+const SharedEditInspector = createEditLocalFileInspector(KimiCodeApiName.Edit);
+
+const EditInspector = memo<BuiltinInspectorProps<KimiEditArgs, EditState>>(
+  ({ args, partialArgs, pluginState, ...rest }) => {
+    const mappedArgs = {
+      path: args?.path,
+      replace: args?.new_string,
+      search: args?.old_string,
+    };
+    const mappedPartialArgs = {
+      path: partialArgs?.path,
+      replace: partialArgs?.new_string,
+      search: partialArgs?.old_string,
+    };
+    const synthesizedState = useMemo<EditState | undefined>(() => {
+      if (pluginState) return pluginState;
+      if (!args?.old_string && !args?.new_string) return;
+
+      return {
+        ...countChangedLines(args.old_string ?? '', args.new_string ?? ''),
+        path: args.path ?? '',
+        replacements: args.replace_all ? 0 : 1,
+      };
+    }, [args, pluginState]);
+
+    return (
+      <SharedEditInspector
+        {...rest}
+        args={mappedArgs}
+        partialArgs={mappedPartialArgs}
+        pluginState={synthesizedState}
+      />
+    );
+  },
+);
+EditInspector.displayName = 'KimiCodeEditInspector';
+
+const TextResult = memo<BuiltinRenderProps>(({ content }) => {
+  if (!content) return null;
+
+  return (
+    <Highlighter
+      wrap
+      language="text"
+      showLanguage={false}
+      style={{ maxHeight: 240, overflow: 'auto' }}
+      variant="borderless"
+    >
+      {content}
+    </Highlighter>
+  );
+});
+TextResult.displayName = 'KimiCodeTextResult';
+
+const MarkdownResult = memo<BuiltinRenderProps>(({ content }) => {
+  if (!content) return null;
+
+  return (
+    <Markdown style={{ maxHeight: 320, overflow: 'auto' }} variant="chat">
+      {content}
+    </Markdown>
+  );
+});
+MarkdownResult.displayName = 'KimiCodeMarkdownResult';
+
+const ReadRender = memo<BuiltinRenderProps<KimiFileArgs>>(({ args, content }) => {
+  const filePath = args?.path ?? '';
+  const source = useMemo(() => stripKimiLineNumbers(content ?? ''), [content]);
+
+  if (!source) return null;
+
+  return (
+    <Highlighter
+      wrap
+      language={path.extname(filePath).slice(1).toLowerCase() || 'text'}
+      showLanguage={false}
+      style={{ maxHeight: 240, overflow: 'auto' }}
+      variant="borderless"
+    >
+      {source}
+    </Highlighter>
+  );
+});
+ReadRender.displayName = 'KimiCodeReadRender';
+
+const WriteRender = memo<BuiltinRenderProps<KimiFileArgs>>(({ args }) => {
+  if (!args) return <Skeleton active />;
+  if (!args.content) return null;
+
+  const extension = path
+    .extname(args.path ?? '')
+    .slice(1)
+    .toLowerCase();
+  if (extension === 'md' || extension === 'mdx') {
+    return (
+      <Markdown style={{ maxHeight: 240, overflow: 'auto' }} variant="chat">
+        {args.content}
+      </Markdown>
+    );
+  }
+
+  return (
+    <Highlighter
+      wrap
+      language={extension || 'text'}
+      showLanguage={false}
+      style={{ maxHeight: 240, overflow: 'auto' }}
+      variant="borderless"
+    >
+      {args.content}
+    </Highlighter>
+  );
+});
+WriteRender.displayName = 'KimiCodeWriteRender';
+
+const EditRender = memo<BuiltinRenderProps<KimiEditArgs>>(({ args }) => {
+  if (!args) return <Skeleton active />;
+
+  const filePath = args.path ?? '';
+  return (
+    <CodeDiff
+      fileName={path.basename(filePath) || filePath}
+      language={path.extname(filePath).slice(1).toLowerCase() || undefined}
+      newContent={args.new_string ?? ''}
+      oldContent={args.old_string ?? ''}
+      showHeader={!!filePath}
+      variant="borderless"
+      viewMode="unified"
+    />
+  );
+});
+EditRender.displayName = 'KimiCodeEditRender';
+
+export const KimiCodeInspectors: Record<string, BuiltinInspector> = {
+  [KimiCodeApiName.Agent]: createKimiLabelInspector(
+    KimiCodeApiName.Agent,
+    'description',
+  ) as BuiltinInspector,
+  [KimiCodeApiName.Bash]: createRunCommandInspector(KimiCodeApiName.Bash) as BuiltinInspector,
+  [KimiCodeApiName.Edit]: EditInspector as BuiltinInspector,
+  [KimiCodeApiName.FetchURL]: createKimiLabelInspector(
+    KimiCodeApiName.FetchURL,
+    'url',
+  ) as BuiltinInspector,
+  [KimiCodeApiName.Glob]: createGlobLocalFilesInspector(KimiCodeApiName.Glob) as BuiltinInspector,
+  [KimiCodeApiName.Grep]: createGrepContentInspector({
+    noResultsKey: 'No results',
+    translationKey: KimiCodeApiName.Grep,
+  }) as BuiltinInspector,
+  [KimiCodeApiName.Read]: createReadLocalFileInspector(KimiCodeApiName.Read) as BuiltinInspector,
+  [KimiCodeApiName.Skill]: createKimiLabelInspector(
+    KimiCodeApiName.Skill,
+    'skill',
+  ) as BuiltinInspector,
+  [KimiCodeApiName.WebSearch]: createKimiLabelInspector(
+    KimiCodeApiName.WebSearch,
+    'query',
+  ) as BuiltinInspector,
+  [KimiCodeApiName.Write]: createWriteLocalFileInspector(KimiCodeApiName.Write) as BuiltinInspector,
+};
+
+export const KimiCodeRenders = {
+  [KimiCodeApiName.Agent]: TextResult,
+  [KimiCodeApiName.Bash]: RunCommandRender,
+  [KimiCodeApiName.Edit]: EditRender,
+  [KimiCodeApiName.FetchURL]: MarkdownResult,
+  [KimiCodeApiName.Glob]: TextResult,
+  [KimiCodeApiName.Grep]: TextResult,
+  [KimiCodeApiName.Read]: ReadRender,
+  [KimiCodeApiName.Skill]: TextResult,
+  [KimiCodeApiName.WebSearch]: TextResult,
+  [KimiCodeApiName.Write]: WriteRender,
+};

--- a/packages/builtin-tools/src/kimiCode/utils.ts
+++ b/packages/builtin-tools/src/kimiCode/utils.ts
@@ -1,0 +1,14 @@
+export const countChangedLines = (oldText: string, newText: string) => {
+  if (oldText === newText) return { linesAdded: 0, linesDeleted: 0 };
+
+  return {
+    linesAdded: newText ? newText.split('\n').length : 0,
+    linesDeleted: oldText ? oldText.split('\n').length : 0,
+  };
+};
+
+export const stripKimiLineNumbers = (content: string): string =>
+  content
+    .split('\n')
+    .map((line) => line.replace(/^\s*\d+\t/, ''))
+    .join('\n');

--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -174,6 +174,7 @@ import { CodexInspectors, CodexRenders } from './codex';
 import { GithubIdentifier, GithubInspectors, GithubRenders } from './github';
 import { registerBuiltinInspectors } from './inspectors';
 import { registerBuiltinInterventions } from './interventions';
+import { KimiCodeInspectors, KimiCodeRenders } from './kimiCode';
 import { LinearIdentifier, LinearInspectors, LinearRenders } from './linear';
 import { NotebookIdentifier, NotebookRenders } from './notebook';
 import { registerBuiltinPlaceholders } from './placeholders';
@@ -186,6 +187,7 @@ const DROID_IDENTIFIER = 'droid';
 const QODER_IDENTIFIER = 'qoder';
 const OPENCODE_IDENTIFIER = 'opencode';
 const PI_IDENTIFIER = 'pi';
+const KIMI_CODE_IDENTIFIER = 'kimi-code';
 
 const heterogeneousCliInspectors: Record<string, BuiltinInspector> = {
   bash: createRunCommandInspector(
@@ -250,6 +252,7 @@ export const registerBuiltinToolSurfaces = (): void => {
     [WebOnboardingManifest.identifier]: WebOnboardingRenders as Record<string, BuiltinRender>,
     [OPENCODE_IDENTIFIER]: heterogeneousCliRenders,
     [PI_IDENTIFIER]: heterogeneousCliRenders,
+    [KIMI_CODE_IDENTIFIER]: KimiCodeRenders,
     codex: {
       ...CodexRenders,
       command_execution: RunCommandRender as BuiltinRender,
@@ -308,6 +311,7 @@ export const registerBuiltinToolSurfaces = (): void => {
     [WebOnboardingManifest.identifier]: WebOnboardingInspectors as Record<string, BuiltinInspector>,
     [OPENCODE_IDENTIFIER]: heterogeneousCliInspectors,
     [PI_IDENTIFIER]: heterogeneousCliInspectors,
+    [KIMI_CODE_IDENTIFIER]: KimiCodeInspectors,
     codex: CodexInspectors,
     [GithubIdentifier]: GithubInspectors,
     [LinearIdentifier]: LinearInspectors,

--- a/src/features/DevPanel/RenderGallery/fixtures/index.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/index.ts
@@ -9,6 +9,7 @@ import { buildSchemaSample, humanize, single, type ToolsetFixtureModule } from '
 import claudeCode from './claude-code';
 import codex from './codex';
 import github from './github';
+import kimiCode from './kimi-code';
 import linear from './linear';
 import lobeActivator from './lobe-activator';
 import lobeAgent from './lobe-agent';
@@ -84,6 +85,7 @@ const toolsetModules: ToolsetFixtureModule[] = [
   claudeCode,
   codex,
   github,
+  kimiCode,
   linear,
   lobeActivator,
   lobeAgent,

--- a/src/features/DevPanel/RenderGallery/fixtures/kimi-code.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/kimi-code.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { defineFixtures, single } from './_helpers';
+
+export default defineFixtures({
+  identifier: 'kimi-code',
+  meta: {
+    description: 'Kimi Code 0.38.0 native tool previews captured from local stream-json traces.',
+    title: 'Kimi Code',
+  },
+  apiList: [
+    { description: 'Delegate a focused task to a Kimi Code sub-agent.', name: 'Agent' },
+    { description: 'Run a shell command.', name: 'Bash' },
+    { description: 'Replace matching content in a file.', name: 'Edit' },
+    { description: 'Fetch and extract a web page.', name: 'FetchURL' },
+    { description: 'Find files by glob pattern.', name: 'Glob' },
+    { description: 'Search file contents.', name: 'Grep' },
+    { description: 'Read file content.', name: 'Read' },
+    { description: 'Load a Kimi Code skill.', name: 'Skill' },
+    { description: 'Search the web.', name: 'WebSearch' },
+    { description: 'Write a new file.', name: 'Write' },
+  ],
+  fixtures: {
+    Agent: single({
+      args: {
+        description: 'Inspect the tool rendering pipeline',
+        prompt: 'Locate the builtin tool registry and summarize how renderers are resolved.',
+        subagent_type: 'explore',
+      },
+      content:
+        'The renderer is resolved by identifier and API name in `packages/builtin-tools/src/renders.ts`, then mounted by the conversation tool card.',
+    }),
+    Bash: single({
+      args: { command: 'bun run check packages/builtin-tools/src/kimiCode' },
+      content: '✓ 4 files · lint clean · tests 2 passed',
+      pluginState: {
+        exitCode: 0,
+        output: '✓ 4 files · lint clean · tests 2 passed',
+        stdout: '✓ 4 files · lint clean · tests 2 passed',
+        success: true,
+      },
+    }),
+    Edit: single({
+      args: {
+        new_string: "const KIMI_CODE_IDENTIFIER = 'kimi-code';",
+        old_string: "const KIMI_IDENTIFIER = 'kimi';",
+        path: 'packages/builtin-tools/src/register.ts',
+      },
+      content: 'Replaced 1 occurrence in packages/builtin-tools/src/register.ts',
+    }),
+    FetchURL: single({
+      args: { url: 'https://github.com/MoonshotAI/kimi-code' },
+      content:
+        '# Kimi Code CLI\n\nKimi Code CLI is an AI coding agent that runs in your terminal. It can read and edit code, run shell commands, search files, fetch web pages, and delegate focused tasks.',
+    }),
+    Glob: single({
+      args: { pattern: 'packages/**/*kimi*/**/*.ts' },
+      content:
+        'packages/heterogeneous-agents/src/adapters/kimiCode.ts\npackages/heterogeneous-agents/src/adapters/kimiCode.test.ts',
+    }),
+    Grep: single({
+      args: {
+        output_mode: 'content',
+        path: 'packages/heterogeneous-agents/src/adapters/kimiCode.ts',
+        pattern: 'parseToolCalls',
+      },
+      content:
+        '98:    const calls = this.parseToolCalls(event.tool_calls);\n181:  private parseToolCalls(value: unknown): ToolCallPayload[] {',
+    }),
+    Read: single({
+      args: { n_lines: 8, path: 'packages/heterogeneous-agents/src/adapters/kimiCode.ts' },
+      content:
+        "1\timport type { AgentEventAdapter } from '../types';\n2\t\n3\tconst KIMI_CODE_IDENTIFIER = 'kimi-code';\n4\t\n5\texport class KimiCodeAdapter implements AgentEventAdapter {",
+    }),
+    Skill: single({
+      args: { skill: 'deep-review' },
+      content: 'Skill "deep-review" loaded inline. Follow its review checklist.',
+    }),
+    WebSearch: single({
+      args: { query: 'Kimi Code official GitHub repository' },
+      content:
+        'Title: GitHub - MoonshotAI/kimi-code\nSite: GitHub\nURL: https://github.com/MoonshotAI/kimi-code\nSnippet: Kimi Code CLI is an AI coding agent that runs in your terminal.',
+    }),
+    Write: single({
+      args: {
+        content: '# Kimi Code tool UI\n\nInspector and Render coverage for native tools.\n',
+        path: 'docs/kimi-code-tool-ui.md',
+      },
+      content: 'Wrote 73 bytes to docs/kimi-code-tool-ui.md',
+    }),
+  },
+});


### PR DESCRIPTION
## Summary

- add dedicated Inspector and Render surfaces for Kimi Code native tools
- cover Agent, Bash, Edit, FetchURL, Glob, Grep, Read, Skill, WebSearch, and Write
- normalize Kimi Read line numbers and synthesize Edit diff metadata
- add a Render Gallery fixture based on local Kimi Code 0.38.0 stream-json traces

## Verification

- `bun run check` on the 6 changed files: lint clean, 2 tests passed
- visually verified all 10 Inspector / settled Render results in the SPA Render Gallery
- Acceptance: https://app.lobehub.com/acceptance/2fb4eb14-9681-4209-85ae-69d32255d081?r=3
