### PR TITLE
🐛 fix(auth): preserve callback origin across auth flows

### DIFF
--- a/src/features/Auth/SignIn/useSignIn.test.ts
+++ b/src/features/Auth/SignIn/useSignIn.test.ts
@@ -124,7 +124,7 @@ describe('useSignIn', () => {
     mockBusinessSignin.preSocialSigninCheck.mockResolvedValue(true);
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { ...originalLocation, href: '' },
+      value: { ...originalLocation, href: '', origin: originalLocation.origin },
       writable: true,
     });
   });
@@ -262,6 +262,7 @@ describe('useSignIn', () => {
 
       expect(mockSignInEmail).toHaveBeenCalledWith(
         expect.objectContaining({
+          callbackURL: `${originalLocation.origin}/`,
           email: 'user@example.com',
           password: 'password123',
         }),
@@ -354,6 +355,32 @@ describe('useSignIn', () => {
   });
 
   describe('handleSocialSignIn', () => {
+    it('should bind relative OAuth callbacks to the current auth origin', async () => {
+      const authOrigin = 'https://auth.example.com';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, href: `${authOrigin}/signin`, origin: authOrigin },
+        writable: true,
+      });
+      mockSearchParamsGet.mockImplementation((key: string) =>
+        key === 'callbackUrl' ? '/workspace?tab=members' : null,
+      );
+      mockSignInSocial.mockResolvedValue({ url: 'https://google.com/auth' });
+
+      const { result } = renderHook(() => useSignIn());
+
+      await act(async () => {
+        await result.current.handleSocialSignIn('google');
+      });
+
+      expect(mockSignInSocial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callbackURL: `${authOrigin}/workspace?tab=members`,
+          newUserCallbackURL: `${authOrigin}/onboarding?callbackUrl=%2Fworkspace%3Ftab%3Dmembers`,
+        }),
+      );
+    });
+
     it('should call signIn.social for builtin providers', async () => {
       mockSignInSocial.mockResolvedValue({ url: 'https://google.com/auth' });
 
@@ -364,7 +391,10 @@ describe('useSignIn', () => {
       });
 
       expect(mockSignInSocial).toHaveBeenCalledWith(
-        expect.objectContaining({ newUserCallbackURL: '/onboarding', provider: 'google' }),
+        expect.objectContaining({
+          newUserCallbackURL: `${originalLocation.origin}/onboarding`,
+          provider: 'google',
+        }),
       );
       expect(mockMessageError).not.toHaveBeenCalled();
     });
@@ -379,7 +409,28 @@ describe('useSignIn', () => {
       });
 
       expect(mockSignInOauth2).toHaveBeenCalledWith(
-        expect.objectContaining({ newUserCallbackURL: '/onboarding', providerId: 'custom-oidc' }),
+        expect.objectContaining({
+          newUserCallbackURL: `${originalLocation.origin}/onboarding`,
+          providerId: 'custom-oidc',
+        }),
+      );
+    });
+
+    it('should preserve a mobile app callback scheme', async () => {
+      const mobileCallbackUrl = 'com.lobehub.app:///auth/callback';
+      mockSearchParamsGet.mockImplementation((key: string) =>
+        key === 'callbackUrl' ? mobileCallbackUrl : null,
+      );
+      mockSignInSocial.mockResolvedValue({ url: 'https://google.com/auth' });
+
+      const { result } = renderHook(() => useSignIn());
+
+      await act(async () => {
+        await result.current.handleSocialSignIn('google');
+      });
+
+      expect(mockSignInSocial).toHaveBeenCalledWith(
+        expect.objectContaining({ callbackURL: mobileCallbackUrl }),
       );
     });
 
@@ -505,7 +556,10 @@ describe('useSignIn', () => {
       });
 
       expect(mockRequestPasswordReset).toHaveBeenCalledWith(
-        expect.objectContaining({ email: 'user@example.com' }),
+        expect.objectContaining({
+          email: 'user@example.com',
+          redirectTo: `${originalLocation.origin}/reset-password?email=user%40example.com`,
+        }),
       );
       // Success is a persistent landing state, not a fleeting toast
       expect(result.current.step).toBe('emailSent');
@@ -593,6 +647,12 @@ describe('useSignIn', () => {
       });
 
       expect(mockSignInMagicLink).toHaveBeenCalledTimes(1);
+      expect(mockSignInMagicLink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callbackURL: `${originalLocation.origin}/`,
+          newUserCallbackURL: `${originalLocation.origin}/onboarding`,
+        }),
+      );
       expect(result.current.step).toBe('emailSent');
       expect(result.current.sentInfo).toEqual(
         expect.objectContaining({ email: 'user@example.com', type: 'magicLink' }),

--- a/src/features/Auth/SignIn/useSignIn.ts
+++ b/src/features/Auth/SignIn/useSignIn.ts
@@ -11,7 +11,11 @@ import { useAuthServerConfigStore } from '@/features/AuthShell';
 import { trackLoginOrSignupClicked } from '@/features/User/UserLoginOrSignup/trackLoginOrSignupClicked';
 import { requestPasswordReset, signIn } from '@/libs/better-auth/auth-client';
 import { isBuiltinProvider, normalizeProviderId } from '@/libs/better-auth/utils/client';
-import { buildOnboardingRedirectUrl, sanitizeRedirectPath } from '@/utils/onboardingRedirect';
+import {
+  buildOnboardingRedirectUrl,
+  sanitizeRedirectPath,
+  toAbsoluteAuthCallbackUrl,
+} from '@/utils/onboardingRedirect';
 
 import { EMAIL_REGEX, USERNAME_REGEX } from './SignInEmailStep';
 
@@ -87,11 +91,15 @@ export const useSignIn = () => {
 
       setSending(true);
       const callbackUrl = searchParams.get('callbackUrl') || '/';
+      const authOrigin = window.location.origin;
       const { error } = await signIn.magicLink({
-        callbackURL: callbackUrl,
+        callbackURL: toAbsoluteAuthCallbackUrl(callbackUrl, authOrigin),
         email: emailValue,
         // First-time magic-link users are signups — land them on onboarding first
-        newUserCallbackURL: buildOnboardingRedirectUrl(callbackUrl),
+        newUserCallbackURL: toAbsoluteAuthCallbackUrl(
+          buildOnboardingRedirectUrl(callbackUrl),
+          authOrigin,
+        ),
       });
       if (error) {
         toast.error(error.message || t('betterAuth.signin.magicLinkError'));
@@ -208,7 +216,11 @@ export const useSignIn = () => {
     try {
       const callbackUrl = searchParams.get('callbackUrl') || '/';
       const result = await signIn.email(
-        { callbackURL: callbackUrl, email, password: values.password },
+        {
+          callbackURL: toAbsoluteAuthCallbackUrl(callbackUrl, window.location.origin),
+          email,
+          password: values.password,
+        },
         {
           onError: (ctx) => {
             console.error('Sign in error:', ctx.error);
@@ -266,19 +278,24 @@ export const useSignIn = () => {
 
       const callbackUrl = searchParams.get('callbackUrl') || '/';
       // First-time OAuth users are signups — land them on onboarding first
-      const newUserCallbackURL = buildOnboardingRedirectUrl(callbackUrl);
+      const authOrigin = window.location.origin;
+      const callbackURL = toAbsoluteAuthCallbackUrl(callbackUrl, authOrigin);
+      const newUserCallbackURL = toAbsoluteAuthCallbackUrl(
+        buildOnboardingRedirectUrl(callbackUrl),
+        authOrigin,
+      );
       const additionalData = await getAdditionalData();
       const signInWithAdditionalData = async () =>
         isBuiltinProvider(normalizedProvider)
           ? await signIn.social({
               additionalData,
-              callbackURL: callbackUrl,
+              callbackURL,
               newUserCallbackURL,
               provider: normalizedProvider,
             })
           : await signIn.oauth2({
               additionalData,
-              callbackURL: callbackUrl,
+              callbackURL,
               newUserCallbackURL,
               providerId: normalizedProvider,
             });
@@ -329,7 +346,10 @@ export const useSignIn = () => {
       // throwing, so a failed send would otherwise land on the "email sent" screen.
       const { error } = await requestPasswordReset({
         email: targetEmail,
-        redirectTo: `/reset-password?email=${encodeURIComponent(targetEmail)}`,
+        redirectTo: toAbsoluteAuthCallbackUrl(
+          `/reset-password?email=${encodeURIComponent(targetEmail)}`,
+          window.location.origin,
+        ),
       });
       if (error) throw error;
       return true;

--- a/src/features/Auth/SignUp/useSignUp.test.ts
+++ b/src/features/Auth/SignUp/useSignUp.test.ts
@@ -61,7 +61,7 @@ describe('useSignUp', () => {
     mockEnableEmailVerification = false;
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { ...originalLocation, href: '' },
+      value: { ...originalLocation, href: '', origin: originalLocation.origin },
       writable: true,
     });
   });
@@ -148,7 +148,9 @@ describe('useSignUp', () => {
       });
 
       expect(mockSignUpEmail).toHaveBeenCalledWith(
-        expect.objectContaining({ callbackURL: '/onboarding?callbackUrl=%2Fdashboard' }),
+        expect.objectContaining({
+          callbackURL: `${originalLocation.origin}/onboarding?callbackUrl=%2Fdashboard`,
+        }),
       );
       expect(window.location.href).toBe('/onboarding?callbackUrl=%2Fdashboard');
     });

--- a/src/features/Auth/SignUp/useSignUp.ts
+++ b/src/features/Auth/SignUp/useSignUp.ts
@@ -11,7 +11,7 @@ import { withCaptchaToken } from '@/features/Auth/utils/authFetchOptions';
 import { useAuthServerConfigStore } from '@/features/AuthShell';
 import { trackLoginOrSignupClicked } from '@/features/User/UserLoginOrSignup/trackLoginOrSignupClicked';
 import { signUp } from '@/libs/better-auth/auth-client';
-import { buildOnboardingRedirectUrl } from '@/utils/onboardingRedirect';
+import { buildOnboardingRedirectUrl, toAbsoluteAuthCallbackUrl } from '@/utils/onboardingRedirect';
 
 import type { BaseSignUpFormValues } from './types';
 
@@ -61,7 +61,7 @@ export const useSignUp = () => {
 
       const submit = async (nextFetchOptions?: AuthFetchOptions) =>
         signUp.email({
-          callbackURL: redirectUrl,
+          callbackURL: toAbsoluteAuthCallbackUrl(redirectUrl, window.location.origin),
           email: values.email,
           fetchOptions: nextFetchOptions,
           name: username,

--- a/src/features/Auth/VerifyEmail/useVerifyEmail.test.ts
+++ b/src/features/Auth/VerifyEmail/useVerifyEmail.test.ts
@@ -1,0 +1,40 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useVerifyEmail } from './useVerifyEmail';
+
+const mockSendVerificationEmail = vi.hoisted(() => vi.fn());
+
+vi.mock('@/libs/better-auth/auth-client', () => ({
+  sendVerificationEmail: mockSendVerificationEmail,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('useVerifyEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendVerificationEmail.mockResolvedValue({ error: null });
+  });
+
+  it('should bind the verification callback to the current auth origin', async () => {
+    const { result } = renderHook(() =>
+      useVerifyEmail({ callbackUrl: '/onboarding', email: 'user@example.com' }),
+    );
+
+    await act(async () => {
+      await result.current.handleResendEmail();
+    });
+
+    expect(mockSendVerificationEmail).toHaveBeenCalledWith({
+      callbackURL: `${window.location.origin}/onboarding`,
+      email: 'user@example.com',
+    });
+  });
+});

--- a/src/features/Auth/VerifyEmail/useVerifyEmail.ts
+++ b/src/features/Auth/VerifyEmail/useVerifyEmail.ts
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { sendVerificationEmail } from '@/libs/better-auth/auth-client';
+import { toAbsoluteAuthCallbackUrl } from '@/utils/onboardingRedirect';
 
 interface UseVerifyEmailParams {
   callbackUrl: string;
@@ -21,7 +22,10 @@ export const useVerifyEmail = ({ email, callbackUrl }: UseVerifyEmailParams) => 
 
     setResending(true);
     try {
-      const result = await sendVerificationEmail({ callbackURL: callbackUrl, email });
+      const result = await sendVerificationEmail({
+        callbackURL: toAbsoluteAuthCallbackUrl(callbackUrl, window.location.origin),
+        email,
+      });
       if (result.error) {
         toast.error(result.error.message || t('betterAuth.verifyEmail.resend.error'));
         return;

--- a/src/utils/onboardingRedirect.test.ts
+++ b/src/utils/onboardingRedirect.test.ts
@@ -9,6 +9,7 @@ import {
   POST_ONBOARDING_HOME_TASK_URL,
   resolvePostOnboardingTargetUrl,
   stashOnboardingCallbackUrl,
+  toAbsoluteAuthCallbackUrl,
 } from './onboardingRedirect';
 
 beforeEach(() => {
@@ -31,6 +32,26 @@ describe('isSafeRedirectPath', () => {
     expect(isSafeRedirectPath('/\\evil.com')).toBe(false);
     expect(isSafeRedirectPath('/\\/evil.com')).toBe(false);
     expect(isSafeRedirectPath('/foo\\bar')).toBe(false);
+  });
+});
+
+describe('toAbsoluteAuthCallbackUrl', () => {
+  const authOrigin = 'https://auth.example.com';
+
+  it('should bind safe relative paths to the current auth origin', () => {
+    expect(toAbsoluteAuthCallbackUrl('/', authOrigin)).toBe(`${authOrigin}/`);
+    expect(toAbsoluteAuthCallbackUrl('/workspace?tab=members', authOrigin)).toBe(
+      `${authOrigin}/workspace?tab=members`,
+    );
+  });
+
+  it.each([
+    'https://app.example.com/workspace',
+    'com.lobehub.app:///auth/callback',
+    '//evil.com/callback',
+    '/\\evil.com',
+  ])('should preserve non-relative callback %s', (callbackUrl) => {
+    expect(toAbsoluteAuthCallbackUrl(callbackUrl, authOrigin)).toBe(callbackUrl);
   });
 });
 

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -12,6 +12,14 @@ export const isSafeRedirectPath = (url: string): boolean =>
   url.startsWith('/') && !url.startsWith('//') && !url.includes('\\');
 
 /**
+ * Better Auth resolves relative callbacks against its server base URL, but auth pages can run on a
+ * different origin. Bind safe web paths to the browser's current origin before sending them to the
+ * server, while preserving explicit absolute URLs and mobile schemes.
+ */
+export const toAbsoluteAuthCallbackUrl = (callbackUrl: string, origin: string): string =>
+  isSafeRedirectPath(callbackUrl) ? new URL(callbackUrl, origin).toString() : callbackUrl;
+
+/**
  * Auth detours can produce same-origin absolute callback URLs (e.g. the
  * protected-route proxy builds `APP_URL + pathname + search`) — normalize
  * them to relative paths instead of dropping them as unsafe.


### PR DESCRIPTION
Relative callback URLs sent to Better Auth are resolved against the configured server base URL. When the auth page is served from a different origin, successful authentication can therefore return users to the wrong origin.

This change:

- binds safe relative callback paths to the current browser origin before sending them to Better Auth
- covers password, social OAuth, custom OAuth, magic link, sign-up verification, verification resend, and password reset flows
- preserves explicit absolute URLs and custom mobile callback schemes
- reuses the existing safe redirect-path validation so protocol-relative and backslash-based paths are not rewritten

#### Key Decisions / Non-goals

The conversion happens only at the client-to-server boundary. Client-side navigation keeps using the original sanitized relative path.

This PR does not change the OAuth provider redirect URI or the Better Auth server base URL.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [x] `bun run check <8 changed files>` — lint clean, 70 tests passed
- [ ] Full repository type-check — local workspace dependencies are currently missing for unrelated packages such as `@achaos/core` and `@xyflow/react`; no reported errors are in changed files

#### 🔗 Related Issue

Fixes LOBE-13481