### PR TITLE
💄 style: hide duplicate selected check on stale model row

### DIFF
--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -28,6 +28,17 @@ const STALE_EXTRA_CLASSNAME = 'lobe-model-select-stale-extra';
 const STALE_TAG_CLASSNAME = 'lobe-model-select-stale-tag';
 
 /**
+ * Marks the stale-model option row so the popup can hide the Select's built-in
+ * selected-item check on it — the row already sits under the "Current selection"
+ * group and (for notEnabled) renders an enable Switch, so the extra check reads
+ * as contradictory and steals the row's right edge.
+ */
+const STALE_OPTION_CLASSNAME = 'lobe-model-select-stale-option';
+
+/** Stable hook on every option's ItemIndicator so CSS can target it. */
+const ITEM_INDICATOR_CLASSNAME = 'lobe-model-select-item-indicator';
+
+/**
  * Sentinel option value for the redirected-model remedy row ("update to
  * successor"). Intercepted in onChange so selecting it triggers the remedy
  * instead of a value change.
@@ -46,6 +57,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
      * descendant selector, so a plain display: none never applies. */
     .${STALE_TAG_CLASSNAME} {
       display: none !important;
+    }
+
+    .${STALE_OPTION_CLASSNAME} .${ITEM_INDICATOR_CLASSNAME} {
+      display: none;
     }
   `,
   select: css`
@@ -260,9 +275,10 @@ const ModelSelect = memo<ModelSelectProps>(
 
       const currentOption = {
         __stale: true,
+        className: STALE_OPTION_CLASSNAME,
         disabled: true,
         label: (
-          <Flexbox gap={4}>
+          <Flexbox gap={4} style={{ width: '100%' }}>
             <Flexbox horizontal align={'center'} gap={8}>
               <ModelIcon model={value.model} size={20} />
               <Text ellipsis style={{ fontSize: 14 }}>
@@ -354,6 +370,7 @@ const ModelSelect = memo<ModelSelectProps>(
         <Select
           allowClear={allowClear}
           className={styles.select}
+          classNames={{ itemIndicator: ITEM_INDICATOR_CLASSNAME }}
           defaultValue={value ? `${value.provider}/${value.model}` : null}
           disabled={disabled}
           labelRender={labelRender}


### PR DESCRIPTION
The stale "Current selection" row in ModelSelect (shown when the persisted model is not enabled) rendered both the enable Switch and the Select's built-in selected checkmark — two conflicting affordances on one row — and the checkmark column kept the Switch away from the row's right edge.

Fix: scope a CSS rule in the popup to hide the built-in `ItemIndicator` on the stale option row only (via a stable class on the row + `classNames.itemIndicator`), and give the label a full-width container so the existing spacer pushes the Switch flush right. Normal options keep their selected checkmark.

| Before | After |
| ------ | ----- |
| Switch + ✓ shown together, Switch floats mid-row | Only the Switch, flush to the row's right edge |

#### Test

Verified in the running web app by forcing a persisted selection onto a disabled model: the stale row shows only the Not enabled tag + Switch (flush right, no ✓); a normally enabled selected model still shows its ✓; toggling the Switch enables the model and dismisses the stale group. Evidence: https://app.lobehub.com/acceptance/0dd58df8-ddd4-4ea5-8ffb-c51d068c8407

- [x] Tested locally
- [x] No tests needed (pure style/CSS scoping change)