### PR TITLE
✨ feat(cli): support role/date filters and topic info in message list

### DIFF
--- a/apps/cli/src/commands/message.test.ts
+++ b/apps/cli/src/commands/message.test.ts
@@ -52,7 +52,7 @@ describe('message command', () => {
   }
 
   describe('list', () => {
-    it('should use listAll when no filters', async () => {
+    it('should use listAll with a default page size of 50 when no filters', async () => {
       mockTrpcClient.message.listAll.query.mockResolvedValue([
         { content: 'Hello', createdAt: new Date().toISOString(), id: 'm1', role: 'user' },
       ]);
@@ -60,7 +60,9 @@ describe('message command', () => {
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'message', 'list']);
 
-      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalled();
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
+        expect.objectContaining({ pageSize: 50 }),
+      );
       expect(mockTrpcClient.message.getMessages.query).not.toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledTimes(2);
     });

--- a/apps/cli/src/commands/message.test.ts
+++ b/apps/cli/src/commands/message.test.ts
@@ -65,20 +65,53 @@ describe('message command', () => {
       expect(consoleSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('should filter by topic-id using getMessages', async () => {
-      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
+    it('should push topic-id filter to listAll', async () => {
+      mockTrpcClient.message.listAll.query.mockResolvedValue([]);
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'message', 'list', '--topic-id', 't1']);
 
-      expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
         expect.objectContaining({ topicId: 't1' }),
       );
-      expect(mockTrpcClient.message.listAll.query).not.toHaveBeenCalled();
+      expect(mockTrpcClient.message.getMessages.query).not.toHaveBeenCalled();
+    });
+
+    it('should push role and date range filters to listAll', async () => {
+      mockTrpcClient.message.listAll.query.mockResolvedValue([]);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'test',
+        'message',
+        'list',
+        '--role',
+        'user',
+        '--start',
+        '2026-08-31',
+        '--end',
+        '2026-09-01',
+      ]);
+
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
+        expect.objectContaining({ endDate: '2026-09-01', role: 'user', startDate: '2026-08-31' }),
+      );
+    });
+
+    it('should treat --user as --role user on the server side', async () => {
+      mockTrpcClient.message.listAll.query.mockResolvedValue([]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'message', 'list', '--user']);
+
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'user' }),
+      );
     });
 
     it('should keep first page on the backend default offset for filtered queries', async () => {
-      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
+      mockTrpcClient.message.listAll.query.mockResolvedValue([]);
 
       const program = createProgram();
       await program.parseAsync([
@@ -92,13 +125,13 @@ describe('message command', () => {
         '200',
       ]);
 
-      expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
         expect.objectContaining({ pageSize: 200, topicId: 't1' }),
       );
     });
 
     it('should convert page 2 to current 1 for filtered queries', async () => {
-      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
+      mockTrpcClient.message.listAll.query.mockResolvedValue([]);
 
       const program = createProgram();
       await program.parseAsync([
@@ -112,18 +145,18 @@ describe('message command', () => {
         '2',
       ]);
 
-      expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
         expect.objectContaining({ current: 1, topicId: 't1' }),
       );
     });
 
     it('should support the short page flag for filtered queries', async () => {
-      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
+      mockTrpcClient.message.listAll.query.mockResolvedValue([]);
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'message', 'list', '--topic-id', 't1', '-P', '2']);
 
-      expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
+      expect(mockTrpcClient.message.listAll.query).toHaveBeenCalledWith(
         expect.objectContaining({ current: 1, topicId: 't1' }),
       );
     });

--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -18,7 +18,7 @@ export function registerMessageCommand(program: Command) {
     .option('--role <role>', 'Filter by role (user, assistant, tool, system)')
     .option('--start <date>', 'Only messages created at/after this date (ISO or YYYY-MM-DD)')
     .option('--end <date>', 'Only messages created at/before this date (ISO or YYYY-MM-DD)')
-    .option('-L, --limit <n>', 'Page size', '30')
+    .option('-L, --limit <n>', 'Page size', '50')
     .option('-P, --page <n>', 'Page number', '1')
     .option('--user', 'Shorthand for --role user')
     .option('--json [fields]', 'Output JSON, optionally specify fields (comma-separated)')
@@ -68,12 +68,13 @@ export function registerMessageCommand(program: Command) {
         const rows = items.map((m: any) => [
           m.id || '',
           m.role || '',
+          m.agentName || m.agentTitle || '',
           truncate(m.content || '', 60),
           m.threadId ? `${m.topicId || ''} › ${m.threadId}` : m.topicId || '',
           m.createdAt ? timeAgo(m.createdAt) : '',
         ]);
 
-        printTable(rows, ['ID', 'ROLE', 'CONTENT', 'TOPIC/THREAD', 'CREATED']);
+        printTable(rows, ['ID', 'ROLE', 'AGENT', 'CONTENT', 'TOPIC/THREAD', 'CREATED']);
       },
     );
 

--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -15,50 +15,44 @@ export function registerMessageCommand(program: Command) {
     .description('List messages')
     .option('--topic-id <id>', 'Filter by topic ID')
     .option('--agent-id <id>', 'Filter by agent ID')
+    .option('--role <role>', 'Filter by role (user, assistant, tool, system)')
+    .option('--start <date>', 'Only messages created at/after this date (ISO or YYYY-MM-DD)')
+    .option('--end <date>', 'Only messages created at/before this date (ISO or YYYY-MM-DD)')
     .option('-L, --limit <n>', 'Page size', '30')
     .option('-P, --page <n>', 'Page number', '1')
-    .option('--user', 'Only show user messages')
+    .option('--user', 'Shorthand for --role user')
     .option('--json [fields]', 'Output JSON, optionally specify fields (comma-separated)')
     .action(
       async (options: {
         agentId?: string;
+        end?: string;
         json?: string | boolean;
         limit?: string;
         page?: string;
+        role?: string;
+        start?: string;
         topicId?: string;
         user?: boolean;
       }) => {
         const client = await getTrpcClient();
 
-        const hasFilter = options.topicId || options.agentId;
         const pageSize = options.limit ? Number.parseInt(options.limit, 10) : undefined;
         const current = options.page
           ? Math.max(Number.parseInt(options.page, 10) - 1, 0)
           : undefined;
 
-        let items: any[];
+        const input: Record<string, any> = {};
+        if (options.topicId) input.topicId = options.topicId;
+        if (options.agentId) input.agentId = options.agentId;
+        if (options.user) input.role = 'user';
+        if (options.role) input.role = options.role;
+        if (options.start) input.startDate = options.start;
+        if (options.end) input.endDate = options.end;
+        if (pageSize) input.pageSize = pageSize;
+        if (current) input.current = current;
 
-        if (hasFilter) {
-          const input: Record<string, any> = {};
-          if (options.topicId) input.topicId = options.topicId;
-          if (options.agentId) input.agentId = options.agentId;
-          if (pageSize) input.pageSize = pageSize;
-          if (current) input.current = current;
-
-          const result = await client.message.getMessages.query(input as any);
-          items = Array.isArray(result) ? result : ((result as any).items ?? []);
-        } else {
-          const input: Record<string, any> = {};
-          if (pageSize) input.pageSize = pageSize;
-          if (current) input.current = current;
-
-          const result = await client.message.listAll.query(input as any);
-          items = Array.isArray(result) ? result : [];
-        }
-
-        if (options.user) {
-          items = items.filter((m: any) => m.role === 'user');
-        }
+        const result = await client.message.listAll.query(input as any);
+        const items: any[] = Array.isArray(result) ? result : [];
 
         if (options.json !== undefined) {
           const fields = typeof options.json === 'string' ? options.json : undefined;
@@ -75,10 +69,11 @@ export function registerMessageCommand(program: Command) {
           m.id || '',
           m.role || '',
           truncate(m.content || '', 60),
+          m.threadId ? `${m.topicId || ''} › ${m.threadId}` : m.topicId || '',
           m.createdAt ? timeAgo(m.createdAt) : '',
         ]);
 
-        printTable(rows, ['ID', 'ROLE', 'CONTENT', 'CREATED']);
+        printTable(rows, ['ID', 'ROLE', 'CONTENT', 'TOPIC/THREAD', 'CREATED']);
       },
     );
 

--- a/apps/server/src/routers/lambda/message.ts
+++ b/apps/server/src/routers/lambda/message.ts
@@ -215,8 +215,8 @@ export const messageRouter = router({
 
   listAll: messageProcedure
     .input(
-      z
-        .object({
+      messageAnalyticsSchema
+        .extend({
           current: z.number().optional(),
           pageSize: z.number().optional(),
         })

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1578,6 +1578,31 @@ describe('MessageModel Query Tests', () => {
       });
       expect(byRoleAndDate.map((m) => m.id)).toEqual(['q-user-new']);
     });
+
+    it('should include agent name/title for messages bound to an agent', async () => {
+      await serverDB
+        .insert(agents)
+        .values([{ id: 'q-agent', name: 'Lobe', title: 'Diary Agent', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          agentId: 'q-agent',
+          content: 'assistant reply',
+          id: 'q-with-agent',
+          role: 'assistant',
+          userId,
+        },
+        { content: 'user question', id: 'q-without-agent', role: 'user', userId },
+      ]);
+
+      const result = await messageModel.queryAll();
+      const withAgent = result.find((m) => m.id === 'q-with-agent');
+      const withoutAgent = result.find((m) => m.id === 'q-without-agent');
+
+      expect(withAgent?.agentName).toBe('Lobe');
+      expect(withAgent?.agentTitle).toBe('Diary Agent');
+      expect(withoutAgent?.agentName).toBeNull();
+      expect(withoutAgent?.agentTitle).toBeNull();
+    });
   });
 
   describe('findById', () => {

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1543,6 +1543,41 @@ describe('MessageModel Query Tests', () => {
       expect(result[0].id).toBe('2');
       expect(result[1].id).toBe('1');
     });
+
+    it('should filter by role and date range on the server side', async () => {
+      await serverDB.insert(messages).values([
+        {
+          id: 'q-user-old',
+          userId,
+          role: 'user',
+          content: 'old user message',
+          createdAt: new Date('2023-01-01'),
+        },
+        {
+          id: 'q-user-new',
+          userId,
+          role: 'user',
+          content: 'recent user message',
+          createdAt: new Date('2023-02-01'),
+        },
+        {
+          id: 'q-assistant-new',
+          userId,
+          role: 'assistant',
+          content: 'recent assistant message',
+          createdAt: new Date('2023-02-01'),
+        },
+      ]);
+
+      const byRole = await messageModel.queryAll({ role: 'user' });
+      expect(byRole.map((m) => m.id)).toEqual(['q-user-new', 'q-user-old']);
+
+      const byRoleAndDate = await messageModel.queryAll({
+        role: 'user',
+        startDate: '2023-01-15',
+      });
+      expect(byRoleAndDate.map((m) => m.id)).toEqual(['q-user-new']);
+    });
   });
 
   describe('findById', () => {

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2036,14 +2036,14 @@ export class MessageModel {
     return result[0];
   };
 
-  queryAll = async (params?: { current?: number; pageSize?: number }) => {
-    const { current = 0, pageSize = 100 } = params ?? {};
+  queryAll = async (params?: MessageAnalyticsFilters & { current?: number; pageSize?: number }) => {
+    const { current = 0, pageSize = 100, ...filters } = params ?? {};
     const offset = current * pageSize;
 
     const result = await this.db
       .select()
       .from(messages)
-      .where(and(this.ownership()))
+      .where(genWhere(this.analyticsConditions(filters)))
       .orderBy(desc(messages.createdAt))
       .limit(pageSize)
       .offset(offset);

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -43,6 +43,7 @@ import {
   count,
   desc,
   eq,
+  getTableColumns,
   gt,
   gte,
   inArray,
@@ -61,6 +62,7 @@ import { today } from '@/utils/time';
 
 import type { FtsSearchCandidateSource } from '../repositories/ftsSearch';
 import {
+  agents,
   agentsToSessions,
   chunks,
   documents,
@@ -2041,14 +2043,22 @@ export class MessageModel {
     const offset = current * pageSize;
 
     const result = await this.db
-      .select()
+      .select({
+        ...getTableColumns(messages),
+        agentName: agents.name,
+        agentTitle: agents.title,
+      })
       .from(messages)
+      .leftJoin(agents, eq(messages.agentId, agents.id))
       .where(genWhere(this.analyticsConditions(filters)))
       .orderBy(desc(messages.createdAt))
       .limit(pageSize)
       .offset(offset);
 
-    return result as DBMessageItem[];
+    return result as (DBMessageItem & {
+      agentName: string | null;
+      agentTitle: string | null;
+    })[];
   };
 
   queryBySessionId = async (sessionId?: string | null) => {

--- a/packages/database/src/utils/genWhere.test.ts
+++ b/packages/database/src/utils/genWhere.test.ts
@@ -145,6 +145,26 @@ describe('genWhere', () => {
       expect(result?.constructor.name).toBe('SQL');
     });
 
+    it('should extend date-only values through the end of that day', () => {
+      let bound: string | undefined;
+      genEndDateWhere('2026-09-01', mockKey, (date) => {
+        bound = date.toISOString();
+        return date.toDate();
+      });
+
+      expect(bound).toBe('2026-09-02T00:00:00.000Z');
+    });
+
+    it('should use precise ISO timestamps as the exact upper bound', () => {
+      let bound: string | undefined;
+      genEndDateWhere('2026-09-01T12:00:00Z', mockKey, (date) => {
+        bound = date.toISOString();
+        return date.toDate();
+      });
+
+      expect(bound).toBe('2026-09-01T12:00:00.000Z');
+    });
+
     it('should handle timestamp number as string', () => {
       const timestamp = Date.now().toString();
       const result = genEndDateWhere(timestamp, mockKey, mockFormat);

--- a/packages/database/src/utils/genWhere.ts
+++ b/packages/database/src/utils/genWhere.ts
@@ -18,13 +18,20 @@ export const genStartDateWhere = (
   return gte(key, format(dayjs(new Date(date))));
 };
 
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
 export const genEndDateWhere = (
   date: string | undefined,
   key: any,
   format: (date: Dayjs) => any,
 ): SQL | undefined => {
   if (!date || !dayjs(date).isValid()) return;
-  return lte(key, format(dayjs(new Date(date)).add(1, 'day')));
+  // A date-only value means "through the end of that day", so push the bound
+  // one day forward; a precise timestamp is used as the exact upper bound.
+  const end = DATE_ONLY.test(date.trim())
+    ? dayjs(new Date(date)).add(1, 'day')
+    : dayjs(new Date(date));
+  return lte(key, format(end));
 };
 
 export const genRangeWhere = (


### PR DESCRIPTION
`lh message list --user` used to fetch a single page (default 30 rows) and filter it client-side, so pulling e.g. "all user messages of the past day" was effectively impossible — a 30-row page typically yields only a couple of user messages, and there was no way to express a time window at all. The backing `message.listAll` procedure only supported pagination.

This PR pushes the filtering down to the server, reusing the existing analytics filter pipeline:

- **model**: `MessageModel.queryAll` now accepts `MessageAnalyticsFilters` (role / agentId / topicId / startDate / endDate / range) and builds its WHERE clause via the already-tested `analyticsConditions` shared with `count` / `countByTopic`. It also left-joins `agents` to expose `agentName` / `agentTitle` on each row, so a mixed user+assistant listing reads as a full conversation record with the responding agent identified.
- **server**: `message.listAll` input extends `messageAnalyticsSchema` with `current` / `pageSize`.
- **cli**: `lh message list` gains `--role`, `--start`, `--end`; `--user` becomes a server-side shorthand for `--role user`; topic/agent filters route through `listAll` uniformly (no more `getMessages` fork); the table output adds AGENT and TOPIC/THREAD columns; the default page size moves from 30 to 50.

Example — the past day's conversation record (user + assistant), with agent and topic/thread attribution:

```bash
lh message list --start 2026-08-31 --end 2026-09-01 -L 100 \
  --json id,role,content,agentName,topicId,threadId,createdAt
```

Note: the new filters take effect once the server side is deployed; against an older server the extra input keys are stripped by zod and silently ignored (no error, just unfiltered results).

#### Test

- `bun run check` on the touched files: lint clean, all related tests pass; type-check errors intersect zero touched files.
- New model regression tests: `queryAll` role + date-range filtering, and agentName/agentTitle join (null for agent-less messages).
- CLI tests updated: default pageSize 50, `--user` pushed down as `role=user`, role/date filters forwarded, topic filter routed through `listAll`.

- [x] Tested locally
- [x] Added/updated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)