### PR TITLE
🐛 fix(home): hide dates on historical brief items

### DIFF
--- a/src/features/HomeInbox/NewsList.tsx
+++ b/src/features/HomeInbox/NewsList.tsx
@@ -73,6 +73,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 interface NewsItemProps {
   bare?: boolean;
   brief: BriefItem;
+  showTime: boolean;
 }
 
 /**
@@ -80,7 +81,7 @@ interface NewsItemProps {
  * it leads the row; opening it reads it (there is nothing to decide) and drops
  * the finding's detail inline.
  */
-const NewsItem = memo<NewsItemProps>(({ bare, brief }) => {
+const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
   const markBriefRead = useBriefStore((s) => s.markBriefRead);
 
   const [expanded, setExpanded] = useState(false);
@@ -130,7 +131,7 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief }) => {
           >
             {brief.title}
           </Text>
-          <Time date={brief.createdAt} />
+          {showTime && <Time date={brief.createdAt} />}
           <Icon
             color={cssVar.colorTextQuaternary}
             icon={expanded ? ChevronDownIcon : ChevronRightIcon}
@@ -157,6 +158,8 @@ interface NewsListProps {
   /** Rendered inside a rail card, which already draws the shell. */
   bare?: boolean;
   news: BriefItem[];
+  /** Relative time is useful within today's feed, but redundant under a dated historical heading. */
+  showTime: boolean;
 }
 
 /**
@@ -164,7 +167,7 @@ interface NewsListProps {
  * recurring run, but there is nothing to decide. One line each — the detail
  * lives behind the click, so a week of findings still fits on screen.
  */
-const NewsList = memo<NewsListProps>(({ bare, news }) => {
+const NewsList = memo<NewsListProps>(({ bare, news, showTime }) => {
   const { t } = useTranslation('home');
   const [expanded, setExpanded] = useState(false);
 
@@ -178,7 +181,7 @@ const NewsList = memo<NewsListProps>(({ bare, news }) => {
   return (
     <Flexbox className={bare ? styles.bareList : styles.list}>
       {shown.map((brief) => (
-        <NewsItem bare={bare} brief={brief} key={brief.id} />
+        <NewsItem bare={bare} brief={brief} key={brief.id} showTime={showTime} />
       ))}
       {collapsed && (
         <Button

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -36,7 +36,7 @@ import { resolveInboxBlockState } from './inboxBlockState';
 import InboxBriefCard from './InboxBriefCard';
 import MarkAllReadButton from './MarkAllReadButton';
 import NeedsYouRailCard from './NeedsYouRailCard';
-import { resolveShownNewsOffset } from './newsDayOffset';
+import { resolveShownNewsOffset, shouldShowNewsItemTime } from './newsDayOffset';
 import NewsList from './NewsList';
 import { ownsRailSections } from './railSectionPlacement';
 import RunningTasksCard from './RunningTasksCard';
@@ -497,7 +497,7 @@ const HomeInbox = memo<HomeInboxProps>((props) => {
             {t(shownNewsOffset === 0 ? 'inbox.news.emptyToday' : 'inbox.news.emptyDay')}
           </span>
         ) : (
-          <NewsList bare={isRail} news={news} />
+          <NewsList bare={isRail} news={news} showTime={shouldShowNewsItemTime(shownNewsOffset)} />
         ),
       subtitle: t('inbox.news.subtitle'),
     });

--- a/src/features/HomeInbox/newsDayOffset.test.ts
+++ b/src/features/HomeInbox/newsDayOffset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveShownNewsOffset } from './newsDayOffset';
+import { resolveShownNewsOffset, shouldShowNewsItemTime } from './newsDayOffset';
 
 describe('resolveShownNewsOffset', () => {
   it('maps the payload day to its offset from today', () => {
@@ -18,5 +18,13 @@ describe('resolveShownNewsOffset', () => {
   // on screen after local midnight must clamp to 0, not become "tomorrow".
   it('clamps a payload from a not-yet-refetched future day to today', () => {
     expect(resolveShownNewsOffset('2026-08-06', '2026-08-05T23:59:00')).toBe(0);
+  });
+});
+
+describe('shouldShowNewsItemTime', () => {
+  it('shows item time only for today', () => {
+    expect(shouldShowNewsItemTime(0)).toBe(true);
+    expect(shouldShowNewsItemTime(1)).toBe(false);
+    expect(shouldShowNewsItemTime(30)).toBe(false);
   });
 });

--- a/src/features/HomeInbox/newsDayOffset.ts
+++ b/src/features/HomeInbox/newsDayOffset.ts
@@ -13,3 +13,6 @@ import dayjs, { type ConfigType } from 'dayjs';
  */
 export const resolveShownNewsOffset = (day: string, now?: ConfigType): number =>
   Math.max(0, dayjs(now).startOf('day').diff(dayjs(day).startOf('day'), 'day'));
+
+/** Historical rows already sit beneath a dated heading; only today's rows need relative time. */
+export const shouldShowNewsItemTime = (dayOffset: number) => dayOffset === 0;


### PR DESCRIPTION
### What changed

- keep relative timestamps on today’s brief items
- hide redundant item dates under yesterday and older daily brief headings
- add regression coverage for the day-offset display rule

### Testing

- `bun run check src/features/HomeInbox/NewsList.tsx src/features/HomeInbox/newsDayOffset.ts src/features/HomeInbox/newsDayOffset.test.ts src/features/HomeInbox/index.tsx`
- lint clean
- 4 tests passed