### PR TITLE
🐛 fix(memory): reset paginated lists before search

### DIFF
--- a/src/features/Memory/MemoryListBoundary.tsx
+++ b/src/features/Memory/MemoryListBoundary.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+
+import AsyncBoundary from '@/components/AsyncBoundary';
+
+interface MemoryListBoundaryProps {
+  children: ReactNode;
+  data: unknown;
+  error?: unknown;
+  isInitialized: boolean;
+  isLoading: boolean;
+  isResetting?: boolean;
+  loading: ReactNode;
+  onRetry: () => void;
+}
+
+/**
+ * Keeps memory list loading, error, and retry behavior consistent. A reset deliberately hides
+ * cached data because the store list has already been cleared for the new query.
+ */
+export const MemoryListBoundary = ({
+  children,
+  data,
+  error,
+  isInitialized,
+  isLoading,
+  isResetting,
+  loading,
+  onRetry,
+}: MemoryListBoundaryProps) => {
+  const pending = Boolean(isResetting) || isLoading || (!isInitialized && !error);
+
+  return (
+    <AsyncBoundary
+      data={isResetting || error ? undefined : data}
+      error={error}
+      errorVariant={'page'}
+      isLoading={pending}
+      loading={loading}
+      onRetry={onRetry}
+    >
+      {children}
+    </AsyncBoundary>
+  );
+};

--- a/src/features/Memory/MemoryListBoundary.tsx
+++ b/src/features/Memory/MemoryListBoundary.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
 
+import { isMemoryListPending } from './isMemoryListPending';
+
 interface MemoryListBoundaryProps {
   children: ReactNode;
   data: unknown;
@@ -27,7 +29,12 @@ export const MemoryListBoundary = ({
   loading,
   onRetry,
 }: MemoryListBoundaryProps) => {
-  const pending = Boolean(isResetting) || isLoading || (!isInitialized && !error);
+  const pending = isMemoryListPending({
+    error,
+    initialized: isInitialized,
+    loading: isLoading,
+    resetting: isResetting,
+  });
 
   return (
     <AsyncBoundary

--- a/src/features/Memory/index.ts
+++ b/src/features/Memory/index.ts
@@ -1,0 +1,1 @@
+export { useResetMemoryList, type ViewMode } from './useResetMemoryList';

--- a/src/features/Memory/index.ts
+++ b/src/features/Memory/index.ts
@@ -1,1 +1,2 @@
+export { MemoryListBoundary } from './MemoryListBoundary';
 export { useResetMemoryList, type ViewMode } from './useResetMemoryList';

--- a/src/features/Memory/isMemoryListPending.test.ts
+++ b/src/features/Memory/isMemoryListPending.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMemoryListPending } from './isMemoryListPending';
+
+describe('isMemoryListPending', () => {
+  it('uses full-surface loading for an initial request', () => {
+    expect(isMemoryListPending({ error: undefined, initialized: false, loading: true })).toBe(true);
+  });
+
+  it('uses full-surface loading while a list resets', () => {
+    expect(
+      isMemoryListPending({
+        error: undefined,
+        initialized: true,
+        loading: true,
+        resetting: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps settled rows visible while a later page loads', () => {
+    expect(isMemoryListPending({ error: undefined, initialized: true, loading: true })).toBe(false);
+  });
+
+  it('uses full-surface loading when retrying a surfaced error', () => {
+    expect(
+      isMemoryListPending({ error: new Error('failed'), initialized: true, loading: true }),
+    ).toBe(true);
+  });
+
+  it('settles into the error state after a failed request', () => {
+    expect(
+      isMemoryListPending({ error: new Error('failed'), initialized: true, loading: false }),
+    ).toBe(false);
+  });
+});

--- a/src/features/Memory/isMemoryListPending.ts
+++ b/src/features/Memory/isMemoryListPending.ts
@@ -1,0 +1,18 @@
+interface MemoryListPendingContext {
+  error?: unknown;
+  initialized: boolean;
+  loading: boolean;
+  resetting?: boolean;
+}
+
+/**
+ * Full-surface loading is reserved for initial loads, resets, and error retries. Later pages
+ * keep settled rows mounted while their list view renders incremental loading feedback.
+ */
+export const isMemoryListPending = ({
+  error,
+  initialized,
+  loading,
+  resetting,
+}: MemoryListPendingContext) =>
+  Boolean(resetting) || (!initialized && !error) || (Boolean(error) && loading);

--- a/src/features/Memory/useCachedMemoryList.test.ts
+++ b/src/features/Memory/useCachedMemoryList.test.ts
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { createElement } from 'react';
+import { type State, SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { userMemoryService } from '@/services/userMemory';
+import { useUserMemoryStore } from '@/store/userMemory';
+import { initialState } from '@/store/userMemory/initialState';
+
+import { useResetMemoryList } from './useResetMemoryList';
+
+const createSWRWrapper = () => {
+  const value = {
+    dedupingInterval: 60_000,
+    provider: () => new Map<string, State>(),
+  };
+
+  return function SWRTestWrapper({ children }: PropsWithChildren) {
+    return createElement(SWRConfig, { value }, children);
+  };
+};
+
+const useActivitySearch = (query: string) => {
+  const activities = useUserMemoryStore((state) => state.activities);
+  const activitiesPage = useUserMemoryStore((state) => state.activitiesPage);
+  const activitiesSearchLoading = useUserMemoryStore((state) => state.activitiesSearchLoading);
+  const resetActivitiesList = useUserMemoryStore((state) => state.resetActivitiesList);
+  const useFetchActivities = useUserMemoryStore((state) => state.useFetchActivities);
+
+  useResetMemoryList({
+    query,
+    resetList: resetActivitiesList,
+    viewMode: 'timeline',
+  });
+  useFetchActivities({ page: activitiesPage, pageSize: 12, q: query });
+
+  return { activities, activitiesSearchLoading };
+};
+
+describe('cached memory list hydration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useUserMemoryStore.setState(initialState, false);
+  });
+
+  it('restores a cached search after switching away and back within the deduping interval', async () => {
+    vi.spyOn(userMemoryService, 'queryActivities').mockImplementation(async ({ q }) => ({
+      items: [{ id: q }] as never,
+      total: 1,
+    }));
+
+    const { rerender, result } = renderHook(({ query }) => useActivitySearch(query), {
+      initialProps: { query: 'alpha' },
+      wrapper: createSWRWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        activities: [{ id: 'alpha' }],
+        activitiesSearchLoading: false,
+      });
+    });
+
+    rerender({ query: 'beta' });
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        activities: [{ id: 'beta' }],
+        activitiesSearchLoading: false,
+      });
+    });
+
+    rerender({ query: 'alpha' });
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        activities: [{ id: 'alpha' }],
+        activitiesSearchLoading: false,
+      });
+    });
+    expect(userMemoryService.queryActivities).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/Memory/useCachedMemoryList.test.ts
+++ b/src/features/Memory/useCachedMemoryList.test.ts
@@ -45,8 +45,10 @@ describe('cached memory list hydration', () => {
   });
 
   it('restores a cached search after switching away and back within the deduping interval', async () => {
-    vi.spyOn(userMemoryService, 'queryActivities').mockImplementation(async ({ q }) => ({
-      items: [{ id: q }] as never,
+    vi.spyOn(userMemoryService, 'queryActivities').mockImplementation(async (params) => ({
+      items: [{ id: params?.q } as never],
+      page: params?.page ?? 1,
+      pageSize: params?.pageSize ?? 12,
       total: 1,
     }));
 

--- a/src/features/Memory/useResetMemoryList.test.ts
+++ b/src/features/Memory/useResetMemoryList.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useResetMemoryList } from './useResetMemoryList';
+import { useResetMemoryList, type ViewMode } from './useResetMemoryList';
 
 describe('useResetMemoryList', () => {
   it('resets a timeline search when the backend uses its default sort', () => {
@@ -21,15 +21,16 @@ describe('useResetMemoryList', () => {
 
   it('does not reset when a view change keeps the effective sort unchanged', () => {
     const resetList = vi.fn();
+    const initialProps: { viewMode: ViewMode } = { viewMode: 'timeline' };
     const { rerender } = renderHook(
-      ({ viewMode }) =>
+      ({ viewMode }: { viewMode: ViewMode }) =>
         useResetMemoryList({
           query: 'late night',
           resetList,
           sort: undefined,
           viewMode,
         }),
-      { initialProps: { viewMode: 'timeline' as const } },
+      { initialProps },
     );
 
     rerender({ viewMode: 'grid' });
@@ -39,15 +40,16 @@ describe('useResetMemoryList', () => {
 
   it('resets when a view change activates an explicit grid sort', () => {
     const resetList = vi.fn();
+    const initialProps: { viewMode: ViewMode } = { viewMode: 'timeline' };
     const { rerender } = renderHook(
-      ({ viewMode }: { viewMode: 'grid' | 'timeline' }) =>
+      ({ viewMode }: { viewMode: ViewMode }) =>
         useResetMemoryList({
           query: 'late night',
           resetList,
           sort: 'scorePriority',
           viewMode,
         }),
-      { initialProps: { viewMode: 'timeline' as const } },
+      { initialProps },
     );
 
     rerender({ viewMode: 'grid' });

--- a/src/features/Memory/useResetMemoryList.ts
+++ b/src/features/Memory/useResetMemoryList.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 export type ViewMode = 'grid' | 'timeline';
 
@@ -10,8 +10,8 @@ interface UseResetMemoryListOptions<Sort extends string> {
 }
 
 /**
- * Reset pagination for every list query change. An undefined sort is the backend default, not a
- * reason to skip a search reset.
+ * Reset pagination before passive SWR hydration effects run for a new list query. An undefined
+ * sort is the backend default, not a reason to skip a search reset.
  */
 export const useResetMemoryList = <Sort extends string>({
   query,
@@ -21,7 +21,7 @@ export const useResetMemoryList = <Sort extends string>({
 }: UseResetMemoryListOptions<Sort>) => {
   const activeSort = viewMode === 'grid' ? sort : undefined;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     resetList({ q: query || undefined, sort: activeSort });
   }, [activeSort, query, resetList]);
 };

--- a/src/features/Memory/useResetMemoryList.ts
+++ b/src/features/Memory/useResetMemoryList.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { type ViewMode } from './ViewModeSwitcher';
+export type ViewMode = 'grid' | 'timeline';
 
 interface UseResetMemoryListOptions<Sort extends string> {
   query: string;

--- a/src/routes/(main)/memory/activities/index.tsx
+++ b/src/routes/(main)/memory/activities/index.tsx
@@ -5,7 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useResetMemoryList } from '@/features/Memory';
+import { MemoryListBoundary, useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -35,6 +35,7 @@ const ActivitiesArea = memo(() => {
   const activitiesPage = useUserMemoryStore((s) => s.activitiesPage);
   const activitiesInit = useUserMemoryStore((s) => s.activitiesInit);
   const activitiesTotal = useUserMemoryStore((s) => s.activitiesTotal);
+  const activitiesSearchError = useUserMemoryStore((s) => s.activitiesSearchError);
   const activitiesSearchLoading = useUserMemoryStore((s) => s.activitiesSearchLoading);
   const useFetchActivities = useUserMemoryStore((s) => s.useFetchActivities);
   const resetActivitiesList = useUserMemoryStore((s) => s.resetActivitiesList);
@@ -53,7 +54,7 @@ const ActivitiesArea = memo(() => {
     viewMode,
   });
 
-  const { isLoading } = useFetchActivities({
+  const { data, isLoading, mutate } = useFetchActivities({
     page: activitiesPage,
     pageSize: 12,
     q: searchValue || undefined,
@@ -73,8 +74,6 @@ const ActivitiesArea = memo(() => {
     },
     [setSortValueRaw],
   );
-
-  const showLoading = activitiesSearchLoading || !activitiesInit;
 
   return (
     <Flexbox flex={1} height={'100%'}>
@@ -105,11 +104,17 @@ const ActivitiesArea = memo(() => {
             onSearch={handleSearch}
             onSortChange={viewMode === 'grid' ? handleSortChange : undefined}
           />
-          {showLoading ? (
-            <Loading viewMode={viewMode} />
-          ) : (
+          <MemoryListBoundary
+            data={data}
+            error={activitiesSearchError}
+            isInitialized={activitiesInit}
+            isLoading={isLoading}
+            isResetting={activitiesSearchLoading}
+            loading={<Loading viewMode={viewMode} />}
+            onRetry={() => void mutate()}
+          >
             <List isLoading={isLoading} searchValue={searchValue} viewMode={viewMode} />
-          )}
+          </MemoryListBoundary>
         </WideScreenContainer>
       </Flexbox>
     </Flexbox>

--- a/src/routes/(main)/memory/activities/index.tsx
+++ b/src/routes/(main)/memory/activities/index.tsx
@@ -2,7 +2,7 @@ import { Flexbox, Icon } from '@lobehub/ui';
 import { Tag } from '@lobehub/ui/base-ui';
 import { CalendarClockIcon } from 'lucide-react';
 import { type FC } from 'react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NavHeader from '@/features/NavHeader';
@@ -16,6 +16,7 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
+import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import ActivityRightPanel from './features/ActivityRightPanel';
@@ -45,11 +46,12 @@ const ActivitiesArea = memo(() => {
 
   const apiSort = sortValue === 'capturedAt' ? undefined : (sortValue as 'startsAt');
 
-  useEffect(() => {
-    if (!apiSort) return;
-    const sort = viewMode === 'grid' ? apiSort : undefined;
-    resetActivitiesList({ q: searchValue || undefined, sort });
-  }, [searchValue, apiSort, viewMode]);
+  useResetMemoryList({
+    query: searchValue,
+    resetList: resetActivitiesList,
+    sort: apiSort,
+    viewMode,
+  });
 
   const { isLoading } = useFetchActivities({
     page: activitiesPage,

--- a/src/routes/(main)/memory/activities/index.tsx
+++ b/src/routes/(main)/memory/activities/index.tsx
@@ -5,6 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -16,7 +17,6 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
-import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import ActivityRightPanel from './features/ActivityRightPanel';

--- a/src/routes/(main)/memory/contexts/index.tsx
+++ b/src/routes/(main)/memory/contexts/index.tsx
@@ -5,6 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -16,7 +17,6 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
-import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import ContextRightPanel from './features/ContextRightPanel';

--- a/src/routes/(main)/memory/contexts/index.tsx
+++ b/src/routes/(main)/memory/contexts/index.tsx
@@ -5,7 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useResetMemoryList } from '@/features/Memory';
+import { MemoryListBoundary, useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -35,6 +35,7 @@ const ContextsArea = memo(() => {
   const contextsPage = useUserMemoryStore((s) => s.contextsPage);
   const contextsInit = useUserMemoryStore((s) => s.contextsInit);
   const contextsTotal = useUserMemoryStore((s) => s.contextsTotal);
+  const contextsSearchError = useUserMemoryStore((s) => s.contextsSearchError);
   const contextsSearchLoading = useUserMemoryStore((s) => s.contextsSearchLoading);
   const useFetchContexts = useUserMemoryStore((s) => s.useFetchContexts);
   const resetContextsList = useUserMemoryStore((s) => s.resetContextsList);
@@ -57,7 +58,7 @@ const ContextsArea = memo(() => {
   });
 
   // Call SWR hook to fetch data
-  const { isLoading } = useFetchContexts({
+  const { data, isLoading, mutate } = useFetchContexts({
     page: contextsPage,
     pageSize: 12,
     q: searchValue || undefined,
@@ -78,9 +79,6 @@ const ContextsArea = memo(() => {
     },
     [setSortValueRaw],
   );
-
-  // Show loading: during search/reset or initial load
-  const showLoading = contextsSearchLoading || !contextsInit;
 
   return (
     <Flexbox flex={1} height={'100%'}>
@@ -111,11 +109,17 @@ const ContextsArea = memo(() => {
             onSearch={handleSearch}
             onSortChange={viewMode === 'grid' ? handleSortChange : undefined}
           />
-          {showLoading ? (
-            <Loading viewMode={viewMode} />
-          ) : (
+          <MemoryListBoundary
+            data={data}
+            error={contextsSearchError}
+            isInitialized={contextsInit}
+            isLoading={isLoading}
+            isResetting={contextsSearchLoading}
+            loading={<Loading viewMode={viewMode} />}
+            onRetry={() => void mutate()}
+          >
             <List isLoading={isLoading} searchValue={searchValue} viewMode={viewMode} />
-          )}
+          </MemoryListBoundary>
         </WideScreenContainer>
       </Flexbox>
     </Flexbox>

--- a/src/routes/(main)/memory/contexts/index.tsx
+++ b/src/routes/(main)/memory/contexts/index.tsx
@@ -2,7 +2,7 @@ import { Flexbox, Icon } from '@lobehub/ui';
 import { Tag } from '@lobehub/ui/base-ui';
 import { BrainCircuitIcon } from 'lucide-react';
 import { type FC } from 'react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NavHeader from '@/features/NavHeader';
@@ -16,6 +16,7 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
+import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import ContextRightPanel from './features/ContextRightPanel';
@@ -48,11 +49,12 @@ const ContextsArea = memo(() => {
   const apiSort =
     sortValue === 'capturedAt' ? undefined : (sortValue as 'scoreImpact' | 'scoreUrgency');
 
-  // Reset list when search or sort changes
-  useEffect(() => {
-    const sort = viewMode === 'grid' ? apiSort : undefined;
-    resetContextsList({ q: searchValue || undefined, sort });
-  }, [searchValue, apiSort, viewMode]);
+  useResetMemoryList({
+    query: searchValue,
+    resetList: resetContextsList,
+    sort: apiSort,
+    viewMode,
+  });
 
   // Call SWR hook to fetch data
   const { isLoading } = useFetchContexts({

--- a/src/routes/(main)/memory/experiences/index.tsx
+++ b/src/routes/(main)/memory/experiences/index.tsx
@@ -2,7 +2,7 @@ import { Flexbox, Icon } from '@lobehub/ui';
 import { Tag } from '@lobehub/ui/base-ui';
 import { BrainCircuitIcon } from 'lucide-react';
 import { type FC } from 'react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NavHeader from '@/features/NavHeader';
@@ -16,6 +16,7 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
+import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import ExperienceRightPanel from './features/ExperienceRightPanel';
@@ -46,12 +47,12 @@ const ExperiencesArea = memo(() => {
   // Convert sort: capturedAt becomes undefined (backend default)
   const apiSort = sortValue === 'capturedAt' ? undefined : (sortValue as 'scoreConfidence');
 
-  // Reset list when search or sort changes
-  useEffect(() => {
-    if (!apiSort) return;
-    const sort = viewMode === 'grid' ? apiSort : undefined;
-    resetExperiencesList({ q: searchValue || undefined, sort });
-  }, [searchValue, apiSort, viewMode]);
+  useResetMemoryList({
+    query: searchValue,
+    resetList: resetExperiencesList,
+    sort: apiSort,
+    viewMode,
+  });
 
   // Call SWR hook to fetch data
   const { isLoading } = useFetchExperiences({

--- a/src/routes/(main)/memory/experiences/index.tsx
+++ b/src/routes/(main)/memory/experiences/index.tsx
@@ -5,6 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -16,7 +17,6 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
-import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import ExperienceRightPanel from './features/ExperienceRightPanel';

--- a/src/routes/(main)/memory/experiences/index.tsx
+++ b/src/routes/(main)/memory/experiences/index.tsx
@@ -5,7 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useResetMemoryList } from '@/features/Memory';
+import { MemoryListBoundary, useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -35,6 +35,7 @@ const ExperiencesArea = memo(() => {
   const experiencesPage = useUserMemoryStore((s) => s.experiencesPage);
   const experiencesInit = useUserMemoryStore((s) => s.experiencesInit);
   const experiencesTotal = useUserMemoryStore((s) => s.experiencesTotal);
+  const experiencesSearchError = useUserMemoryStore((s) => s.experiencesSearchError);
   const experiencesSearchLoading = useUserMemoryStore((s) => s.experiencesSearchLoading);
   const useFetchExperiences = useUserMemoryStore((s) => s.useFetchExperiences);
   const resetExperiencesList = useUserMemoryStore((s) => s.resetExperiencesList);
@@ -55,7 +56,7 @@ const ExperiencesArea = memo(() => {
   });
 
   // Call SWR hook to fetch data
-  const { isLoading } = useFetchExperiences({
+  const { data, isLoading, mutate } = useFetchExperiences({
     page: experiencesPage,
     pageSize: 12,
     q: searchValue || undefined,
@@ -76,9 +77,6 @@ const ExperiencesArea = memo(() => {
     },
     [setSortValueRaw],
   );
-
-  // Show loading: during search/reset or initial load
-  const showLoading = experiencesSearchLoading || !experiencesInit;
 
   return (
     <Flexbox flex={1} height={'100%'}>
@@ -109,11 +107,17 @@ const ExperiencesArea = memo(() => {
             onSearch={handleSearch}
             onSortChange={viewMode === 'grid' ? handleSortChange : undefined}
           />
-          {showLoading ? (
-            <Loading viewMode={viewMode} />
-          ) : (
+          <MemoryListBoundary
+            data={data}
+            error={experiencesSearchError}
+            isInitialized={experiencesInit}
+            isLoading={isLoading}
+            isResetting={experiencesSearchLoading}
+            loading={<Loading viewMode={viewMode} />}
+            onRetry={() => void mutate()}
+          >
             <List isLoading={isLoading} searchValue={searchValue} viewMode={viewMode} />
-          )}
+          </MemoryListBoundary>
         </WideScreenContainer>
       </Flexbox>
     </Flexbox>

--- a/src/routes/(main)/memory/features/ViewModeSwitcher.tsx
+++ b/src/routes/(main)/memory/features/ViewModeSwitcher.tsx
@@ -6,8 +6,9 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
+import { type ViewMode } from '@/features/Memory';
 
-export type ViewMode = 'timeline' | 'grid';
+export type { ViewMode } from '@/features/Memory';
 
 interface ViewModeSwitcherProps {
   onChange: (mode: ViewMode) => void;

--- a/src/routes/(main)/memory/features/useResetMemoryList.test.ts
+++ b/src/routes/(main)/memory/features/useResetMemoryList.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useResetMemoryList } from './useResetMemoryList';
+
+describe('useResetMemoryList', () => {
+  it('resets a timeline search when the backend uses its default sort', () => {
+    const resetList = vi.fn();
+
+    renderHook(() =>
+      useResetMemoryList({
+        query: 'late night',
+        resetList,
+        sort: undefined,
+        viewMode: 'timeline',
+      }),
+    );
+
+    expect(resetList).toHaveBeenCalledWith({ q: 'late night', sort: undefined });
+  });
+
+  it('does not reset when a view change keeps the effective sort unchanged', () => {
+    const resetList = vi.fn();
+    const { rerender } = renderHook(
+      ({ viewMode }) =>
+        useResetMemoryList({
+          query: 'late night',
+          resetList,
+          sort: undefined,
+          viewMode,
+        }),
+      { initialProps: { viewMode: 'timeline' as const } },
+    );
+
+    rerender({ viewMode: 'grid' });
+
+    expect(resetList).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets when a view change activates an explicit grid sort', () => {
+    const resetList = vi.fn();
+    const { rerender } = renderHook(
+      ({ viewMode }: { viewMode: 'grid' | 'timeline' }) =>
+        useResetMemoryList({
+          query: 'late night',
+          resetList,
+          sort: 'scorePriority',
+          viewMode,
+        }),
+      { initialProps: { viewMode: 'timeline' as const } },
+    );
+
+    rerender({ viewMode: 'grid' });
+
+    expect(resetList).toHaveBeenNthCalledWith(2, {
+      q: 'late night',
+      sort: 'scorePriority',
+    });
+  });
+});

--- a/src/routes/(main)/memory/features/useResetMemoryList.ts
+++ b/src/routes/(main)/memory/features/useResetMemoryList.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+import { type ViewMode } from './ViewModeSwitcher';
+
+interface UseResetMemoryListOptions<Sort extends string> {
+  query: string;
+  resetList: (params: { q?: string; sort?: Sort }) => void;
+  sort?: Sort;
+  viewMode: ViewMode;
+}
+
+/**
+ * Reset pagination for every list query change. An undefined sort is the backend default, not a
+ * reason to skip a search reset.
+ */
+export const useResetMemoryList = <Sort extends string>({
+  query,
+  resetList,
+  sort,
+  viewMode,
+}: UseResetMemoryListOptions<Sort>) => {
+  const activeSort = viewMode === 'grid' ? sort : undefined;
+
+  useEffect(() => {
+    resetList({ q: query || undefined, sort: activeSort });
+  }, [activeSort, query, resetList]);
+};

--- a/src/routes/(main)/memory/preferences/index.tsx
+++ b/src/routes/(main)/memory/preferences/index.tsx
@@ -2,7 +2,7 @@ import { Flexbox, Icon } from '@lobehub/ui';
 import { Tag } from '@lobehub/ui/base-ui';
 import { BrainCircuitIcon } from 'lucide-react';
 import { type FC } from 'react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NavHeader from '@/features/NavHeader';
@@ -16,6 +16,7 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
+import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import List from './features/List';
@@ -46,12 +47,12 @@ const PreferencesArea = memo(() => {
   // Convert sort: capturedAt becomes undefined (backend default)
   const apiSort = sortValue === 'capturedAt' ? undefined : (sortValue as 'scorePriority');
 
-  // Reset list when search or sort changes
-  useEffect(() => {
-    if (!apiSort) return;
-    const sort = viewMode === 'grid' ? apiSort : undefined;
-    resetPreferencesList({ q: searchValue || undefined, sort });
-  }, [searchValue, apiSort, viewMode]);
+  useResetMemoryList({
+    query: searchValue,
+    resetList: resetPreferencesList,
+    sort: apiSort,
+    viewMode,
+  });
 
   // Call SWR hook to fetch data
   const { isLoading } = useFetchPreferences({

--- a/src/routes/(main)/memory/preferences/index.tsx
+++ b/src/routes/(main)/memory/preferences/index.tsx
@@ -5,6 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -16,7 +17,6 @@ import { useUserMemoryStore } from '@/store/userMemory';
 import EditableModal from '../features/EditableModal';
 import FilterBar from '../features/FilterBar';
 import Loading from '../features/Loading';
-import { useResetMemoryList } from '../features/useResetMemoryList';
 import { type ViewMode } from '../features/ViewModeSwitcher';
 import ViewModeSwitcher from '../features/ViewModeSwitcher';
 import List from './features/List';

--- a/src/routes/(main)/memory/preferences/index.tsx
+++ b/src/routes/(main)/memory/preferences/index.tsx
@@ -5,7 +5,7 @@ import { type FC } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useResetMemoryList } from '@/features/Memory';
+import { MemoryListBoundary, useResetMemoryList } from '@/features/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -35,6 +35,7 @@ const PreferencesArea = memo(() => {
   const preferencesPage = useUserMemoryStore((s) => s.preferencesPage);
   const preferencesInit = useUserMemoryStore((s) => s.preferencesInit);
   const preferencesTotal = useUserMemoryStore((s) => s.preferencesTotal);
+  const preferencesSearchError = useUserMemoryStore((s) => s.preferencesSearchError);
   const preferencesSearchLoading = useUserMemoryStore((s) => s.preferencesSearchLoading);
   const useFetchPreferences = useUserMemoryStore((s) => s.useFetchPreferences);
   const resetPreferencesList = useUserMemoryStore((s) => s.resetPreferencesList);
@@ -55,7 +56,7 @@ const PreferencesArea = memo(() => {
   });
 
   // Call SWR hook to fetch data
-  const { isLoading } = useFetchPreferences({
+  const { data, isLoading, mutate } = useFetchPreferences({
     page: preferencesPage,
     pageSize: 12,
     q: searchValue || undefined,
@@ -76,9 +77,6 @@ const PreferencesArea = memo(() => {
     },
     [setSortValueRaw],
   );
-
-  // Show loading: during search/reset or initial load
-  const showLoading = preferencesSearchLoading || !preferencesInit;
 
   return (
     <Flexbox flex={1} height={'100%'}>
@@ -109,11 +107,17 @@ const PreferencesArea = memo(() => {
             onSearch={handleSearch}
             onSortChange={viewMode === 'grid' ? handleSortChange : undefined}
           />
-          {showLoading ? (
-            <Loading viewMode={viewMode} />
-          ) : (
+          <MemoryListBoundary
+            data={data}
+            error={preferencesSearchError}
+            isInitialized={preferencesInit}
+            isLoading={isLoading}
+            isResetting={preferencesSearchLoading}
+            loading={<Loading viewMode={viewMode} />}
+            onRetry={() => void mutate()}
+          >
             <List isLoading={isLoading} searchValue={searchValue} viewMode={viewMode} />
-          )}
+          </MemoryListBoundary>
         </WideScreenContainer>
       </Flexbox>
     </Flexbox>

--- a/src/store/userMemory/slices/activity/action.ts
+++ b/src/store/userMemory/slices/activity/action.ts
@@ -11,6 +11,7 @@ import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
 import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
+import { shouldSurfaceMemoryListError } from '../utils/shouldSurfaceMemoryListError';
 
 const n = setNamespace('userMemory/activity');
 
@@ -64,6 +65,7 @@ export class ActivityActionImpl {
         draft.activities = [];
         draft.activitiesPage = 1;
         draft.activitiesQuery = params?.q;
+        draft.activitiesSearchError = undefined;
         draft.activitiesSearchLoading = true;
         draft.activitiesSort = params?.sort;
       }),
@@ -88,7 +90,7 @@ export class ActivityActionImpl {
         });
       },
       {
-        onError: () => {
+        onError: (error: unknown) => {
           const state = this.#get();
           if (
             !isMemoryListRequestCurrent(
@@ -102,8 +104,15 @@ export class ActivityActionImpl {
           )
             return;
 
+          const shouldSurfaceError = shouldSurfaceMemoryListError({
+            initialized: state.activitiesInit,
+            page,
+            resetting: state.activitiesSearchLoading,
+          });
+
           this.#set(
             produce((draft) => {
+              if (shouldSurfaceError) draft.activitiesSearchError = error;
               draft.activitiesSearchLoading = false;
             }),
             false,
@@ -126,6 +135,7 @@ export class ActivityActionImpl {
 
           this.#set(
             produce((draft) => {
+              draft.activitiesSearchError = undefined;
               draft.activitiesSearchLoading = false;
               draft.activitiesTotal = data.total;
 

--- a/src/store/userMemory/slices/activity/action.ts
+++ b/src/store/userMemory/slices/activity/action.ts
@@ -10,6 +10,7 @@ import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
+import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
 
 const n = setNamespace('userMemory/activity');
 
@@ -88,6 +89,19 @@ export class ActivityActionImpl {
       },
       {
         onSuccess: (data: ActivityListResult) => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              {
+                page: state.activitiesPage,
+                q: state.activitiesQuery,
+                sort: state.activitiesSort,
+              },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
           this.#set(
             produce((draft) => {
               draft.activitiesSearchLoading = false;

--- a/src/store/userMemory/slices/activity/action.ts
+++ b/src/store/userMemory/slices/activity/action.ts
@@ -1,6 +1,7 @@
 import { type ActivityListResult } from '@lobechat/types';
 import { uniqBy } from 'es-toolkit/compat';
 import { produce } from 'immer';
+import { useEffect } from 'react';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
@@ -23,6 +24,8 @@ export interface ActivityQueryParams {
   status?: string[];
   types?: string[];
 }
+
+type ActivityListRequest = ActivityQueryParams & { page: number };
 
 type Setter = StoreSetter<UserMemoryStore>;
 export const createActivitySlice = (set: Setter, get: () => UserMemoryStore, _api?: unknown) =>
@@ -59,6 +62,76 @@ export class ActivityActionImpl {
     }
   };
 
+  internal_acceptActivitiesList = (
+    data: ActivityListResult,
+    request: ActivityListRequest,
+  ): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        {
+          page: state.activitiesPage,
+          q: state.activitiesQuery,
+          sort: state.activitiesSort,
+        },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    this.#set(
+      produce((draft) => {
+        draft.activitiesSearchError = undefined;
+        draft.activitiesSearchLoading = false;
+        draft.activitiesTotal = data.total;
+
+        if (!draft.activitiesInit) {
+          draft.activitiesInit = true;
+        }
+
+        if (request.page === 1) {
+          draft.activities = uniqBy(data.items, 'id');
+        } else {
+          draft.activities = uniqBy([...draft.activities, ...data.items], 'id');
+        }
+
+        draft.activitiesHasMore = data.items.length >= (request.pageSize || 20);
+      }),
+      false,
+      n('internal_acceptActivitiesList'),
+    );
+  };
+
+  internal_failActivitiesList = (error: unknown, request: ActivityListRequest): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        {
+          page: state.activitiesPage,
+          q: state.activitiesQuery,
+          sort: state.activitiesSort,
+        },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    const shouldSurfaceError = shouldSurfaceMemoryListError({
+      initialized: state.activitiesInit,
+      page: request.page,
+      resetting: state.activitiesSearchLoading,
+    });
+
+    this.#set(
+      produce((draft) => {
+        if (shouldSurfaceError) draft.activitiesSearchError = error;
+        draft.activitiesSearchLoading = false;
+      }),
+      false,
+      n('internal_failActivitiesList'),
+    );
+  };
+
   resetActivitiesList = (params?: Omit<ActivityQueryParams, 'page' | 'pageSize'>): void => {
     this.#set(
       produce((draft) => {
@@ -74,10 +147,13 @@ export class ActivityActionImpl {
     );
   };
 
+  /**
+   * Hydrate the store from SWR's rendered state because deduped cache hits do not invoke SWR's
+   * request lifecycle callbacks.
+   */
   useFetchActivities = (params: ActivityQueryParams): SWRResponse<ActivityListResult> => {
     const page = params.page ?? 1;
-
-    return useSWR(
+    const response = useSWR(
       userMemoryKeys.activities(params),
       async () => {
         return userMemoryService.queryActivities({
@@ -90,74 +166,21 @@ export class ActivityActionImpl {
         });
       },
       {
-        onError: (error: unknown) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              {
-                page: state.activitiesPage,
-                q: state.activitiesQuery,
-                sort: state.activitiesSort,
-              },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          const shouldSurfaceError = shouldSurfaceMemoryListError({
-            initialized: state.activitiesInit,
-            page,
-            resetting: state.activitiesSearchLoading,
-          });
-
-          this.#set(
-            produce((draft) => {
-              if (shouldSurfaceError) draft.activitiesSearchError = error;
-              draft.activitiesSearchLoading = false;
-            }),
-            false,
-            n('useFetchActivities/onError'),
-          );
-        },
-        onSuccess: (data: ActivityListResult) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              {
-                page: state.activitiesPage,
-                q: state.activitiesQuery,
-                sort: state.activitiesSort,
-              },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          this.#set(
-            produce((draft) => {
-              draft.activitiesSearchError = undefined;
-              draft.activitiesSearchLoading = false;
-              draft.activitiesTotal = data.total;
-
-              if (!draft.activitiesInit) {
-                draft.activitiesInit = true;
-              }
-
-              if (page === 1) {
-                draft.activities = uniqBy(data.items, 'id');
-              } else {
-                draft.activities = uniqBy([...draft.activities, ...data.items], 'id');
-              }
-
-              draft.activitiesHasMore = data.items.length >= (params.pageSize || 20);
-            }),
-            false,
-            n('useFetchActivities/onSuccess'),
-          );
-        },
         revalidateOnFocus: false,
       },
     );
+
+    useEffect(() => {
+      if (response.data !== undefined)
+        this.internal_acceptActivitiesList(response.data, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.data]);
+
+    useEffect(() => {
+      if (response.error !== undefined)
+        this.internal_failActivitiesList(response.error, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.error]);
+
+    return response;
   };
 }
 

--- a/src/store/userMemory/slices/activity/action.ts
+++ b/src/store/userMemory/slices/activity/action.ts
@@ -88,6 +88,28 @@ export class ActivityActionImpl {
         });
       },
       {
+        onError: () => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              {
+                page: state.activitiesPage,
+                q: state.activitiesQuery,
+                sort: state.activitiesSort,
+              },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
+          this.#set(
+            produce((draft) => {
+              draft.activitiesSearchLoading = false;
+            }),
+            false,
+            n('useFetchActivities/onError'),
+          );
+        },
         onSuccess: (data: ActivityListResult) => {
           const state = this.#get();
           if (

--- a/src/store/userMemory/slices/activity/initialState.ts
+++ b/src/store/userMemory/slices/activity/initialState.ts
@@ -6,6 +6,7 @@ export interface ActivitySliceState {
   activitiesInit: boolean;
   activitiesPage: number;
   activitiesQuery?: string;
+  activitiesSearchError?: unknown;
   activitiesSearchLoading?: boolean;
   activitiesSort?: 'capturedAt' | 'startsAt';
   activitiesTotal: number;
@@ -17,6 +18,7 @@ export const activityInitialState: ActivitySliceState = {
   activitiesInit: false,
   activitiesPage: 1,
   activitiesQuery: undefined,
+  activitiesSearchError: undefined,
   activitiesSearchLoading: undefined,
   activitiesSort: undefined,
   activitiesTotal: 0,

--- a/src/store/userMemory/slices/context/action.ts
+++ b/src/store/userMemory/slices/context/action.ts
@@ -12,6 +12,7 @@ import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
 import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
+import { shouldSurfaceMemoryListError } from '../utils/shouldSurfaceMemoryListError';
 
 const n = setNamespace('userMemory/context');
 
@@ -61,6 +62,7 @@ export class ContextActionImpl {
         draft.contexts = [];
         draft.contextsPage = 1;
         draft.contextsQuery = params?.q;
+        draft.contextsSearchError = undefined;
         draft.contextsSearchLoading = true;
         draft.contextsSort = params?.sort;
       }),
@@ -86,7 +88,7 @@ export class ContextActionImpl {
         return result;
       },
       {
-        onError: () => {
+        onError: (error: unknown) => {
           const state = this.#get();
           if (
             !isMemoryListRequestCurrent(
@@ -96,8 +98,15 @@ export class ContextActionImpl {
           )
             return;
 
+          const shouldSurfaceError = shouldSurfaceMemoryListError({
+            initialized: state.contextsInit,
+            page,
+            resetting: state.contextsSearchLoading,
+          });
+
           this.#set(
             produce((draft) => {
+              if (shouldSurfaceError) draft.contextsSearchError = error;
               draft.contextsSearchLoading = false;
             }),
             false,
@@ -116,6 +125,7 @@ export class ContextActionImpl {
 
           this.#set(
             produce((draft) => {
+              draft.contextsSearchError = undefined;
               draft.contextsSearchLoading = false;
               draft.contextsInit = true;
               draft.contextsTotal = data.total;

--- a/src/store/userMemory/slices/context/action.ts
+++ b/src/store/userMemory/slices/context/action.ts
@@ -1,5 +1,6 @@
 import { uniqBy } from 'es-toolkit/compat';
 import { produce } from 'immer';
+import { useEffect } from 'react';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
@@ -22,6 +23,8 @@ export interface ContextQueryParams {
   q?: string;
   sort?: 'capturedAt' | 'scoreImpact' | 'scoreUrgency';
 }
+
+type ContextListRequest = ContextQueryParams & { page: number };
 
 type Setter = StoreSetter<UserMemoryStore>;
 export const createContextSlice = (set: Setter, get: () => UserMemoryStore, _api?: unknown) =>
@@ -56,6 +59,68 @@ export class ContextActionImpl {
     }
   };
 
+  internal_acceptContextsList = (data: any, request: ContextListRequest): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        { page: state.contextsPage, q: state.contextsQuery, sort: state.contextsSort },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    this.#set(
+      produce((draft) => {
+        draft.contextsSearchError = undefined;
+        draft.contextsSearchLoading = false;
+        draft.contextsInit = true;
+        draft.contextsTotal = data.total;
+
+        const transformedItems: DisplayContextMemory[] = data.items.map((item: any) => ({
+          ...item.memory,
+          ...item.context,
+          source: null,
+        }));
+
+        if (request.page === 1) {
+          draft.contexts = uniqBy(transformedItems, 'id');
+        } else {
+          draft.contexts = uniqBy([...draft.contexts, ...transformedItems], 'id');
+        }
+
+        draft.contextsHasMore = data.items.length >= (request.pageSize || 20);
+      }),
+      false,
+      n('internal_acceptContextsList'),
+    );
+  };
+
+  internal_failContextsList = (error: unknown, request: ContextListRequest): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        { page: state.contextsPage, q: state.contextsQuery, sort: state.contextsSort },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    const shouldSurfaceError = shouldSurfaceMemoryListError({
+      initialized: state.contextsInit,
+      page: request.page,
+      resetting: state.contextsSearchLoading,
+    });
+
+    this.#set(
+      produce((draft) => {
+        if (shouldSurfaceError) draft.contextsSearchError = error;
+        draft.contextsSearchLoading = false;
+      }),
+      false,
+      n('internal_failContextsList'),
+    );
+  };
+
   resetContextsList = (params?: Omit<ContextQueryParams, 'page' | 'pageSize'>): void => {
     this.#set(
       produce((draft) => {
@@ -71,10 +136,13 @@ export class ContextActionImpl {
     );
   };
 
+  /**
+   * Hydrate the store from SWR's rendered state because deduped cache hits do not invoke SWR's
+   * request lifecycle callbacks.
+   */
   useFetchContexts = (params: ContextQueryParams): SWRResponse<any> => {
     const page = params.page ?? 1;
-
-    return useSWR(
+    const response = useSWR(
       userMemoryKeys.contexts(params),
       async () => {
         const result = await userMemoryService.queryMemories({
@@ -88,74 +156,21 @@ export class ContextActionImpl {
         return result;
       },
       {
-        onError: (error: unknown) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              { page: state.contextsPage, q: state.contextsQuery, sort: state.contextsSort },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          const shouldSurfaceError = shouldSurfaceMemoryListError({
-            initialized: state.contextsInit,
-            page,
-            resetting: state.contextsSearchLoading,
-          });
-
-          this.#set(
-            produce((draft) => {
-              if (shouldSurfaceError) draft.contextsSearchError = error;
-              draft.contextsSearchLoading = false;
-            }),
-            false,
-            n('useFetchContexts/onError'),
-          );
-        },
-        onSuccess: (data: any) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              { page: state.contextsPage, q: state.contextsQuery, sort: state.contextsSort },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          this.#set(
-            produce((draft) => {
-              draft.contextsSearchError = undefined;
-              draft.contextsSearchLoading = false;
-              draft.contextsInit = true;
-              draft.contextsTotal = data.total;
-
-              // Transform data structure
-              const transformedItems: DisplayContextMemory[] = data.items.map((item: any) => ({
-                ...item.memory,
-                ...item.context,
-                source: null,
-              }));
-
-              // Accumulate data logic
-              if (page === 1) {
-                // First page, set directly
-                draft.contexts = uniqBy(transformedItems, 'id');
-              } else {
-                // Subsequent pages, accumulate data
-                draft.contexts = uniqBy([...draft.contexts, ...transformedItems], 'id');
-              }
-
-              // Update hasMore
-              draft.contextsHasMore = data.items.length >= (params.pageSize || 20);
-            }),
-            false,
-            n('useFetchContexts/onSuccess'),
-          );
-        },
         revalidateOnFocus: false,
       },
     );
+
+    useEffect(() => {
+      if (response.data !== undefined)
+        this.internal_acceptContextsList(response.data, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.data]);
+
+    useEffect(() => {
+      if (response.error !== undefined)
+        this.internal_failContextsList(response.error, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.error]);
+
+    return response;
   };
 }
 

--- a/src/store/userMemory/slices/context/action.ts
+++ b/src/store/userMemory/slices/context/action.ts
@@ -86,6 +86,24 @@ export class ContextActionImpl {
         return result;
       },
       {
+        onError: () => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              { page: state.contextsPage, q: state.contextsQuery, sort: state.contextsSort },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
+          this.#set(
+            produce((draft) => {
+              draft.contextsSearchLoading = false;
+            }),
+            false,
+            n('useFetchContexts/onError'),
+          );
+        },
         onSuccess: (data: any) => {
           const state = this.#get();
           if (

--- a/src/store/userMemory/slices/context/action.ts
+++ b/src/store/userMemory/slices/context/action.ts
@@ -11,6 +11,7 @@ import { LayersEnum } from '@/types/userMemory';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
+import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
 
 const n = setNamespace('userMemory/context');
 
@@ -86,6 +87,15 @@ export class ContextActionImpl {
       },
       {
         onSuccess: (data: any) => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              { page: state.contextsPage, q: state.contextsQuery, sort: state.contextsSort },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
           this.#set(
             produce((draft) => {
               draft.contextsSearchLoading = false;

--- a/src/store/userMemory/slices/context/initialState.ts
+++ b/src/store/userMemory/slices/context/initialState.ts
@@ -6,6 +6,7 @@ export interface ContextSliceState {
   contextsInit: boolean;
   contextsPage: number;
   contextsQuery?: string;
+  contextsSearchError?: unknown;
   contextsSearchLoading?: boolean;
   contextsSort?: 'capturedAt' | 'scoreImpact' | 'scoreUrgency';
   contextsTotal: number;
@@ -17,6 +18,8 @@ export const contextInitialState: ContextSliceState = {
   contextsInit: false,
   contextsPage: 1,
   contextsQuery: undefined,
+  contextsSearchError: undefined,
+  contextsSearchLoading: undefined,
   contextsSort: undefined,
   contextsTotal: 0,
 };

--- a/src/store/userMemory/slices/experience/action.ts
+++ b/src/store/userMemory/slices/experience/action.ts
@@ -11,6 +11,7 @@ import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
 import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
+import { shouldSurfaceMemoryListError } from '../utils/shouldSurfaceMemoryListError';
 
 const n = setNamespace('userMemory/experience');
 
@@ -63,6 +64,7 @@ export class ExperienceActionImpl {
         draft.experiences = [];
         draft.experiencesPage = 1;
         draft.experiencesQuery = params?.q;
+        draft.experiencesSearchError = undefined;
         draft.experiencesSearchLoading = true;
         draft.experiencesSort = params?.sort;
       }),
@@ -86,7 +88,7 @@ export class ExperienceActionImpl {
         });
       },
       {
-        onError: () => {
+        onError: (error: unknown) => {
           const state = this.#get();
           if (
             !isMemoryListRequestCurrent(
@@ -100,8 +102,15 @@ export class ExperienceActionImpl {
           )
             return;
 
+          const shouldSurfaceError = shouldSurfaceMemoryListError({
+            initialized: state.experiencesInit,
+            page,
+            resetting: state.experiencesSearchLoading,
+          });
+
           this.#set(
             produce((draft) => {
+              if (shouldSurfaceError) draft.experiencesSearchError = error;
               draft.experiencesSearchLoading = false;
             }),
             false,
@@ -124,6 +133,7 @@ export class ExperienceActionImpl {
 
           this.#set(
             produce((draft) => {
+              draft.experiencesSearchError = undefined;
               draft.experiencesSearchLoading = false;
               draft.experiencesTotal = data.total;
 

--- a/src/store/userMemory/slices/experience/action.ts
+++ b/src/store/userMemory/slices/experience/action.ts
@@ -1,6 +1,7 @@
 import { type ExperienceListResult } from '@lobechat/types';
 import { uniqBy } from 'es-toolkit/compat';
 import { produce } from 'immer';
+import { useEffect } from 'react';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
@@ -21,6 +22,8 @@ export interface ExperienceQueryParams {
   q?: string;
   sort?: 'capturedAt' | 'scoreConfidence';
 }
+
+type ExperienceListRequest = ExperienceQueryParams & { page: number };
 
 type Setter = StoreSetter<UserMemoryStore>;
 export const createExperienceSlice = (set: Setter, get: () => UserMemoryStore, _api?: unknown) =>
@@ -58,6 +61,76 @@ export class ExperienceActionImpl {
     }
   };
 
+  internal_acceptExperiencesList = (
+    data: ExperienceListResult,
+    request: ExperienceListRequest,
+  ): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        {
+          page: state.experiencesPage,
+          q: state.experiencesQuery,
+          sort: state.experiencesSort,
+        },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    this.#set(
+      produce((draft) => {
+        draft.experiencesSearchError = undefined;
+        draft.experiencesSearchLoading = false;
+        draft.experiencesTotal = data.total;
+
+        if (!draft.experiencesInit) {
+          draft.experiencesInit = true;
+        }
+
+        if (request.page === 1) {
+          draft.experiences = uniqBy(data.items, 'id');
+        } else {
+          draft.experiences = uniqBy([...draft.experiences, ...data.items], 'id');
+        }
+
+        draft.experiencesHasMore = data.items.length >= (request.pageSize || 20);
+      }),
+      false,
+      n('internal_acceptExperiencesList'),
+    );
+  };
+
+  internal_failExperiencesList = (error: unknown, request: ExperienceListRequest): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        {
+          page: state.experiencesPage,
+          q: state.experiencesQuery,
+          sort: state.experiencesSort,
+        },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    const shouldSurfaceError = shouldSurfaceMemoryListError({
+      initialized: state.experiencesInit,
+      page: request.page,
+      resetting: state.experiencesSearchLoading,
+    });
+
+    this.#set(
+      produce((draft) => {
+        if (shouldSurfaceError) draft.experiencesSearchError = error;
+        draft.experiencesSearchLoading = false;
+      }),
+      false,
+      n('internal_failExperiencesList'),
+    );
+  };
+
   resetExperiencesList = (params?: Omit<ExperienceQueryParams, 'page' | 'pageSize'>): void => {
     this.#set(
       produce((draft) => {
@@ -73,10 +146,13 @@ export class ExperienceActionImpl {
     );
   };
 
+  /**
+   * Hydrate the store from SWR's rendered state because deduped cache hits do not invoke SWR's
+   * request lifecycle callbacks.
+   */
   useFetchExperiences = (params: ExperienceQueryParams): SWRResponse<ExperienceListResult> => {
     const page = params.page ?? 1;
-
-    return useSWR(
+    const response = useSWR(
       userMemoryKeys.experiences(params),
       async () => {
         // Use the new dedicated queryExperiences API
@@ -88,75 +164,21 @@ export class ExperienceActionImpl {
         });
       },
       {
-        onError: (error: unknown) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              {
-                page: state.experiencesPage,
-                q: state.experiencesQuery,
-                sort: state.experiencesSort,
-              },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          const shouldSurfaceError = shouldSurfaceMemoryListError({
-            initialized: state.experiencesInit,
-            page,
-            resetting: state.experiencesSearchLoading,
-          });
-
-          this.#set(
-            produce((draft) => {
-              if (shouldSurfaceError) draft.experiencesSearchError = error;
-              draft.experiencesSearchLoading = false;
-            }),
-            false,
-            n('useFetchExperiences/onError'),
-          );
-        },
-        onSuccess: (data: ExperienceListResult) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              {
-                page: state.experiencesPage,
-                q: state.experiencesQuery,
-                sort: state.experiencesSort,
-              },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          this.#set(
-            produce((draft) => {
-              draft.experiencesSearchError = undefined;
-              draft.experiencesSearchLoading = false;
-              draft.experiencesTotal = data.total;
-
-              if (!draft.experiencesInit) {
-                draft.experiencesInit = true;
-              }
-
-              // Backend now returns flat structure directly, no transformation needed
-              if (page === 1) {
-                draft.experiences = uniqBy(data.items, 'id');
-              } else {
-                draft.experiences = uniqBy([...draft.experiences, ...data.items], 'id');
-              }
-
-              draft.experiencesHasMore = data.items.length >= (params.pageSize || 20);
-            }),
-            false,
-            n('useFetchExperiences/onSuccess'),
-          );
-        },
         revalidateOnFocus: false,
       },
     );
+
+    useEffect(() => {
+      if (response.data !== undefined)
+        this.internal_acceptExperiencesList(response.data, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.data]);
+
+    useEffect(() => {
+      if (response.error !== undefined)
+        this.internal_failExperiencesList(response.error, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.error]);
+
+    return response;
   };
 }
 

--- a/src/store/userMemory/slices/experience/action.ts
+++ b/src/store/userMemory/slices/experience/action.ts
@@ -86,6 +86,28 @@ export class ExperienceActionImpl {
         });
       },
       {
+        onError: () => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              {
+                page: state.experiencesPage,
+                q: state.experiencesQuery,
+                sort: state.experiencesSort,
+              },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
+          this.#set(
+            produce((draft) => {
+              draft.experiencesSearchLoading = false;
+            }),
+            false,
+            n('useFetchExperiences/onError'),
+          );
+        },
         onSuccess: (data: ExperienceListResult) => {
           const state = this.#get();
           if (

--- a/src/store/userMemory/slices/experience/action.ts
+++ b/src/store/userMemory/slices/experience/action.ts
@@ -10,6 +10,7 @@ import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
+import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
 
 const n = setNamespace('userMemory/experience');
 
@@ -86,6 +87,19 @@ export class ExperienceActionImpl {
       },
       {
         onSuccess: (data: ExperienceListResult) => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              {
+                page: state.experiencesPage,
+                q: state.experiencesQuery,
+                sort: state.experiencesSort,
+              },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
           this.#set(
             produce((draft) => {
               draft.experiencesSearchLoading = false;

--- a/src/store/userMemory/slices/experience/initialState.ts
+++ b/src/store/userMemory/slices/experience/initialState.ts
@@ -6,6 +6,7 @@ export interface ExperienceSliceState {
   experiencesInit: boolean;
   experiencesPage: number;
   experiencesQuery?: string;
+  experiencesSearchError?: unknown;
   experiencesSearchLoading?: boolean;
   experiencesSort?: 'capturedAt' | 'scoreConfidence';
   experiencesTotal: number;
@@ -17,6 +18,8 @@ export const experienceInitialState: ExperienceSliceState = {
   experiencesInit: false,
   experiencesPage: 1,
   experiencesQuery: undefined,
+  experiencesSearchError: undefined,
+  experiencesSearchLoading: undefined,
   experiencesSort: undefined,
   experiencesTotal: 0,
 };

--- a/src/store/userMemory/slices/listRequestGuard.test.ts
+++ b/src/store/userMemory/slices/listRequestGuard.test.ts
@@ -1,14 +1,11 @@
-import useSWR from 'swr';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { useUserMemoryStore } from '@/store/userMemory';
 import { initialState } from '@/store/userMemory/initialState';
 
-vi.mock('swr', () => ({ default: vi.fn(() => ({})) }));
-
 interface GuardCase {
-  fetchCurrent: () => unknown;
-  fetchPageTwo: () => unknown;
+  accept: (request: { page: number; pageSize: number; q?: string }) => void;
+  fail: (error: Error, request: { page: number; pageSize: number; q?: string }) => void;
   name: string;
   readList: () => unknown[];
   readSearchError: () => unknown;
@@ -20,9 +17,12 @@ interface GuardCase {
 
 const cases: GuardCase[] = [
   {
-    fetchCurrent: () =>
-      useUserMemoryStore.getState().useFetchActivities({ page: 1, pageSize: 12, q: 'late night' }),
-    fetchPageTwo: () => useUserMemoryStore.getState().useFetchActivities({ page: 2, pageSize: 12 }),
+    accept: (request) =>
+      useUserMemoryStore
+        .getState()
+        .internal_acceptActivitiesList({ items: [], total: 22 }, request),
+    fail: (error, request) =>
+      useUserMemoryStore.getState().internal_failActivitiesList(error, request),
     name: 'activities',
     readList: () => useUserMemoryStore.getState().activities,
     readSearchError: () => useUserMemoryStore.getState().activitiesSearchError,
@@ -38,9 +38,10 @@ const cases: GuardCase[] = [
       useUserMemoryStore.setState({ activities: [{ id: 'existing' } as never], activitiesPage: 2 }),
   },
   {
-    fetchCurrent: () =>
-      useUserMemoryStore.getState().useFetchContexts({ page: 1, pageSize: 12, q: 'late night' }),
-    fetchPageTwo: () => useUserMemoryStore.getState().useFetchContexts({ page: 2, pageSize: 12 }),
+    accept: (request) =>
+      useUserMemoryStore.getState().internal_acceptContextsList({ items: [], total: 22 }, request),
+    fail: (error, request) =>
+      useUserMemoryStore.getState().internal_failContextsList(error, request),
     name: 'contexts',
     readList: () => useUserMemoryStore.getState().contexts,
     readSearchError: () => useUserMemoryStore.getState().contextsSearchError,
@@ -56,10 +57,12 @@ const cases: GuardCase[] = [
       useUserMemoryStore.setState({ contexts: [{ id: 'existing' } as never], contextsPage: 2 }),
   },
   {
-    fetchCurrent: () =>
-      useUserMemoryStore.getState().useFetchExperiences({ page: 1, pageSize: 12, q: 'late night' }),
-    fetchPageTwo: () =>
-      useUserMemoryStore.getState().useFetchExperiences({ page: 2, pageSize: 12 }),
+    accept: (request) =>
+      useUserMemoryStore
+        .getState()
+        .internal_acceptExperiencesList({ items: [], total: 22 }, request),
+    fail: (error, request) =>
+      useUserMemoryStore.getState().internal_failExperiencesList(error, request),
     name: 'experiences',
     readList: () => useUserMemoryStore.getState().experiences,
     readSearchError: () => useUserMemoryStore.getState().experiencesSearchError,
@@ -78,10 +81,12 @@ const cases: GuardCase[] = [
       }),
   },
   {
-    fetchCurrent: () =>
-      useUserMemoryStore.getState().useFetchPreferences({ page: 1, pageSize: 12, q: 'late night' }),
-    fetchPageTwo: () =>
-      useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 }),
+    accept: (request) =>
+      useUserMemoryStore
+        .getState()
+        .internal_acceptPreferencesList({ items: [], total: 22 }, request),
+    fail: (error, request) =>
+      useUserMemoryStore.getState().internal_failPreferencesList(error, request),
     name: 'preferences',
     readList: () => useUserMemoryStore.getState().preferences,
     readSearchError: () => useUserMemoryStore.getState().preferencesSearchError,
@@ -102,21 +107,14 @@ const cases: GuardCase[] = [
 ];
 
 beforeEach(() => {
-  vi.clearAllMocks();
   useUserMemoryStore.setState(initialState, false);
 });
 
 describe('memory list request guards', () => {
   it.each(cases)('ignores a late $name response after a search reset', (testCase) => {
     testCase.seedPageTwo();
-    testCase.fetchPageTwo();
-
     testCase.resetWithSearch();
-    const onSuccess = vi.mocked(useSWR).mock.calls[0][2]?.onSuccess as (data: {
-      items: unknown[];
-      total: number;
-    }) => void;
-    onSuccess({ items: [], total: 22 });
+    testCase.accept({ page: 2, pageSize: 12 });
 
     expect(testCase.readList()).toEqual([]);
     expect(testCase.readSearchLoading()).toBe(true);
@@ -124,11 +122,8 @@ describe('memory list request guards', () => {
 
   it.each(cases)('keeps $name loading when an obsolete request fails', (testCase) => {
     testCase.seedPageTwo();
-    testCase.fetchPageTwo();
-
     testCase.resetWithSearch();
-    const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
-    onError(new Error('request failed'));
+    testCase.fail(new Error('request failed'), { page: 2, pageSize: 12 });
 
     expect(testCase.readSearchError()).toBeUndefined();
     expect(testCase.readSearchLoading()).toBe(true);
@@ -136,11 +131,8 @@ describe('memory list request guards', () => {
 
   it.each(cases)('preserves the current $name search error after loading settles', (testCase) => {
     testCase.resetWithSearch();
-    testCase.fetchCurrent();
-
-    const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
     const error = new Error('request failed');
-    onError(error);
+    testCase.fail(error, { page: 1, pageSize: 12, q: 'late night' });
 
     expect(testCase.readSearchError()).toBe(error);
     expect(testCase.readSearchLoading()).toBe(false);
@@ -148,10 +140,7 @@ describe('memory list request guards', () => {
 
   it.each(cases)('preserves settled $name content when a background refresh fails', (testCase) => {
     testCase.seedSettledSearch();
-    testCase.fetchCurrent();
-
-    const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
-    onError(new Error('request failed'));
+    testCase.fail(new Error('request failed'), { page: 1, pageSize: 12, q: 'late night' });
 
     expect(testCase.readList()).toHaveLength(1);
     expect(testCase.readSearchError()).toBeUndefined();

--- a/src/store/userMemory/slices/listRequestGuard.test.ts
+++ b/src/store/userMemory/slices/listRequestGuard.test.ts
@@ -1,0 +1,72 @@
+import useSWR from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserMemoryStore } from '@/store/userMemory';
+import { initialState } from '@/store/userMemory/initialState';
+
+vi.mock('swr', () => ({ default: vi.fn(() => ({})) }));
+
+interface GuardCase {
+  fetchPageTwo: () => unknown;
+  name: string;
+  readList: () => unknown[];
+  readSearchLoading: () => boolean | undefined;
+  resetWithSearch: () => void;
+  seedPageTwo: () => void;
+}
+
+const cases: GuardCase[] = [
+  {
+    fetchPageTwo: () => useUserMemoryStore.getState().useFetchActivities({ page: 2, pageSize: 12 }),
+    name: 'activities',
+    readList: () => useUserMemoryStore.getState().activities,
+    readSearchLoading: () => useUserMemoryStore.getState().activitiesSearchLoading,
+    resetWithSearch: () => useUserMemoryStore.getState().resetActivitiesList({ q: 'late night' }),
+    seedPageTwo: () =>
+      useUserMemoryStore.setState({ activities: [{ id: 'existing' } as never], activitiesPage: 2 }),
+  },
+  {
+    fetchPageTwo: () => useUserMemoryStore.getState().useFetchContexts({ page: 2, pageSize: 12 }),
+    name: 'contexts',
+    readList: () => useUserMemoryStore.getState().contexts,
+    readSearchLoading: () => useUserMemoryStore.getState().contextsSearchLoading,
+    resetWithSearch: () => useUserMemoryStore.getState().resetContextsList({ q: 'late night' }),
+    seedPageTwo: () =>
+      useUserMemoryStore.setState({ contexts: [{ id: 'existing' } as never], contextsPage: 2 }),
+  },
+  {
+    fetchPageTwo: () =>
+      useUserMemoryStore.getState().useFetchExperiences({ page: 2, pageSize: 12 }),
+    name: 'experiences',
+    readList: () => useUserMemoryStore.getState().experiences,
+    readSearchLoading: () => useUserMemoryStore.getState().experiencesSearchLoading,
+    resetWithSearch: () => useUserMemoryStore.getState().resetExperiencesList({ q: 'late night' }),
+    seedPageTwo: () =>
+      useUserMemoryStore.setState({
+        experiences: [{ id: 'existing' } as never],
+        experiencesPage: 2,
+      }),
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUserMemoryStore.setState(initialState, false);
+});
+
+describe('memory list request guards', () => {
+  it.each(cases)('ignores a late $name response after a search reset', (testCase) => {
+    testCase.seedPageTwo();
+    testCase.fetchPageTwo();
+
+    testCase.resetWithSearch();
+    const onSuccess = vi.mocked(useSWR).mock.calls[0][2]?.onSuccess as (data: {
+      items: unknown[];
+      total: number;
+    }) => void;
+    onSuccess({ items: [], total: 22 });
+
+    expect(testCase.readList()).toEqual([]);
+    expect(testCase.readSearchLoading()).toBe(true);
+  });
+});

--- a/src/store/userMemory/slices/listRequestGuard.test.ts
+++ b/src/store/userMemory/slices/listRequestGuard.test.ts
@@ -11,9 +11,11 @@ interface GuardCase {
   fetchPageTwo: () => unknown;
   name: string;
   readList: () => unknown[];
+  readSearchError: () => unknown;
   readSearchLoading: () => boolean | undefined;
   resetWithSearch: () => void;
   seedPageTwo: () => void;
+  seedSettledSearch: () => void;
 }
 
 const cases: GuardCase[] = [
@@ -23,8 +25,15 @@ const cases: GuardCase[] = [
     fetchPageTwo: () => useUserMemoryStore.getState().useFetchActivities({ page: 2, pageSize: 12 }),
     name: 'activities',
     readList: () => useUserMemoryStore.getState().activities,
+    readSearchError: () => useUserMemoryStore.getState().activitiesSearchError,
     readSearchLoading: () => useUserMemoryStore.getState().activitiesSearchLoading,
     resetWithSearch: () => useUserMemoryStore.getState().resetActivitiesList({ q: 'late night' }),
+    seedSettledSearch: () =>
+      useUserMemoryStore.setState({
+        activities: [{ id: 'existing' } as never],
+        activitiesInit: true,
+        activitiesQuery: 'late night',
+      }),
     seedPageTwo: () =>
       useUserMemoryStore.setState({ activities: [{ id: 'existing' } as never], activitiesPage: 2 }),
   },
@@ -34,8 +43,15 @@ const cases: GuardCase[] = [
     fetchPageTwo: () => useUserMemoryStore.getState().useFetchContexts({ page: 2, pageSize: 12 }),
     name: 'contexts',
     readList: () => useUserMemoryStore.getState().contexts,
+    readSearchError: () => useUserMemoryStore.getState().contextsSearchError,
     readSearchLoading: () => useUserMemoryStore.getState().contextsSearchLoading,
     resetWithSearch: () => useUserMemoryStore.getState().resetContextsList({ q: 'late night' }),
+    seedSettledSearch: () =>
+      useUserMemoryStore.setState({
+        contexts: [{ id: 'existing' } as never],
+        contextsInit: true,
+        contextsQuery: 'late night',
+      }),
     seedPageTwo: () =>
       useUserMemoryStore.setState({ contexts: [{ id: 'existing' } as never], contextsPage: 2 }),
   },
@@ -46,8 +62,15 @@ const cases: GuardCase[] = [
       useUserMemoryStore.getState().useFetchExperiences({ page: 2, pageSize: 12 }),
     name: 'experiences',
     readList: () => useUserMemoryStore.getState().experiences,
+    readSearchError: () => useUserMemoryStore.getState().experiencesSearchError,
     readSearchLoading: () => useUserMemoryStore.getState().experiencesSearchLoading,
     resetWithSearch: () => useUserMemoryStore.getState().resetExperiencesList({ q: 'late night' }),
+    seedSettledSearch: () =>
+      useUserMemoryStore.setState({
+        experiences: [{ id: 'existing' } as never],
+        experiencesInit: true,
+        experiencesQuery: 'late night',
+      }),
     seedPageTwo: () =>
       useUserMemoryStore.setState({
         experiences: [{ id: 'existing' } as never],
@@ -61,8 +84,15 @@ const cases: GuardCase[] = [
       useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 }),
     name: 'preferences',
     readList: () => useUserMemoryStore.getState().preferences,
+    readSearchError: () => useUserMemoryStore.getState().preferencesSearchError,
     readSearchLoading: () => useUserMemoryStore.getState().preferencesSearchLoading,
     resetWithSearch: () => useUserMemoryStore.getState().resetPreferencesList({ q: 'late night' }),
+    seedSettledSearch: () =>
+      useUserMemoryStore.setState({
+        preferences: [{ id: 'existing' } as never],
+        preferencesInit: true,
+        preferencesQuery: 'late night',
+      }),
     seedPageTwo: () =>
       useUserMemoryStore.setState({
         preferences: [{ id: 'existing' } as never],
@@ -100,16 +130,30 @@ describe('memory list request guards', () => {
     const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
     onError(new Error('request failed'));
 
+    expect(testCase.readSearchError()).toBeUndefined();
     expect(testCase.readSearchLoading()).toBe(true);
   });
 
-  it.each(cases)('clears $name loading when the current request fails', (testCase) => {
+  it.each(cases)('preserves the current $name search error after loading settles', (testCase) => {
     testCase.resetWithSearch();
+    testCase.fetchCurrent();
+
+    const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
+    const error = new Error('request failed');
+    onError(error);
+
+    expect(testCase.readSearchError()).toBe(error);
+    expect(testCase.readSearchLoading()).toBe(false);
+  });
+
+  it.each(cases)('preserves settled $name content when a background refresh fails', (testCase) => {
+    testCase.seedSettledSearch();
     testCase.fetchCurrent();
 
     const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
     onError(new Error('request failed'));
 
-    expect(testCase.readSearchLoading()).toBe(false);
+    expect(testCase.readList()).toHaveLength(1);
+    expect(testCase.readSearchError()).toBeUndefined();
   });
 });

--- a/src/store/userMemory/slices/listRequestGuard.test.ts
+++ b/src/store/userMemory/slices/listRequestGuard.test.ts
@@ -20,7 +20,10 @@ const cases: GuardCase[] = [
     accept: (request) =>
       useUserMemoryStore
         .getState()
-        .internal_acceptActivitiesList({ items: [], total: 22 }, request),
+        .internal_acceptActivitiesList(
+          { items: [], page: request.page, pageSize: request.pageSize, total: 22 },
+          request,
+        ),
     fail: (error, request) =>
       useUserMemoryStore.getState().internal_failActivitiesList(error, request),
     name: 'activities',
@@ -60,7 +63,10 @@ const cases: GuardCase[] = [
     accept: (request) =>
       useUserMemoryStore
         .getState()
-        .internal_acceptExperiencesList({ items: [], total: 22 }, request),
+        .internal_acceptExperiencesList(
+          { items: [], page: request.page, pageSize: request.pageSize, total: 22 },
+          request,
+        ),
     fail: (error, request) =>
       useUserMemoryStore.getState().internal_failExperiencesList(error, request),
     name: 'experiences',

--- a/src/store/userMemory/slices/listRequestGuard.test.ts
+++ b/src/store/userMemory/slices/listRequestGuard.test.ts
@@ -7,6 +7,7 @@ import { initialState } from '@/store/userMemory/initialState';
 vi.mock('swr', () => ({ default: vi.fn(() => ({})) }));
 
 interface GuardCase {
+  fetchCurrent: () => unknown;
   fetchPageTwo: () => unknown;
   name: string;
   readList: () => unknown[];
@@ -17,6 +18,8 @@ interface GuardCase {
 
 const cases: GuardCase[] = [
   {
+    fetchCurrent: () =>
+      useUserMemoryStore.getState().useFetchActivities({ page: 1, pageSize: 12, q: 'late night' }),
     fetchPageTwo: () => useUserMemoryStore.getState().useFetchActivities({ page: 2, pageSize: 12 }),
     name: 'activities',
     readList: () => useUserMemoryStore.getState().activities,
@@ -26,6 +29,8 @@ const cases: GuardCase[] = [
       useUserMemoryStore.setState({ activities: [{ id: 'existing' } as never], activitiesPage: 2 }),
   },
   {
+    fetchCurrent: () =>
+      useUserMemoryStore.getState().useFetchContexts({ page: 1, pageSize: 12, q: 'late night' }),
     fetchPageTwo: () => useUserMemoryStore.getState().useFetchContexts({ page: 2, pageSize: 12 }),
     name: 'contexts',
     readList: () => useUserMemoryStore.getState().contexts,
@@ -35,6 +40,8 @@ const cases: GuardCase[] = [
       useUserMemoryStore.setState({ contexts: [{ id: 'existing' } as never], contextsPage: 2 }),
   },
   {
+    fetchCurrent: () =>
+      useUserMemoryStore.getState().useFetchExperiences({ page: 1, pageSize: 12, q: 'late night' }),
     fetchPageTwo: () =>
       useUserMemoryStore.getState().useFetchExperiences({ page: 2, pageSize: 12 }),
     name: 'experiences',
@@ -45,6 +52,21 @@ const cases: GuardCase[] = [
       useUserMemoryStore.setState({
         experiences: [{ id: 'existing' } as never],
         experiencesPage: 2,
+      }),
+  },
+  {
+    fetchCurrent: () =>
+      useUserMemoryStore.getState().useFetchPreferences({ page: 1, pageSize: 12, q: 'late night' }),
+    fetchPageTwo: () =>
+      useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 }),
+    name: 'preferences',
+    readList: () => useUserMemoryStore.getState().preferences,
+    readSearchLoading: () => useUserMemoryStore.getState().preferencesSearchLoading,
+    resetWithSearch: () => useUserMemoryStore.getState().resetPreferencesList({ q: 'late night' }),
+    seedPageTwo: () =>
+      useUserMemoryStore.setState({
+        preferences: [{ id: 'existing' } as never],
+        preferencesPage: 2,
       }),
   },
 ];
@@ -68,5 +90,26 @@ describe('memory list request guards', () => {
 
     expect(testCase.readList()).toEqual([]);
     expect(testCase.readSearchLoading()).toBe(true);
+  });
+
+  it.each(cases)('keeps $name loading when an obsolete request fails', (testCase) => {
+    testCase.seedPageTwo();
+    testCase.fetchPageTwo();
+
+    testCase.resetWithSearch();
+    const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
+    onError(new Error('request failed'));
+
+    expect(testCase.readSearchLoading()).toBe(true);
+  });
+
+  it.each(cases)('clears $name loading when the current request fails', (testCase) => {
+    testCase.resetWithSearch();
+    testCase.fetchCurrent();
+
+    const onError = vi.mocked(useSWR).mock.calls[0][2]?.onError as (error: Error) => void;
+    onError(new Error('request failed'));
+
+    expect(testCase.readSearchLoading()).toBe(false);
   });
 });

--- a/src/store/userMemory/slices/preference/action.test.ts
+++ b/src/store/userMemory/slices/preference/action.test.ts
@@ -1,21 +1,11 @@
-import useSWR from 'swr';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { useUserMemoryStore } from '@/store/userMemory';
 import { initialState } from '@/store/userMemory/initialState';
 
-vi.mock('swr', () => ({ default: vi.fn(() => ({})) }));
-
 const resultItem = (id: string) => ({ memory: { id }, preference: {} });
 
-const getOnSuccess = (call: number) =>
-  vi.mocked(useSWR).mock.calls[call][2]?.onSuccess as (data: {
-    items: ReturnType<typeof resultItem>[];
-    total: number;
-  }) => void;
-
 beforeEach(() => {
-  vi.clearAllMocks();
   useUserMemoryStore.setState(
     {
       ...initialState,
@@ -32,13 +22,19 @@ beforeEach(() => {
 
 describe('preference actions', () => {
   it('ignores a late response from the list state that preceded a search', () => {
-    useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 });
-
     useUserMemoryStore.getState().resetPreferencesList({ q: 'late night' });
-    useUserMemoryStore.getState().useFetchPreferences({ page: 1, pageSize: 12, q: 'late night' });
-
-    getOnSuccess(1)({ items: [resultItem('matching')], total: 1 });
-    getOnSuccess(0)({ items: [resultItem('stale')], total: 22 });
+    useUserMemoryStore
+      .getState()
+      .internal_acceptPreferencesList(
+        { items: [resultItem('matching')], total: 1 },
+        { page: 1, pageSize: 12, q: 'late night' },
+      );
+    useUserMemoryStore
+      .getState()
+      .internal_acceptPreferencesList(
+        { items: [resultItem('stale')], total: 22 },
+        { page: 2, pageSize: 12 },
+      );
 
     expect(useUserMemoryStore.getState()).toMatchObject({
       preferences: [{ id: 'matching' }],
@@ -48,10 +44,13 @@ describe('preference actions', () => {
   });
 
   it('accepts an earlier page when pagination advances before its response arrives', () => {
-    useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 });
     useUserMemoryStore.setState({ preferencesPage: 3 });
-
-    getOnSuccess(0)({ items: [resultItem('page-2')], total: 22 });
+    useUserMemoryStore
+      .getState()
+      .internal_acceptPreferencesList(
+        { items: [resultItem('page-2')], total: 22 },
+        { page: 2, pageSize: 12 },
+      );
 
     expect(useUserMemoryStore.getState().preferences).toEqual([
       { id: 'existing' },

--- a/src/store/userMemory/slices/preference/action.test.ts
+++ b/src/store/userMemory/slices/preference/action.test.ts
@@ -1,0 +1,61 @@
+import useSWR from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserMemoryStore } from '@/store/userMemory';
+import { initialState } from '@/store/userMemory/initialState';
+
+vi.mock('swr', () => ({ default: vi.fn(() => ({})) }));
+
+const resultItem = (id: string) => ({ memory: { id }, preference: {} });
+
+const getOnSuccess = (call: number) =>
+  vi.mocked(useSWR).mock.calls[call][2]?.onSuccess as (data: {
+    items: ReturnType<typeof resultItem>[];
+    total: number;
+  }) => void;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUserMemoryStore.setState(
+    {
+      ...initialState,
+      preferences: [{ id: 'existing' } as never],
+      preferencesInit: true,
+      preferencesPage: 2,
+      preferencesQuery: undefined,
+      preferencesSearchLoading: false,
+      preferencesTotal: 22,
+    },
+    false,
+  );
+});
+
+describe('preference actions', () => {
+  it('ignores a late response from the list state that preceded a search', () => {
+    useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 });
+
+    useUserMemoryStore.getState().resetPreferencesList({ q: 'late night' });
+    useUserMemoryStore.getState().useFetchPreferences({ page: 1, pageSize: 12, q: 'late night' });
+
+    getOnSuccess(1)({ items: [resultItem('matching')], total: 1 });
+    getOnSuccess(0)({ items: [resultItem('stale')], total: 22 });
+
+    expect(useUserMemoryStore.getState()).toMatchObject({
+      preferences: [{ id: 'matching' }],
+      preferencesSearchLoading: false,
+      preferencesTotal: 1,
+    });
+  });
+
+  it('accepts an earlier page when pagination advances before its response arrives', () => {
+    useUserMemoryStore.getState().useFetchPreferences({ page: 2, pageSize: 12 });
+    useUserMemoryStore.setState({ preferencesPage: 3 });
+
+    getOnSuccess(0)({ items: [resultItem('page-2')], total: 22 });
+
+    expect(useUserMemoryStore.getState().preferences).toEqual([
+      { id: 'existing' },
+      { id: 'page-2' },
+    ]);
+  });
+});

--- a/src/store/userMemory/slices/preference/action.ts
+++ b/src/store/userMemory/slices/preference/action.ts
@@ -89,6 +89,28 @@ export class PreferenceActionImpl {
         return result;
       },
       {
+        onError: () => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              {
+                page: state.preferencesPage,
+                q: state.preferencesQuery,
+                sort: state.preferencesSort,
+              },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
+          this.#set(
+            produce((draft) => {
+              draft.preferencesSearchLoading = false;
+            }),
+            false,
+            n('useFetchPreferences/onError'),
+          );
+        },
         onSuccess: (data: any) => {
           const state = this.#get();
           if (

--- a/src/store/userMemory/slices/preference/action.ts
+++ b/src/store/userMemory/slices/preference/action.ts
@@ -11,6 +11,7 @@ import { LayersEnum } from '@/types/userMemory';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
+import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
 
 const n = setNamespace('userMemory/preference');
 
@@ -89,14 +90,27 @@ export class PreferenceActionImpl {
       },
       {
         onSuccess: (data: any) => {
+          const state = this.#get();
+          if (
+            !isMemoryListRequestCurrent(
+              {
+                page: state.preferencesPage,
+                q: state.preferencesQuery,
+                sort: state.preferencesSort,
+              },
+              { page, q: params.q, sort: params.sort },
+            )
+          )
+            return;
+
           this.#set(
             produce((draft) => {
               draft.preferencesSearchLoading = false;
+              draft.preferencesTotal = data.total;
 
               // Set basic information
               if (!draft.preferencesInit) {
                 draft.preferencesInit = true;
-                draft.preferencesTotal = data.total;
               }
 
               // Transform data structure

--- a/src/store/userMemory/slices/preference/action.ts
+++ b/src/store/userMemory/slices/preference/action.ts
@@ -1,5 +1,6 @@
 import { uniqBy } from 'es-toolkit/compat';
 import { produce } from 'immer';
+import { useEffect } from 'react';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
@@ -22,6 +23,8 @@ export interface PreferenceQueryParams {
   q?: string;
   sort?: 'capturedAt' | 'scorePriority';
 }
+
+type PreferenceListRequest = PreferenceQueryParams & { page: number };
 
 type Setter = StoreSetter<UserMemoryStore>;
 export const createPreferenceSlice = (set: Setter, get: () => UserMemoryStore, _api?: unknown) =>
@@ -59,6 +62,78 @@ export class PreferenceActionImpl {
     }
   };
 
+  internal_acceptPreferencesList = (data: any, request: PreferenceListRequest): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        {
+          page: state.preferencesPage,
+          q: state.preferencesQuery,
+          sort: state.preferencesSort,
+        },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    this.#set(
+      produce((draft) => {
+        draft.preferencesSearchError = undefined;
+        draft.preferencesSearchLoading = false;
+        draft.preferencesTotal = data.total;
+
+        if (!draft.preferencesInit) {
+          draft.preferencesInit = true;
+        }
+
+        const transformedItems: DisplayPreferenceMemory[] = data.items.map((item: any) => ({
+          ...item.memory,
+          ...item.preference,
+        }));
+
+        if (request.page === 1) {
+          draft.preferences = uniqBy(transformedItems, 'id');
+        } else {
+          draft.preferences = uniqBy([...draft.preferences, ...transformedItems], 'id');
+        }
+
+        draft.preferencesHasMore = data.items.length >= (request.pageSize || 20);
+      }),
+      false,
+      n('internal_acceptPreferencesList'),
+    );
+  };
+
+  internal_failPreferencesList = (error: unknown, request: PreferenceListRequest): void => {
+    const state = this.#get();
+    if (
+      !isMemoryListRequestCurrent(
+        {
+          page: state.preferencesPage,
+          q: state.preferencesQuery,
+          sort: state.preferencesSort,
+        },
+        { page: request.page, q: request.q, sort: request.sort },
+      )
+    )
+      return;
+
+    const shouldSurfaceError = shouldSurfaceMemoryListError({
+      initialized: state.preferencesInit,
+      page: request.page,
+      resetting: state.preferencesSearchLoading,
+    });
+
+    this.#set(
+      produce((draft) => {
+        if (shouldSurfaceError) draft.preferencesSearchError = error;
+        draft.preferencesSearchLoading = false;
+      }),
+      false,
+      n('internal_failPreferencesList'),
+    );
+  };
+
   resetPreferencesList = (params?: Omit<PreferenceQueryParams, 'page' | 'pageSize'>): void => {
     this.#set(
       produce((draft) => {
@@ -74,10 +149,13 @@ export class PreferenceActionImpl {
     );
   };
 
+  /**
+   * Hydrate the store from SWR's rendered state because deduped cache hits do not invoke SWR's
+   * request lifecycle callbacks.
+   */
   useFetchPreferences = (params: PreferenceQueryParams): SWRResponse<any> => {
     const page = params.page ?? 1;
-
-    return useSWR(
+    const response = useSWR(
       userMemoryKeys.preferences(params),
       async () => {
         const result = await userMemoryService.queryMemories({
@@ -91,85 +169,21 @@ export class PreferenceActionImpl {
         return result;
       },
       {
-        onError: (error: unknown) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              {
-                page: state.preferencesPage,
-                q: state.preferencesQuery,
-                sort: state.preferencesSort,
-              },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          const shouldSurfaceError = shouldSurfaceMemoryListError({
-            initialized: state.preferencesInit,
-            page,
-            resetting: state.preferencesSearchLoading,
-          });
-
-          this.#set(
-            produce((draft) => {
-              if (shouldSurfaceError) draft.preferencesSearchError = error;
-              draft.preferencesSearchLoading = false;
-            }),
-            false,
-            n('useFetchPreferences/onError'),
-          );
-        },
-        onSuccess: (data: any) => {
-          const state = this.#get();
-          if (
-            !isMemoryListRequestCurrent(
-              {
-                page: state.preferencesPage,
-                q: state.preferencesQuery,
-                sort: state.preferencesSort,
-              },
-              { page, q: params.q, sort: params.sort },
-            )
-          )
-            return;
-
-          this.#set(
-            produce((draft) => {
-              draft.preferencesSearchError = undefined;
-              draft.preferencesSearchLoading = false;
-              draft.preferencesTotal = data.total;
-
-              // Set basic information
-              if (!draft.preferencesInit) {
-                draft.preferencesInit = true;
-              }
-
-              // Transform data structure
-              const transformedItems: DisplayPreferenceMemory[] = data.items.map((item: any) => ({
-                ...item.memory,
-                ...item.preference,
-              }));
-
-              // Accumulate data logic
-              if (page === 1) {
-                // First page, set directly
-                draft.preferences = uniqBy(transformedItems, 'id');
-              } else {
-                // Subsequent pages, accumulate data
-                draft.preferences = uniqBy([...draft.preferences, ...transformedItems], 'id');
-              }
-
-              // Update hasMore
-              draft.preferencesHasMore = data.items.length >= (params.pageSize || 20);
-            }),
-            false,
-            n('useFetchPreferences/onSuccess'),
-          );
-        },
         revalidateOnFocus: false,
       },
     );
+
+    useEffect(() => {
+      if (response.data !== undefined)
+        this.internal_acceptPreferencesList(response.data, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.data]);
+
+    useEffect(() => {
+      if (response.error !== undefined)
+        this.internal_failPreferencesList(response.error, { ...params, page });
+    }, [page, params.pageSize, params.q, params.sort, response.error]);
+
+    return response;
   };
 }
 

--- a/src/store/userMemory/slices/preference/action.ts
+++ b/src/store/userMemory/slices/preference/action.ts
@@ -12,6 +12,7 @@ import { setNamespace } from '@/utils/storeDebug';
 
 import { type UserMemoryStore } from '../../store';
 import { isMemoryListRequestCurrent } from '../utils/isMemoryListRequestCurrent';
+import { shouldSurfaceMemoryListError } from '../utils/shouldSurfaceMemoryListError';
 
 const n = setNamespace('userMemory/preference');
 
@@ -64,6 +65,7 @@ export class PreferenceActionImpl {
         draft.preferences = [];
         draft.preferencesPage = 1;
         draft.preferencesQuery = params?.q;
+        draft.preferencesSearchError = undefined;
         draft.preferencesSearchLoading = true;
         draft.preferencesSort = params?.sort;
       }),
@@ -89,7 +91,7 @@ export class PreferenceActionImpl {
         return result;
       },
       {
-        onError: () => {
+        onError: (error: unknown) => {
           const state = this.#get();
           if (
             !isMemoryListRequestCurrent(
@@ -103,8 +105,15 @@ export class PreferenceActionImpl {
           )
             return;
 
+          const shouldSurfaceError = shouldSurfaceMemoryListError({
+            initialized: state.preferencesInit,
+            page,
+            resetting: state.preferencesSearchLoading,
+          });
+
           this.#set(
             produce((draft) => {
+              if (shouldSurfaceError) draft.preferencesSearchError = error;
               draft.preferencesSearchLoading = false;
             }),
             false,
@@ -127,6 +136,7 @@ export class PreferenceActionImpl {
 
           this.#set(
             produce((draft) => {
+              draft.preferencesSearchError = undefined;
               draft.preferencesSearchLoading = false;
               draft.preferencesTotal = data.total;
 

--- a/src/store/userMemory/slices/preference/initialState.ts
+++ b/src/store/userMemory/slices/preference/initialState.ts
@@ -6,6 +6,7 @@ export interface PreferenceSliceState {
   preferencesInit: boolean;
   preferencesPage: number;
   preferencesQuery?: string;
+  preferencesSearchError?: unknown;
   preferencesSearchLoading?: boolean;
   preferencesSort?: 'capturedAt' | 'scorePriority';
   preferencesTotal: number;
@@ -17,6 +18,8 @@ export const preferenceInitialState: PreferenceSliceState = {
   preferencesInit: false,
   preferencesPage: 1,
   preferencesQuery: undefined,
+  preferencesSearchError: undefined,
+  preferencesSearchLoading: undefined,
   preferencesSort: undefined,
   preferencesTotal: 0,
 };

--- a/src/store/userMemory/slices/utils/isMemoryListRequestCurrent.test.ts
+++ b/src/store/userMemory/slices/utils/isMemoryListRequestCurrent.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMemoryListRequestCurrent } from './isMemoryListRequestCurrent';
+
+describe('isMemoryListRequestCurrent', () => {
+  it('rejects a page beyond the current page after a list reset', () => {
+    expect(
+      isMemoryListRequestCurrent(
+        { page: 1, q: 'late night', sort: undefined },
+        { page: 2, q: 'late night', sort: undefined },
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts an earlier page when pagination advances before its response arrives', () => {
+    expect(
+      isMemoryListRequestCurrent(
+        { page: 3, q: 'late night', sort: undefined },
+        { page: 2, q: 'late night', sort: undefined },
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects responses from an earlier search or sort', () => {
+    expect(
+      isMemoryListRequestCurrent(
+        { page: 1, q: 'late night', sort: 'scorePriority' },
+        { page: 1, q: undefined, sort: undefined },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/store/userMemory/slices/utils/isMemoryListRequestCurrent.ts
+++ b/src/store/userMemory/slices/utils/isMemoryListRequestCurrent.ts
@@ -1,0 +1,14 @@
+interface MemoryListRequest {
+  page: number;
+  q?: string;
+  sort?: string;
+}
+
+/**
+ * Reject responses from a list state that was replaced by a search, sort, or pagination reset.
+ * Earlier pages remain valid after pagination advances, so only pages beyond the current one are stale.
+ */
+export const isMemoryListRequestCurrent = (
+  current: MemoryListRequest,
+  request: MemoryListRequest,
+) => current.page >= request.page && current.q === request.q && current.sort === request.sort;

--- a/src/store/userMemory/slices/utils/shouldSurfaceMemoryListError.ts
+++ b/src/store/userMemory/slices/utils/shouldSurfaceMemoryListError.ts
@@ -1,0 +1,15 @@
+interface MemoryListErrorContext {
+  initialized: boolean;
+  page: number;
+  resetting?: boolean;
+}
+
+/**
+ * Only replace a list with an error when its first page has no current content. Background
+ * refresh and pagination failures must keep already-settled content visible.
+ */
+export const shouldSurfaceMemoryListError = ({
+  initialized,
+  page,
+  resetting,
+}: MemoryListErrorContext) => page === 1 && (Boolean(resetting) || !initialized);


### PR DESCRIPTION
Fixes memory timeline searches that could keep stale paginated results when the backend default sort was active.

## What changed

- Reset memory list pagination whenever the search query or effective sort changes, including the default sort.
- Ignore late responses from superseded list states across activities, contexts, experiences, and preferences.
- Preserve active search failures and render an error state with Retry instead of a misleading empty result or permanent loading state.
- Keep settled list content visible when a background refresh fails and while later pages load.
- Refresh the preference result count after searches.
- Keep shared memory behavior under `src/features/Memory` and route segments focused on page composition.
- Add regression coverage for timeline search resets, view-mode sort behavior, stale responses, request failures, background refresh failures, pagination loading, and valid out-of-order pagination responses.

## Key Decisions / Non-goals

- Earlier pages from the active query remain valid after pagination advances; only responses from a replaced query, sort, or reset page state are discarded.
- Full-surface loading is limited to initial loads, list resets, and error retries; later pages use incremental list loading without replacing settled rows.
- This PR does not change backend search matching or ranking behavior.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- `bun run check <changed files> --lint --test --type` (types clean)
- `rtk vitest run src/store/userMemory/slices/listRequestGuard.test.ts` (16 passed)
- `rtk vitest run src/features/Memory/isMemoryListPending.test.ts` (5 passed)