### PR TITLE
🐛 fix(acceptance): center reject modal instead of pinning it left

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.36.0",
+    "@lobehub/ui": "^5.37.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/src/features/Acceptance/Viewer/CheckList.test.ts
+++ b/src/features/Acceptance/Viewer/CheckList.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   canDismissRejectModal,
   CHECK_REJECT_MODAL_SIZE,
+  checkRejectModalShell,
   checkRejectModalSize,
   mergeRejectComments,
   rejectModalTitle,
@@ -149,6 +150,19 @@ describe('check reject modal presentation', () => {
   it('keeps a text-only rejection compact', () => {
     expect(checkRejectModalSize(0)).toEqual({ height: 'auto', width: TEXT_REJECT_MODAL_WIDTH });
     expect(checkRejectModalSize(1)).toEqual(CHECK_REJECT_MODAL_SIZE);
+  });
+
+  it('does not size the overlay, which would pin the dialog to the left', () => {
+    const text = checkRejectModalShell(0);
+    const media = checkRejectModalShell(1);
+
+    expect(text.styles.popup?.height).toBeUndefined();
+    expect(text.styles.popup?.maxWidth).toBeUndefined();
+    expect(media.styles.popup?.height).toBeUndefined();
+    expect(media.styles.popup?.maxWidth).toBeUndefined();
+    expect(text.width).toBe(TEXT_REJECT_MODAL_WIDTH);
+    expect(media.width).toBe(CHECK_REJECT_MODAL_SIZE.width);
+    expect(media.classNames.popup).not.toBe(text.classNames.popup);
   });
 
   it('shows the acceptance item description below its title', () => {

--- a/src/features/Acceptance/Viewer/CheckList.test.ts
+++ b/src/features/Acceptance/Viewer/CheckList.test.ts
@@ -18,7 +18,6 @@ import {
   checkRejectModalShell,
   checkRejectModalSize,
   mergeRejectComments,
-  REJECT_MODAL_INLINE_PADDING,
   rejectModalTitle,
   TEXT_REJECT_MODAL_WIDTH,
 } from './CheckRejectModal';
@@ -166,10 +165,12 @@ describe('check reject modal presentation', () => {
     expect(media.classNames.popup).not.toBe(text.classNames.popup);
   });
 
-  it('keeps title and body on the same inline inset', () => {
+  it('does not restyle header or content inset, so title and body share the modal padding', () => {
     const shell = checkRejectModalShell(0);
-    expect(shell.styles.content?.paddingInline).toBe(0);
-    expect(shell.styles.header?.paddingInline).toBe(REJECT_MODAL_INLINE_PADDING);
+    expect(shell.styles.header).toBeUndefined();
+    expect(shell.styles.content?.padding).toBeUndefined();
+    expect(shell.styles.content?.paddingInline).toBeUndefined();
+    expect(shell.styles.content?.paddingBlock).toBeUndefined();
   });
 
   it('shows the acceptance item description below its title', () => {

--- a/src/features/Acceptance/Viewer/CheckList.test.ts
+++ b/src/features/Acceptance/Viewer/CheckList.test.ts
@@ -156,10 +156,8 @@ describe('check reject modal presentation', () => {
     const text = checkRejectModalShell(0);
     const media = checkRejectModalShell(1);
 
-    expect(text.styles.popup?.height).toBeUndefined();
-    expect(text.styles.popup?.maxWidth).toBeUndefined();
-    expect(media.styles.popup?.height).toBeUndefined();
-    expect(media.styles.popup?.maxWidth).toBeUndefined();
+    expect(Object.hasOwn(text.styles, 'popup')).toBe(false);
+    expect(Object.hasOwn(media.styles, 'popup')).toBe(false);
     expect(text.width).toBe(TEXT_REJECT_MODAL_WIDTH);
     expect(media.width).toBe(CHECK_REJECT_MODAL_SIZE.width);
     expect(media.classNames.popup).not.toBe(text.classNames.popup);
@@ -167,10 +165,10 @@ describe('check reject modal presentation', () => {
 
   it('does not restyle header or content inset, so title and body share the modal padding', () => {
     const shell = checkRejectModalShell(0);
-    expect(shell.styles.header).toBeUndefined();
-    expect(shell.styles.content?.padding).toBeUndefined();
-    expect(shell.styles.content?.paddingInline).toBeUndefined();
-    expect(shell.styles.content?.paddingBlock).toBeUndefined();
+    expect(Object.hasOwn(shell.styles, 'header')).toBe(false);
+    expect(Object.hasOwn(shell.styles.content, 'padding')).toBe(false);
+    expect(Object.hasOwn(shell.styles.content, 'paddingInline')).toBe(false);
+    expect(Object.hasOwn(shell.styles.content, 'paddingBlock')).toBe(false);
   });
 
   it('shows the acceptance item description below its title', () => {

--- a/src/features/Acceptance/Viewer/CheckList.test.ts
+++ b/src/features/Acceptance/Viewer/CheckList.test.ts
@@ -18,6 +18,7 @@ import {
   checkRejectModalShell,
   checkRejectModalSize,
   mergeRejectComments,
+  REJECT_MODAL_INLINE_PADDING,
   rejectModalTitle,
   TEXT_REJECT_MODAL_WIDTH,
 } from './CheckRejectModal';
@@ -163,6 +164,12 @@ describe('check reject modal presentation', () => {
     expect(text.width).toBe(TEXT_REJECT_MODAL_WIDTH);
     expect(media.width).toBe(CHECK_REJECT_MODAL_SIZE.width);
     expect(media.classNames.popup).not.toBe(text.classNames.popup);
+  });
+
+  it('keeps title and body on the same inline inset', () => {
+    const shell = checkRejectModalShell(0);
+    expect(shell.styles.content?.paddingInline).toBe(0);
+    expect(shell.styles.header?.paddingInline).toBe(REJECT_MODAL_INLINE_PADDING);
   });
 
   it('shows the acceptance item description below its title', () => {

--- a/src/features/Acceptance/Viewer/CheckList.tsx
+++ b/src/features/Acceptance/Viewer/CheckList.tsx
@@ -1491,6 +1491,7 @@ const CheckRow = memo<{
                 <Flexbox gap={10} style={{ marginBlockStart: 6 }}>
                   {hasAnnotatableEvidence(check) && (
                     <Button
+                      outdent
                       icon={<Icon icon={Images} />}
                       style={{ alignSelf: 'flex-start' }}
                       type={'text'}

--- a/src/features/Acceptance/Viewer/CheckRejectModal.tsx
+++ b/src/features/Acceptance/Viewer/CheckRejectModal.tsx
@@ -14,7 +14,6 @@ import { frostedModalStyles } from './modals';
 
 export const CHECK_REJECT_MODAL_SIZE = { height: '98dvh', width: '98vw' } as const;
 export const TEXT_REJECT_MODAL_WIDTH = 'min(560px, calc(100vw - 32px))';
-export const REJECT_MODAL_INLINE_PADDING = 16;
 
 const styles = createStaticStyles(({ css }) => ({
   modalPopup: css`
@@ -51,8 +50,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   modalFooter: css`
     flex: none;
-    padding-block: 12px;
-    padding-inline: ${REJECT_MODAL_INLINE_PADDING}px;
+    padding-block-start: 12px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   regionIndex: css`
@@ -207,16 +205,7 @@ export const checkRejectModalShell = (evidenceCount: number) => {
     },
     styles: {
       ...frostedModalStyles,
-      content: {
-        display: 'flex',
-        flex: 1,
-        minHeight: 0,
-        overflow: 'hidden',
-        padding: 0,
-        paddingBlock: 0,
-        paddingInline: 0,
-      },
-      header: { paddingInline: REJECT_MODAL_INLINE_PADDING },
+      content: { display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' },
     },
     width: modalSize.width,
   };
@@ -486,7 +475,7 @@ const CheckRejectModalContent = memo<CheckRejectModalProps>(
     return (
       <div className={styles.modalBody}>
         {activeEvidence && (
-          <Flexbox flex={1} gap={12} padding={REJECT_MODAL_INLINE_PADDING} style={{ minHeight: 0 }}>
+          <Flexbox flex={1} gap={12} style={{ minHeight: 0 }}>
             <Flexbox gap={12} height={'100%'} style={{ minHeight: 0 }}>
               {thumbnails}
               <div className={styles.fullscreenBody} style={{ position: 'relative' }}>

--- a/src/features/Acceptance/Viewer/CheckRejectModal.tsx
+++ b/src/features/Acceptance/Viewer/CheckRejectModal.tsx
@@ -14,6 +14,7 @@ import { frostedModalStyles } from './modals';
 
 export const CHECK_REJECT_MODAL_SIZE = { height: '98dvh', width: '98vw' } as const;
 export const TEXT_REJECT_MODAL_WIDTH = 'min(560px, calc(100vw - 32px))';
+export const REJECT_MODAL_INLINE_PADDING = 16;
 
 const styles = createStaticStyles(({ css }) => ({
   modalPopup: css`
@@ -51,7 +52,7 @@ const styles = createStaticStyles(({ css }) => ({
   modalFooter: css`
     flex: none;
     padding-block: 12px;
-    padding-inline: 20px;
+    padding-inline: ${REJECT_MODAL_INLINE_PADDING}px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   regionIndex: css`
@@ -206,7 +207,16 @@ export const checkRejectModalShell = (evidenceCount: number) => {
     },
     styles: {
       ...frostedModalStyles,
-      content: { display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden', padding: 0 },
+      content: {
+        display: 'flex',
+        flex: 1,
+        minHeight: 0,
+        overflow: 'hidden',
+        padding: 0,
+        paddingBlock: 0,
+        paddingInline: 0,
+      },
+      header: { paddingInline: REJECT_MODAL_INLINE_PADDING },
     },
     width: modalSize.width,
   };
@@ -476,7 +486,7 @@ const CheckRejectModalContent = memo<CheckRejectModalProps>(
     return (
       <div className={styles.modalBody}>
         {activeEvidence && (
-          <Flexbox flex={1} gap={12} padding={16} style={{ minHeight: 0 }}>
+          <Flexbox flex={1} gap={12} padding={REJECT_MODAL_INLINE_PADDING} style={{ minHeight: 0 }}>
             <Flexbox gap={12} height={'100%'} style={{ minHeight: 0 }}>
               {thumbnails}
               <div className={styles.fullscreenBody} style={{ position: 'relative' }}>

--- a/src/features/Acceptance/Viewer/CheckRejectModal.tsx
+++ b/src/features/Acceptance/Viewer/CheckRejectModal.tsx
@@ -12,12 +12,21 @@ import { AnnotationCanvas } from './Annotation';
 import { AttachmentStrip, AttachmentUploadButton, useFeedbackAttachments } from './attachments';
 import { frostedModalStyles } from './modals';
 
+export const CHECK_REJECT_MODAL_SIZE = { height: '98dvh', width: '98vw' } as const;
+export const TEXT_REJECT_MODAL_WIDTH = 'min(560px, calc(100vw - 32px))';
+
 const styles = createStaticStyles(({ css }) => ({
   modalPopup: css`
     > div {
       display: flex;
       flex-direction: column;
-      height: 100%;
+    }
+  `,
+  modalPopupMedia: css`
+    > div {
+      width: ${CHECK_REJECT_MODAL_SIZE.width};
+      max-width: ${CHECK_REJECT_MODAL_SIZE.width};
+      height: ${CHECK_REJECT_MODAL_SIZE.height};
     }
   `,
   fullscreenBody: css`
@@ -184,13 +193,24 @@ const readDraft = (key: string | undefined): RejectDraft | null => {
 
 const ZOOM_STEPS = [0.5, 0.75, 1, 1.5, 2, 3, 4];
 
-export const CHECK_REJECT_MODAL_SIZE = { height: '98dvh', width: '98vw' } as const;
-export const TEXT_REJECT_MODAL_WIDTH = 'min(560px, calc(100vw - 32px))';
-
 export const checkRejectModalSize = (evidenceCount: number) =>
   evidenceCount > 0
     ? CHECK_REJECT_MODAL_SIZE
     : ({ height: 'auto', width: TEXT_REJECT_MODAL_WIDTH } as const);
+
+export const checkRejectModalShell = (evidenceCount: number) => {
+  const modalSize = checkRejectModalSize(evidenceCount);
+  return {
+    classNames: {
+      popup: cx(styles.modalPopup, evidenceCount > 0 && styles.modalPopupMedia),
+    },
+    styles: {
+      ...frostedModalStyles,
+      content: { display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden', padding: 0 },
+    },
+    width: modalSize.width,
+  };
+};
 
 export const rejectModalTitle = (title: string, description?: string) => ({
   description: description?.trim() || undefined,
@@ -518,23 +538,13 @@ CheckRejectModalContent.displayName = 'AcceptanceCheckRejectModalContent';
 /** Per-check reject modal — media gets a near-fullscreen annotation surface without losing context. */
 export const openCheckRejectModal = (options: CheckRejectModalProps) => {
   const modalTitle = rejectModalTitle(options.checkTitle, options.checkDescription);
-  const modalSize = checkRejectModalSize(options.evidence.length);
+  const shell = checkRejectModalShell(options.evidence.length);
 
   return createModal({
-    classNames: { popup: styles.modalPopup },
+    ...shell,
     content: <CheckRejectModalContent {...options} />,
     footer: null,
     maskClosable: true,
-    styles: {
-      ...frostedModalStyles,
-      content: { display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden', padding: 0 },
-      popup: {
-        display: 'flex',
-        flexDirection: 'column',
-        height: modalSize.height,
-        maxWidth: modalSize.width,
-      },
-    },
     title: (
       <Flexbox gap={2}>
         <Text strong>{modalTitle.title}</Text>
@@ -545,6 +555,5 @@ export const openCheckRejectModal = (options: CheckRejectModalProps) => {
         )}
       </Flexbox>
     ),
-    width: modalSize.width,
   });
 };

--- a/src/features/Acceptance/Viewer/attachments.tsx
+++ b/src/features/Acceptance/Viewer/attachments.tsx
@@ -15,6 +15,14 @@ import { useFileStore } from '@/store/file';
 const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024;
 
 const styles = createStaticStyles(({ css }) => ({
+  flushUpload: css`
+    display: contents;
+
+    .ant-upload,
+    .ant-upload-select {
+      display: contents;
+    }
+  `,
   remove: css`
     cursor: pointer;
 
@@ -213,6 +221,7 @@ export const AttachmentUploadButton = memo<AttachmentUploadButtonProps>(({ disab
     <Upload
       multiple
       accept={'image/*'}
+      className={styles.flushUpload}
       disabled={disabled}
       showUploadList={false}
       beforeUpload={(file, fileList) => {
@@ -221,7 +230,13 @@ export const AttachmentUploadButton = memo<AttachmentUploadButtonProps>(({ disab
         return false;
       }}
     >
-      <Button disabled={disabled} icon={<Icon icon={ImagePlus} />} size={'small'} type={'text'}>
+      <Button
+        outdent
+        disabled={disabled}
+        icon={<Icon icon={ImagePlus} />}
+        size={'small'}
+        type={'text'}
+      >
         {t('acceptance.review.attach')}
       </Button>
     </Upload>

--- a/src/features/Portal/Acceptance/Header.tsx
+++ b/src/features/Portal/Acceptance/Header.tsx
@@ -57,6 +57,7 @@ const AcceptanceHeader = memo(() => {
 
   return (
     <Header
+      paddingInline={24}
       rightExtra={
         <ActionIcon
           disabled={!externalUrl}

--- a/src/features/Portal/AcceptanceCheck/Header.tsx
+++ b/src/features/Portal/AcceptanceCheck/Header.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { memo } from 'react';
+
+import PortalChromeHeader from '@/features/Portal/components/Header';
+
+import Title from './Title';
+
+const Header = memo(() => <PortalChromeHeader paddingInline={24} title={<Title />} />);
+
+Header.displayName = 'AcceptanceCheckPortalHeader';
+
+export default Header;

--- a/src/features/Portal/AcceptanceCheck/index.ts
+++ b/src/features/Portal/AcceptanceCheck/index.ts
@@ -1,5 +1,6 @@
 import type { PortalImpl } from '../type';
 import Body from './Body';
+import Header from './Header';
 import Title from './Title';
 
-export const AcceptanceCheck: PortalImpl = { Body, Title };
+export const AcceptanceCheck: PortalImpl = { Body, Header, Title };

--- a/src/features/Portal/components/Header.tsx
+++ b/src/features/Portal/components/Header.tsx
@@ -17,7 +17,11 @@ import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwar
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
-const Header = memo<{ rightExtra?: ReactNode; title: ReactNode }>(({ title, rightExtra }) => {
+const Header = memo<{
+  paddingInline?: number;
+  rightExtra?: ReactNode;
+  title: ReactNode;
+}>(({ paddingInline = 8, rightExtra, title }) => {
   const location = useLocation();
   const navigate = useWorkspaceAwareNavigate();
   const params = useParams<{ aid?: string; topicId?: string }>();
@@ -34,7 +38,7 @@ const Header = memo<{ rightExtra?: ReactNode; title: ReactNode }>(({ title, righ
   return (
     <NavHeader
       showTogglePanelButton={false}
-      style={{ paddingBlock: 8, paddingInline: 8, width: '100%' }}
+      style={{ paddingBlock: 8, paddingInline, width: '100%' }}
       left={
         <Flexbox horizontal align="center" flex={1} gap={4} style={{ minWidth: 0 }}>
           {canGoBack && (
@@ -63,7 +67,7 @@ const Header = memo<{ rightExtra?: ReactNode; title: ReactNode }>(({ title, righ
       styles={{
         left: {
           flex: 1,
-          marginLeft: canGoBack ? 0 : 6,
+          marginLeft: canGoBack || paddingInline !== 8 ? 0 : 6,
           minWidth: 0,
         },
         right: {


### PR DESCRIPTION
<!-- Brief and heads-up -->

`createModal`'s `styles.popup` is the full-screen overlay (`position: fixed; inset: 0`), not the dialog panel. The per-check reject modal was applying `height` / `maxWidth` there, so `left: 0` won when max-width underconstrained the box and the dialog stuck to the left edge.

| Before | After |
| ------ | ----- |
| Overlay sized to 560px / 98vw, dialog pinned left | Overlay stays full-viewport flex-center; panel size lives on the inner dialog |

#### Test

<!-- How you tested your changes -->

- Open an acceptance check and click **Reject with comment**.
- Text-only reject: compact dialog is centered in the viewport (equal left/right gutters).
- With screenshot evidence: near-fullscreen annotation surface keeps equal ~1% gutters on both sides.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Visual round: https://app.lobehub.com/acceptance/97b7492e-9819-48ed-9ff0-5a35b75f8f1b?r=1

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

N/A