### PR TITLE
⚡️ perf(review): unmount hidden review panel

### DIFF
--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -135,7 +135,7 @@ vi.mock('../Files', () => ({
 vi.mock('../Review', () => ({
   default: (props: { composerTarget: ComposerTarget }) => {
     renderedReview.current = props;
-    return <div />;
+    return <div data-testid="review" />;
   },
 }));
 vi.mock('../ProgressSection', () => ({ default: () => <div /> }));
@@ -882,6 +882,24 @@ describe('AgentWorkingSidebar — tab strip', () => {
     expect(globalStore.openWorkingSidebar).toHaveBeenCalledWith('review');
   });
 
+  it('mounts Review only while its visible tab is active', () => {
+    agentStore.activeAgentId = 'agent';
+    reviewState.repoType = 'git';
+    reviewState.workingDirectory = '/repo';
+    localStorageState.openTabsByContext = { 'draft:agent:/repo': ['params', 'review'] };
+    globalStore.status.workingSidebarTab = 'params';
+
+    render(<AgentWorkingSidebar />);
+
+    expect(screen.queryByTestId('review')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.review.title' }));
+    expect(screen.getByTestId('review')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'settingModel.params.panel.tab' }));
+    expect(screen.queryByTestId('review')).not.toBeInTheDocument();
+  });
+
   it('opens Skills and Documents by default for a new workspace context', () => {
     localStorageState.openTabsByContext = {};
     globalStore.status.workingSidebarTab = 'overview';
@@ -957,6 +975,9 @@ describe('AgentWorkingSidebar — tab strip', () => {
       contextKey: expectedKey,
       writable: true,
     });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Review from Overview' }));
+    await waitFor(() => expect(screen.getByTestId('review')).toBeInTheDocument());
     expect(renderedReview.current?.composerTarget).toEqual({
       contextKey: expectedKey,
       writable: true,
@@ -985,6 +1006,9 @@ describe('AgentWorkingSidebar — tab strip', () => {
       reason: 'read-only',
       writable: false,
     });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Review from Overview' }));
+    await waitFor(() => expect(screen.getByTestId('review')).toBeInTheDocument());
     expect(renderedReview.current?.composerTarget).toEqual({
       reason: 'read-only',
       writable: false,

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -1018,10 +1018,10 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
                     </Suspense>
                   </Flexbox>
                 )}
-                {reviewAvailable && (
-                  <Flexbox className={activeTab === 'review' ? styles.pane : styles.paneHidden}>
+                {reviewAvailable && showRightPanel && fits && activeTab === 'review' && (
+                  <Flexbox className={styles.pane}>
                     <Review
-                      active={activeTab === 'review'}
+                      active
                       composerTarget={composerTarget}
                       deviceId={remoteDeviceId}
                       showTree={showReviewTree}


### PR DESCRIPTION
## Summary

- mount Review only while the right panel is visible, fits, and the Review tab is active
- release hidden PatchDiff/Shiki DOM when users switch tabs
- cover mount/unmount behavior and preserve the existing composer-target checks

## Verification

- bun run check src/features/Conversation/WorkingSidebar/index.tsx src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx — lint clean, 49 tests passed
- real Electron preserved-tab-tree run: Review active = 46 Review nodes / 2 diff containers; Files active = 0 / 0
- real Electron Shiki A/B found no repeatable memory or latency benefit from 1- or 2-worker pools, so this PR does not add extra Shiki runtimes

Acceptance: https://app.lobehub.com/acceptance/9db6d82f-a084-4707-b476-5797ffb4ccfb