### PR TITLE
🐛 fix(inspector): shimmer the label span instead of the whole row

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.37.1",
+    "@lobehub/ui": "^5.38.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.37.0",
+    "@lobehub/ui": "^5.37.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/packages/builtin-tool-activator/src/client/Inspector/ActivateSkill/index.tsx
+++ b/packages/builtin-tool-activator/src/client/Inspector/ActivateSkill/index.tsx
@@ -78,14 +78,14 @@ export const ActivateSkillInspector = memo<
   if (isArgumentsStreaming) {
     if (!displayName)
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{label}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>{label}</span>
         </div>
       );
 
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{label}:</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>{label}:</span>
         <span className={styles.chip}>
           <SkillsIcon className={styles.skillIcon} size={12} />
           <span className={styles.skillName}>{displayName}</span>
@@ -95,8 +95,8 @@ export const ActivateSkillInspector = memo<
   }
 
   return (
-    <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-      <span>{label}:</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx(isLoading && shinyTextStyles.shinyText)}>{label}:</span>
       {displayName && (
         <span className={styles.chip}>
           <SkillsIcon className={styles.skillIcon} size={12} />

--- a/packages/builtin-tool-activator/src/client/Inspector/ActivateTools/index.tsx
+++ b/packages/builtin-tool-activator/src/client/Inspector/ActivateTools/index.tsx
@@ -3,7 +3,7 @@
 import { type BuiltinInspectorProps } from '@lobechat/types';
 import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Avatar } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { AlertTriangle } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -69,8 +69,10 @@ export const ActivateToolsInspector = memo<
   // Streaming / Loading: show identifiers from arguments
   if (isArgumentsStreaming || isLoading) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-activator.apiName.activateTools')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-activator.apiName.activateTools')}
+        </span>
         {identifiers && identifiers.length > 0 && (
           <span className={styles.tools}>
             {identifiers.map((id) => (

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/GetAvailableModels/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/GetAvailableModels/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { BuiltinInspectorProps } from '@lobechat/types';
-import { cx } from 'antd-style';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,8 +32,10 @@ export const GetAvailableModelsInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming || isLoading) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-builder.apiName.getAvailableModels')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-builder.apiName.getAvailableModels')}
+        </span>
         {providerId && (
           <>
             :<span className={highlightTextStyles.primary}>{providerId}</span>

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/InstallPlugin/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/InstallPlugin/index.tsx
@@ -28,8 +28,10 @@ export const InstallPluginInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !identifier) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-builder.apiName.installPlugin')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-builder.apiName.installPlugin')}
+        </span>
       </div>
     );
   }
@@ -39,13 +41,10 @@ export const InstallPluginInspector = memo<
   const hasResult = pluginState?.success !== undefined;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-builder.apiName.installPlugin')}: </span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-builder.apiName.installPlugin')}:{' '}
+      </span>
       {displayName && <span className={highlightTextStyles.primary}>{displayName}</span>}
       {!isLoading &&
         hasResult &&

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/SearchMarketTools/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/SearchMarketTools/index.tsx
@@ -22,8 +22,10 @@ export const SearchMarketToolsInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !displayText) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-builder.apiName.searchMarketTools')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-builder.apiName.searchMarketTools')}
+        </span>
       </div>
     );
   }
@@ -32,13 +34,10 @@ export const SearchMarketToolsInspector = memo<
   const hasResults = resultCount > 0;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-builder.apiName.searchMarketTools')}: </span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-builder.apiName.searchMarketTools')}:{' '}
+      </span>
       {displayText && <span className={highlightTextStyles.primary}>{displayText}</span>}
       {!isLoading &&
         !isArgumentsStreaming &&

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/UpdateConfig/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/UpdateConfig/index.tsx
@@ -61,8 +61,10 @@ export const UpdateConfigInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !displayText) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-builder.apiName.updateConfig')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-builder.apiName.updateConfig')}
+        </span>
       </div>
     );
   }
@@ -70,13 +72,10 @@ export const UpdateConfigInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-builder.apiName.updateConfig')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-builder.apiName.updateConfig')}
+      </span>
       {displayText && (
         <>
           :<span className={highlightTextStyles.primary}>{displayText}</span>

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/UpdatePrompt/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/UpdatePrompt/index.tsx
@@ -39,8 +39,10 @@ export const UpdatePromptInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !prompt) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-builder.apiName.updatePrompt')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-builder.apiName.updatePrompt')}
+        </span>
       </div>
     );
   }
@@ -50,13 +52,10 @@ export const UpdatePromptInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-builder.apiName.updatePrompt')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-builder.apiName.updatePrompt')}
+      </span>
       {/* Show length diff when completed */}
       {!isLoading && !isArgumentsStreaming && lengthDiff !== null && (
         <Text

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/CopyDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/CopyDocument/index.tsx
@@ -21,21 +21,19 @@ export const CopyDocumentInspector = memo<
 
   if (isArgumentsStreaming && !id && !newTitle) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.copyDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.copyDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.copyDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.copyDocument')}
+      </span>
       {id && <span className={styles.idChip}>{formatDocumentId(id)}</span>}
       {newTitle && (
         <>

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/CreateDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/CreateDocument/index.tsx
@@ -21,21 +21,19 @@ export const CreateDocumentInspector = memo<
 
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.createDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.createDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.createDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.createDocument')}
+      </span>
       {title && <span className={styles.chip}>{title}</span>}
       {scope && (
         <>

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ListDocuments/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ListDocuments/index.tsx
@@ -20,14 +20,10 @@ export const ListDocumentsInspector = memo<
   const styles = inspectorChipStyles;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.listDocuments')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.listDocuments')}
+      </span>
       {scope && (
         <>
           <span className={styles.separator}>·</span>

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ModifyNodes/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ModifyNodes/index.tsx
@@ -24,21 +24,19 @@ export const ModifyNodesInspector = memo<
 
   if (isArgumentsStreaming && !id) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.modifyNodes')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.modifyNodes')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.modifyNodes')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.modifyNodes')}
+      </span>
       {id && <span className={styles.idChip}>{formatDocumentId(id)}</span>}
       {(typeof totalCount === 'number' || opCount > 0) && (
         <>

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ReadDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ReadDocument/index.tsx
@@ -21,21 +21,19 @@ export const ReadDocumentInspector = memo<
 
   if (isArgumentsStreaming && !title && !id) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.readDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.readDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.readDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.readDocument')}
+      </span>
       {title ? (
         <span className={styles.chip}>{title}</span>
       ) : (

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/RemoveDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/RemoveDocument/index.tsx
@@ -36,14 +36,11 @@ export const RemoveDocumentInspector = memo<
   const id = args?.id || partialArgs?.id;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span style={{ color: cssVar.colorError }}>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span
+        className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
+        style={{ color: cssVar.colorError }}
+      >
         {t('builtins.lobe-agent-documents.apiName.removeDocument')}
       </span>
       {id && <span className={styles.removeChip}>{formatDocumentId(id)}</span>}

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/RenameDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/RenameDocument/index.tsx
@@ -21,21 +21,19 @@ export const RenameDocumentInspector = memo<
 
   if (isArgumentsStreaming && !id && !newTitle) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.renameDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.renameDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.renameDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.renameDocument')}
+      </span>
       {id && <span className={styles.idChip}>{formatDocumentId(id)}</span>}
       {newTitle && (
         <>

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ReplaceDocumentContent/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ReplaceDocumentContent/index.tsx
@@ -21,21 +21,19 @@ export const ReplaceDocumentContentInspector = memo<
 
   if (isArgumentsStreaming && !id) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.replaceDocumentContent')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.replaceDocumentContent')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.replaceDocumentContent')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.replaceDocumentContent')}
+      </span>
       {id && <span className={styles.idChip}>{formatDocumentId(id)}</span>}
       {typeof content === 'string' && content.length > 0 && (
         <>

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/UpdateLoadRule/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/UpdateLoadRule/index.tsx
@@ -21,21 +21,19 @@ export const UpdateLoadRuleInspector = memo<
 
   if (isArgumentsStreaming && !id) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-documents.apiName.updateLoadRule')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-documents.apiName.updateLoadRule')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-agent-documents.apiName.updateLoadRule')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent-documents.apiName.updateLoadRule')}
+      </span>
       {id && <span className={styles.idChip}>{formatDocumentId(id)}</span>}
       {ruleType && (
         <>

--- a/packages/builtin-tool-agent-management/src/client/Inspector/CallAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/CallAgent/index.tsx
@@ -43,8 +43,10 @@ export const CallAgentInspector = memo<BuiltinInspectorProps<CallAgentParams>>(
 
     if (isArgumentsStreaming && !agentId) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.callAgent')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.callAgent')}
+          </span>
         </div>
       );
     }
@@ -56,13 +58,10 @@ export const CallAgentInspector = memo<BuiltinInspectorProps<CallAgentParams>>(
     const agentName = agentMeta?.title || agentId;
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>{t(titleKey)}</span>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
+          {t(titleKey)}
+        </span>
         {agentMeta && (
           <Avatar
             avatar={agentMeta.avatar || DEFAULT_AVATAR}

--- a/packages/builtin-tool-agent-management/src/client/Inspector/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/CreateAgent/index.tsx
@@ -37,20 +37,17 @@ export const CreateAgentInspector = memo<BuiltinInspectorProps<CreateAgentParams
 
     if (isArgumentsStreaming && !title) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.createAgent')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.createAgent')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-agent-management.inspector.createAgent.title')}
         </span>
         <Avatar

--- a/packages/builtin-tool-agent-management/src/client/Inspector/DuplicateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/DuplicateAgent/index.tsx
@@ -33,20 +33,17 @@ export const DuplicateAgentInspector = memo<BuiltinInspectorProps<DuplicateAgent
 
     if (isArgumentsStreaming && !agentId) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.duplicateAgent')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.duplicateAgent')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-agent-management.inspector.duplicateAgent.title')}
         </span>
         <span className={highlightTextStyles.primary}>{newTitle || agentId}</span>

--- a/packages/builtin-tool-agent-management/src/client/Inspector/GetAgentDetail/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/GetAgentDetail/index.tsx
@@ -38,20 +38,17 @@ export const GetAgentDetailInspector = memo<
 
   if (isArgumentsStreaming && !agentId) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent-management.apiName.getAgentDetail')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent-management.apiName.getAgentDetail')}
+        </span>
       </div>
     );
   }
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
         {t('builtins.lobe-agent-management.inspector.getAgentDetail.title')}
       </span>
       {title ? (

--- a/packages/builtin-tool-agent-management/src/client/Inspector/InstallPlugin/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/InstallPlugin/index.tsx
@@ -32,20 +32,17 @@ export const InstallPluginInspector = memo<BuiltinInspectorProps<InstallPluginPa
 
     if (isArgumentsStreaming && !identifier) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.installPlugin')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.installPlugin')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-agent-management.inspector.installPlugin.title')}
         </span>
         {identifier && <span className={highlightTextStyles.primary}>{identifier}</span>}

--- a/packages/builtin-tool-agent-management/src/client/Inspector/SearchAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/SearchAgent/index.tsx
@@ -49,20 +49,19 @@ export const SearchAgentInspector = memo<BuiltinInspectorProps<SearchAgentParams
 
     if (isArgumentsStreaming && !keyword) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.searchAgent')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.searchAgent')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>{t(titleKey)}</span>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
+          {t(titleKey)}
+        </span>
         {keyword && <span className={highlightTextStyles.primary}>{keyword}</span>}
       </Flexbox>
     );

--- a/packages/builtin-tool-agent-management/src/client/Inspector/UpdateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/UpdateAgent/index.tsx
@@ -32,20 +32,17 @@ export const UpdateAgentInspector = memo<BuiltinInspectorProps<UpdateAgentParams
 
     if (isArgumentsStreaming && !agentId) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.updateAgent')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.updateAgent')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-agent-management.inspector.updateAgent.title')}
         </span>
         {agentId && <span className={highlightTextStyles.primary}>{agentId}</span>}

--- a/packages/builtin-tool-agent-management/src/client/Inspector/UpdatePrompt/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/UpdatePrompt/index.tsx
@@ -32,20 +32,17 @@ export const UpdatePromptInspector = memo<BuiltinInspectorProps<UpdatePromptPara
 
     if (isArgumentsStreaming && !agentId) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.updatePrompt')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent-management.apiName.updatePrompt')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-agent-management.inspector.updatePrompt.title')}
         </span>
         {agentId && <span className={highlightTextStyles.primary}>{agentId}</span>}

--- a/packages/builtin-tool-browser/src/client/Inspector/Browser.tsx
+++ b/packages/builtin-tool-browser/src/client/Inspector/Browser.tsx
@@ -118,13 +118,10 @@ export const BrowserInspector = memo<BuiltinInspectorProps<BrowserArgs>>(
     const Icon = API_ICONS[browserApiName];
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{value ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {value ? `${label}:` : label}
+        </span>
         {value && Icon && (
           <span className={styles.chip}>
             <Icon className={styles.icon} size={14} />

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
@@ -190,8 +190,8 @@ export const AgentInspector = memo<BuiltinInspectorProps<AgentArgs>>(
       ) : null;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span className={styles.label}>Agent:</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(styles.label, isShiny && shinyTextStyles.shinyText)}>Agent:</span>
         <Icon className={styles.icon} size={14} />
         <span className={styles.label}>{labelText}</span>
         {description && (

--- a/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
@@ -74,13 +74,15 @@ export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuesti
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span className={styles.label}>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span
+          className={cx(
+            styles.label,
+            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          )}
+        >
+          {label}
+        </span>
         {shown.length > 0 && (
           <div className={styles.chips}>
             {shown.map((header, idx) => (

--- a/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
@@ -78,7 +78,7 @@ export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuesti
         <span
           className={cx(
             styles.label,
-            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+            (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
           )}
         >
           {label}

--- a/packages/builtin-tool-claude-code/src/client/Inspector/BrowserMcp.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/BrowserMcp.tsx
@@ -141,8 +141,10 @@ const BrowserMcpInspector = memo<BuiltinInspectorProps<BrowserMcpArgs>>(
     const isShiny = isArgumentsStreaming || isLoading;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{value ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>
+          {value ? `${label}:` : label}
+        </span>
         {value && (
           <span className={styles.chip}>
             <Icon className={styles.icon} size={14} />

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Monitor.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Monitor.tsx
@@ -113,8 +113,8 @@ export const MonitorInspector = memo<BuiltinInspectorProps<MonitorArgs>>(
     const isError = success === false || (typeof exitCode === 'number' && exitCode !== 0);
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{label}:</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>{label}:</span>
         {chipText && (
           <span className={styles.chip}>
             <MonitorIcon className={styles.monitorIcon} size={12} />

--- a/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
@@ -69,8 +69,10 @@ export const ScheduleWakeupInspector = memo<BuiltinInspectorProps<ScheduleWakeup
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{reason || typeof delay === 'number' ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>
+          {reason || typeof delay === 'number' ? `${label}:` : label}
+        </span>
         {reason && <span className={styles.chip}>{reason}</span>}
         {typeof delay === 'number' && <span className={styles.delay}>· {formatDelay(delay)}</span>}
       </div>

--- a/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
@@ -49,8 +49,10 @@ export const SendMessageInspector = memo<BuiltinInspectorProps<SendMessageArgs>>
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{recap ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>
+          {recap ? `${label}:` : label}
+        </span>
         {recap && <span className={styles.chip}>{recap}</span>}
       </div>
     );

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Skill.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Skill.tsx
@@ -52,13 +52,10 @@ export const SkillInspector = memo<BuiltinInspectorProps<SkillArgs>>(
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {skillName && (
           <span className={styles.chip}>
             <SkillsIcon className={styles.skillIcon} size={12} />

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Task.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Task.tsx
@@ -189,14 +189,19 @@ export const TaskInspector = memo<BuiltinInspectorProps<TaskInspectorArgs, TaskP
       );
       const text = subject ? `${label}${subject}` : label;
       return (
-        <div className={cx(inspectorTextStyles.root, inFlight && shinyTextStyles.shinyText)}>
+        <div className={inspectorTextStyles.root}>
           <ProgressRing stats={stats} />
           {stats.total > 0 && (
             <span className={styles.countChip}>
               {stats.completed}/{stats.total}
             </span>
           )}
-          <span style={{ marginInlineStart: 6 }}>{text}</span>
+          <span
+            className={cx(inFlight && shinyTextStyles.shinyText)}
+            style={{ marginInlineStart: 6 }}
+          >
+            {text}
+          </span>
         </div>
       );
     }
@@ -230,19 +235,17 @@ export const TaskInspector = memo<BuiltinInspectorProps<TaskInspectorArgs, TaskP
                 ? t('builtins.lobe-claude-code.task.updateInProgress')
                 : t('builtins.lobe-claude-code.task.updatePending');
         return (
-          <div
-            className={cx(
-              inspectorTextStyles.root,
-              (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-            )}
-          >
+          <div className={inspectorTextStyles.root}>
             <ProgressRing stats={stats} />
             {stats.total > 0 && (
               <span className={styles.countChip}>
                 {stats.completed}/{stats.total}
               </span>
             )}
-            <span style={{ marginInlineStart: stats.total > 0 ? 6 : 0 }}>
+            <span
+              className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
+              style={{ marginInlineStart: stats.total > 0 ? 6 : 0 }}
+            >
               {subject ? `${verb}: ${subject}` : verb}
             </span>
           </div>
@@ -266,14 +269,17 @@ export const TaskInspector = memo<BuiltinInspectorProps<TaskInspectorArgs, TaskP
             : 'builtins.lobe-claude-code.task.updateSubject.completed',
         );
         return (
-          <div className={cx(inspectorTextStyles.root, inFlight && shinyTextStyles.shinyText)}>
+          <div className={inspectorTextStyles.root}>
             <ProgressRing stats={stats} />
             {stats.total > 0 && (
               <span className={styles.countChip}>
                 {stats.completed}/{stats.total}
               </span>
             )}
-            <span style={{ marginInlineStart: stats.total > 0 ? 6 : 0 }}>
+            <span
+              className={cx(inFlight && shinyTextStyles.shinyText)}
+              style={{ marginInlineStart: stats.total > 0 ? 6 : 0 }}
+            >
               {`${verb}: ${subject}`}
             </span>
           </div>
@@ -324,9 +330,9 @@ export const TaskInspector = memo<BuiltinInspectorProps<TaskInspectorArgs, TaskP
         : undefined;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+      <div className={inspectorTextStyles.root}>
         <ProgressRing stats={stats} />
-        <span>{label}</span>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>{label}</span>
         {detail && (
           <>
             <span>:</span>

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
@@ -49,8 +49,10 @@ export const TaskOutputInspector = memo<BuiltinInspectorProps<TaskOutputArgs>>(
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{taskId ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>
+          {taskId ? `${label}:` : label}
+        </span>
         {taskId && <span className={styles.chip}>{taskId}</span>}
       </div>
     );

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
@@ -49,8 +49,10 @@ export const TaskStopInspector = memo<BuiltinInspectorProps<TaskStopArgs>>(
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{taskId ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>
+          {taskId ? `${label}:` : label}
+        </span>
         {taskId && <span className={styles.chip}>{taskId}</span>}
       </div>
     );

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TodoWrite.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TodoWrite.tsx
@@ -22,13 +22,12 @@ export const TodoWriteInspector = memo<BuiltinInspectorProps<TodoWriteArgs>>(
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <TodoInspectorSummary label={label} summary={summary} />
+      <div className={inspectorTextStyles.root}>
+        <TodoInspectorSummary
+          label={label}
+          shiny={isArgumentsStreaming || isLoading}
+          summary={summary}
+        />
       </div>
     );
   },

--- a/packages/builtin-tool-claude-code/src/client/Inspector/ToolSearch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ToolSearch.tsx
@@ -79,14 +79,8 @@ export const ToolSearchInspector = memo<BuiltinInspectorProps<ToolSearchArgs>>(
 
     if (parsed?.names) {
       return (
-        <div
-          className={cx(
-            inspectorTextStyles.root,
-            styles.baseline,
-            isShiny && shinyTextStyles.shinyText,
-          )}
-        >
-          <span>{label}:</span>
+        <div className={cx(inspectorTextStyles.root, styles.baseline)}>
+          <span className={cx(isShiny && shinyTextStyles.shinyText)}>{label}:</span>
           <span className={styles.tagsList}>
             {parsed.names.map((name, index) => (
               <span className={styles.tag} key={`${index}-${name}`}>
@@ -99,8 +93,8 @@ export const ToolSearchInspector = memo<BuiltinInspectorProps<ToolSearchArgs>>(
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>{label}</span>
         {parsed && (
           <>
             <span>: </span>

--- a/packages/builtin-tool-claude-code/src/client/Inspector/WebFetch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/WebFetch.tsx
@@ -61,8 +61,10 @@ export const WebFetchInspector = memo<BuiltinInspectorProps<WebFetchArgs>>(
     const isShiny = isArgumentsStreaming || isLoading;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{url ? `${label}:` : label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>
+          {url ? `${label}:` : label}
+        </span>
         {url && (
           <span className={styles.chip}>
             <Globe className={styles.icon} size={14} />

--- a/packages/builtin-tool-claude-code/src/client/Inspector/WebSearch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/WebSearch.tsx
@@ -25,8 +25,8 @@ export const WebSearchInspector = memo<BuiltinInspectorProps<WebSearchArgs>>(
     const isShiny = isArgumentsStreaming || isLoading;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isShiny && shinyTextStyles.shinyText)}>{label}</span>
         {query && (
           <>
             <span>: </span>

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Worktree.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Worktree.tsx
@@ -129,13 +129,10 @@ export const EnterWorktreeInspector = memo<BuiltinInspectorProps<EnterWorktreeAr
     const label = t((path ? ENTER_LABEL_KEYS : CREATE_LABEL_KEYS)[phase]);
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {target && <WorktreeTarget target={target} />}
       </div>
     );
@@ -158,14 +155,11 @@ export const ExitWorktreeInspector = memo<BuiltinInspectorProps<ExitWorktreeArgs
     const label = t((action === 'remove' ? REMOVE_LABEL_KEYS : EXIT_LABEL_KEYS)[phase]);
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={inspectorTextStyles.root}>
         <GitForkIcon className={cx(styles.icon, styles.leadingIcon)} size={12} />
-        <span>{label}</span>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {action === 'remove' && discardChanges && (
           <span className={styles.risk}>
             {t('builtins.lobe-claude-code.worktree.discardChanges')}

--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExecuteCode/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExecuteCode/index.tsx
@@ -33,23 +33,29 @@ export const ExecuteCodeInspector = memo<
   if (isArgumentsStreaming) {
     if (!description)
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-cloud-sandbox.apiName.executeCode')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-cloud-sandbox.apiName.executeCode')}
+          </span>
         </div>
       );
 
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-cloud-sandbox.apiName.executeCode')}: </span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-cloud-sandbox.apiName.executeCode')}:{' '}
+        </span>
         <span className={highlightTextStyles.gold}>{description}</span>
       </div>
     );
   }
 
   return (
-    <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+    <div className={inspectorTextStyles.root}>
       <span style={{ marginInlineStart: 2 }}>
-        <span>{t('builtins.lobe-cloud-sandbox.apiName.executeCode')}: </span>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-cloud-sandbox.apiName.executeCode')}:{' '}
+        </span>
         {description && <span className={highlightTextStyles.primary}>{description}</span>}
         {isLoading ? null : pluginState?.success ? (
           <Check className={styles.statusIcon} color={cssVar.colorSuccess} size={14} />

--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExportFile/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExportFile/index.tsx
@@ -23,8 +23,8 @@ export const ExportFileInspector = memo<BuiltinInspectorProps<ExportFileArgs, Ex
     const showShiny = isArgumentsStreaming || isLoading;
 
     return (
-      <div className={cx(inspectorTextStyles.root, showShiny && shinyTextStyles.shinyText)}>
-        <span style={{ marginInlineEnd: 6 }}>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(showShiny && shinyTextStyles.shinyText)} style={{ marginInlineEnd: 6 }}>
           {t('builtins.lobe-cloud-sandbox.apiName.exportFile')}:
         </span>
         {filePath && <FilePathDisplay filePath={filePath} />}

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
@@ -76,7 +76,7 @@ export const BatchCreateAgentsInspector = memo<
       <span
         className={cx(
           styles.title,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.batchCreateAgents')}:

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
@@ -59,8 +59,10 @@ export const BatchCreateAgentsInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !displayInfo) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.batchCreateAgents')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.batchCreateAgents')}
+        </span>
       </div>
     );
   }
@@ -70,13 +72,13 @@ export const BatchCreateAgentsInspector = memo<
   const totalCount = displayInfo?.count ?? 0;
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span
+        className={cx(
+          styles.title,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.batchCreateAgents')}:
       </span>
       {displayInfo && (

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateAgent/index.tsx
@@ -41,8 +41,10 @@ export const CreateAgentInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.createAgent')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.createAgent')}
+        </span>
       </div>
     );
   }
@@ -50,13 +52,13 @@ export const CreateAgentInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span
+        className={cx(
+          styles.title,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.createAgent')}:
       </span>
       {avatar && <Avatar avatar={avatar} shape={'square'} size={20} title={title || undefined} />}

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateAgent/index.tsx
@@ -56,7 +56,7 @@ export const CreateAgentInspector = memo<
       <span
         className={cx(
           styles.title,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.createAgent')}:

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateGroup/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateGroup/index.tsx
@@ -55,7 +55,7 @@ export const CreateGroupInspector = memo<
       <span
         className={cx(
           styles.title,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.createGroup')}:

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateGroup/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateGroup/index.tsx
@@ -40,8 +40,10 @@ export const CreateGroupInspector = memo<
 
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.createGroup')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.createGroup')}
+        </span>
       </div>
     );
   }
@@ -49,13 +51,13 @@ export const CreateGroupInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span
+        className={cx(
+          styles.title,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.createGroup')}:
       </span>
       {avatar && <Avatar avatar={avatar} shape={'square'} size={20} title={title || undefined} />}

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
@@ -7,7 +7,7 @@ import { createStaticStyles, cx } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { shinyTextStyles } from '@/styles';
+import { shinyGroupStyles, shinyTextStyles } from '@/styles';
 
 import type { GetAgentInfoParams } from '../../../types';
 
@@ -51,7 +51,12 @@ export const GetAgentInfoInspector = memo<
   }
 
   return (
-    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+    <Flexbox
+      horizontal
+      align={'center'}
+      className={cx(styles.root, shinyGroupStyles.shinyGroup)}
+      gap={8}
+    >
       <span
         className={cx(
           styles.title,
@@ -61,7 +66,9 @@ export const GetAgentInfoInspector = memo<
         {t('builtins.lobe-group-agent-builder.apiName.getAgentInfo')}:
       </span>
       {avatar && <Avatar avatar={avatar} shape={'square'} size={20} title={title || undefined} />}
-      <span>{title || agentId}</span>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {title || agentId}
+      </span>
     </Flexbox>
   );
 });

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
@@ -55,7 +55,7 @@ export const GetAgentInfoInspector = memo<
       <span
         className={cx(
           styles.title,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.getAgentInfo')}:

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
@@ -42,20 +42,22 @@ export const GetAgentInfoInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !agentId) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.getAgentInfo')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.getAgentInfo')}
+        </span>
       </div>
     );
   }
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span
+        className={cx(
+          styles.title,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.getAgentInfo')}:
       </span>
       {avatar && <Avatar avatar={avatar} shape={'square'} size={20} title={title || undefined} />}

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/InviteAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/InviteAgent/index.tsx
@@ -42,8 +42,10 @@ export const InviteAgentInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !agentId) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.inviteAgent')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.inviteAgent')}
+        </span>
       </div>
     );
   }
@@ -51,13 +53,13 @@ export const InviteAgentInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span
+        className={cx(
+          styles.title,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.inviteAgent')}:
       </span>
       {avatar && (

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/InviteAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/InviteAgent/index.tsx
@@ -57,7 +57,7 @@ export const InviteAgentInspector = memo<
       <span
         className={cx(
           styles.title,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.inviteAgent')}:

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/RemoveAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/RemoveAgent/index.tsx
@@ -57,7 +57,7 @@ export const RemoveAgentInspector = memo<
       <span
         className={cx(
           styles.title,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.removeAgent')}:

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/RemoveAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/RemoveAgent/index.tsx
@@ -42,8 +42,10 @@ export const RemoveAgentInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !agentId) {
     return (
-      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.removeAgent')}</span>
+      <div className={styles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.removeAgent')}
+        </span>
       </div>
     );
   }
@@ -51,13 +53,13 @@ export const RemoveAgentInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={8}
-    >
-      <span className={styles.title}>
+    <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+      <span
+        className={cx(
+          styles.title,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.removeAgent')}:
       </span>
       {avatar && (

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/SearchAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/SearchAgent/index.tsx
@@ -20,8 +20,10 @@ export const SearchAgentInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !query) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.searchAgent')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.searchAgent')}
+        </span>
       </div>
     );
   }
@@ -30,13 +32,10 @@ export const SearchAgentInspector = memo<
   const hasResults = resultCount > 0;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-group-agent-builder.apiName.searchAgent')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-group-agent-builder.apiName.searchAgent')}
+      </span>
       {query && (
         <>
           :<span className={highlightTextStyles.primary}>{query}</span>

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateAgentPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateAgentPrompt/index.tsx
@@ -64,8 +64,10 @@ export const UpdateAgentPromptInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !agentId) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.updateAgentPrompt')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.updateAgentPrompt')}
+        </span>
       </div>
     );
   }
@@ -80,13 +82,15 @@ export const UpdateAgentPromptInspector = memo<
     : 'builtins.lobe-group-agent-builder.apiName.updateAgentPrompt';
 
   return (
-    <Flexbox
-      horizontal
-      align="center"
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={6}
-    >
-      <span className={styles.label}>{t(labelKey)}</span>
+    <Flexbox horizontal align="center" className={styles.root} gap={6}>
+      <span
+        className={cx(
+          styles.label,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
+        {t(labelKey)}
+      </span>
       {/* Only show avatar and title for non-supervisor agents */}
       {agent && !isSupervisor && (
         <>

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateAgentPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateAgentPrompt/index.tsx
@@ -86,7 +86,7 @@ export const UpdateAgentPromptInspector = memo<
       <span
         className={cx(
           styles.label,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t(labelKey)}

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroup/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroup/index.tsx
@@ -54,8 +54,10 @@ export const UpdateGroupInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !displayText) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.updateGroup')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.updateGroup')}
+        </span>
       </div>
     );
   }
@@ -63,13 +65,10 @@ export const UpdateGroupInspector = memo<
   const isSuccess = pluginState?.success;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-group-agent-builder.apiName.updateGroup')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-group-agent-builder.apiName.updateGroup')}
+      </span>
       {displayText && (
         <>
           :<span className={highlightTextStyles.primary}>{displayText}</span>

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroupPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroupPrompt/index.tsx
@@ -68,7 +68,7 @@ export const UpdateGroupPromptInspector = memo<
       <span
         className={cx(
           styles.label,
-          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
         {t('builtins.lobe-group-agent-builder.apiName.updateGroupPrompt')}

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroupPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroupPrompt/index.tsx
@@ -53,8 +53,10 @@ export const UpdateGroupPromptInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !prompt) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-group-agent-builder.apiName.updateGroupPrompt')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-group-agent-builder.apiName.updateGroupPrompt')}
+        </span>
       </div>
     );
   }
@@ -62,13 +64,13 @@ export const UpdateGroupPromptInspector = memo<
   const streamingLength = prompt?.length ?? 0;
 
   return (
-    <Flexbox
-      horizontal
-      align="center"
-      className={cx(styles.root, (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
-      gap={6}
-    >
-      <span className={styles.label}>
+    <Flexbox horizontal align="center" className={styles.root} gap={6}>
+      <span
+        className={cx(
+          styles.label,
+          cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+        )}
+      >
         {t('builtins.lobe-group-agent-builder.apiName.updateGroupPrompt')}
       </span>
       {/* Show length diff when completed */}

--- a/packages/builtin-tool-group-management/src/client/Inspector/Broadcast/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/Broadcast/index.tsx
@@ -63,20 +63,17 @@ export const BroadcastInspector = memo<BuiltinInspectorProps<BroadcastParams>>(
 
     if (isArgumentsStreaming && agents.length === 0) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-group-management.apiName.broadcast')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-group-management.apiName.broadcast')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-group-management.inspector.broadcast.title')}
         </span>
         {avatarItems.length > 0 && <Avatar.Group items={avatarItems} shape={'circle'} size={24} />}

--- a/packages/builtin-tool-group-management/src/client/Inspector/ExecuteAgentTask/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/ExecuteAgentTask/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { agentGroupSelectors } from '@/store/agentGroup/selectors';
-import { highlightTextStyles, shinyTextStyles } from '@/styles';
+import { highlightTextStyles, shinyGroupStyles, shinyTextStyles } from '@/styles';
 
 import type { ExecuteTaskParams } from '../../../types';
 
@@ -55,7 +55,12 @@ export const ExecuteAgentTaskInspector = memo<BuiltinInspectorProps<ExecuteTaskP
         );
       if (agent) {
         return (
-          <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+          <Flexbox
+            horizontal
+            align={'center'}
+            className={cx(styles.root, shinyGroupStyles.shinyGroup)}
+            gap={8}
+          >
             <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
               {t('builtins.lobe-group-management.inspector.executeAgentTask.assignTo')}
             </span>
@@ -68,7 +73,9 @@ export const ExecuteAgentTaskInspector = memo<BuiltinInspectorProps<ExecuteTaskP
                   size={24}
                   title={agent.title || undefined}
                 />
-                <span>{agent?.title}</span>
+                <span className={cx(isArgumentsStreaming && shinyTextStyles.shinyText)}>
+                  {agent?.title}
+                </span>
               </>
             )}
             {taskTitle && (

--- a/packages/builtin-tool-group-management/src/client/Inspector/ExecuteAgentTask/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/ExecuteAgentTask/index.tsx
@@ -47,19 +47,16 @@ export const ExecuteAgentTaskInspector = memo<BuiltinInspectorProps<ExecuteTaskP
     if (isArgumentsStreaming) {
       if (!agent && !taskTitle)
         return (
-          <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-            <span>{t('builtins.lobe-group-management.apiName.executeAgentTask')}</span>
+          <div className={styles.root}>
+            <span className={shinyTextStyles.shinyText}>
+              {t('builtins.lobe-group-management.apiName.executeAgentTask')}
+            </span>
           </div>
         );
       if (agent) {
         return (
-          <Flexbox
-            horizontal
-            align={'center'}
-            className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-            gap={8}
-          >
-            <span className={styles.title}>
+          <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+            <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
               {t('builtins.lobe-group-management.inspector.executeAgentTask.assignTo')}
             </span>
             {agent && (
@@ -90,13 +87,8 @@ export const ExecuteAgentTaskInspector = memo<BuiltinInspectorProps<ExecuteTaskP
     const agentName = agent?.title || agentId;
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-group-management.inspector.executeAgentTask.assignTo')}
         </span>
         {agent && (

--- a/packages/builtin-tool-group-management/src/client/Inspector/ExecuteAgentTasks/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/ExecuteAgentTasks/index.tsx
@@ -76,20 +76,17 @@ export const ExecuteAgentTasksInspector = memo<BuiltinInspectorProps<ExecuteTask
 
     if (isArgumentsStreaming && agents.length === 0) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-group-management.apiName.executeAgentTasks')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-group-management.apiName.executeAgentTasks')}
+          </span>
         </div>
       );
     }
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-group-management.inspector.executeAgentTasks.title')}
         </span>
         {avatarItems.length > 0 && <Avatar.Group items={avatarItems} shape={'circle'} size={24} />}

--- a/packages/builtin-tool-group-management/src/client/Inspector/Speak/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/Speak/index.tsx
@@ -45,8 +45,10 @@ export const SpeakInspector = memo<BuiltinInspectorProps<SpeakParams>>(
 
     if (isArgumentsStreaming && !agent) {
       return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-group-management.apiName.speak')}</span>
+        <div className={styles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-group-management.apiName.speak')}
+          </span>
         </div>
       );
     }
@@ -54,13 +56,8 @@ export const SpeakInspector = memo<BuiltinInspectorProps<SpeakParams>>(
     const agentName = agent?.title || agentId;
 
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
+      <Flexbox horizontal align={'center'} className={styles.root} gap={8}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-group-management.inspector.speak.title')}
         </span>
         {agent && (

--- a/packages/builtin-tool-image-generation/src/client/Inspector/index.tsx
+++ b/packages/builtin-tool-image-generation/src/client/Inspector/index.tsx
@@ -100,15 +100,16 @@ const ImageGenerationInspector = memo<BuiltinInspectorProps<ImageGenerationInspe
     const Icon = meta.Icon;
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          styles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={cx(inspectorTextStyles.root, styles.root)}>
         <Icon className={styles.icon} size={14} />
-        <span className={styles.label}>{label}</span>
+        <span
+          className={cx(
+            styles.label,
+            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          )}
+        >
+          {label}
+        </span>
         {apiName === ImageGenerationApiName.generateImage && prompt && (
           <span className={cx(highlightTextStyles.primary, styles.prompt)}>{prompt}</span>
         )}

--- a/packages/builtin-tool-image-generation/src/client/Inspector/index.tsx
+++ b/packages/builtin-tool-image-generation/src/client/Inspector/index.tsx
@@ -105,7 +105,7 @@ const ImageGenerationInspector = memo<BuiltinInspectorProps<ImageGenerationInspe
         <span
           className={cx(
             styles.label,
-            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+            (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
           )}
         >
           {label}

--- a/packages/builtin-tool-knowledge-base/src/client/Inspector/ReadKnowledge/index.tsx
+++ b/packages/builtin-tool-knowledge-base/src/client/Inspector/ReadKnowledge/index.tsx
@@ -31,14 +31,18 @@ export const ReadKnowledgeInspector = memo<
   if (isArgumentsStreaming) {
     if (fileCount === 0)
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-knowledge-base.apiName.readKnowledge')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-knowledge-base.apiName.readKnowledge')}
+          </span>
         </div>
       );
 
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-knowledge-base.apiName.readKnowledge')}: </span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-knowledge-base.apiName.readKnowledge')}:{' '}
+        </span>
         <span className={highlightTextStyles.gold}>
           {fileCount} {fileCount === 1 ? 'file' : 'files'}
         </span>
@@ -73,9 +77,11 @@ export const ReadKnowledgeInspector = memo<
   };
 
   return (
-    <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+    <div className={inspectorTextStyles.root}>
       <span style={{ marginInlineStart: 2 }}>
-        <span>{t('builtins.lobe-knowledge-base.apiName.readKnowledge')}: </span>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-knowledge-base.apiName.readKnowledge')}:{' '}
+        </span>
         {renderFileInfo()}
       </span>
     </div>

--- a/packages/builtin-tool-knowledge-base/src/client/Inspector/SearchKnowledgeBase/index.tsx
+++ b/packages/builtin-tool-knowledge-base/src/client/Inspector/SearchKnowledgeBase/index.tsx
@@ -24,23 +24,29 @@ export const SearchKnowledgeBaseInspector = memo<
   if (isArgumentsStreaming) {
     if (!query)
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-knowledge-base.apiName.searchKnowledgeBase')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-knowledge-base.apiName.searchKnowledgeBase')}
+          </span>
         </div>
       );
 
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-knowledge-base.apiName.searchKnowledgeBase')}: </span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-knowledge-base.apiName.searchKnowledgeBase')}:{' '}
+        </span>
         <span className={highlightTextStyles.gold}>{query}</span>
       </div>
     );
   }
 
   return (
-    <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+    <div className={inspectorTextStyles.root}>
       <span style={{ marginInlineStart: 2 }}>
-        <span>{t('builtins.lobe-knowledge-base.apiName.searchKnowledgeBase')}: </span>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-knowledge-base.apiName.searchKnowledgeBase')}:{' '}
+        </span>
         {query && <span className={highlightTextStyles.gold}>{query}</span>}
         {!isLoading &&
           pluginState?.fileResults &&

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/AnalyzeMedia/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/AnalyzeMedia/index.tsx
@@ -25,8 +25,10 @@ export const AnalyzeMediaInspector = memo<
 
   if (isArgumentsStreaming && !question) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent.apiName.analyzeMedia')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent.apiName.analyzeMedia')}
+        </span>
       </div>
     );
   }

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/CallSubAgent/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/CallSubAgent/index.tsx
@@ -66,11 +66,11 @@ export const CallSubAgentInspector = memo<
   const stats = hasFinalStats ? pluginState : pluginState?.progress;
 
   return (
-    <div
-      className={cx(inspectorTextStyles.root, styles.root, isShiny && shinyTextStyles.shinyText)}
-    >
+    <div className={cx(inspectorTextStyles.root, styles.root)}>
       <GroupBotIcon className={styles.icon} size={14} />
-      <span className={styles.label}>{t('builtins.lobe-agent.apiName.callSubAgent')}</span>
+      <span className={cx(styles.label, isShiny && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-agent.apiName.callSubAgent')}
+      </span>
       {description && <span className={styles.chip}>{description}</span>}
       {stats && (
         <SubAgentStats

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/ClearTodos/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/ClearTodos/index.tsx
@@ -25,8 +25,10 @@ export const ClearTodosInspector = memo<BuiltinInspectorProps<ClearTodosParams, 
 
     if (isArgumentsStreaming && !mode) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent.apiName.clearTodos')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent.apiName.clearTodos')}
+          </span>
         </div>
       );
     }

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/CreatePlan/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/CreatePlan/index.tsx
@@ -17,8 +17,10 @@ export const CreatePlanInspector = memo<BuiltinInspectorProps<CreatePlanParams, 
 
     if (isArgumentsStreaming && !goal) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent.apiName.createPlan')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent.apiName.createPlan')}
+          </span>
         </div>
       );
     }

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/CreateTodos/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/CreateTodos/index.tsx
@@ -2,7 +2,6 @@
 
 import { TodoInspectorSummary } from '@lobechat/shared-tool-ui/components';
 import type { BuiltinInspectorProps } from '@lobechat/types';
-import { cx } from 'antd-style';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -34,20 +33,21 @@ export const CreateTodosInspector = memo<
 
   if (isArgumentsStreaming && summary.total === 0) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-agent.apiName.createTodos')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-agent.apiName.createTodos')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <TodoInspectorSummary label={t(TODO_SUMMARY_LABEL_KEYS[summary.state])} summary={summary} />
+    <div className={inspectorTextStyles.root}>
+      <TodoInspectorSummary
+        label={t(TODO_SUMMARY_LABEL_KEYS[summary.state])}
+        shiny={isArgumentsStreaming || isLoading}
+        summary={summary}
+      />
     </div>
   );
 });

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdatePlan/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdatePlan/index.tsx
@@ -29,15 +29,19 @@ export const UpdatePlanInspector = memo<BuiltinInspectorProps<UpdatePlanParams, 
 
     if (isArgumentsStreaming && !planId) {
       return (
-        <div className={cx(oneLineEllipsis, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent.apiName.updatePlan')}</span>
+        <div className={oneLineEllipsis}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-agent.apiName.updatePlan')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div className={cx(oneLineEllipsis, isArgumentsStreaming && shinyTextStyles.shinyText)}>
-        <span className={styles.title}>{t('builtins.lobe-agent.apiName.updatePlan')}</span>
+      <div className={oneLineEllipsis}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-agent.apiName.updatePlan')}
+        </span>
         {completed && (
           <Text code as={'span'} color={cssVar.colorSuccess} fontSize={12}>
             <Icon icon={CheckCircle} size={12} />

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdateTodos/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdateTodos/index.tsx
@@ -31,15 +31,19 @@ export const UpdateTodosInspector = memo<
 
   if (summary.total === 0) {
     return (
-      <div className={cx(inspectorTextStyles.root, shiny)}>
-        <span>{t('builtins.lobe-agent.apiName.updateTodos')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(shiny)}>{t('builtins.lobe-agent.apiName.updateTodos')}</span>
       </div>
     );
   }
 
   return (
-    <div className={cx(inspectorTextStyles.root, shiny)}>
-      <TodoInspectorSummary label={t(TODO_SUMMARY_LABEL_KEYS[summary.state])} summary={summary} />
+    <div className={inspectorTextStyles.root}>
+      <TodoInspectorSummary
+        label={t(TODO_SUMMARY_LABEL_KEYS[summary.state])}
+        shiny={isArgumentsStreaming || isLoading}
+        summary={summary}
+      />
     </div>
   );
 });

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/Vent/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/Vent/index.tsx
@@ -59,8 +59,8 @@ export const VentInspector = memo<BuiltinInspectorProps<VentParams, VentState>>(
 
     if (isArgumentsStreaming && !hasContext) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{title}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>{title}</span>
         </div>
       );
     }
@@ -68,14 +68,10 @@ export const VentInspector = memo<BuiltinInspectorProps<VentParams, VentState>>(
     const isSettled = !isArgumentsStreaming && !isLoading && !!pluginState;
 
     return (
-      <div
-        style={{ flexWrap: 'wrap', gap: 4 }}
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{title}</span>
+      <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {title}
+        </span>
         {summary && (
           <span className={cx(highlightTextStyles.primary, styles.summary)}>{summary}</span>
         )}

--- a/packages/builtin-tool-local-system/src/client/Render/SearchFiles/SearchQuery/SearchView.tsx
+++ b/packages/builtin-tool-local-system/src/client/Render/SearchFiles/SearchQuery/SearchView.tsx
@@ -31,14 +31,9 @@ const SearchBar = memo<SearchBarProps>(({ defaultQuery, resultsNumber, searching
   const { t } = useTranslation('tool');
   return (
     <Flexbox horizontal align={'center'} distribution={'space-between'} gap={40} height={26}>
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.query, searching && shinyTextStyles.shinyText)}
-        gap={8}
-      >
+      <Flexbox horizontal align={'center'} className={styles.query} gap={8}>
         <Icon icon={SearchIcon} />
-        {defaultQuery}
+        <span className={cx(searching && shinyTextStyles.shinyText)}>{defaultQuery}</span>
       </Flexbox>
 
       <Flexbox horizontal align={'center'} className={styles.font}>

--- a/packages/builtin-tool-memory/src/client/Inspector/AddActivityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddActivityMemory/index.tsx
@@ -27,8 +27,10 @@ export const AddActivityMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.addActivityMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.addActivityMemory')}
+        </span>
       </div>
     );
   }
@@ -36,13 +38,10 @@ export const AddActivityMemoryInspector = memo<
   const isSuccess = pluginState?.memoryId;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.addActivityMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.addActivityMemory')}
+      </span>
       {title && (
         <>
           :<span className={highlightTextStyles.primary}>{title}</span>

--- a/packages/builtin-tool-memory/src/client/Inspector/AddContextMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddContextMemory/index.tsx
@@ -27,8 +27,10 @@ export const AddContextMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.addContextMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.addContextMemory')}
+        </span>
       </div>
     );
   }
@@ -36,13 +38,10 @@ export const AddContextMemoryInspector = memo<
   const isSuccess = pluginState?.memoryId;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.addContextMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.addContextMemory')}
+      </span>
       {title && (
         <>
           :<span className={highlightTextStyles.primary}>{title}</span>

--- a/packages/builtin-tool-memory/src/client/Inspector/AddExperienceMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddExperienceMemory/index.tsx
@@ -27,8 +27,10 @@ export const AddExperienceMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.addExperienceMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.addExperienceMemory')}
+        </span>
       </div>
     );
   }
@@ -36,13 +38,10 @@ export const AddExperienceMemoryInspector = memo<
   const isSuccess = pluginState?.memoryId;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.addExperienceMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.addExperienceMemory')}
+      </span>
       {title && (
         <>
           :<span className={highlightTextStyles.primary}>{title}</span>

--- a/packages/builtin-tool-memory/src/client/Inspector/AddIdentityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddIdentityMemory/index.tsx
@@ -27,8 +27,10 @@ export const AddIdentityMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.addIdentityMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.addIdentityMemory')}
+        </span>
       </div>
     );
   }
@@ -36,13 +38,10 @@ export const AddIdentityMemoryInspector = memo<
   const isSuccess = pluginState?.memoryId;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.addIdentityMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.addIdentityMemory')}
+      </span>
       {title && (
         <>
           :<span className={highlightTextStyles.primary}>{title}</span>

--- a/packages/builtin-tool-memory/src/client/Inspector/AddPreferenceMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddPreferenceMemory/index.tsx
@@ -27,8 +27,10 @@ export const AddPreferenceMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !title) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.addPreferenceMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.addPreferenceMemory')}
+        </span>
       </div>
     );
   }
@@ -36,13 +38,10 @@ export const AddPreferenceMemoryInspector = memo<
   const isSuccess = pluginState?.memoryId;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.addPreferenceMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.addPreferenceMemory')}
+      </span>
       {title && (
         <>
           :<span className={highlightTextStyles.primary}>{title}</span>

--- a/packages/builtin-tool-memory/src/client/Inspector/QueryTaxonomyOptions/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/QueryTaxonomyOptions/index.tsx
@@ -35,20 +35,19 @@ export const QueryTaxonomyOptionsInspector = memo<
 
   if (isArgumentsStreaming && !query) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.queryTaxonomyOptions')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.queryTaxonomyOptions')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.queryTaxonomyOptions')}: </span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.queryTaxonomyOptions')}:{' '}
+      </span>
       {query && <span className={highlightTextStyles.primary}>{query}</span>}
       {!isLoading &&
         !isArgumentsStreaming &&

--- a/packages/builtin-tool-memory/src/client/Inspector/RemoveIdentityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/RemoveIdentityMemory/index.tsx
@@ -27,8 +27,10 @@ export const RemoveIdentityMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !id) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.removeIdentityMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.removeIdentityMemory')}
+        </span>
       </div>
     );
   }
@@ -36,13 +38,10 @@ export const RemoveIdentityMemoryInspector = memo<
   const isSuccess = pluginState?.identityId;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.removeIdentityMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.removeIdentityMemory')}
+      </span>
       {id && (
         <>
           :<span className={highlightTextStyles.warning}>{id}</span>

--- a/packages/builtin-tool-memory/src/client/Inspector/SearchUserMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/SearchUserMemory/index.tsx
@@ -23,8 +23,10 @@ export const SearchUserMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !query) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.searchUserMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.searchUserMemory')}
+        </span>
       </div>
     );
   }
@@ -40,13 +42,10 @@ export const SearchUserMemoryInspector = memo<
   const hasResults = resultCount > 0;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.searchUserMemory')}: </span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.searchUserMemory')}:{' '}
+      </span>
       {query && <span className={highlightTextStyles.primary}>{query}</span>}
       {!isLoading &&
         !isArgumentsStreaming &&

--- a/packages/builtin-tool-memory/src/client/Inspector/UpdateIdentityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/UpdateIdentityMemory/index.tsx
@@ -19,20 +19,19 @@ export const UpdateIdentityMemoryInspector = memo<
   // Initial streaming state
   if (isArgumentsStreaming && !id) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-user-memory.apiName.updateIdentityMemory')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-user-memory.apiName.updateIdentityMemory')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-user-memory.apiName.updateIdentityMemory')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-user-memory.apiName.updateIdentityMemory')}
+      </span>
     </div>
   );
 });

--- a/packages/builtin-tool-page-agent/src/client/Inspector/GetPageContent/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/GetPageContent/index.tsx
@@ -17,13 +17,10 @@ export const GetPageContentInspector = memo<BuiltinInspectorProps>(({ isArgument
   const { t } = useTranslation('plugin');
 
   return (
-    <div
-      className={cx(
-        oneLineEllipsis,
-        isArgumentsStreaming ? shinyTextStyles.shinyText : styles.done,
-      )}
-    >
-      <span>{t('builtins.lobe-page-agent.apiName.getPageContent')}</span>
+    <div className={oneLineEllipsis}>
+      <span className={cx(isArgumentsStreaming ? shinyTextStyles.shinyText : styles.done)}>
+        {t('builtins.lobe-page-agent.apiName.getPageContent')}
+      </span>
     </div>
   );
 });

--- a/packages/builtin-tool-page-agent/src/client/Inspector/InitPage/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/InitPage/index.tsx
@@ -4,7 +4,7 @@ import type { InitDocumentArgs } from '@lobechat/editor-runtime';
 import type { BuiltinInspectorProps } from '@lobechat/types';
 import { Icon } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { Plus } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,8 +38,10 @@ export const InitPageInspector = memo<BuiltinInspectorProps<InitDocumentArgs, In
     if (isArgumentsStreaming) {
       if (!hasContent)
         return (
-          <div className={cx(oneLineEllipsis, shinyTextStyles.shinyText)}>
-            <span>{t('builtins.lobe-page-agent.apiName.initPage')}</span>
+          <div className={oneLineEllipsis}>
+            <span className={shinyTextStyles.shinyText}>
+              {t('builtins.lobe-page-agent.apiName.initPage')}
+            </span>
           </div>
         );
 

--- a/packages/builtin-tool-page-agent/src/client/Inspector/ModifyNodes/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/ModifyNodes/index.tsx
@@ -65,8 +65,10 @@ export const ModifyNodesInspector = memo<BuiltinInspectorProps<ModifyNodesArgs, 
     // During streaming without operations yet, show init message
     if (isArgumentsStreaming && !hasOperations) {
       return (
-        <div className={cx(oneLineEllipsis, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-page-agent.apiName.modifyNodes.init')}</span>
+        <div className={oneLineEllipsis}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-page-agent.apiName.modifyNodes.init')}
+          </span>
         </div>
       );
     }
@@ -99,8 +101,10 @@ export const ModifyNodesInspector = memo<BuiltinInspectorProps<ModifyNodesArgs, 
     }
 
     return (
-      <div className={cx(oneLineEllipsis, isArgumentsStreaming && shinyTextStyles.shinyText)}>
-        <span className={styles.title}>{t('builtins.lobe-page-agent.apiName.modifyNodes')}</span>
+      <div className={oneLineEllipsis}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-page-agent.apiName.modifyNodes')}
+        </span>
         {statsParts.length > 0 && (
           <>
             {' '}

--- a/packages/builtin-tool-page-agent/src/client/Inspector/ReplaceText/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/ReplaceText/index.tsx
@@ -38,8 +38,10 @@ export const ReplaceTextInspector = memo<BuiltinInspectorProps<ReplaceTextArgs, 
     // During streaming without searchText yet, show init message
     if (isArgumentsStreaming && !from) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-page-agent.apiName.replaceText.init')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-page-agent.apiName.replaceText.init')}
+          </span>
         </div>
       );
     }
@@ -48,10 +50,10 @@ export const ReplaceTextInspector = memo<BuiltinInspectorProps<ReplaceTextArgs, 
     const hasResult = from && to !== undefined;
 
     return (
-      <div
-        className={cx(inspectorTextStyles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-      >
-        <span className={styles.title}>{t('builtins.lobe-page-agent.apiName.replaceText')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(styles.title, isArgumentsStreaming && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-page-agent.apiName.replaceText')}
+        </span>
         {hasResult && (
           <>
             <span className={styles.from}>{from}</span>

--- a/packages/builtin-tool-remote-device/src/client/Inspector/ActivateDevice/index.tsx
+++ b/packages/builtin-tool-remote-device/src/client/Inspector/ActivateDevice/index.tsx
@@ -39,13 +39,10 @@ export const ActivateDeviceInspector = memo<
     (requestedDeviceId ? requestedDeviceId.slice(0, 12) : '');
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-remote-device.apiName.activateDevice')}</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-remote-device.apiName.activateDevice')}
+      </span>
       {deviceLabel && <span className={styles.device}>{deviceLabel}</span>}
     </div>
   );

--- a/packages/builtin-tool-remote-device/src/client/Inspector/ListOnlineDevices/index.tsx
+++ b/packages/builtin-tool-remote-device/src/client/Inspector/ListOnlineDevices/index.tsx
@@ -38,11 +38,11 @@ export const ListOnlineDevicesInspector = memo<
   const deviceCount = pluginState?.devices?.length;
 
   return (
-    <div
-      className={cx(inspectorTextStyles.root, styles.root, isPending && shinyTextStyles.shinyText)}
-    >
+    <div className={cx(inspectorTextStyles.root, styles.root)}>
       <Icon className={styles.icon} icon={MonitorIcon} size={14} />
-      <span>{t('builtins.lobe-remote-device.apiName.listOnlineDevices')}</span>
+      <span className={cx(isPending && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-remote-device.apiName.listOnlineDevices')}
+      </span>
       {!isPending && deviceCount !== undefined && (
         <span className={styles.count}>
           {t('builtins.lobe-remote-device.inspector.onlineCount', { count: deviceCount })}

--- a/packages/builtin-tool-self-iteration/src/client/Inspector/DeclareSelfFeedbackIntent/index.tsx
+++ b/packages/builtin-tool-self-iteration/src/client/Inspector/DeclareSelfFeedbackIntent/index.tsx
@@ -75,8 +75,8 @@ export const DeclareSelfFeedbackIntentInspector = memo<
 
   if (isArgumentsStreaming && !hasContext) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{title}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>{title}</span>
       </div>
     );
   }
@@ -84,14 +84,10 @@ export const DeclareSelfFeedbackIntentInspector = memo<
   const isSettled = !isArgumentsStreaming && !isLoading && !!pluginState;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{title}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {title}
+      </span>
       {summary && (
         <span className={cx(highlightTextStyles.primary, styles.summary)}>{summary}</span>
       )}

--- a/packages/builtin-tool-skill-store/src/client/Inspector/ImportFromMarket/index.tsx
+++ b/packages/builtin-tool-skill-store/src/client/Inspector/ImportFromMarket/index.tsx
@@ -27,8 +27,10 @@ export const ImportFromMarketInspector = memo<
 
   if (isArgumentsStreaming && !identifier) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-skill-store.apiName.importFromMarket')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-skill-store.apiName.importFromMarket')}
+        </span>
       </div>
     );
   }
@@ -37,13 +39,10 @@ export const ImportFromMarketInspector = memo<
   const hasResult = pluginState?.success !== undefined;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-skill-store.apiName.importFromMarket')}:</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-skill-store.apiName.importFromMarket')}:
+      </span>
       {displayName && <span className={highlightTextStyles.primary}>{displayName}</span>}
       {!isLoading &&
         hasResult &&

--- a/packages/builtin-tool-skill-store/src/client/Inspector/ImportSkill/index.tsx
+++ b/packages/builtin-tool-skill-store/src/client/Inspector/ImportSkill/index.tsx
@@ -27,8 +27,10 @@ export const ImportSkillInspector = memo<
 
   if (isArgumentsStreaming && !url) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-skill-store.apiName.importSkill')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-skill-store.apiName.importSkill')}
+        </span>
       </div>
     );
   }
@@ -37,13 +39,10 @@ export const ImportSkillInspector = memo<
   const hasResult = pluginState?.success !== undefined;
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-skill-store.apiName.importSkill')}: </span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-skill-store.apiName.importSkill')}:{' '}
+      </span>
       {displayName && <span className={highlightTextStyles.primary}>{displayName}</span>}
       {!isLoading &&
         hasResult &&

--- a/packages/builtin-tool-skill-store/src/client/Inspector/SearchSkill/index.tsx
+++ b/packages/builtin-tool-skill-store/src/client/Inspector/SearchSkill/index.tsx
@@ -22,20 +22,17 @@ export const SearchSkillInspector = memo<
 
   if (isArgumentsStreaming && !query) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-skill-store.apiName.searchSkill')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-skill-store.apiName.searchSkill')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
         {t('builtins.lobe-skill-store.apiName.searchSkill')}:{'\u00A0'}
       </span>
       {query && <span className={highlightTextStyles.primary}>{query}</span>}

--- a/packages/builtin-tool-skills/src/client/Inspector/ExecScript/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/ExecScript/index.tsx
@@ -28,14 +28,18 @@ export const ExecScriptInspector = memo<BuiltinInspectorProps<ExecScriptParams, 
     if (isArgumentsStreaming) {
       if (!description)
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-            <span>{t('builtins.lobe-skills.apiName.execScript')}</span>
+          <div className={inspectorTextStyles.root}>
+            <span className={shinyTextStyles.shinyText}>
+              {t('builtins.lobe-skills.apiName.execScript')}
+            </span>
           </div>
         );
 
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-skills.apiName.execScript')}: </span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-skills.apiName.execScript')}:{' '}
+          </span>
           <span className={highlightTextStyles.primary}>{description}</span>
         </div>
       );
@@ -49,9 +53,11 @@ export const ExecScriptInspector = memo<BuiltinInspectorProps<ExecScriptParams, 
     const isStillRunning = pluginState?.exitCode === undefined && !!pluginState?.shellId;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+      <div className={inspectorTextStyles.root}>
         <span style={{ marginInlineStart: 2 }}>
-          <span>{t('builtins.lobe-skills.apiName.execScript')}: </span>
+          <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+            {t('builtins.lobe-skills.apiName.execScript')}:{' '}
+          </span>
           {description && <span className={highlightTextStyles.primary}>{description}</span>}
           {isLoading ? null : isStillRunning ? (
             <Icon spin className={styles.statusIcon} icon={LoaderCircle} size={14} />

--- a/packages/builtin-tool-skills/src/client/Inspector/ReadReference/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/ReadReference/index.tsx
@@ -20,23 +20,29 @@ export const ReadReferenceInspector = memo<
   if (isArgumentsStreaming) {
     if (!path)
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-skills.apiName.readReference')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-skills.apiName.readReference')}
+          </span>
         </div>
       );
 
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-skills.apiName.readReference')}:</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-skills.apiName.readReference')}:
+        </span>
         <span>{path}</span>
       </div>
     );
   }
 
   return (
-    <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+    <div className={inspectorTextStyles.root}>
       <span className={inspectorTextStyles.root}>
-        <span>{t('builtins.lobe-skills.apiName.readReference')}:</span>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-skills.apiName.readReference')}:
+        </span>
         <span className={highlightTextStyles.primary}>{resolvedPath}</span>
       </span>
     </div>

--- a/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
@@ -93,14 +93,14 @@ export const RunSkillInspector = memo<
   if (isArgumentsStreaming) {
     if (!displayName)
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{label}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>{label}</span>
         </div>
       );
 
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{label}:</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>{label}:</span>
         <span className={styles.chip}>
           <SkillsIcon className={styles.skillIcon} size={12} />
           <span className={styles.skillName}>{displayName}</span>
@@ -110,8 +110,8 @@ export const RunSkillInspector = memo<
   }
 
   return (
-    <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-      <span>{label}:</span>
+    <div className={inspectorTextStyles.root}>
+      <span className={cx(isLoading && shinyTextStyles.shinyText)}>{label}:</span>
       {displayName && (
         <span className={styles.chip}>
           <SkillsIcon className={styles.skillIcon} size={12} />

--- a/packages/builtin-tool-task/src/client/Inspector/CreateGoal/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/CreateGoal/index.tsx
@@ -15,13 +15,10 @@ const CreateGoalInspector = memo<BuiltinInspectorProps<CreateGoalParams, CreateG
     const name = args?.name || partialArgs?.name || pluginState?.name;
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{t('builtins.lobe-goal.apiName.createGoal')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-goal.apiName.createGoal')}
+        </span>
         {name && <span> · {name}</span>}
       </div>
     );

--- a/packages/builtin-tool-task/src/client/Inspector/CreateTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/CreateTask/index.tsx
@@ -74,21 +74,19 @@ export const CreateTaskInspector = memo<BuiltinInspectorProps<CreateTaskParams, 
 
     if (isArgumentsStreaming && !name) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-task.apiName.createTask')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-task.apiName.createTask')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div
-        style={{ flexWrap: 'wrap', gap: 4 }}
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{t('builtins.lobe-task.apiName.createTask')}</span>
+      <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-task.apiName.createTask')}
+        </span>
         {identifier && (
           <span className={styles.identifierChip} style={{ marginInlineStart: 6 }}>
             {identifier}

--- a/packages/builtin-tool-task/src/client/Inspector/CreateTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/CreateTasks/index.tsx
@@ -66,21 +66,19 @@ export const CreateTasksInspector = memo<
 
   if (isArgumentsStreaming && count === 0) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-task.apiName.createTasks')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-task.apiName.createTasks')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 6 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-task.apiName.createTasks')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 6 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-task.apiName.createTasks')}
+      </span>
       {count > 0 && (
         <span className={styles.countBadge}>
           {t('builtins.lobe-task.createTasks.count', { count })}

--- a/packages/builtin-tool-task/src/client/Inspector/DeleteTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/DeleteTask/index.tsx
@@ -35,13 +35,11 @@ export const DeleteTaskInspector = memo<BuiltinInspectorProps<DeleteTaskParams, 
     const identifier = args?.identifier || partialArgs?.identifier;
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span style={{ color: cssVar.colorError }}>
+      <div className={inspectorTextStyles.root}>
+        <span
+          className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}
+          style={{ color: cssVar.colorError }}
+        >
           {t('builtins.lobe-task.apiName.deleteTask')}
         </span>
         {identifier && <span className={styles.identifierChip}>{identifier}</span>}

--- a/packages/builtin-tool-task/src/client/Inspector/EditTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/EditTask/index.tsx
@@ -239,14 +239,10 @@ export const EditTaskInspector = memo<BuiltinInspectorProps<EditTaskParams, Edit
     }
 
     return (
-      <div
-        style={{ flexWrap: 'wrap', gap: 6 }}
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{t('builtins.lobe-task.apiName.editTask')}</span>
+      <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 6 }}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-task.apiName.editTask')}
+        </span>
         {identifier && <span className={styles.identifierChip}>{identifier}</span>}
         {segments.map((segment, index) => (
           <span className={styles.group} key={segment.key}>

--- a/packages/builtin-tool-task/src/client/Inspector/ListTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/ListTasks/index.tsx
@@ -26,15 +26,19 @@ export const ListTasksInspector = memo<BuiltinInspectorProps<ListTasksParams, Li
 
     if (isArgumentsStreaming && !filterText) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-task.apiName.listTasks')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-task.apiName.listTasks')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-task.apiName.listTasks')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-task.apiName.listTasks')}
+        </span>
         {filterText && (
           <Text as={'span'} color={cssVar.colorTextTertiary} fontSize={12}>
             {' · '}

--- a/packages/builtin-tool-task/src/client/Inspector/RunTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/RunTask/index.tsx
@@ -60,15 +60,11 @@ export const RunTaskInspector = memo<BuiltinInspectorProps<RunTaskParams, RunTas
     const prompt = params.prompt;
 
     return (
-      <div
-        style={{ flexWrap: 'wrap', gap: 4 }}
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
         <Icon icon={Play} size={12} style={{ color: cssVar.colorWarning }} />
-        <span>{t('builtins.lobe-task.apiName.runTask')}</span>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-task.apiName.runTask')}
+        </span>
         {identifier && (
           <span className={styles.identifierChip} style={{ marginInlineStart: 4 }}>
             {identifier}

--- a/packages/builtin-tool-task/src/client/Inspector/RunTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/RunTasks/index.tsx
@@ -74,23 +74,21 @@ export const RunTasksInspector = memo<BuiltinInspectorProps<RunTasksParams, RunT
 
     if (isArgumentsStreaming && count === 0) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
+        <div className={inspectorTextStyles.root}>
           <Icon icon={Play} size={12} style={{ color: cssVar.colorWarning }} />
-          <span>{t('builtins.lobe-task.apiName.runTasks')}</span>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-task.apiName.runTasks')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div
-        style={{ flexWrap: 'wrap', gap: 6 }}
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 6 }}>
         <Icon icon={Play} size={12} style={{ color: cssVar.colorWarning }} />
-        <span>{t('builtins.lobe-task.apiName.runTasks')}</span>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-task.apiName.runTasks')}
+        </span>
         {count > 0 && (
           <span className={styles.countBadge}>
             {t('builtins.lobe-task.runTasks.count', { count })}

--- a/packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx
@@ -51,14 +51,10 @@ export const SetTaskScheduleInspector = memo<
   const modeLabel = automationMode === null ? 'off' : automationMode;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-task.apiName.setTaskSchedule')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-task.apiName.setTaskSchedule')}
+      </span>
       {identifier && <span className={styles.identifierChip}>{identifier}</span>}
       {modeLabel && (
         <>

--- a/packages/builtin-tool-task/src/client/Inspector/SetTaskVerify/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/SetTaskVerify/index.tsx
@@ -33,14 +33,10 @@ export const SetTaskVerifyInspector = memo<
   const identifier = args?.identifier || partialArgs?.identifier;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-task.apiName.setTaskVerify')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-task.apiName.setTaskVerify')}
+      </span>
       {identifier && <span className={styles.identifierChip}>{identifier}</span>}
     </div>
   );

--- a/packages/builtin-tool-task/src/client/Inspector/TaskComment/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/TaskComment/index.tsx
@@ -95,13 +95,10 @@ export const TaskCommentInspector = memo<TaskCommentInspectorProps>(
     const content = 'content' in params ? params.content : undefined;
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{t(selectLabelKey(apiName))}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t(selectLabelKey(apiName))}
+        </span>
         {identifier && <span className={styles.chip}>{identifier}</span>}
         {commentId && <span className={styles.chip}>{commentId}</span>}
         {content && <span className={styles.contentChip}>{content}</span>}

--- a/packages/builtin-tool-task/src/client/Inspector/UpdateTaskStatus/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/UpdateTaskStatus/index.tsx
@@ -58,14 +58,10 @@ export const UpdateTaskStatusInspector = memo<
   const tone = status ? STATUS_TONE[status] : undefined;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-task.apiName.updateTaskStatus')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-task.apiName.updateTaskStatus')}
+      </span>
       {identifier && <span className={styles.identifierChip}>{identifier}</span>}
       {status && (
         <>

--- a/packages/builtin-tool-task/src/client/Inspector/ViewTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/ViewTask/index.tsx
@@ -33,13 +33,10 @@ export const ViewTaskInspector = memo<BuiltinInspectorProps<ViewTaskParams, View
     const identifier = args?.identifier || partialArgs?.identifier || pluginState?.identifier;
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{t('builtins.lobe-task.apiName.viewTask')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {t('builtins.lobe-task.apiName.viewTask')}
+        </span>
         {identifier && <span className={styles.identifierChip}>{identifier}</span>}
       </div>
     );

--- a/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.test.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.test.tsx
@@ -66,7 +66,7 @@ describe('AskUserQuestionInspector', () => {
       />,
     );
 
-    expect(screen.getByTestId('ask-user-question-inspector').classList).toContain('shiny-text');
+    expect(screen.getByText('Ask user question').classList).toContain('shiny-text');
     expect(screen.getByText('Next step')).toBeTruthy();
   });
 

--- a/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.tsx
@@ -53,14 +53,10 @@ export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuesti
     }
 
     return (
-      <div
-        data-testid="ask-user-question-inspector"
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root} data-testid="ask-user-question-inspector">
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {summary && <span className={styles.chip}>{summary}</span>}
       </div>
     );

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlMultiPages/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlMultiPages/index.tsx
@@ -31,17 +31,17 @@ export const CrawlMultiPagesInspector = memo<BuiltinInspectorProps<CrawlMultiPag
 
     if (isArgumentsStreaming && !displayText) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-web-browsing.apiName.crawlMultiPages')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-web-browsing.apiName.crawlMultiPages')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div
-        className={cx(inspectorTextStyles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-      >
-        <span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-web-browsing.apiName.crawlMultiPages')}:{'\u00A0'}
         </span>
         {displayText && <span className={highlightTextStyles.gold}>{displayText}</span>}

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlSinglePage/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlSinglePage/index.tsx
@@ -19,17 +19,17 @@ export const CrawlSinglePageInspector = memo<BuiltinInspectorProps<CrawlSinglePa
 
     if (isArgumentsStreaming && !url) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-web-browsing.apiName.crawlSinglePage')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-web-browsing.apiName.crawlSinglePage')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div
-        className={cx(inspectorTextStyles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-      >
-        <span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isArgumentsStreaming && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-web-browsing.apiName.crawlSinglePage')}:{'\u00A0'}
         </span>
         {url && <span className={highlightTextStyles.gold}>{url}</span>}

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/Search/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/Search/index.tsx
@@ -18,20 +18,17 @@ export const SearchInspector = memo<BuiltinInspectorProps<SearchQuery, UniformSe
 
     if (isArgumentsStreaming && !query) {
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-web-browsing.apiName.search')}</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText}>
+            {t('builtins.lobe-web-browsing.apiName.search')}
+          </span>
         </div>
       );
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
           {t('builtins.lobe-web-browsing.apiName.search')}:{'\u00A0'}
         </span>
         {query && <span className={highlightTextStyles.primary}>{query}</span>}

--- a/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchQuery/SearchView.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchQuery/SearchView.tsx
@@ -41,7 +41,7 @@ const SearchBar = memo<SearchBarProps>(
           clickable
           horizontal
           align={'center'}
-          className={cx(styles.query, searching && shinyTextStyles.shinyText)}
+          className={styles.query}
           gap={8}
           variant={'borderless'}
           onClick={() => {
@@ -49,7 +49,7 @@ const SearchBar = memo<SearchBarProps>(
           }}
         >
           <Icon icon={SearchIcon} />
-          {defaultQuery}
+          <span className={cx(searching && shinyTextStyles.shinyText)}>{defaultQuery}</span>
         </Block>
 
         {searching ? (

--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/ShowAgentMarketplace/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/ShowAgentMarketplace/index.tsx
@@ -24,8 +24,10 @@ export const ShowAgentMarketplaceInspector = memo<
 
   if (isArgumentsStreaming && categoryHints.length === 0) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{tPlugin('builtins.lobe-web-onboarding.apiName.showAgentMarketplace')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {tPlugin('builtins.lobe-web-onboarding.apiName.showAgentMarketplace')}
+        </span>
       </div>
     );
   }
@@ -34,14 +36,10 @@ export const ShowAgentMarketplaceInspector = memo<
   const overflowCount = categoryHints.length - visibleHints.length;
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{tPlugin('builtins.lobe-web-onboarding.apiName.showAgentMarketplace')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {tPlugin('builtins.lobe-web-onboarding.apiName.showAgentMarketplace')}
+      </span>
       {visibleHints.map((slug) => {
         const labelKey = CATEGORY_LABEL_I18N_KEYS[slug];
         return (

--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/SubmitAgentPick/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/SubmitAgentPick/index.tsx
@@ -21,21 +21,19 @@ export const SubmitAgentPickInspector = memo<
 
   if (isArgumentsStreaming && ids.length === 0) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{tPlugin('builtins.lobe-web-onboarding.apiName.submitAgentPick')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {tPlugin('builtins.lobe-web-onboarding.apiName.submitAgentPick')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{tPlugin('builtins.lobe-web-onboarding.apiName.submitAgentPick')}</span>
+    <div className={inspectorTextStyles.root} style={{ gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {tPlugin('builtins.lobe-web-onboarding.apiName.submitAgentPick')}
+      </span>
       {ids.length > 0 && (
         <span className={styles.meta}>
           {tTool('agentMarketplace.inspector.pickCount', { count: ids.length })}

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/FinishOnboarding/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/FinishOnboarding/index.tsx
@@ -22,14 +22,10 @@ export const FinishOnboardingInspector = memo<
   const succeeded = !!result && !result.error;
 
   return (
-    <div
-      style={{ gap: 6 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-web-onboarding.apiName.finishOnboarding')}</span>
+    <div className={inspectorTextStyles.root} style={{ gap: 6 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-web-onboarding.apiName.finishOnboarding')}
+      </span>
       {succeeded && <Icon className={styles.done} icon={CheckCircle2} size={14} />}
     </div>
   );

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/ReadDocument/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/ReadDocument/index.tsx
@@ -24,21 +24,19 @@ export const ReadDocumentInspector = memo<
 
   if (isArgumentsStreaming && !type) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-web-onboarding.apiName.readDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-web-onboarding.apiName.readDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-web-onboarding.apiName.readDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-web-onboarding.apiName.readDocument')}
+      </span>
       {type && (
         <span className={styles.chip}>
           {t(`builtins.lobe-web-onboarding.docType.${type}` as const)}

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/SaveUserQuestion/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/SaveUserQuestion/index.tsx
@@ -26,21 +26,19 @@ export const SaveUserQuestionInspector = memo<
 
   if (isArgumentsStreaming && !hasAnyField) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-web-onboarding.apiName.saveUserQuestion')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-web-onboarding.apiName.saveUserQuestion')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ flexWrap: 'wrap', gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-web-onboarding.apiName.saveUserQuestion')}</span>
+    <div className={inspectorTextStyles.root} style={{ flexWrap: 'wrap', gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-web-onboarding.apiName.saveUserQuestion')}
+      </span>
       {(agentName || agentEmoji) && (
         <span className={styles.chip}>
           {agentEmoji && <span className={styles.emoji}>{agentEmoji}</span>}

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/UpdateDocument/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/UpdateDocument/index.tsx
@@ -23,21 +23,19 @@ export const UpdateDocumentInspector = memo<
 
   if (isArgumentsStreaming && !type) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-web-onboarding.apiName.updateDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-web-onboarding.apiName.updateDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-web-onboarding.apiName.updateDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-web-onboarding.apiName.updateDocument')}
+      </span>
       {type && (
         <span className={styles.chip}>
           {t(`builtins.lobe-web-onboarding.docType.${type}` as const)}

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/WriteDocument/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/WriteDocument/index.tsx
@@ -27,21 +27,19 @@ export const WriteDocumentInspector = memo<
 
   if (isArgumentsStreaming && !type) {
     return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>{t('builtins.lobe-web-onboarding.apiName.writeDocument')}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={shinyTextStyles.shinyText}>
+          {t('builtins.lobe-web-onboarding.apiName.writeDocument')}
+        </span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{ gap: 4 }}
-      className={cx(
-        inspectorTextStyles.root,
-        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-      )}
-    >
-      <span>{t('builtins.lobe-web-onboarding.apiName.writeDocument')}</span>
+    <div className={inspectorTextStyles.root} style={{ gap: 4 }}>
+      <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+        {t('builtins.lobe-web-onboarding.apiName.writeDocument')}
+      </span>
       {type && (
         <span className={styles.chip}>
           {t(`builtins.lobe-web-onboarding.docType.${type}` as const)}

--- a/packages/builtin-tools/src/codex/CollabToolInspector.tsx
+++ b/packages/builtin-tools/src/codex/CollabToolInspector.tsx
@@ -53,13 +53,10 @@ const CollabToolInspector = memo<BuiltinInspectorProps<CodexCollabToolArgs, Code
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {target && (
           <>
             <span>: </span>

--- a/packages/builtin-tools/src/codex/ErrorInspector.test.tsx
+++ b/packages/builtin-tools/src/codex/ErrorInspector.test.tsx
@@ -44,8 +44,7 @@ describe('Codex ErrorInspector', () => {
       />,
     );
 
-    expect(screen.getByText('Session compatibility warning')).toBeTruthy();
-    expect(screen.getByTestId('codex-error-inspector').classList).toContain('shiny-text');
+    expect(screen.getByText('Session compatibility warning').classList).toContain('shiny-text');
   });
 
   it('uses localized fallback copy when no message is available', () => {

--- a/packages/builtin-tools/src/codex/ErrorInspector.tsx
+++ b/packages/builtin-tools/src/codex/ErrorInspector.tsx
@@ -44,15 +44,18 @@ const ErrorInspector = memo<BuiltinInspectorProps<CodexErrorArgs>>(
 
     return (
       <div
+        className={cx(inspectorTextStyles.root, styles.root)}
         data-testid="codex-error-inspector"
-        className={cx(
-          inspectorTextStyles.root,
-          styles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
       >
         <Icon className={styles.icon} icon={AlertTriangle} size={14} />
-        <span className={styles.message}>{message || fallback}</span>
+        <span
+          className={cx(
+            styles.message,
+            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          )}
+        >
+          {message || fallback}
+        </span>
       </div>
     );
   },

--- a/packages/builtin-tools/src/codex/ErrorInspector.tsx
+++ b/packages/builtin-tools/src/codex/ErrorInspector.tsx
@@ -51,7 +51,7 @@ const ErrorInspector = memo<BuiltinInspectorProps<CodexErrorArgs>>(
         <span
           className={cx(
             styles.message,
-            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+            (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
           )}
         >
           {message || fallback}

--- a/packages/builtin-tools/src/codex/McpToolInspector.tsx
+++ b/packages/builtin-tools/src/codex/McpToolInspector.tsx
@@ -88,13 +88,10 @@ const McpToolInspector = memo<BuiltinInspectorProps<CodexMcpToolArgs, CodexMcpTo
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {target && (
           <>
             <span>: </span>

--- a/packages/builtin-tools/src/codex/WebSearchInspector.tsx
+++ b/packages/builtin-tools/src/codex/WebSearchInspector.tsx
@@ -24,13 +24,10 @@ const WebSearchInspector = memo<BuiltinInspectorProps<CodexWebSearchArgs, CodexW
     }
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {query && (
           <>
             <span>: </span>

--- a/packages/builtin-tools/src/github/RunCommandInspector.tsx
+++ b/packages/builtin-tools/src/github/RunCommandInspector.tsx
@@ -67,9 +67,9 @@ const GithubRunCommandInspector = memo<
   const hasResult = !pulse && pluginState && pluginState.success !== undefined;
 
   return (
-    <div className={cx(inspectorTextStyles.root, pulse && shinyTextStyles.shinyText)}>
+    <div className={inspectorTextStyles.root}>
       <Github className={styles.icon} size={14} />
-      <span className={styles.ghPrefix}>gh</span>
+      <span className={cx(styles.ghPrefix, pulse && shinyTextStyles.shinyText)}>gh</span>
       {label && (
         <span className={styles.chip}>
           <span className={styles.command}>{label}</span>

--- a/packages/builtin-tools/src/kimiCode/index.tsx
+++ b/packages/builtin-tools/src/kimiCode/index.tsx
@@ -74,13 +74,10 @@ const KimiLabelInspector = memo<KimiLabelInspectorProps>(
     const value = args?.[field] || partialArgs?.[field] || '';
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
-        <span>{label}</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText)}>
+          {label}
+        </span>
         {value && (
           <>
             <span>: </span>

--- a/packages/shared-tool-ui/src/Inspector/EditLocalFile/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/EditLocalFile/index.tsx
@@ -45,14 +45,16 @@ export const EditLocalFileInspector = memo<EditLocalFileInspectorProps>(
     if (isArgumentsStreaming) {
       if (!filePath)
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-            <span>{t(translationKey as any)}</span>
+          <div className={inspectorTextStyles.root}>
+            <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
           </div>
         );
 
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-          <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+        <div className={inspectorTextStyles.root}>
+          <span className={shinyTextStyles.shinyText} style={{ marginInlineEnd: 6 }}>
+            {t(translationKey as any)}:
+          </span>
           <FilePathDisplay filePath={filePath} />
         </div>
       );
@@ -80,8 +82,10 @@ export const EditLocalFileInspector = memo<EditLocalFileInspectorProps>(
     }
 
     return (
-      <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-        <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+      <div className={inspectorTextStyles.root}>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)} style={{ marginInlineEnd: 6 }}>
+          {t(translationKey as any)}:
+        </span>
         <FilePathDisplay filePath={filePath} />
         {!isLoading && statsParts.length > 0 && (
           <>

--- a/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.tsx
@@ -225,7 +225,7 @@ const GitHubInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>
         <span
           className={cx(
             styles.productPrefix,
-            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+            (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
           )}
         >
           GitHub

--- a/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/GitHub/Inspector.tsx
@@ -220,14 +220,16 @@ const GitHubInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>
     const { branch, primary } = pickChip(effectiveArgs);
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={inspectorTextStyles.root}>
         <GitHubMark />
-        <span className={styles.productPrefix}>GitHub</span>
+        <span
+          className={cx(
+            styles.productPrefix,
+            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          )}
+        >
+          GitHub
+        </span>
         <span className={styles.chip}>
           <span className={styles.chipAction}>{label}</span>
           {primary && (

--- a/packages/shared-tool-ui/src/Inspector/GlobLocalFiles/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/GlobLocalFiles/index.tsx
@@ -46,14 +46,14 @@ export const createGlobLocalFilesInspector = (translationKey: string) => {
       if (isArgumentsStreaming) {
         if (!pattern)
           return (
-            <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-              <span>{t(translationKey as any)}</span>
+            <div className={inspectorTextStyles.root}>
+              <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
             </div>
           );
 
         return (
-          <div className={cx(inspectorTextStyles.root, styles.baseline, shinyTextStyles.shinyText)}>
-            <span>{t(translationKey as any)}:</span>
+          <div className={cx(inspectorTextStyles.root, styles.baseline)}>
+            <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}:</span>
             <span className={styles.tag}>{pattern}</span>
           </div>
         );
@@ -62,14 +62,10 @@ export const createGlobLocalFilesInspector = (translationKey: string) => {
       const hasFiles = (pluginState?.totalCount ?? 0) > 0;
 
       return (
-        <div
-          className={cx(
-            inspectorTextStyles.root,
-            styles.baseline,
-            isLoading && shinyTextStyles.shinyText,
-          )}
-        >
-          <span>{t(translationKey as any)}:</span>
+        <div className={cx(inspectorTextStyles.root, styles.baseline)}>
+          <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+            {t(translationKey as any)}:
+          </span>
           {pattern && <span className={styles.tag}>{pattern}</span>}
           {isLoading ? null : pluginState ? (
             hasFiles ? (

--- a/packages/shared-tool-ui/src/Inspector/GrepContent/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/GrepContent/index.tsx
@@ -88,14 +88,14 @@ export const createGrepContentInspector = ({
       if (isArgumentsStreaming) {
         if (!pattern)
           return (
-            <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-              <span>{t(translationKey as any)}</span>
+            <div className={inspectorTextStyles.root}>
+              <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
             </div>
           );
 
         return (
-          <div className={cx(inspectorTextStyles.root, styles.baseline, shinyTextStyles.shinyText)}>
-            <span>{t(translationKey as any)}:</span>
+          <div className={cx(inspectorTextStyles.root, styles.baseline)}>
+            <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}:</span>
             <PatternTags pattern={pattern} />
           </div>
         );
@@ -105,14 +105,10 @@ export const createGrepContentInspector = ({
       const hasResults = resultCount > 0;
 
       return (
-        <div
-          className={cx(
-            inspectorTextStyles.root,
-            styles.baseline,
-            isLoading && shinyTextStyles.shinyText,
-          )}
-        >
-          <span>{t(translationKey as any)}:</span>
+        <div className={cx(inspectorTextStyles.root, styles.baseline)}>
+          <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+            {t(translationKey as any)}:
+          </span>
           {pattern && <PatternTags pattern={pattern} />}
           {!isLoading &&
             pluginState &&

--- a/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
@@ -248,7 +248,7 @@ const LinearInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>
         <span
           className={cx(
             styles.productPrefix,
-            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+            (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
           )}
         >
           Linear

--- a/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
@@ -243,14 +243,16 @@ const LinearInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>
     const { primary, parentId } = pickChip(parsed, effectiveArgs);
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={inspectorTextStyles.root}>
         <LinearLogomark />
-        <span className={styles.productPrefix}>Linear</span>
+        <span
+          className={cx(
+            styles.productPrefix,
+            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          )}
+        >
+          Linear
+        </span>
         <span className={styles.chip}>
           <span className={styles.chipAction}>{label}</span>
           {primary && (

--- a/packages/shared-tool-ui/src/Inspector/ListLocalFiles/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/ListLocalFiles/index.tsx
@@ -24,22 +24,29 @@ export const createListLocalFilesInspector = (translationKey: string) => {
       if (isArgumentsStreaming) {
         if (!dirPath)
           return (
-            <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-              <span>{t(translationKey as any)}</span>
+            <div className={inspectorTextStyles.root}>
+              <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
             </div>
           );
 
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-            <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+          <div className={inspectorTextStyles.root}>
+            <span className={shinyTextStyles.shinyText} style={{ marginInlineEnd: 6 }}>
+              {t(translationKey as any)}:
+            </span>
             <FilePathDisplay isDirectory filePath={dirPath} />
           </div>
         );
       }
 
       return (
-        <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-          <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+        <div className={inspectorTextStyles.root}>
+          <span
+            className={cx(isLoading && shinyTextStyles.shinyText)}
+            style={{ marginInlineEnd: 6 }}
+          >
+            {t(translationKey as any)}:
+          </span>
           <FilePathDisplay isDirectory filePath={dirPath} />
           {!isLoading && resultCount > 0 && (
             <span style={{ marginInlineStart: 4 }}>({resultCount})</span>

--- a/packages/shared-tool-ui/src/Inspector/MoveLocalFiles/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/MoveLocalFiles/index.tsx
@@ -32,8 +32,13 @@ export const createMoveLocalFilesInspector = (translationKey: string) => {
       const showShiny = isArgumentsStreaming || isLoading;
 
       return (
-        <div className={cx(inspectorTextStyles.root, showShiny && shinyTextStyles.shinyText)}>
-          <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}</span>
+        <div className={inspectorTextStyles.root}>
+          <span
+            className={cx(showShiny && shinyTextStyles.shinyText)}
+            style={{ marginInlineEnd: 6 }}
+          >
+            {t(translationKey as any)}
+          </span>
           {totalCount > 0 && (
             <Text code as={'span'} fontSize={12}>
               {successCount === undefined ? totalCount : `${successCount}/${totalCount}`}

--- a/packages/shared-tool-ui/src/Inspector/ReadLocalFile/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/ReadLocalFile/index.tsx
@@ -51,22 +51,29 @@ export const createReadLocalFileInspector = (translationKey: string) => {
       if (isArgumentsStreaming) {
         if (!filePath)
           return (
-            <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-              <span>{t(translationKey as any)}</span>
+            <div className={inspectorTextStyles.root}>
+              <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
             </div>
           );
 
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-            <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+          <div className={inspectorTextStyles.root}>
+            <span className={shinyTextStyles.shinyText} style={{ marginInlineEnd: 6 }}>
+              {t(translationKey as any)}:
+            </span>
             <FilePathDisplay filePath={filePath} />
           </div>
         );
       }
 
       return (
-        <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-          <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+        <div className={inspectorTextStyles.root}>
+          <span
+            className={cx(isLoading && shinyTextStyles.shinyText)}
+            style={{ marginInlineEnd: 6 }}
+          >
+            {t(translationKey as any)}:
+          </span>
           <FilePathDisplay filePath={filePath} />
           {lineRange && <span style={{ marginInlineStart: 4 }}>({lineRange})</span>}
         </div>

--- a/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
@@ -97,16 +97,16 @@ export const RunCommandInspector = memo<RunCommandInspectorProps>(
     if (isArgumentsStreaming) {
       if (!description)
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
+          <div className={inspectorTextStyles.root}>
             {leading}
-            <span>{t(translationKey as any)}</span>
+            <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
           </div>
         );
 
       return (
-        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
+        <div className={inspectorTextStyles.root}>
           {leading}
-          <span>{t(translationKey as any)}:</span>
+          <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}:</span>
           <span className={styles.chip}>
             {chipIcon}
             <span className={styles.command}>{description}</span>
@@ -118,9 +118,11 @@ export const RunCommandInspector = memo<RunCommandInspectorProps>(
     const isSuccess = pluginState?.success || pluginState?.exitCode === 0;
 
     return (
-      <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+      <div className={inspectorTextStyles.root}>
         {leading}
-        <span>{t(translationKey as any)}:</span>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+          {t(translationKey as any)}:
+        </span>
         {description && (
           <span className={styles.chip}>
             {chipIcon}

--- a/packages/shared-tool-ui/src/Inspector/SearchLocalFiles/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/SearchLocalFiles/index.tsx
@@ -41,14 +41,14 @@ export const createSearchLocalFilesInspector = ({
       if (isArgumentsStreaming) {
         if (!query)
           return (
-            <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-              <span>{t(translationKey as any)}</span>
+            <div className={inspectorTextStyles.root}>
+              <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
             </div>
           );
 
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-            <span>{t(translationKey as any)}: </span>
+          <div className={inspectorTextStyles.root}>
+            <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}: </span>
             <span className={highlightTextStyles.primary}>{query}</span>
           </div>
         );
@@ -58,9 +58,11 @@ export const createSearchLocalFilesInspector = ({
       const hasResults = resultCount > 0;
 
       return (
-        <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
+        <div className={inspectorTextStyles.root}>
           <span style={{ marginInlineStart: 2 }}>
-            <span>{t(translationKey as any)}: </span>
+            <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+              {t(translationKey as any)}:{' '}
+            </span>
             {query && <span className={highlightTextStyles.primary}>{query}</span>}
             {!isLoading &&
               pluginState &&

--- a/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
@@ -156,14 +156,16 @@ const TwitterInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>
     const primary = pickPrimaryChip(effectiveArgs);
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={inspectorTextStyles.root}>
         <XLogomark />
-        <span className={styles.productPrefix}>X (Twitter)</span>
+        <span
+          className={cx(
+            styles.productPrefix,
+            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+          )}
+        >
+          X (Twitter)
+        </span>
         <span className={styles.chip}>
           <span className={styles.chipAction}>{label}</span>
           {primary && (

--- a/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
@@ -161,7 +161,7 @@ const TwitterInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>
         <span
           className={cx(
             styles.productPrefix,
-            cx((isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText),
+            (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
           )}
         >
           X (Twitter)

--- a/packages/shared-tool-ui/src/Inspector/WriteLocalFile/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/WriteLocalFile/index.tsx
@@ -36,22 +36,29 @@ export const createWriteLocalFileInspector = (translationKey: string) => {
       if (isArgumentsStreaming) {
         if (!filePath)
           return (
-            <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-              <span>{t(translationKey as any)}</span>
+            <div className={inspectorTextStyles.root}>
+              <span className={shinyTextStyles.shinyText}>{t(translationKey as any)}</span>
             </div>
           );
 
         return (
-          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-            <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+          <div className={inspectorTextStyles.root}>
+            <span className={shinyTextStyles.shinyText} style={{ marginInlineEnd: 6 }}>
+              {t(translationKey as any)}:
+            </span>
             <FilePathDisplay filePath={filePath} />
           </div>
         );
       }
 
       return (
-        <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
-          <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}:</span>
+        <div className={inspectorTextStyles.root}>
+          <span
+            className={cx(isLoading && shinyTextStyles.shinyText)}
+            style={{ marginInlineEnd: 6 }}
+          >
+            {t(translationKey as any)}:
+          </span>
           <FilePathDisplay filePath={filePath} />
           {!isLoading && lineCount && (
             <>

--- a/packages/shared-tool-ui/src/components/TodoProgress/index.tsx
+++ b/packages/shared-tool-ui/src/components/TodoProgress/index.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Icon } from '@lobehub/ui';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { CircleArrowRight, CircleCheckBig, ListTodo } from 'lucide-react';
 import { memo } from 'react';
+
+import { shinyTextStyles } from '../../styles';
 
 /**
  * Visual state of a todo summary:
@@ -170,6 +172,7 @@ TodoProgressRing.displayName = 'TodoProgressRing';
 
 interface TodoSummaryContentProps {
   label: string;
+  shiny?: boolean;
   summary: TodoSummary;
 }
 
@@ -177,7 +180,7 @@ interface TodoSummaryContentProps {
  * Inline inspector summary: progress ring + count chip + "label: detail".
  * Render it inside an `inspectorTextStyles.root` flex container.
  */
-export const TodoInspectorSummary = memo<TodoSummaryContentProps>(({ label, summary }) => {
+export const TodoInspectorSummary = memo<TodoSummaryContentProps>(({ label, shiny, summary }) => {
   const { completed, detail, state, total } = summary;
 
   return (
@@ -189,7 +192,7 @@ export const TodoInspectorSummary = memo<TodoSummaryContentProps>(({ label, summ
         </span>
       )}
       <span className={styles.summaryText}>
-        {label}
+        <span className={cx(shiny && shinyTextStyles.shinyText)}>{label}</span>
         {detail && (
           <>
             {': '}

--- a/packages/shared-tool-ui/src/styles.ts
+++ b/packages/shared-tool-ui/src/styles.ts
@@ -6,6 +6,12 @@ import { createStaticStyles } from 'antd-style';
  */
 export const inspectorTextStyles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
+    /* Coordinate space for the shiny sweep: every shimmering span in the row
+     * resolves its overlay against this box, so they read as one wave. */
+    --shiny-origin: static;
+
+    position: relative;
+
     overflow: hidden;
     display: flex;
     align-items: center;
@@ -49,3 +55,15 @@ export const highlightTextStyles = createStaticStyles(({ css, cssVar }) => {
 export const shinyTextStyles = {
   shinyText: textStyles.shiny,
 };
+
+/**
+ * Sweep coordinate space for a row that shimmers several separate spans.
+ * Mirrors lobe-ui's textGroupStyles.shinyGroup until the version bump lands.
+ */
+export const shinyGroupStyles = createStaticStyles(({ css }) => ({
+  shinyGroup: css`
+    --shiny-origin: static;
+
+    position: relative;
+  `,
+}));

--- a/packages/shared-tool-ui/src/styles.ts
+++ b/packages/shared-tool-ui/src/styles.ts
@@ -1,4 +1,4 @@
-import { textStyles } from '@lobehub/ui/base-ui';
+import { textGroupStyles, textStyles } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 
 /**
@@ -8,9 +8,7 @@ export const inspectorTextStyles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
     /* Coordinate space for the shiny sweep: every shimmering span in the row
      * resolves its overlay against this box, so they read as one wave. */
-    --shiny-origin: static;
-
-    position: relative;
+    ${textGroupStyles.shinyGroup}
 
     overflow: hidden;
     display: flex;
@@ -56,14 +54,6 @@ export const shinyTextStyles = {
   shinyText: textStyles.shiny,
 };
 
-/**
- * Sweep coordinate space for a row that shimmers several separate spans.
- * Mirrors lobe-ui's textGroupStyles.shinyGroup until the version bump lands.
- */
-export const shinyGroupStyles = createStaticStyles(({ css }) => ({
-  shinyGroup: css`
-    --shiny-origin: static;
-
-    position: relative;
-  `,
-}));
+export const shinyGroupStyles = {
+  shinyGroup: textGroupStyles.shinyGroup,
+};

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
@@ -100,14 +100,8 @@ const ToolTitle = memo<ToolTitleProps>(
     }, [params.length, remainingCount, t]);
 
     return (
-      <div
-        className={cx(
-          styles.root,
-          isLoading && shinyTextStyles.shinyText,
-          isAborted && styles.aborted,
-        )}
-      >
-        <span>
+      <div className={cx(styles.root, isAborted && styles.aborted)}>
+        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
           {isBuiltinPlugin
             ? t(`builtins.${identifier}.title`, { defaultValue: identifier })
             : pluginTitle}

--- a/src/styles/text.ts
+++ b/src/styles/text.ts
@@ -1,3 +1,4 @@
+import { textGroupStyles } from '@lobehub/ui/base-ui';
 import { createStaticStyles, css, cx } from 'antd-style';
 
 export const lineEllipsis = (line: number) =>
@@ -20,9 +21,7 @@ export const inspectorTextStyles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
     /* Coordinate space for the shiny sweep: every shimmering span in the row
      * resolves its overlay against this box, so they read as one wave. */
-    --shiny-origin: static;
-
-    position: relative;
+    ${textGroupStyles.shinyGroup}
 
     overflow: hidden;
     display: flex;
@@ -65,14 +64,6 @@ export const highlightTextStyles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-/**
- * Sweep coordinate space for a row that shimmers several separate spans.
- * Mirrors lobe-ui's textGroupStyles.shinyGroup until the version bump lands.
- */
-export const shinyGroupStyles = createStaticStyles(({ css }) => ({
-  shinyGroup: css`
-    --shiny-origin: static;
-
-    position: relative;
-  `,
-}));
+export const shinyGroupStyles = {
+  shinyGroup: textGroupStyles.shinyGroup,
+};

--- a/src/styles/text.ts
+++ b/src/styles/text.ts
@@ -18,6 +18,12 @@ export const oneLineEllipsis = lineEllipsis(1);
  */
 export const inspectorTextStyles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
+    /* Coordinate space for the shiny sweep: every shimmering span in the row
+     * resolves its overlay against this box, so they read as one wave. */
+    --shiny-origin: static;
+
+    position: relative;
+
     overflow: hidden;
     display: flex;
     align-items: center;
@@ -58,3 +64,15 @@ export const highlightTextStyles = createStaticStyles(({ css, cssVar }) => {
     warning: highlightBase(cssVar.colorWarningBg),
   };
 });
+
+/**
+ * Sweep coordinate space for a row that shimmers several separate spans.
+ * Mirrors lobe-ui's textGroupStyles.shinyGroup until the version bump lands.
+ */
+export const shinyGroupStyles = createStaticStyles(({ css }) => ({
+  shinyGroup: css`
+    --shiny-origin: static;
+
+    position: relative;
+  `,
+}));


### PR DESCRIPTION
## 💡 Motivation

`textStyles.shiny`（lobe-ui）的 GPU 快路径用 `mask-clip: text` 把内容裁到字形上，而 mask 会作用于**整个子树**。所有把 shiny 挂在整行 `div` 上的 inspector，行内的 lucide icon、命令 chip 的胶囊底、状态 ✓ 都会被整块抹掉 —— 线上表现为 `Bash:` 后面的终端 icon 和 chip 背景消失。

配套修复：lobehub/lobe-ui#635（mask 路径加 `:not(:has(*))` 守卫 + 提高扫光对比度）。那个 PR 让 icon 行**退回 paint 路径**（原 commit 记录 ~20% CPU/line），本 PR 把 shiny 挪到纯文本 span 上，让常见行重新走回合成器路径。

## 🔍 Changes

- 121 个文件由 codemod 自动迁移（TypeScript compiler API 解析 JSX，把 shiny className 从 row 移到第一个纯文本 label span），11 个手工处理。
- 35 个 row 本身就只有文本，原本就在快路径上，未改动。
- `TodoInspectorSummary` 新增 `shiny` prop，供 3 个把 label 委托给它的 todo inspector 使用。
- 唯一保留 fallback 的是 `ClearTodos` 里包 `<Trans>` 的一行（Trans 自己生成 span，没有干净的纯文本目标），行为与改前一致。

视觉差异：loading 时只有 label 闪，chip / highlight 里的文字本来就是 opaque `colorText`，从来没参与过扫光。

## ✅ Verification

`bun run check` → 136 files · lint 3 warnings（均为既有 `react-hooks/exhaustive-deps`）· tests 12 passed

两个原本断言「row 上有 shiny-text」的测试改为断言 label span。

## ⚠️ Merge order

需要先合并并发布 lobehub/lobe-ui#635，再升 `@lobehub/ui`，两边才完整生效。本 PR 单独合并也是安全的（只是把 class 换了个挂载点）。