### PR TITLE
🐛 fix(search): bound long Elasticsearch queries

### DIFF
--- a/.agents/skills/full-text-search/SKILL.md
+++ b/.agents/skills/full-text-search/SKILL.md
@@ -66,6 +66,11 @@ applicable item:
 Schema fields, mappings, builders, and fixed fixtures must agree exactly. A field that is not in the
 document schema must not appear in the mapping or query field list.
 
+Elasticsearch `multi_match` query length is bounded by a shared leaf-clause budget divided by the
+selected query-field count. Adding a field reduces that entity's safe query length, and changing a
+query analyzer to emit multiple terms per Unicode code point requires revisiting the budget and its
+field-count regression tests.
+
 ## Capture, Reindex, and Sync
 
 - Regular database migrations own durable schema: the revision sequence, Outbox table and indexes,

--- a/apps/server/src/routers/lambda/userMemories.ts
+++ b/apps/server/src/routers/lambda/userMemories.ts
@@ -27,6 +27,8 @@ import {
   type IdentityEntryPayload,
 } from '@/database/models/userMemory';
 import {
+  normalizeUserMemorySearchQueries,
+  shouldRunUserMemoryLexicalSearch,
   UserMemoryActivityModel,
   UserMemoryExperienceModel,
   UserMemoryIdentityModel,
@@ -48,6 +50,10 @@ import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { createFtsSearchRepo } from '@/server/services/ftsSearch';
+import {
+  recordUserMemoryLexicalSearchDecision,
+  type UserMemoryLexicalSearchSource,
+} from '@/server/services/ftsSearch/observability';
 import type { UserMemoryEmbeddingRuntime } from '@/server/services/memory/userMemory/embedding';
 import { embedUserMemoryTexts } from '@/server/services/memory/userMemory/embedding';
 import { normalizeSearchMemoryParams } from '@/server/services/memory/userMemory/searchParams';
@@ -121,14 +127,13 @@ const applySearchLimitsByEffort = (
 const searchUserMemories = async (
   ctx: MemorySearchContext,
   input: z.infer<typeof searchMemorySchema>,
+  source: UserMemoryLexicalSearchSource,
 ): Promise<SearchMemoryResult> => {
   const normalizedInput = normalizeSearchMemoryParams(input);
   const { provider, model: embeddingModel } =
     getServerDefaultFilesConfig().embeddingModel || DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM;
   const modelRuntime = await initModelRuntimeFromDB(ctx.serverDB, ctx.userId, provider);
-  const normalizedQueries = [
-    ...new Set((normalizedInput.queries ?? []).map((query) => query.trim()).filter(Boolean)),
-  ];
+  const normalizedQueries = normalizeUserMemorySearchQueries(normalizedInput.queries);
 
   const queryEmbeddings =
     normalizedQueries.length > 0
@@ -142,6 +147,12 @@ const searchUserMemories = async (
           })
         ).filter((embedding): embedding is number[] => Boolean(embedding))
       : [];
+  const lexicalSearch = shouldRunUserMemoryLexicalSearch(normalizedQueries, queryEmbeddings);
+  recordUserMemoryLexicalSearchDecision({
+    decision: lexicalSearch ? 'executed' : 'skipped_long_context',
+    queryCharacters: Array.from(normalizedQueries.join(' ')).length,
+    source,
+  });
 
   const effectiveEffort = normalizeMemoryEffort(normalizedInput.effort ?? ctx.memoryEffort);
   const effortDefaults = MEMORY_SEARCH_TOP_K_LIMITS[effectiveEffort];
@@ -977,7 +988,7 @@ export const userMemoriesRouter = router({
           topK: DEFAULT_SEARCH_USER_MEMORY_TOP_K,
         };
 
-        const result = await searchUserMemories(ctx, searchParams);
+        const result = await searchUserMemories(ctx, searchParams, 'topic_retrieval');
         return result;
       } catch (error) {
         rethrowCandidateSearchError(error);
@@ -988,7 +999,7 @@ export const userMemoriesRouter = router({
 
   searchMemory: memorySearchProcedure.input(searchMemorySchema).query(async ({ input, ctx }) => {
     try {
-      return await searchUserMemories(ctx, input);
+      return await searchUserMemories(ctx, input, 'api');
     } catch (error) {
       rethrowCandidateSearchError(error);
       console.error('Failed to retrieve memories:', error);
@@ -1328,7 +1339,7 @@ export const userMemoriesRouter = router({
   toolSearchMemory: memorySearchProcedure
     .input(searchMemorySchema)
     .query(async ({ input, ctx }) => {
-      const result = await searchUserMemories(ctx, input);
+      const result = await searchUserMemories(ctx, input, 'tool');
       return result;
     }),
 

--- a/apps/server/src/services/ftsSearch/elasticsearch.test.ts
+++ b/apps/server/src/services/ftsSearch/elasticsearch.test.ts
@@ -13,6 +13,7 @@ vi.mock('./observability', () => ({
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -73,8 +74,12 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
       client.search({
         body: { query: { match_all: {} }, size: 1 },
         entity: 'agents',
+        executedQueryChars: 0,
         index: 'lobehub-dev-agents',
+        originalQueryChars: 0,
         pagination: 'bounded',
+        queryFieldCount: 0,
+        truncated: false,
       }),
     ).resolves.toEqual({
       hits: {
@@ -99,23 +104,37 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
       decodedBytes: expect.any(Number),
       durationMs: expect.any(Number),
       entity: 'agents',
+      errorCode: 'none',
+      executedQueryChars: 0,
       hits: 1,
+      originalQueryChars: 0,
       pagination: 'bounded',
+      queryFieldCount: 0,
       requestBytes: expect.any(Number),
       result: 'success',
       serverTookMs: 12,
+      traceContext: expect.any(String),
+      truncated: false,
     });
   });
 
-  it('surfaces HTTP failures without copying response payloads into the error', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValue(
-          new Response(JSON.stringify({ error: 'sensitive backend detail' }), { status: 503 }),
-        ),
+  it('classifies nested clause-limit failures without copying response payloads into the error', async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: {
+          caused_by: {
+            reason: 'too many nested clauses: secret-query-fragment',
+            type: 'too_many_clauses',
+          },
+          reason: 'all shards failed',
+          root_cause: [{ type: 'query_shard_exception' }],
+          type: 'search_phase_execution_exception',
+        },
+      }),
+      { status: 400 },
     );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
     const client = new ElasticsearchFtsSearchHttpClient({
       apiKey: 'test-api-key',
       url: 'https://search.example.com',
@@ -125,16 +144,72 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
       client.search({
         body: { query: { match_all: {} } },
         entity: 'agents',
+        executedQueryChars: 96,
         index: 'lobehub-dev-agents',
+        originalQueryChars: 7000,
         pagination: 'bounded',
+        queryFieldCount: 8,
+        truncated: true,
       }),
     ).rejects.toMatchObject({
-      message: 'Elasticsearch search request failed (503)',
+      errorCode: 'too_many_clauses',
+      message: 'Elasticsearch search request failed (400, too_many_clauses)',
+      status: 400,
+    });
+    expect(response.bodyUsed).toBe(true);
+    expect(mocks.recordSearchRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: 'agents',
+        errorCode: 'too_many_clauses',
+        result: 'http_error',
+      }),
+    );
+    expect(errorSpy).toHaveBeenCalledWith('[fts-search] Elasticsearch request failed', {
+      entity: 'agents',
+      errorCode: 'too_many_clauses',
+      executedQueryChars: 96,
+      originalQueryChars: 7000,
+      queryFieldCount: 8,
+      requestBytes: expect.any(Number),
+      status: 400,
+      traceContext: expect.any(String),
+      traceId: expect.any(String),
+      truncated: true,
+    });
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('secret-query-fragment');
+  });
+
+  it('classifies generic server failures without exposing the response body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ error: 'sensitive backend detail' }), { status: 503 }),
+        ),
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new ElasticsearchFtsSearchHttpClient({
+      apiKey: 'test-api-key',
+      url: 'https://search.example.com',
+    });
+
+    await expect(
+      client.search({
+        body: { query: { match_all: {} } },
+        entity: 'agents',
+        executedQueryChars: 0,
+        index: 'lobehub-dev-agents',
+        originalQueryChars: 0,
+        pagination: 'bounded',
+        queryFieldCount: 0,
+        truncated: false,
+      }),
+    ).rejects.toMatchObject({
+      errorCode: 'server_error',
+      message: 'Elasticsearch search request failed (503, server_error)',
       status: 503,
     });
-    expect(mocks.recordSearchRequest).toHaveBeenCalledWith(
-      expect.objectContaining({ entity: 'agents', result: 'http_error' }),
-    );
   });
 
   it('rejects malformed successful responses', async () => {
@@ -156,8 +231,12 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
       client.search({
         body: { query: { match_all: {} } },
         entity: 'agents',
+        executedQueryChars: 0,
         index: 'lobehub-dev-agents',
+        originalQueryChars: 0,
         pagination: 'bounded',
+        queryFieldCount: 0,
+        truncated: false,
       }),
     ).rejects.toThrow('Elasticsearch search response has an invalid shape');
     expect(mocks.recordSearchRequest).toHaveBeenCalledWith(
@@ -173,8 +252,12 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
     const input = {
       body: { query: { match_all: {} } },
       entity: 'agents' as const,
+      executedQueryChars: 0,
       index: 'lobehub-dev-agents',
+      originalQueryChars: 0,
       pagination: 'bounded' as const,
+      queryFieldCount: 0,
+      truncated: false,
     };
 
     vi.stubGlobal(

--- a/apps/server/src/services/ftsSearch/elasticsearch.ts
+++ b/apps/server/src/services/ftsSearch/elasticsearch.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 
+import { trace } from '@lobechat/observability-otel/api';
 import { z } from 'zod';
 
 import type {
@@ -10,8 +11,14 @@ import type {
 } from '@/database/repositories/ftsSearch';
 import { parseElasticsearchUrl } from '@/database/repositories/ftsSearch/elasticsearch/url';
 
-import type { ElasticsearchFtsSearchRequestResult } from './observability';
+import type {
+  ElasticsearchFtsSearchErrorCode,
+  ElasticsearchFtsSearchRequestResult,
+  ElasticsearchFtsSearchTraceContext,
+} from './observability';
 import { recordElasticsearchFtsSearchRequest } from './observability';
+
+const MAX_ERROR_RESPONSE_BYTES = 16_384;
 
 const searchResponseSchema = z.object({
   hits: z.object({
@@ -118,11 +125,18 @@ export interface ElasticsearchFtsSearchSyncIndexIdentity {
 }
 
 export class ElasticsearchFtsSearchRequestError extends Error {
+  readonly errorCode: ElasticsearchFtsSearchErrorCode;
   readonly status?: number;
 
-  constructor(message: string, status?: number, cause?: unknown) {
+  constructor(
+    message: string,
+    status?: number,
+    cause?: unknown,
+    errorCode: ElasticsearchFtsSearchErrorCode = 'unknown_http_error',
+  ) {
     super(message, { cause });
     this.name = 'ElasticsearchFtsSearchRequestError';
+    this.errorCode = errorCode;
     this.status = status;
   }
 }
@@ -137,6 +151,85 @@ const readContentLength = (response: Response): number | undefined => {
   if (!header) return;
   const value = Number(header);
   return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+};
+
+const readBoundedResponseText = async (response: Response): Promise<string> => {
+  if (!response.body) return '';
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let completed = false;
+  let totalBytes = 0;
+
+  try {
+    while (totalBytes < MAX_ERROR_RESPONSE_BYTES) {
+      const result = await reader.read();
+      if (result.done) {
+        completed = true;
+        break;
+      }
+
+      const remainingBytes = MAX_ERROR_RESPONSE_BYTES - totalBytes;
+      const chunk = Buffer.from(result.value.subarray(0, remainingBytes));
+      chunks.push(chunk);
+      totalBytes += chunk.byteLength;
+    }
+  } finally {
+    if (!completed) {
+      try {
+        await reader.cancel();
+      } catch {
+        // The classification fallback still uses the HTTP status when the stream cannot cancel.
+      }
+    }
+  }
+
+  return Buffer.concat(chunks, totalBytes).toString('utf8');
+};
+
+/** Extracts only bounded Elasticsearch error type identifiers, never free-form reasons. */
+const readElasticsearchErrorTypes = (responseText: string): Set<string> => {
+  const errorTypes = new Set<string>();
+
+  for (const match of responseText.matchAll(/"type"\s*:\s*"(\w+)"/gi)) {
+    if (match[1]) errorTypes.add(match[1].toLowerCase());
+  }
+
+  return errorTypes;
+};
+
+const classifyHttpError = (
+  status: number,
+  responseText: string,
+): ElasticsearchFtsSearchErrorCode => {
+  const errorTypes = readElasticsearchErrorTypes(responseText);
+  if (errorTypes.has('too_many_clauses') || errorTypes.has('too_many_nested_clauses')) {
+    return 'too_many_clauses';
+  }
+  if (status === 401) return 'authentication';
+  if (status === 403) return 'authorization';
+  if (status === 404 || errorTypes.has('index_not_found_exception')) return 'index_not_found';
+  if (status === 413) return 'request_too_large';
+  if (status === 429) return 'rate_limited';
+  if (status >= 500) return 'server_error';
+  if (status === 400) return 'invalid_query';
+
+  return 'unknown_http_error';
+};
+
+const getTraceDetails = (): {
+  span: ReturnType<typeof trace.getActiveSpan>;
+  traceContext: ElasticsearchFtsSearchTraceContext;
+  traceId: string;
+} => {
+  const span = trace.getActiveSpan();
+  if (!span) return { span, traceContext: 'missing', traceId: 'none' };
+
+  return {
+    span,
+    traceContext: span.isRecording() ? 'recording' : 'non_recording',
+    traceId: span.spanContext().traceId || 'none',
+  };
 };
 
 /** HTTP transport that never logs credentials, request text, or Elasticsearch payloads. */
@@ -396,10 +489,19 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
     let contentLength: number | undefined;
     let decodedBytes: number | undefined;
     let recorded = false;
+    const { span, traceContext, traceId } = getTraceDetails();
+    span?.setAttributes({
+      'fts.search.elasticsearch.executed_query_characters': input.executedQueryChars,
+      'fts.search.elasticsearch.original_query_characters': input.originalQueryChars,
+      'fts.search.elasticsearch.query_field_count': input.queryFieldCount,
+      'fts.search.elasticsearch.query_truncated': input.truncated,
+      'fts.search.elasticsearch.trace_context': traceContext,
+    });
     const record = (
       result: ElasticsearchFtsSearchRequestResult,
       hits?: number,
       serverTookMs?: number,
+      errorCode: ElasticsearchFtsSearchErrorCode = 'none',
     ) => {
       recorded = true;
       recordElasticsearchFtsSearchRequest({
@@ -407,11 +509,35 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
         decodedBytes,
         durationMs: Date.now() - startedAt,
         entity: input.entity,
+        errorCode,
+        executedQueryChars: input.executedQueryChars,
         hits,
+        originalQueryChars: input.originalQueryChars,
         pagination: input.pagination,
+        queryFieldCount: input.queryFieldCount,
         requestBytes,
         result,
         serverTookMs,
+        traceContext,
+        truncated: input.truncated,
+      });
+    };
+    const logFailure = (errorCode: ElasticsearchFtsSearchErrorCode, status?: number) => {
+      span?.setAttributes({
+        'fts.search.elasticsearch.error_code': errorCode,
+        ...(status === undefined ? {} : { 'fts.search.elasticsearch.http_status_code': status }),
+      });
+      console.error('[fts-search] Elasticsearch request failed', {
+        entity: input.entity,
+        errorCode,
+        executedQueryChars: input.executedQueryChars,
+        originalQueryChars: input.originalQueryChars,
+        queryFieldCount: input.queryFieldCount,
+        requestBytes,
+        status: status ?? 0,
+        traceContext,
+        traceId,
+        truncated: input.truncated,
       });
     };
 
@@ -428,10 +554,20 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
       contentLength = readContentLength(response);
 
       if (!response.ok) {
-        record('http_error');
+        let responseText = '';
+        try {
+          responseText = await readBoundedResponseText(response);
+        } catch {
+          // HTTP status still provides a safe, bounded classification fallback.
+        }
+        const errorCode = classifyHttpError(response.status, responseText);
+        record('http_error', undefined, undefined, errorCode);
+        logFailure(errorCode, response.status);
         throw new ElasticsearchFtsSearchRequestError(
-          `Elasticsearch search request failed (${response.status})`,
+          `Elasticsearch search request failed (${response.status}, ${errorCode})`,
           response.status,
+          undefined,
+          errorCode,
         );
       }
 
@@ -441,28 +577,39 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
         decodedBytes = Buffer.byteLength(responseText);
         payload = JSON.parse(responseText);
       } catch (error) {
-        record(error instanceof SyntaxError ? 'parse_error' : classifyRequestError(error));
+        const result = error instanceof SyntaxError ? 'parse_error' : classifyRequestError(error);
+        const errorCode = result === 'timeout' ? 'timeout' : 'response_parse_error';
+        record(result, undefined, undefined, errorCode);
+        logFailure(errorCode, response.status);
         throw new ElasticsearchFtsSearchRequestError(
           'Elasticsearch search response is not valid JSON',
           response.status,
           error,
+          errorCode,
         );
       }
 
       const parsed = searchResponseSchema.safeParse(payload);
       if (!parsed.success) {
-        record('parse_error');
+        record('parse_error', undefined, undefined, 'response_parse_error');
+        logFailure('response_parse_error', response.status);
         throw new ElasticsearchFtsSearchRequestError(
           'Elasticsearch search response has an invalid shape',
           response.status,
           parsed.error,
+          'response_parse_error',
         );
       }
 
       record('success', parsed.data.hits.hits.length, parsed.data.took);
       return parsed.data;
     } catch (error) {
-      if (!recorded) record(classifyRequestError(error));
+      if (!recorded) {
+        const result = classifyRequestError(error);
+        const errorCode = result === 'timeout' ? 'timeout' : 'transport_error';
+        record(result, undefined, undefined, errorCode);
+        logFailure(errorCode);
+      }
       throw error;
     }
   }

--- a/apps/server/src/services/ftsSearch/observability.test.ts
+++ b/apps/server/src/services/ftsSearch/observability.test.ts
@@ -6,6 +6,7 @@ import type { FtsSearchBackend } from '@/database/repositories/ftsSearch';
 import {
   buildFtsSearchBackendMetricAttributes,
   recordElasticsearchFtsSearchRequest,
+  recordUserMemoryLexicalSearchDecision,
   withFtsSearchBackendObservability,
 } from './observability';
 
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => {
   const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
   const span = {
     end: vi.fn(),
+    recordException: vi.fn(),
     setAttribute: vi.fn(),
     setStatus: vi.fn(),
   };
@@ -153,25 +155,76 @@ describe('full-text search backend observability', () => {
       decodedBytes: 2048,
       durationMs: 40,
       entity: 'messages',
+      errorCode: 'none',
+      executedQueryChars: 32,
       hits: 20,
+      originalQueryChars: 64,
       pagination: 'bounded',
+      queryFieldCount: 2,
       requestBytes: 512,
       result: 'success',
       serverTookMs: 12,
+      traceContext: 'recording',
+      truncated: true,
     });
 
-    const attributes = { entity: 'messages', pagination: 'bounded', result: 'success' };
+    const requestAttributes = {
+      entity: 'messages',
+      error_code: 'none',
+      pagination: 'bounded',
+      query_truncated: true,
+      result: 'success',
+      trace_context: 'recording',
+    };
+    const histogramAttributes = {
+      entity: 'messages',
+      pagination: 'bounded',
+      result: 'success',
+    };
     expect(mocks.counters.get('fts_search_elasticsearch_requests_total')?.add).toHaveBeenCalledWith(
       1,
-      attributes,
+      requestAttributes,
     );
     expect(
       mocks.histograms.get('fts_search_elasticsearch_server_took')?.record,
-    ).toHaveBeenCalledWith(12, attributes);
+    ).toHaveBeenCalledWith(12, histogramAttributes);
     expect(
       mocks.histograms.get('fts_search_elasticsearch_response_decoded_size')?.record,
-    ).toHaveBeenCalledWith(2048, attributes);
-    expect(Object.keys(attributes)).toEqual(['entity', 'pagination', 'result']);
+    ).toHaveBeenCalledWith(2048, histogramAttributes);
+    expect(
+      mocks.histograms.get('fts_search_elasticsearch_original_query_characters')?.record,
+    ).toHaveBeenCalledWith(64, histogramAttributes);
+    expect(
+      mocks.histograms.get('fts_search_elasticsearch_executed_query_characters')?.record,
+    ).toHaveBeenCalledWith(32, histogramAttributes);
+    expect(
+      mocks.histograms.get('fts_search_elasticsearch_request_duration')?.record,
+    ).toHaveBeenCalledWith(40, histogramAttributes);
+    expect(Object.keys(requestAttributes)).toEqual([
+      'entity',
+      'error_code',
+      'pagination',
+      'query_truncated',
+      'result',
+      'trace_context',
+    ]);
+    expect(Object.keys(histogramAttributes)).toEqual(['entity', 'pagination', 'result']);
+  });
+
+  it('records when long user-memory context skips conjunction-based lexical search', () => {
+    recordUserMemoryLexicalSearchDecision({
+      decision: 'skipped_long_context',
+      queryCharacters: 7000,
+      source: 'topic_retrieval',
+    });
+
+    const attributes = { decision: 'skipped_long_context', source: 'topic_retrieval' };
+    expect(
+      mocks.counters.get('fts_search_user_memory_lexical_decisions_total')?.add,
+    ).toHaveBeenCalledWith(1, attributes);
+    expect(
+      mocks.histograms.get('fts_search_user_memory_lexical_query_characters')?.record,
+    ).toHaveBeenCalledWith(7000, attributes);
   });
 
   it('preserves the selected provider error', async () => {
@@ -191,6 +244,7 @@ describe('full-text search backend observability', () => {
         scope: { userId: 'private-user' },
       }),
     ).rejects.toBe(providerError);
+    expect(mocks.span.recordException).not.toHaveBeenCalled();
   });
 
   it('does not change the provider result when telemetry finalization fails', async () => {

--- a/apps/server/src/services/ftsSearch/observability.ts
+++ b/apps/server/src/services/ftsSearch/observability.ts
@@ -16,6 +16,24 @@ export type FtsSearchBackendOperation = 'candidate_query' | 'pg_hydration' | 'pr
 export type FtsSearchBackendOperationResult = 'error' | 'success';
 export type ElasticsearchFtsSearchRequestResult =
   'http_error' | 'other_error' | 'parse_error' | 'success' | 'timeout';
+export type ElasticsearchFtsSearchErrorCode =
+  | 'authentication'
+  | 'authorization'
+  | 'index_not_found'
+  | 'invalid_query'
+  | 'none'
+  | 'rate_limited'
+  | 'request_too_large'
+  | 'response_parse_error'
+  | 'server_error'
+  | 'timeout'
+  | 'too_many_clauses'
+  | 'transport_error'
+  | 'unknown_http_error';
+export type ElasticsearchFtsSearchTraceContext = 'missing' | 'non_recording' | 'recording';
+export type UserMemoryLexicalSearchDecision = 'executed' | 'skipped_long_context';
+export type UserMemoryLexicalSearchSource =
+  'api' | 'memory_extraction' | 'tool' | 'topic_retrieval';
 
 export interface FtsSearchBackendOperationAttributes {
   entity: FtsSearchBackendEntity;
@@ -63,6 +81,22 @@ const elasticsearchRequestBytes = meter.createHistogram('fts_search_elasticsearc
   unit: 'By',
 });
 
+const elasticsearchOriginalQueryCharacters = meter.createHistogram(
+  'fts_search_elasticsearch_original_query_characters',
+  {
+    description: 'Unicode code points in the original Elasticsearch lexical query.',
+    unit: '{character}',
+  },
+);
+
+const elasticsearchExecutedQueryCharacters = meter.createHistogram(
+  'fts_search_elasticsearch_executed_query_characters',
+  {
+    description: 'Unicode code points sent in the bounded Elasticsearch lexical query.',
+    unit: '{character}',
+  },
+);
+
 const elasticsearchServerTook = meter.createHistogram('fts_search_elasticsearch_server_took', {
   description: 'Elasticsearch-reported server processing time for successful search requests.',
   unit: 'ms',
@@ -87,6 +121,22 @@ const elasticsearchResponseDecodedBytes = meter.createHistogram(
 const elasticsearchResponseHits = meter.createHistogram('fts_search_elasticsearch_response_hits', {
   description: 'Hits returned by each Elasticsearch search request.',
 });
+
+const userMemoryLexicalDecisions = meter.createCounter(
+  'fts_search_user_memory_lexical_decisions_total',
+  {
+    description: 'User-memory lexical search decisions grouped by bounded source and decision.',
+    unit: '{decision}',
+  },
+);
+
+const userMemoryLexicalQueryCharacters = meter.createHistogram(
+  'fts_search_user_memory_lexical_query_characters',
+  {
+    description: 'Unicode code points considered for user-memory lexical retrieval.',
+    unit: '{character}',
+  },
+);
 
 const recordSafely = (operation: string, record: () => void): void => {
   try {
@@ -132,31 +182,59 @@ export const recordElasticsearchFtsSearchRequest = (input: {
   decodedBytes?: number;
   durationMs: number;
   entity: ElasticsearchFtsSearchEntity;
+  errorCode: ElasticsearchFtsSearchErrorCode;
+  executedQueryChars: number;
   hits?: number;
+  originalQueryChars: number;
   pagination: 'bounded' | 'unbounded';
+  queryFieldCount: number;
   requestBytes: number;
   result: ElasticsearchFtsSearchRequestResult;
   serverTookMs?: number;
+  traceContext: ElasticsearchFtsSearchTraceContext;
+  truncated: boolean;
 }): void => {
   recordSafely('Elasticsearch search request', () => {
-    const attributes: Attributes = {
+    const histogramAttributes: Attributes = {
       entity: input.entity,
       pagination: input.pagination,
       result: input.result,
     };
-    elasticsearchRequests.add(1, attributes);
-    elasticsearchRequestDuration.record(input.durationMs, attributes);
-    elasticsearchRequestBytes.record(input.requestBytes, attributes);
+    const requestAttributes: Attributes = {
+      ...histogramAttributes,
+      error_code: input.errorCode,
+      query_truncated: input.truncated,
+      trace_context: input.traceContext,
+    };
+    elasticsearchRequests.add(1, requestAttributes);
+    elasticsearchRequestDuration.record(input.durationMs, histogramAttributes);
+    elasticsearchRequestBytes.record(input.requestBytes, histogramAttributes);
+    elasticsearchOriginalQueryCharacters.record(input.originalQueryChars, histogramAttributes);
+    elasticsearchExecutedQueryCharacters.record(input.executedQueryChars, histogramAttributes);
     if (input.contentLength !== undefined) {
-      elasticsearchResponseContentLength.record(input.contentLength, attributes);
+      elasticsearchResponseContentLength.record(input.contentLength, histogramAttributes);
     }
     if (input.decodedBytes !== undefined) {
-      elasticsearchResponseDecodedBytes.record(input.decodedBytes, attributes);
+      elasticsearchResponseDecodedBytes.record(input.decodedBytes, histogramAttributes);
     }
-    if (input.hits !== undefined) elasticsearchResponseHits.record(input.hits, attributes);
+    if (input.hits !== undefined) {
+      elasticsearchResponseHits.record(input.hits, histogramAttributes);
+    }
     if (input.serverTookMs !== undefined) {
-      elasticsearchServerTook.record(input.serverTookMs, attributes);
+      elasticsearchServerTook.record(input.serverTookMs, histogramAttributes);
     }
+  });
+};
+
+export const recordUserMemoryLexicalSearchDecision = (input: {
+  decision: UserMemoryLexicalSearchDecision;
+  queryCharacters: number;
+  source: UserMemoryLexicalSearchSource;
+}): void => {
+  recordSafely('user-memory lexical search decision', () => {
+    const attributes: Attributes = { decision: input.decision, source: input.source };
+    userMemoryLexicalDecisions.add(1, attributes);
+    userMemoryLexicalQueryCharacters.record(input.queryCharacters, attributes);
   });
 };
 

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -65,7 +65,11 @@ import { TopicModel } from '@/database/models/topic';
 import { type ListUsersForMemoryExtractorCursor } from '@/database/models/user';
 import { UserModel } from '@/database/models/user';
 import type { UserMemoryHybridSearchAggregatedResult } from '@/database/models/userMemory';
-import { UserMemoryModel } from '@/database/models/userMemory';
+import {
+  normalizeUserMemorySearchQueries,
+  shouldRunUserMemoryLexicalSearch,
+  UserMemoryModel,
+} from '@/database/models/userMemory';
 import { UserMemorySourceBenchmarkLoCoMoModel } from '@/database/models/userMemory/sources/benchmarkLoCoMo';
 import { AiInfraRepos } from '@/database/repositories/aiInfra';
 import { asyncTasks } from '@/database/schemas';
@@ -79,6 +83,7 @@ import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { S3 } from '@/server/modules/S3';
 import { getUserScopedAiProviderRuntimeState } from '@/server/services/aiProviderAccess';
 import { createFtsSearchRepo } from '@/server/services/ftsSearch';
+import { recordUserMemoryLexicalSearchDecision } from '@/server/services/ftsSearch/observability';
 import {
   AsyncTaskError,
   type AsyncTaskErrorBody,
@@ -1425,9 +1430,17 @@ export class MemoryExtractionExecutor {
 
     const vector = embeddings?.[0];
     if (vector) {
+      const queries = normalizeUserMemorySearchQueries([aggregatedContent]);
+      recordUserMemoryLexicalSearchDecision({
+        decision: shouldRunUserMemoryLexicalSearch(queries, [vector])
+          ? 'executed'
+          : 'skipped_long_context',
+        queryCharacters: Array.from(aggregatedContent).length,
+        source: 'memory_extraction',
+      });
       const retrieved = await userMemoryModel.searchMemory(
         {
-          queries: [aggregatedContent],
+          queries,
           topK: {
             activities: topK,
             contexts: topK,

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/memory.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/memory.test.ts
@@ -1,5 +1,5 @@
 import type { LobeChatDatabase } from '@lobechat/database';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ToolExecutionContext } from '../../types';
 
@@ -8,10 +8,15 @@ const mocks = vi.hoisted(() => ({
   embeddings: vi.fn(),
   initModelRuntimeFromDB: vi.fn(),
   initModelRuntimeWithUserPayload: vi.fn(),
+  normalizeUserMemorySearchQueries: vi.fn((queries?: string[]) => queries ?? []),
+  recordUserMemoryLexicalSearchDecision: vi.fn(),
   searchMemory: vi.fn(),
+  shouldRunUserMemoryLexicalSearch: vi.fn(),
 }));
 
 vi.mock('@/database/models/userMemory', () => ({
+  normalizeUserMemorySearchQueries: mocks.normalizeUserMemorySearchQueries,
+  shouldRunUserMemoryLexicalSearch: mocks.shouldRunUserMemoryLexicalSearch,
   UserMemoryModel: vi.fn().mockImplementation(() => ({
     searchMemory: mocks.searchMemory,
   })),
@@ -45,6 +50,10 @@ vi.mock('@/server/services/ftsSearch', () => ({
   createFtsSearchRepo: mocks.createFtsSearchRepo,
 }));
 
+vi.mock('@/server/services/ftsSearch/observability', () => ({
+  recordUserMemoryLexicalSearchDecision: mocks.recordUserMemoryLexicalSearchDecision,
+}));
+
 const { memoryRuntime } = await import('../memory');
 
 const createContext = (): ToolExecutionContext => ({
@@ -68,6 +77,10 @@ const createContext = (): ToolExecutionContext => ({
 });
 
 describe('memoryRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('uses server-owned embedding runtime for memory search', async () => {
     mocks.embeddings.mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
     mocks.initModelRuntimeWithUserPayload.mockReturnValueOnce({
@@ -105,5 +118,31 @@ describe('memoryRuntime', () => {
       expect.objectContaining({ queries: ['renewal timeline'] }),
       [[0.1, 0.2, 0.3]],
     );
+  });
+
+  it('records the lexical decision on the default Gateway memory path', async () => {
+    const longQuery = 'context '.repeat(40).trimEnd();
+    const embedding = [0.1, 0.2, 0.3];
+    mocks.embeddings.mockResolvedValueOnce([embedding]);
+    mocks.initModelRuntimeWithUserPayload.mockReturnValueOnce({ embeddings: mocks.embeddings });
+    mocks.searchMemory.mockResolvedValueOnce({
+      activities: [],
+      contexts: [],
+      experiences: [],
+      identities: [],
+      preferences: [],
+    });
+    mocks.shouldRunUserMemoryLexicalSearch.mockReturnValueOnce(false);
+
+    const runtime = await memoryRuntime.factory(createContext());
+
+    await runtime.searchUserMemory({ queries: [longQuery] });
+
+    expect(mocks.shouldRunUserMemoryLexicalSearch).toHaveBeenCalledWith([longQuery], [embedding]);
+    expect(mocks.recordUserMemoryLexicalSearchDecision).toHaveBeenCalledWith({
+      decision: 'skipped_long_context',
+      queryCharacters: Array.from(longQuery).length,
+      source: 'tool',
+    });
   });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/memory.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/memory.ts
@@ -38,6 +38,8 @@ import type { z } from 'zod';
 import {
   type IdentityEntryBasePayload,
   type IdentityEntryPayload,
+  normalizeUserMemorySearchQueries,
+  shouldRunUserMemoryLexicalSearch,
   UserMemoryModel,
 } from '@/database/models/userMemory';
 import { userSettings } from '@/database/schemas';
@@ -52,6 +54,7 @@ import {
 } from '@/server/services/agentSignal/procedure';
 import { redisPolicyStateStore } from '@/server/services/agentSignal/store/adapters/redis/policyStateStore';
 import { createFtsSearchRepo } from '@/server/services/ftsSearch';
+import { recordUserMemoryLexicalSearchDecision } from '@/server/services/ftsSearch/observability';
 import type { UserMemoryEmbeddingRuntime } from '@/server/services/memory/userMemory/embedding';
 import { embedUserMemoryTexts } from '@/server/services/memory/userMemory/embedding';
 import { normalizeSearchMemoryParams } from '@/server/services/memory/userMemory/searchParams';
@@ -227,9 +230,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
           defaultEmbeddingConfig.provider,
           this.workspaceId,
         );
-    const normalizedQueries = [
-      ...new Set((normalizedParams.queries ?? []).map((query) => query.trim()).filter(Boolean)),
-    ];
+    const normalizedQueries = normalizeUserMemorySearchQueries(normalizedParams.queries);
 
     const queryEmbeddings =
       normalizedQueries.length > 0
@@ -243,6 +244,12 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
             })
           ).filter((embedding): embedding is number[] => Boolean(embedding))
         : [];
+    const lexicalSearch = shouldRunUserMemoryLexicalSearch(normalizedQueries, queryEmbeddings);
+    recordUserMemoryLexicalSearchDecision({
+      decision: lexicalSearch ? 'executed' : 'skipped_long_context',
+      queryCharacters: Array.from(normalizedQueries.join(' ')).length,
+      source: 'tool',
+    });
 
     const effectiveEffort = normalizeMemoryEffort(normalizedParams.effort ?? this.memoryEffort);
     const effortDefaults = MEMORY_SEARCH_TOP_K_LIMITS[effectiveEffort];

--- a/packages/database/src/models/userMemory/__tests__/query.test.ts
+++ b/packages/database/src/models/userMemory/__tests__/query.test.ts
@@ -425,6 +425,30 @@ describe('user memory query layer', () => {
       expect(semanticSpy).toHaveBeenCalledOnce();
     });
 
+    it('skips the lexical leg for long context when semantic retrieval is available', async () => {
+      const ftsSearchCandidates = vi.fn().mockResolvedValue({ candidates: [], total: 0 });
+      const model = new UserMemoryModel(serverDB, userId, {
+        ftsSearchCandidateEnabled: true,
+        ftsSearchCandidates,
+      });
+      const queryModel = Reflect.get(model, 'queryModel') as {
+        searchActivitiesSemantic: (...args: unknown[]) => Promise<unknown[]>;
+      };
+      const semanticSpy = vi.spyOn(queryModel, 'searchActivitiesSemantic').mockResolvedValue([]);
+
+      await model.searchMemory(
+        {
+          layers: [LayersEnum.Activity],
+          queries: ['对话'.repeat(200)],
+          topK: { activities: 2, contexts: 0, experiences: 0, identities: 0, preferences: 0 },
+        },
+        [[0.1, 0.2, 0.3]],
+      );
+
+      expect(semanticSpy).toHaveBeenCalledOnce();
+      expect(ftsSearchCandidates).not.toHaveBeenCalled();
+    });
+
     it('deduplicates contexts before applying the lexical candidate limit', async () => {
       const { memory: linkedMemoryOne } = await createContextPair({
         description: 'Atlas roadmap and staffing',

--- a/packages/database/src/models/userMemory/query.ts
+++ b/packages/database/src/models/userMemory/query.ts
@@ -171,7 +171,7 @@ interface LayerScalarAggregationConfig {
   userIdColumn: AnyColumn;
 }
 
-const normalizeSearchQueries = (queries?: string[]): string[] => {
+export const normalizeUserMemorySearchQueries = (queries?: string[]): string[] => {
   if (!queries) return [];
 
   return [...new Set(queries.map((query) => query.trim()).filter(Boolean))];
@@ -182,6 +182,12 @@ const buildRetrievalQuery = (queries: string[]) => {
 
   return queries.join(' ');
 };
+
+/**
+ * Long conversation context is useful to embeddings but not to conjunction-based lexical search:
+ * requiring hundreds of analyzed terms to match one field produces no meaningful candidates.
+ */
+export const USER_MEMORY_LEXICAL_QUERY_CHARACTER_LIMIT = 256;
 
 const combineEmbeddings = (embeddings: number[][]) => {
   if (embeddings.length === 0) return undefined;
@@ -198,6 +204,13 @@ const combineEmbeddings = (embeddings: number[][]) => {
 
     return sum / embeddings.length;
   });
+};
+
+export const shouldRunUserMemoryLexicalSearch = (queries: string[], embeddings: number[][]) => {
+  const retrievalQuery = buildRetrievalQuery(queries);
+  if (!retrievalQuery || !combineEmbeddings(embeddings)) return true;
+
+  return Array.from(retrievalQuery).length <= USER_MEMORY_LEXICAL_QUERY_CHARACTER_LIMIT;
 };
 
 const normalizeSimilarityTerm = (value: string) => value.trim().toLowerCase();
@@ -810,7 +823,8 @@ export class UserMemoryQueryModel {
     params: SearchMemoryParams,
     queryEmbeddings: number[][] = [],
   ): Promise<UserMemoryHybridSearchAggregatedResult> => {
-    const appliedQueries = normalizeSearchQueries(params.queries);
+    const appliedQueries = normalizeUserMemorySearchQueries(params.queries);
+    const lexicalSearch = shouldRunUserMemoryLexicalSearch(appliedQueries, queryEmbeddings);
     const limits: HybridLayerLimitRecord = {
       activities: params.topK?.activities ?? DEFAULT_HYBRID_SEARCH_LIMIT,
       contexts: params.topK?.contexts ?? DEFAULT_HYBRID_SEARCH_LIMIT,
@@ -846,6 +860,7 @@ export class UserMemoryQueryModel {
       requestedLayers.has(LayersEnum.Activity)
         ? this.searchHybridActivities({
             embeddings: queryEmbeddings,
+            lexicalSearch,
             params,
             queries: appliedQueries,
           })
@@ -853,6 +868,7 @@ export class UserMemoryQueryModel {
       requestedLayers.has(LayersEnum.Context)
         ? this.searchHybridContexts({
             embeddings: queryEmbeddings,
+            lexicalSearch,
             params,
             queries: appliedQueries,
           })
@@ -860,6 +876,7 @@ export class UserMemoryQueryModel {
       requestedLayers.has(LayersEnum.Experience)
         ? this.searchHybridExperiences({
             embeddings: queryEmbeddings,
+            lexicalSearch,
             params,
             queries: appliedQueries,
           })
@@ -867,6 +884,7 @@ export class UserMemoryQueryModel {
       requestedLayers.has(LayersEnum.Identity)
         ? this.searchHybridIdentities({
             embeddings: queryEmbeddings,
+            lexicalSearch,
             params,
             queries: appliedQueries,
           })
@@ -874,6 +892,7 @@ export class UserMemoryQueryModel {
       requestedLayers.has(LayersEnum.Preference)
         ? this.searchHybridPreferences({
             embeddings: queryEmbeddings,
+            lexicalSearch,
             params,
             queries: appliedQueries,
           })
@@ -1627,6 +1646,7 @@ export class UserMemoryQueryModel {
 
   private async searchHybridActivities(params: {
     embeddings: number[][];
+    lexicalSearch: boolean;
     params: SearchMemoryParams;
     queries: string[];
   }) {
@@ -1641,7 +1661,7 @@ export class UserMemoryQueryModel {
         : [];
     const retrievalQuery = buildRetrievalQuery(params.queries);
     const lexicalLists =
-      retrievalQuery || this.hasSearchFilters(params.params)
+      params.lexicalSearch && (retrievalQuery || this.hasSearchFilters(params.params))
         ? [await this.searchActivitiesLexical(retrievalQuery, limit, params.params)]
         : [];
 
@@ -1663,6 +1683,7 @@ export class UserMemoryQueryModel {
 
   private async searchHybridContexts(params: {
     embeddings: number[][];
+    lexicalSearch: boolean;
     params: SearchMemoryParams;
     queries: string[];
   }) {
@@ -1677,7 +1698,7 @@ export class UserMemoryQueryModel {
         : [];
     const retrievalQuery = buildRetrievalQuery(params.queries);
     const lexicalLists =
-      retrievalQuery || this.hasSearchFilters(params.params)
+      params.lexicalSearch && (retrievalQuery || this.hasSearchFilters(params.params))
         ? [await this.searchContextsLexical(retrievalQuery, limit, params.params)]
         : [];
 
@@ -1699,6 +1720,7 @@ export class UserMemoryQueryModel {
 
   private async searchHybridExperiences(params: {
     embeddings: number[][];
+    lexicalSearch: boolean;
     params: SearchMemoryParams;
     queries: string[];
   }) {
@@ -1713,7 +1735,7 @@ export class UserMemoryQueryModel {
         : [];
     const retrievalQuery = buildRetrievalQuery(params.queries);
     const lexicalLists =
-      retrievalQuery || this.hasSearchFilters(params.params)
+      params.lexicalSearch && (retrievalQuery || this.hasSearchFilters(params.params))
         ? [await this.searchExperiencesLexical(retrievalQuery, limit, params.params)]
         : [];
 
@@ -1735,6 +1757,7 @@ export class UserMemoryQueryModel {
 
   private async searchHybridIdentities(params: {
     embeddings: number[][];
+    lexicalSearch: boolean;
     params: SearchMemoryParams;
     queries: string[];
   }) {
@@ -1749,7 +1772,7 @@ export class UserMemoryQueryModel {
         : [];
     const retrievalQuery = buildRetrievalQuery(params.queries);
     const lexicalLists =
-      retrievalQuery || this.hasSearchFilters(params.params)
+      params.lexicalSearch && (retrievalQuery || this.hasSearchFilters(params.params))
         ? [await this.searchIdentitiesLexical(retrievalQuery, limit, params.params)]
         : [];
 
@@ -1771,6 +1794,7 @@ export class UserMemoryQueryModel {
 
   private async searchHybridPreferences(params: {
     embeddings: number[][];
+    lexicalSearch: boolean;
     params: SearchMemoryParams;
     queries: string[];
   }) {
@@ -1785,7 +1809,7 @@ export class UserMemoryQueryModel {
         : [];
     const retrievalQuery = buildRetrievalQuery(params.queries);
     const lexicalLists =
-      retrievalQuery || this.hasSearchFilters(params.params)
+      params.lexicalSearch && (retrievalQuery || this.hasSearchFilters(params.params))
         ? [await this.searchPreferencesLexical(retrievalQuery, limit, params.params)]
         : [];
 

--- a/packages/database/src/repositories/ftsSearch/__tests__/elasticsearch.test.ts
+++ b/packages/database/src/repositories/ftsSearch/__tests__/elasticsearch.test.ts
@@ -85,6 +85,117 @@ afterEach(async () => {
 });
 
 describe('ElasticsearchFtsSearchBackend', () => {
+  it('backs up to a word boundary when the clause budget cuts a Latin word', async () => {
+    const client = createClient([]);
+    const backend = new ElasticsearchFtsSearchBackend(db, { client, indexNamespace });
+    const completeWords = 'word '.repeat(19);
+    const query = `${completeWords}fragment`;
+
+    await backend.search({
+      entity: 'memoryExperiences',
+      filters: {},
+      mode: 'candidates',
+      pagination: { limit: 3 },
+      query: { text: query },
+      scope: { userId },
+    });
+
+    expect(client.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: {
+            bool: expect.objectContaining({
+              must: [
+                {
+                  multi_match: expect.objectContaining({
+                    query: completeWords.trimEnd(),
+                  }),
+                },
+              ],
+            }),
+          },
+        }),
+        executedQueryChars: completeWords.trimEnd().length,
+        originalQueryChars: Array.from(query).length,
+        queryFieldCount: 8,
+        truncated: true,
+      }),
+    );
+  });
+
+  it('bounds long Unicode queries before building an eight-field multi-match request', async () => {
+    const client = createClient([]);
+    const backend = new ElasticsearchFtsSearchBackend(db, { client, indexNamespace });
+    const query = `${'界'.repeat(95)}😀${'文'.repeat(7000)}`;
+
+    await backend.search({
+      entity: 'memoryExperiences',
+      filters: {},
+      mode: 'candidates',
+      pagination: { limit: 3 },
+      query: { text: query },
+      scope: { userId },
+    });
+
+    expect(client.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: {
+            bool: expect.objectContaining({
+              must: [
+                {
+                  multi_match: expect.objectContaining({
+                    query: `${'界'.repeat(95)}😀`,
+                  }),
+                },
+              ],
+            }),
+          },
+        }),
+        executedQueryChars: 96,
+        originalQueryChars: 7096,
+        queryFieldCount: 8,
+        truncated: true,
+      }),
+    );
+  });
+
+  it('scales the query-character budget with the selected field count', async () => {
+    const client = createClient([]);
+    const backend = new ElasticsearchFtsSearchBackend(db, { client, indexNamespace });
+
+    await backend.search({
+      entity: 'userMemories',
+      filters: {},
+      mode: 'candidates',
+      pagination: { limit: 3 },
+      query: { fields: ['title', 'summary', 'details'], text: '界'.repeat(300) },
+      scope: { userId },
+    });
+
+    expect(client.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: {
+            bool: expect.objectContaining({
+              must: [
+                {
+                  multi_match: expect.objectContaining({
+                    query: '界'.repeat(256),
+                  }),
+                },
+              ],
+            }),
+          },
+        }),
+        executedQueryChars: 256,
+        originalQueryChars: 300,
+        queryFieldCount: 3,
+        truncated: true,
+      }),
+    );
+  });
+
   it('searches and reauthorizes unified user-memory candidates in PostgreSQL', async () => {
     await db.insert(userMemories).values([
       {
@@ -257,8 +368,12 @@ describe('ElasticsearchFtsSearchBackend', () => {
         track_total_hits: true,
       },
       entity: 'memoryContexts',
+      executedQueryChars: 13,
       index: 'lobehub-dev-memory-contexts',
+      originalQueryChars: 13,
       pagination: 'bounded',
+      queryFieldCount: 4,
+      truncated: false,
     });
   });
 
@@ -679,8 +794,12 @@ describe('ElasticsearchFtsSearchBackend', () => {
         sort: [{ _score: 'desc' }, { id: 'asc' }],
       },
       entity: 'agents',
+      executedQueryChars: 13,
       index: 'lobehub-dev-agents',
+      originalQueryChars: 13,
       pagination: 'bounded',
+      queryFieldCount: 5,
+      truncated: false,
     });
 
     const publicCaller = await backend.search(

--- a/packages/database/src/repositories/ftsSearch/elasticsearch/candidates.ts
+++ b/packages/database/src/repositories/ftsSearch/elasticsearch/candidates.ts
@@ -33,6 +33,66 @@ const CANDIDATE_MULTIPLIER = 4;
 const UNBOUNDED_CANDIDATE_PAGE_SIZE = 1000;
 
 /**
+ * Elasticsearch expands `multi_match` queries into roughly `fields * analyzed terms` leaf
+ * clauses. Its dynamic clause limit never drops below 1024, so 768 leaves headroom for filters.
+ *
+ * This relies on the current search analyzers producing at most one query term per Unicode code
+ * point. Revisit the budget before adding ngram-style query analyzers.
+ *
+ * @see https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-multi-match-query
+ * @see https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/search-settings
+ */
+const MULTI_MATCH_LEAF_CLAUSE_BUDGET = 768;
+
+const CJK_CHARACTER_PATTERN =
+  /[\p{Script=Han}\p{Script=Hangul}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+const WORD_CHARACTER_PATTERN = /[\p{L}\p{M}\p{N}_]/u;
+
+const isNonCjkWordCharacter = (character: string) =>
+  WORD_CHARACTER_PATTERN.test(character) && !CJK_CHARACTER_PATTERN.test(character);
+
+/**
+ * Preserve complete whitespace-delimited words when the clause budget cuts Latin-like text.
+ * CJK text keeps the exact budget because its analyzer emits terms without word separators.
+ */
+const sliceQueryAtLexicalBoundary = (characters: string[], maximumCharacters: number) => {
+  const executedCharacters = characters.slice(0, maximumCharacters);
+  const lastCharacter = executedCharacters.at(-1);
+  const nextCharacter = characters[maximumCharacters];
+
+  if (
+    !lastCharacter ||
+    !nextCharacter ||
+    !isNonCjkWordCharacter(lastCharacter) ||
+    !isNonCjkWordCharacter(nextCharacter)
+  ) {
+    return executedCharacters;
+  }
+
+  const boundaryIndex = executedCharacters.findLastIndex(
+    (character) => !isNonCjkWordCharacter(character),
+  );
+
+  return boundaryIndex > 0 ? executedCharacters.slice(0, boundaryIndex) : executedCharacters;
+};
+
+const prepareMultiMatchQuery = (query: string, fieldCount: number) => {
+  const originalCharacters = Array.from(query);
+  const maximumCharacters = Math.max(
+    1,
+    Math.floor(MULTI_MATCH_LEAF_CLAUSE_BUDGET / Math.max(1, fieldCount)),
+  );
+  const executedCharacters = sliceQueryAtLexicalBoundary(originalCharacters, maximumCharacters);
+
+  return {
+    executedQuery: executedCharacters.join(''),
+    executedQueryChars: executedCharacters.length,
+    originalQueryChars: originalCharacters.length,
+    truncated: executedCharacters.length < originalCharacters.length,
+  };
+};
+
+/**
  * Rolling reindexes leave legacy documents without newly denormalized fields. Keep those documents
  * eligible as candidates because PostgreSQL reapplies the exact filters during hydration.
  */
@@ -273,6 +333,7 @@ export const searchElasticsearchCandidates = async (
         : isElasticsearchFtsSearchMemoryEntity(target.entity)
           ? ELASTICSEARCH_FTS_SEARCH_MEMORY_QUERY_FIELDS[target.entity]
           : ELASTICSEARCH_FTS_SEARCH_RESOURCE_QUERY_FIELDS[target.entity]);
+  const preparedQuery = prepareMultiMatchQuery(query, fields.length);
   const requestedLimit = request.pagination.limit;
   const size = requestedLimit
     ? requestedLimit * CANDIDATE_MULTIPLIER
@@ -300,7 +361,7 @@ export const searchElasticsearchCandidates = async (
                 multi_match: {
                   fields,
                   operator: 'and',
-                  query,
+                  query: preparedQuery.executedQuery,
                   type: 'best_fields',
                 },
               },
@@ -314,8 +375,12 @@ export const searchElasticsearchCandidates = async (
         ...(trackTotalHits && isFirstPage ? { track_total_hits: true } : {}),
       },
       entity,
+      executedQueryChars: preparedQuery.executedQueryChars,
       index: getFtsSearchIndexAlias(indexNamespace, entity),
+      originalQueryChars: preparedQuery.originalQueryChars,
       pagination: requestedLimit ? 'bounded' : 'unbounded',
+      queryFieldCount: fields.length,
+      truncated: preparedQuery.truncated,
     });
     if (isFirstPage) {
       const responseTotal = response.hits.total;

--- a/packages/database/src/repositories/ftsSearch/elasticsearch/types.ts
+++ b/packages/database/src/repositories/ftsSearch/elasticsearch/types.ts
@@ -17,8 +17,12 @@ import type { ElasticsearchFtsSearchEntity } from './query-fields';
 export interface ElasticsearchFtsSearchInput {
   body: Record<string, unknown>;
   entity: ElasticsearchFtsSearchEntity;
+  executedQueryChars: number;
   index: string;
+  originalQueryChars: number;
   pagination: 'bounded' | 'unbounded';
+  queryFieldCount: number;
+  truncated: boolean;
 }
 
 export interface ElasticsearchFtsSearchResponse {


### PR DESCRIPTION
## Summary

- Bound Elasticsearch `multi_match` queries by the selected field count to stay below the leaf-clause limit.
- Preserve complete Latin-like words when truncating while keeping Unicode code-point-safe CJK handling.
- Skip low-value conjunction-based lexical retrieval for long user-memory context when semantic retrieval is available.
- Add bounded Elasticsearch error classification plus privacy-safe metrics, traces, and logs.
- Record the lexical-search decision across every server memory entry point, including the default Gateway runtime.

## Key Decisions / Non-goals

- The selected provider remains fail-closed: errors are surfaced and never silently rerouted.
- PostgreSQL hydration remains the authoritative permission boundary.
- This does not change index mappings, provider selection, or deployment configuration.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed
- `bun run check` — 74 tests passed
- `bun run check --type` — clean