### PR TITLE
✨ feat(agent-documents): support parent folder on create

### DIFF
--- a/apps/server/src/routers/lambda/agentDocument.ts
+++ b/apps/server/src/routers/lambda/agentDocument.ts
@@ -981,6 +981,7 @@ export const agentDocumentRouter = router({
           agentId: z.string(),
           content: z.string(),
           hintIsSkill: z.boolean().optional(),
+          parentId: z.string().optional(),
           title: z.string(),
         })
         .and(agentDocumentToolTriggerSchema),
@@ -993,6 +994,7 @@ export const agentDocumentRouter = router({
           input.content,
           {
             hintIsSkill: input.hintIsSkill,
+            parentId: input.parentId,
           },
         );
 
@@ -1037,6 +1039,7 @@ export const agentDocumentRouter = router({
           agentId: z.string(),
           content: z.string(),
           hintIsSkill: z.boolean().optional(),
+          parentId: z.string().optional(),
           title: z.string(),
           topicId: z.string(),
         })
@@ -1051,7 +1054,7 @@ export const agentDocumentRouter = router({
           title,
           input.content,
           input.topicId,
-          { hintIsSkill: input.hintIsSkill },
+          { hintIsSkill: input.hintIsSkill, parentId: input.parentId },
         );
 
         if (input.trigger === 'tool') {

--- a/apps/server/src/services/agentDocuments/index.test.ts
+++ b/apps/server/src/services/agentDocuments/index.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { AGENT_DOCUMENT_FILE_TYPE } from '@lobechat/const';
+import { DOCUMENT_FOLDER_TYPE } from '@lobechat/database/schemas';
 import { createHeadlessEditor } from '@lobehub/editor/headless';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -143,7 +144,7 @@ describe('AgentDocumentsService', () => {
 
   describe('createDocument', () => {
     it('should append a numeric suffix when the base filename already exists', async () => {
-      mockModel.findByFilename
+      mockModel.findByParentAndFilename
         .mockResolvedValueOnce({ id: 'existing-doc' })
         .mockResolvedValueOnce(undefined);
       mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'note-2' });
@@ -151,8 +152,13 @@ describe('AgentDocumentsService', () => {
       const service = new AgentDocumentsService(db, userId);
       const result = await service.createDocument('agent-1', 'note', 'content');
 
-      expect(mockModel.findByFilename).toHaveBeenNthCalledWith(1, 'agent-1', 'note');
-      expect(mockModel.findByFilename).toHaveBeenNthCalledWith(2, 'agent-1', 'note-2');
+      expect(mockModel.findByParentAndFilename).toHaveBeenNthCalledWith(1, 'agent-1', null, 'note');
+      expect(mockModel.findByParentAndFilename).toHaveBeenNthCalledWith(
+        2,
+        'agent-1',
+        null,
+        'note-2',
+      );
       expect(mockModel.create).toHaveBeenCalledWith('agent-1', 'note-2', 'content', {
         editorData: { root: { children: [] } },
         title: 'note',
@@ -161,13 +167,13 @@ describe('AgentDocumentsService', () => {
     });
 
     it('should preserve an explicit filename extension', async () => {
-      mockModel.findByFilename.mockResolvedValueOnce(undefined);
+      mockModel.findByParentAndFilename.mockResolvedValueOnce(undefined);
       mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'notes.txt' });
 
       const service = new AgentDocumentsService(db, userId);
       await service.createDocument('agent-1', 'notes.txt', 'content');
 
-      expect(mockModel.findByFilename).toHaveBeenCalledWith('agent-1', 'notes.txt');
+      expect(mockModel.findByParentAndFilename).toHaveBeenCalledWith('agent-1', null, 'notes.txt');
       expect(mockModel.create).toHaveBeenCalledWith('agent-1', 'notes.txt', 'content', {
         editorData: { root: { children: [] } },
         title: 'notes.txt',
@@ -175,7 +181,7 @@ describe('AgentDocumentsService', () => {
     });
 
     it('should append collision suffix before the filename extension', async () => {
-      mockModel.findByFilename
+      mockModel.findByParentAndFilename
         .mockResolvedValueOnce({ id: 'existing-doc' })
         .mockResolvedValueOnce(undefined);
       mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'Untitled document-2.md' });
@@ -183,14 +189,16 @@ describe('AgentDocumentsService', () => {
       const service = new AgentDocumentsService(db, userId);
       const result = await service.createDocument('agent-1', 'Untitled document.md', 'content');
 
-      expect(mockModel.findByFilename).toHaveBeenNthCalledWith(
+      expect(mockModel.findByParentAndFilename).toHaveBeenNthCalledWith(
         1,
         'agent-1',
+        null,
         'Untitled document.md',
       );
-      expect(mockModel.findByFilename).toHaveBeenNthCalledWith(
+      expect(mockModel.findByParentAndFilename).toHaveBeenNthCalledWith(
         2,
         'agent-1',
+        null,
         'Untitled document-2.md',
       );
       expect(mockModel.create).toHaveBeenCalledWith(
@@ -206,7 +214,7 @@ describe('AgentDocumentsService', () => {
     });
 
     it('should throw after too many filename collisions', async () => {
-      mockModel.findByFilename.mockResolvedValue({ id: 'existing-doc' });
+      mockModel.findByParentAndFilename.mockResolvedValue({ id: 'existing-doc' });
 
       const service = new AgentDocumentsService(db, userId);
 
@@ -221,7 +229,7 @@ describe('AgentDocumentsService', () => {
         content: 'body',
         title: 'My Title',
       });
-      mockModel.findByFilename.mockResolvedValue(undefined);
+      mockModel.findByParentAndFilename.mockResolvedValue(undefined);
       mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'My Title' });
 
       const service = new AgentDocumentsService(db, userId);
@@ -235,7 +243,7 @@ describe('AgentDocumentsService', () => {
     });
 
     it('persists agent signal skill hints in document metadata', async () => {
-      mockModel.findByFilename.mockResolvedValue(undefined);
+      mockModel.findByParentAndFilename.mockResolvedValue(undefined);
       mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'Reusable Procedure' });
 
       const service = new AgentDocumentsService(db, userId);
@@ -257,11 +265,52 @@ describe('AgentDocumentsService', () => {
         }),
       );
     });
+
+    it('creates a document under a parent folder and scopes filename collisions to it', async () => {
+      mockModel.findByDocumentId.mockResolvedValue({
+        documentId: 'folder-doc-id',
+        fileType: DOCUMENT_FOLDER_TYPE,
+        id: 'folder-agent-doc-id',
+      });
+      mockModel.findByParentAndFilename.mockResolvedValue(undefined);
+      mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'note' });
+
+      const service = new AgentDocumentsService(db, userId);
+      await service.createDocument('agent-1', 'note', 'content', {
+        parentId: 'folder-doc-id',
+      });
+
+      expect(mockModel.findByParentAndFilename).toHaveBeenCalledWith(
+        'agent-1',
+        'folder-doc-id',
+        'note',
+      );
+      expect(mockModel.create).toHaveBeenCalledWith('agent-1', 'note', 'content', {
+        editorData: { root: { children: [] } },
+        parentId: 'folder-doc-id',
+        title: 'note',
+      });
+    });
+
+    it('rejects a parentId that does not identify an agent folder', async () => {
+      mockModel.findByDocumentId.mockResolvedValue({
+        documentId: 'file-doc-id',
+        fileType: 'text/markdown',
+        id: 'file-agent-doc-id',
+      });
+
+      const service = new AgentDocumentsService(db, userId);
+
+      await expect(
+        service.createDocument('agent-1', 'note', 'content', { parentId: 'file-doc-id' }),
+      ).rejects.toThrow('Parent document is not a folder: file-doc-id');
+      expect(mockModel.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('createForTopic', () => {
     it('should create an agent document and associate the underlying document with the topic', async () => {
-      mockModel.findByFilename.mockResolvedValue(undefined);
+      mockModel.findByParentAndFilename.mockResolvedValue(undefined);
       mockModel.create.mockResolvedValue({
         documentId: 'documents-1',
         filename: 'note',

--- a/apps/server/src/services/agentDocuments/index.ts
+++ b/apps/server/src/services/agentDocuments/index.ts
@@ -65,6 +65,7 @@ interface UpsertDocumentParams {
 
 interface CreateAgentDocumentOptions {
   hintIsSkill?: boolean;
+  parentId?: string;
 }
 
 type AgentDocumentWithLiteXML = AgentDocument & { litexml?: string };
@@ -236,6 +237,7 @@ export class AgentDocumentsService {
       loadPosition?: DocumentLoadPosition;
       loadRules?: DocumentLoadRules;
       metadata?: Record<string, unknown>;
+      parentId?: string;
       policy?: AgentDocumentPolicy;
       templateId?: string;
     },
@@ -245,7 +247,13 @@ export class AgentDocumentsService {
     let filename = baseFilename;
     let suffix = 2;
 
-    while (await this.agentDocumentModel.findByFilename(agentId, filename)) {
+    while (
+      await this.agentDocumentModel.findByParentAndFilename(
+        agentId,
+        params?.parentId ?? null,
+        filename,
+      )
+    ) {
       if (suffix > MAX_UNIQUE_FILENAME_ATTEMPTS) {
         throw new Error(
           `Unable to generate a unique filename for "${title}" after ${MAX_UNIQUE_FILENAME_ATTEMPTS} attempts.`,
@@ -516,6 +524,14 @@ export class AgentDocumentsService {
     content: string,
     options: CreateAgentDocumentOptions = {},
   ) {
+    if (options.parentId) {
+      const parent = await this.agentDocumentModel.findByDocumentId(agentId, options.parentId);
+      if (!parent) throw new Error(`Parent folder not found: ${options.parentId}`);
+      if (parent.fileType !== DOCUMENT_FOLDER_TYPE) {
+        throw new Error(`Parent document is not a folder: ${options.parentId}`);
+      }
+    }
+
     const { title: extractedTitle, content: strippedContent } = extractMarkdownH1Title(content);
     const finalTitle = extractedTitle || title;
     const metadata = options.hintIsSkill
@@ -527,12 +543,10 @@ export class AgentDocumentsService {
         }
       : undefined;
 
-    return this.createWithUniqueFilename(
-      agentId,
-      finalTitle,
-      strippedContent,
-      metadata ? { metadata } : undefined,
-    );
+    return this.createWithUniqueFilename(agentId, finalTitle, strippedContent, {
+      ...(metadata ? { metadata } : {}),
+      ...(options.parentId ? { parentId: options.parentId } : {}),
+    });
   }
 
   async createForTopic(

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
@@ -341,6 +341,29 @@ describe('AgentDocumentsExecutionRuntime.createDocument', () => {
     });
   });
 
+  it('forwards parentId when creating a document in a folder', async () => {
+    const stub = makeStub();
+    stub.createDocument.mockResolvedValue({
+      documentId: 'documents-row-id',
+      filename: 'daily-brief',
+      id: 'agent-doc-assoc-id',
+      title: 'Daily Brief',
+    });
+
+    const runtime = new AgentDocumentsExecutionRuntime(stub);
+    await runtime.createDocument(
+      { content: 'body', parentId: 'folder-doc-id', title: 'Daily Brief' },
+      { agentId: 'agent-1' },
+    );
+
+    expect(stub.createDocument).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      content: 'body',
+      parentId: 'folder-doc-id',
+      title: 'Daily Brief',
+    });
+  });
+
   it('includes a document URL when a URL builder is configured', async () => {
     const stub = makeStub();
     stub.createDocument.mockResolvedValue({

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentDocuments.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentDocuments.ts
@@ -146,7 +146,7 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
           );
           return doc;
         },
-        createDocument: async ({ agentId, content, hintIsSkill, title }) => {
+        createDocument: async ({ agentId, content, hintIsSkill, parentId, title }) => {
           const doc = await pinToTask(
             await withDocumentOutcome(
               {
@@ -158,12 +158,19 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
                 summary: 'Agent documents created a document.',
                 toolAction: 'create',
               },
-              () => service.createDocument(agentId, title, content, { hintIsSkill }),
+              () => service.createDocument(agentId, title, content, { hintIsSkill, parentId }),
             ),
           );
           return doc;
         },
-        createTopicDocument: async ({ agentId, content, hintIsSkill, title, topicId }) => {
+        createTopicDocument: async ({
+          agentId,
+          content,
+          hintIsSkill,
+          parentId,
+          title,
+          topicId,
+        }) => {
           const doc = await pinToTask(
             await withDocumentOutcome(
               {
@@ -175,7 +182,11 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
                 summary: 'Agent documents created a topic document.',
                 toolAction: 'create',
               },
-              () => service.createForTopic(agentId, title, content, topicId, { hintIsSkill }),
+              () =>
+                service.createForTopic(agentId, title, content, topicId, {
+                  hintIsSkill,
+                  parentId,
+                }),
             ),
           );
           return doc;

--- a/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.test.ts
@@ -31,6 +31,7 @@ describe('AgentDocumentsExecutionRuntime', () => {
       {
         content: 'steps',
         hintIsSkill: true,
+        parentId: 'folder-doc-1',
         title: 'Reusable Procedure',
       },
       { agentId: 'agent-1' },
@@ -40,6 +41,7 @@ describe('AgentDocumentsExecutionRuntime', () => {
       agentId: 'agent-1',
       content: 'steps',
       hintIsSkill: true,
+      parentId: 'folder-doc-1',
       title: 'Reusable Procedure',
     });
     expect(result.state).toMatchObject({

--- a/packages/builtin-tool-agent-documents/src/manifest.ts
+++ b/packages/builtin-tool-agent-documents/src/manifest.ts
@@ -24,6 +24,11 @@ export const AgentDocumentsManifest: BuiltinToolManifest = {
               'Set true only when the document captures reusable procedural knowledge or durable agent behavior.',
             type: 'boolean',
           },
+          parentId: {
+            description:
+              'Parent folder document ID. Use the "documentId" field returned for a folder by listDocuments. Omit to create at the root.',
+            type: 'string',
+          },
           scope: {
             default: 'agent',
             description:

--- a/packages/builtin-tool-agent-documents/src/systemRole.ts
+++ b/packages/builtin-tool-agent-documents/src/systemRole.ts
@@ -21,7 +21,7 @@ export const systemPrompt = `You have access to an Agent Documents tool for crea
 
 <tool_selection_guidelines>
 - By default, if the user does not explicitly specify otherwise, and the relevant Agent Documents tool is available for the task, prefer Agent Documents over Cloud Sandbox because it is easier for collaboration and multi-agent coordination.
-- **createDocument**: create a new document with title + content. Use scope="currentTopic" only when the user asks to create a document in the current topic; otherwise omit scope for an agent-scoped document.
+- **createDocument**: create a new document with title + content. To create it inside a folder, pass that folder's \`documentId\` from listDocuments as \`parentId\`; omit parentId to create at the root. Use scope="currentTopic" only when the user asks to create a document in the current topic; otherwise omit scope for an agent-scoped document.
 - Set hintIsSkill=true only when creating a document that contains reusable procedural knowledge, workflow instructions, tool usage guidance, or durable agent behavior. Leave ordinary notes unhinted.
 - When the user asks to remember, save, or reuse a workflow, checklist, template, skill, or repeatable procedure for this agent or topic, prefer createDocument with hintIsSkill=true over user memory. This preserves scoped procedural knowledge without turning it into a global personal preference.
 - Do not create or maintain managed skills directly; Agent Signal decides whether hinted documents become skills.

--- a/packages/builtin-tool-agent-documents/src/types.ts
+++ b/packages/builtin-tool-agent-documents/src/types.ts
@@ -15,6 +15,8 @@ export const AgentDocumentsApiName = {
 export interface CreateDocumentArgs {
   content: string;
   hintIsSkill?: boolean;
+  /** Parent folder's underlying `documents.id`, as returned by listDocuments.documentId. */
+  parentId?: string;
   scope?: 'agent' | 'currentTopic';
   title: string;
 }

--- a/src/services/agentDocument.ts
+++ b/src/services/agentDocument.ts
@@ -96,6 +96,7 @@ class AgentDocumentService {
       agentId: string;
       content: string;
       hintIsSkill?: boolean;
+      parentId?: string;
       title: string;
     } & AgentDocumentToolTriggerInput,
   ) => {
@@ -115,6 +116,7 @@ class AgentDocumentService {
       agentId: string;
       content: string;
       hintIsSkill?: boolean;
+      parentId?: string;
       title: string;
       topicId: string;
     } & AgentDocumentToolTriggerInput,

--- a/src/store/tool/slices/builtin/executors/__tests__/lobe-agent-documents.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/lobe-agent-documents.test.ts
@@ -77,6 +77,7 @@ describe('agentDocumentsExecutor', () => {
       'createDocument',
       {
         content: 'Body',
+        parentId: 'folder-document-1',
         title: 'Test Document',
       },
       createContext(),
@@ -87,6 +88,7 @@ describe('agentDocumentsExecutor', () => {
       expect.objectContaining({
         agentId: 'agent-1',
         content: 'Body',
+        parentId: 'folder-document-1',
         title: 'Test Document',
         toolContext: expect.objectContaining({
           messageId: 'user-message-1',

--- a/src/store/tool/slices/builtin/executors/lobe-agent-documents.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-agent-documents.ts
@@ -102,11 +102,20 @@ const runtime = new AgentDocumentsExecutionRuntime(
       });
       return doc;
     },
-    createDocument: async ({ agentId, content, hintIsSkill, title, toolContext, trigger }) => {
+    createDocument: async ({
+      agentId,
+      content,
+      hintIsSkill,
+      parentId,
+      title,
+      toolContext,
+      trigger,
+    }) => {
       const doc = await agentDocumentService.createDocument({
         agentId,
         content,
         hintIsSkill,
+        parentId,
         title,
         toolContext,
         trigger,
@@ -126,6 +135,7 @@ const runtime = new AgentDocumentsExecutionRuntime(
       agentId,
       content,
       hintIsSkill,
+      parentId,
       title,
       toolContext,
       topicId,
@@ -135,6 +145,7 @@ const runtime = new AgentDocumentsExecutionRuntime(
         agentId,
         content,
         hintIsSkill,
+        parentId,
         title,
         toolContext,
         topicId,


### PR DESCRIPTION
## Summary

- add optional `parentId` to the agent documents `createDocument` tool
- forward the parent folder through client and server execution paths, including current-topic documents
- validate that the parent belongs to the current agent and is a folder
- scope filename collision handling to siblings under the same parent
- document that `parentId` uses the folder `documentId` returned by `listDocuments`

## Test plan

- `bun run check <changed files>` — 86 related tests passed
- `bun run check --type` — types clean
- `git diff --check`