### PR TITLE
feat(model-bank): add deepseek-v4-flash-vision-exp with vision capability (#18813)

### DIFF
--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -60,6 +60,36 @@ const deepseekChatModels: AIChatModelCard[] = [
     },
     type: 'chat',
   },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576,
+    description:
+      'DeepSeek V4 Flash Vision Exp extends DeepSeek V4 Flash with native visual input understanding, multimodal hybrid reasoning, and a 1M context window.',
+    displayName: 'DeepSeek V4 Flash Vision Exp',
+    enabled: true,
+    family: 'deepseek',
+    generation: 'deepseek-v4',
+    id: 'deepseek-v4-flash-vision-exp',
+    maxOutput: 393_216,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.05, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-08-25',
+    settings: {
+      extendParams: ['deepseekV4GAReasoningEffort'],
+    },
+    type: 'chat',
+  },
 ];
 
 export const allModels = [...deepseekChatModels];


### PR DESCRIPTION
Fixes #18813

## Summary
Adds the model card for deepseek-v4-flash-vision-exp to packages/model-bank/src/aiModels/deepseek.ts.

Previously, deepseek-v4-flash-vision-exp had no entry in model-bank, causing isCanUseVision to resolve ision=false during runtime context resolution and stripping image blocks from user prompts.

## Changes Made
- Registered deepseek-v4-flash-vision-exp with native bilities.vision: true.
- Included standard amily: 'deepseek' and generation: 'deepseek-v4' metadata.
- Configured 1,048,576 context tokens, max output limits, and deepseekV4GAReasoningEffort extended parameter.