### PR TITLE
🐛 fix: normalize Kimi Code render registry type

### DIFF
--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -252,7 +252,7 @@ export const registerBuiltinToolSurfaces = (): void => {
     [WebOnboardingManifest.identifier]: WebOnboardingRenders as Record<string, BuiltinRender>,
     [OPENCODE_IDENTIFIER]: heterogeneousCliRenders,
     [PI_IDENTIFIER]: heterogeneousCliRenders,
-    [KIMI_CODE_IDENTIFIER]: KimiCodeRenders,
+    [KIMI_CODE_IDENTIFIER]: KimiCodeRenders as Record<string, BuiltinRender>,
     codex: {
       ...CodexRenders,
       command_execution: RunCommandRender as BuiltinRender,


### PR DESCRIPTION
Align the Kimi Code render map with the existing builtin render registry boundary. This keeps the render components' precise local prop types while erasing them only when registering through the dynamic API-name map.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed — this is a compile-time compatibility fix covered by the full type check
- `bun run check lobehub/packages/builtin-tools/src/register.ts --lint --test --type`
- `bun run type-check:vercel`

#### 🔗 Related Issue

Related to #18950