### PR TITLE
🐛 fix(ci): correct observability test fixture cast

### DIFF
--- a/packages/observability-otel/src/node.test.ts
+++ b/packages/observability-otel/src/node.test.ts
@@ -66,7 +66,7 @@ describe('Node observability resource attributes', () => {
       sampler,
       spanProcessors: [sentrySpanProcessor],
       textMapPropagator,
-    } as Parameters<typeof register>[0]);
+    } as unknown as Parameters<typeof register>[0]);
 
     expect(mocks.nodeSdkOptions).toMatchObject({
       contextManager,


### PR DESCRIPTION
## Summary

- fix the invalid direct cast used by the observability registration test fixture
- preserve the lightweight test doubles while making the intentional unsafe boundary explicit
- unblock the canary code-quality TypeScript check (`TS2352`)

## Verification

- `bun run check packages/observability-otel/src/node.test.ts`
- lint clean
- 5 tests passed