### PR TITLE
🐛 fix(search): harden sync acknowledgements and trace export

### DIFF
--- a/packages/database/src/repositories/ftsSearchSyncOutbox/__tests__/index.test.ts
+++ b/packages/database/src/repositories/ftsSearchSyncOutbox/__tests__/index.test.ts
@@ -593,6 +593,58 @@ describe.sequential('FtsSearchSyncOutboxRepository', () => {
     await expect(repository.stats()).resolves.toMatchObject({ pending: 0, ready: 0 });
   });
 
+  it('retries an acknowledgement after PostgreSQL aborts it with a deadlock', async () => {
+    const work = {
+      documentId: 'deadlocked-agent',
+      entity: 'agents' as const,
+      leaseToken: '123.456',
+      revision: 7,
+    };
+    const deadlock = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed query', { cause: deadlock }))
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            document_id: work.documentId,
+            entity: work.entity,
+            lease_token: work.leaseToken,
+            revision: work.revision,
+          },
+        ],
+      });
+    const database = {
+      execute,
+      transaction: vi.fn(),
+    } as unknown as ConstructorParameters<typeof FtsSearchSyncOutboxRepository>[0];
+    const deadlockRepository = new FtsSearchSyncOutboxRepository(database);
+
+    await expect(deadlockRepository.acknowledgeMany([work])).resolves.toEqual([work]);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry acknowledgement failures that are not PostgreSQL deadlocks', async () => {
+    const execute = vi.fn().mockRejectedValue(new Error('connection unavailable'));
+    const database = {
+      execute,
+      transaction: vi.fn(),
+    } as unknown as ConstructorParameters<typeof FtsSearchSyncOutboxRepository>[0];
+    const failingRepository = new FtsSearchSyncOutboxRepository(database);
+
+    await expect(
+      failingRepository.acknowledgeMany([
+        {
+          documentId: 'failed-agent',
+          entity: 'agents',
+          leaseToken: '456.789',
+          revision: 8,
+        },
+      ]),
+    ).rejects.toThrow('connection unavailable');
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
   it('keeps concurrent claims disjoint and marks permanent failures dead', async () => {
     await db.insert(agents).values([
       { id: 'claim-agent-a', title: 'a', userId: USER_ID },

--- a/packages/database/src/repositories/ftsSearchSyncOutbox/index.ts
+++ b/packages/database/src/repositories/ftsSearchSyncOutbox/index.ts
@@ -45,6 +45,10 @@ export interface FtsSearchSyncOutboxStats extends FtsSearchSyncOutboxEntityStats
 /** Approximately one day of durable retries when the exponential delay is capped at one hour. */
 export const FTS_SEARCH_SYNC_MAX_ATTEMPTS = 36;
 
+const ACKNOWLEDGEMENT_DEADLOCK_MAX_ATTEMPTS = 3;
+const ACKNOWLEDGEMENT_DEADLOCK_RETRY_BASE_DELAY_MS = 10;
+const POSTGRES_DEADLOCK_DETECTED = '40P01';
+
 const FTS_SEARCH_SYNC_CAPTURE_SOURCE_TABLE_IDENTIFIERS = sql.join(
   [...new Set(FTS_SEARCH_SYNC_CAPTURE_TRIGGER_TARGETS.map(({ table }) => table))].map(
     (table) => sql`${sql.identifier('public')}.${sql.identifier(table)}`,
@@ -241,6 +245,26 @@ const toWork = (row: FtsSearchSyncRow): FtsSearchSyncWork => ({
 const errorMessage = (error: unknown) =>
   (error instanceof Error ? error.message : String(error)).slice(0, 2000);
 
+const postgresErrorCode = (error: unknown): string | undefined => {
+  let current = error;
+
+  for (let depth = 0; depth < 5 && current && typeof current === 'object'; depth++) {
+    const code = (current as Record<string, unknown>).code;
+    if (typeof code === 'string') return code;
+
+    current = (current as { cause?: unknown }).cause;
+  }
+};
+
+const waitForAcknowledgementDeadlockRetry = async (attempt: number): Promise<void> => {
+  const jitter = Math.floor(Math.random() * ACKNOWLEDGEMENT_DEADLOCK_RETRY_BASE_DELAY_MS);
+  const delay = ACKNOWLEDGEMENT_DEADLOCK_RETRY_BASE_DELAY_MS * attempt + jitter;
+
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, delay);
+  });
+};
+
 const revisionNumber = (value: number | string | undefined, operation: string, minimum = 0) => {
   const revision = Number(value);
   if (!Number.isSafeInteger(revision) || revision < minimum) {
@@ -385,7 +409,7 @@ export class FtsSearchSyncOutboxRepository {
       ),
       sql`, `,
     );
-    const result = await this.db.execute(sql`
+    const statement = sql`
       WITH acknowledged(entity, document_id, revision, lease_token) AS (
         VALUES ${values}
       )
@@ -397,9 +421,38 @@ export class FtsSearchSyncOutboxRepository {
         AND EXTRACT(EPOCH FROM outbox.locked_until) = acknowledged.lease_token
       RETURNING outbox.entity, outbox.document_id, outbox.revision,
                 EXTRACT(EPOCH FROM outbox.locked_until)::text AS lease_token
-    `);
+    `;
 
-    return rowsOf<FtsSearchSyncRow>(result).map(toWork);
+    let attempt = 1;
+    while (true) {
+      try {
+        const result = await this.db.execute(statement);
+        return rowsOf<FtsSearchSyncRow>(result).map(toWork);
+      } catch (error) {
+        if (
+          postgresErrorCode(error) !== POSTGRES_DEADLOCK_DETECTED ||
+          attempt === ACKNOWLEDGEMENT_DEADLOCK_MAX_ATTEMPTS
+        ) {
+          throw error;
+        }
+
+        /**
+         * `acknowledgeMany` is one autocommit statement, so PostgreSQL has already rolled the
+         * deadlocked transaction back. The revision and lease-token fences make retrying the exact
+         * DELETE safe even when a newer capture committed while this worker was waiting.
+         */
+        console.warn(
+          '[fts-search-sync] Retrying outbox acknowledgement after PostgreSQL deadlock',
+          {
+            attempt,
+            maxAttempts: ACKNOWLEDGEMENT_DEADLOCK_MAX_ATTEMPTS,
+            workCount: works.length,
+          },
+        );
+        await waitForAcknowledgementDeadlockRetry(attempt);
+        attempt += 1;
+      }
+    }
   }
 
   /** Keeps PostgreSQL's microsecond precision in the token instead of truncating through JS Date. */

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -26,6 +26,7 @@
     "@opentelemetry/resources": "^2.8.0",
     "@opentelemetry/sdk-metrics": "^2.8.0",
     "@opentelemetry/sdk-node": "^0.217.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@opentelemetry/sdk-trace-node": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@vercel/otel": "^2.1.3"

--- a/packages/observability-otel/src/node.test.ts
+++ b/packages/observability-otel/src/node.test.ts
@@ -55,6 +55,28 @@ describe('Node observability resource attributes', () => {
     });
   });
 
+  it('registers Sentry and OTLP processors on one tracer provider', () => {
+    const contextManager = { name: 'sentry-context-manager' };
+    const sampler = { name: 'sentry-sampler' };
+    const sentrySpanProcessor = { name: 'sentry-span-processor' };
+    const textMapPropagator = { name: 'sentry-propagator' };
+
+    register({
+      contextManager,
+      sampler,
+      spanProcessors: [sentrySpanProcessor],
+      textMapPropagator,
+    } as Parameters<typeof register>[0]);
+
+    expect(mocks.nodeSdkOptions).toMatchObject({
+      contextManager,
+      sampler,
+      textMapPropagator,
+    });
+    expect(mocks.nodeSdkOptions?.traceExporter).toBeUndefined();
+    expect(mocks.nodeSdkOptions?.spanProcessors).toEqual([sentrySpanProcessor, expect.any(Object)]);
+  });
+
   it('does not expose telemetry shutdown failures to the caller', async () => {
     const shutdown = vi.fn().mockRejectedValue(new Error('collector unavailable'));
 

--- a/packages/observability-otel/src/node.ts
+++ b/packages/observability-otel/src/node.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { env } from 'node:process';
 
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
@@ -11,6 +12,8 @@ import type { DetectedResourceAttributes } from '@opentelemetry/resources';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { AggregationType, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import type { Sampler, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 /**
@@ -100,9 +103,10 @@ function debugLogLevelFromString(level?: string | null): DiagLogLevel | undefine
   }
 }
 
-export function register(options?: {
+export interface RegisterOptions {
   autoDetectResources?: boolean;
   autoInstrumentations?: boolean;
+  contextManager?: ContextManager;
   debug?: true | DiagLogLevel;
   environment?: string;
   histogramViews?: {
@@ -111,8 +115,13 @@ export function register(options?: {
     meterName?: string;
   }[];
   name?: string;
+  sampler?: Sampler;
+  spanProcessors?: SpanProcessor[];
+  textMapPropagator?: TextMapPropagator;
   version?: string;
-}) {
+}
+
+export function register(options?: RegisterOptions) {
   const attributes = attributesCommon();
 
   if (typeof options?.environment !== 'undefined') {
@@ -143,6 +152,7 @@ export function register(options?: {
 
   const sdk = new NodeSDK({
     autoDetectResources: options?.autoDetectResources,
+    contextManager: options?.contextManager,
     instrumentations:
       options?.autoInstrumentations === false
         ? []
@@ -154,7 +164,12 @@ export function register(options?: {
       }),
     ],
     resource: resourceFromAttributes(attributes),
-    traceExporter: new OTLPTraceExporter(),
+    sampler: options?.sampler,
+    spanProcessors: [
+      ...(options?.spanProcessors ?? []),
+      new BatchSpanProcessor(new OTLPTraceExporter()),
+    ],
+    textMapPropagator: options?.textMapPropagator,
     views: options?.histogramViews?.map(({ boundaries, instrumentName, meterName }) => ({
       aggregation: {
         options: { boundaries: [...boundaries] },


### PR DESCRIPTION
This change hardens full-text search sync acknowledgements and allows one OpenTelemetry provider to export traces to multiple backends.

- Retry PostgreSQL `40P01` deadlocks during fenced outbox acknowledgements, with three bounded attempts and short jitter.
- Keep non-deadlock failures visible without retrying them.
- Let observability callers provide a context manager, sampler, propagator, and span processors while always attaching the OTLP batch exporter.

#### Key Decisions / Non-goals

- The acknowledgement retry remains one autocommit statement and preserves the existing revision and lease-token fences.
- This does not change schemas, search behavior, or provider selection.
- The observability options are generic and preserve existing callers' default behavior.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check` for the affected Cloud and submodule files: 47 tests passed.
- `bun run check --type`: passed.

#### 🔗 Related Issue

N/A