### PR TITLE
✨ feat(devdock): integrate Mesurer inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
     "mammoth": "^1.12.1",
     "marked": "^17.0.6",
     "mdast-util-to-markdown": "^2.1.2",
+    "mesurer": "^0.1.0",
     "model-bank": "workspace:*",
     "motion": "^12.43.0",
     "nanoid": "^5.1.16",

--- a/src/features/DevDock/index.tsx
+++ b/src/features/DevDock/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { lazy, Suspense, useCallback, useState } from 'react';
+
 import { registerBusinessDevDockItems } from '@/business/client/registerDevDockItems';
 import FlagOverrideHydrator from '@/features/DevFeatureFlagPanel/Hydrator';
 
@@ -7,14 +9,38 @@ import Bar from './Bar';
 import PanelHost from './PanelHost';
 import ReactScanController from './ReactScanController';
 import { registerBuiltinDevDockItems } from './registerBuiltinItems';
+import { useDevDockStore } from './store';
+
+const Mesurer = lazy(() => import('mesurer').then((module) => ({ default: module.Mesurer })));
+
+const MesurerPortal = () => {
+  const [portalTarget, setPortalTarget] = useState<ShadowRoot | null>(null);
+  const setPortalHost = useCallback((host: HTMLDivElement | null) => {
+    if (host) setPortalTarget(host.shadowRoot ?? host.attachShadow({ mode: 'open' }));
+  }, []);
+
+  return (
+    <>
+      <div ref={setPortalHost} />
+      {portalTarget && (
+        <Suspense fallback={null}>
+          <Mesurer portalTarget={portalTarget} />
+        </Suspense>
+      )}
+    </>
+  );
+};
 
 registerBuiltinDevDockItems();
 registerBusinessDevDockItems();
 
 const DevDock = () => {
+  const mesurer = useDevDockStore((state) => state.mesurer);
+
   return (
     <>
       <FlagOverrideHydrator />
+      {mesurer && <MesurerPortal />}
       <ReactScanController />
       <PanelHost />
       <Bar />

--- a/src/features/DevDock/registerBuiltinItems.ts
+++ b/src/features/DevDock/registerBuiltinItems.ts
@@ -12,6 +12,7 @@ import {
   MemoryStick,
   RotateCw,
   Route,
+  Ruler,
   ScanEye,
   Terminal,
 } from 'lucide-react';
@@ -103,6 +104,15 @@ export const registerBuiltinDevDockItems = () => {
           slot: 'right',
           type: 'readout',
         },
+    {
+      getChecked: () => useDevDockStore.getState().mesurer,
+      icon: Ruler,
+      id: 'mesurer',
+      label: 'Mesurer',
+      onToggle: (checked) => useDevDockStore.getState().setMesurer(checked),
+      subscribe: subscribeDevDock,
+      type: 'toggle',
+    },
     {
       getChecked: () => useDevDockStore.getState().reactScan,
       icon: ScanEye,

--- a/src/features/DevDock/store.test.ts
+++ b/src/features/DevDock/store.test.ts
@@ -16,6 +16,7 @@ describe('DevDock store', () => {
       activePanelId: null,
       expanded: true,
       maximized: false,
+      mesurer: false,
       panelHeight: 360,
       pinOverrides: {},
       reactScan: false,
@@ -44,10 +45,16 @@ describe('DevDock store', () => {
 
   it('persists UI state to localStorage', () => {
     useDevDockStore.getState().setExpanded(false);
+    useDevDockStore.getState().setMesurer(true);
     useDevDockStore.getState().setScrollDebug(true);
     useDevDockStore.getState().setReactScan(true);
 
-    expect(readPersisted()).toMatchObject({ expanded: false, reactScan: true, scrollDebug: true });
+    expect(readPersisted()).toMatchObject({
+      expanded: false,
+      mesurer: true,
+      reactScan: true,
+      scrollDebug: true,
+    });
   });
 
   it('merges pin overrides per id and persists them', () => {

--- a/src/features/DevDock/store.ts
+++ b/src/features/DevDock/store.ts
@@ -8,6 +8,7 @@ interface DevDockUIState {
   activePanelId: string | null;
   expanded: boolean;
   maximized: boolean;
+  mesurer: boolean;
   panelHeight: number;
   pinOverrides: Record<string, boolean>;
   reactScan: boolean;
@@ -20,6 +21,7 @@ const DEFAULT_UI: DevDockUIState = {
   activePanelId: null,
   expanded: true,
   maximized: false,
+  mesurer: false,
   panelHeight: 360,
   pinOverrides: {},
   reactScan: bootReactScan,
@@ -40,6 +42,7 @@ const readPersisted = (): DevDockUIState => {
 export interface DevDockStore extends DevDockUIState {
   setExpanded: (expanded: boolean) => void;
   setMaximized: (maximized: boolean) => void;
+  setMesurer: (mesurer: boolean) => void;
   setPanelHeight: (panelHeight: number) => void;
   setPinned: (id: string, pinned: boolean) => void;
   setReactScan: (reactScan: boolean) => void;
@@ -55,6 +58,7 @@ export const useDevDockStore = create<DevDockStore>((set, get) => {
       activePanelId,
       expanded,
       maximized,
+      mesurer,
       panelHeight,
       pinOverrides,
       reactScan,
@@ -66,6 +70,7 @@ export const useDevDockStore = create<DevDockStore>((set, get) => {
         activePanelId,
         expanded,
         maximized,
+        mesurer,
         panelHeight,
         pinOverrides,
         reactScan,
@@ -78,6 +83,7 @@ export const useDevDockStore = create<DevDockStore>((set, get) => {
     ...readPersisted(),
     setExpanded: (expanded) => update({ expanded }),
     setMaximized: (maximized) => update({ maximized }),
+    setMesurer: (mesurer) => update({ mesurer }),
     setPanelHeight: (panelHeight) =>
       update({ panelHeight: Math.max(MIN_PANEL_HEIGHT, panelHeight) }),
     setPinned: (id, pinned) => update({ pinOverrides: { ...get().pinOverrides, [id]: pinned } }),


### PR DESCRIPTION
Integrates [Mesurer](https://mesurer.dev/) as a built-in DevDock toggle.

- lazy-loads the inspector only when enabled
- mounts Mesurer in a Shadow Root so LobeHub theme styles cannot override its toolbar
- persists the DevDock toggle alongside the existing React Scan and scroll-debug settings

| Before | After |
| ------ | ----- |
| DevDock has no integrated visual inspector | `More tools` includes a Mesurer toggle that mounts the inspector toolbar |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check package.json src/features/DevDock/index.tsx src/features/DevDock/registerBuiltinItems.ts src/features/DevDock/store.ts src/features/DevDock/store.test.ts`
- `bun run check --type package.json src/features/DevDock/index.tsx src/features/DevDock/registerBuiltinItems.ts src/features/DevDock/store.ts src/features/DevDock/store.test.ts`
- Browser runtime: enabling the toggle renders the styled Mesurer toolbar; disabling it removes the toolbar and Shadow Root.

#### 🔗 Related Issue

N/A
