### PR TITLE
💄 style: satisfy eslint-plugin-perfectionist 5.11 sort rules

### DIFF
--- a/src/features/Acceptance/Viewer/AcceptanceDecision.tsx
+++ b/src/features/Acceptance/Viewer/AcceptanceDecision.tsx
@@ -18,8 +18,8 @@ import DecisionBar from './DecisionBar';
 import FeedbackDrawer, { type FeedbackListEntry } from './FeedbackDrawer';
 import { openAcceptModal, openGroupFeedbackModal, openRejectModal } from './modals';
 import { useAcceptanceBundle } from './useAcceptanceBundle';
-import { canReviewAcceptance } from './visibility';
 import { formatAcceptanceCountsText, LIVE_ACCEPTANCE_STATUSES } from './verdict';
+import { canReviewAcceptance } from './visibility';
 
 const AcceptanceDecision = () => {
   const { t } = useTranslation('verify');

--- a/src/features/Acceptance/Workspace/batchSelection.test.ts
+++ b/src/features/Acceptance/Workspace/batchSelection.test.ts
@@ -5,8 +5,8 @@ import type { AcceptanceListItem } from '@/services/verify';
 import {
   ACCEPTANCE_BATCH_CHUNK,
   acceptanceBatchTargets,
-  chunkAcceptanceBatch,
   acceptanceSelectAllState,
+  chunkAcceptanceBatch,
   nextAcceptanceSelectAll,
   toggleAcceptanceSelection,
   visibleAcceptanceSelection,

--- a/src/features/Acceptance/Workspace/groupAcceptanceList.ts
+++ b/src/features/Acceptance/Workspace/groupAcceptanceList.ts
@@ -16,14 +16,14 @@ export const normalizeAcceptanceGroupMode = (value: unknown): AcceptanceGroupMod
 export interface AcceptanceListGroup {
   items: AcceptanceListItem[];
   key: string;
+  /** i18n key under `verify:acceptance.workspace.groups.*` for a fixed bucket. */
+  labelKey: string | null;
   /**
    * Header text that comes from the data itself (a project's name). Fixed
    * buckets carry a `labelKey` instead, so the panel never has to translate a
    * user's project name or hardcode a bucket's wording.
    */
   name: string | null;
-  /** i18n key under `verify:acceptance.workspace.groups.*` for a fixed bucket. */
-  labelKey: string | null;
   projectName: string | null;
 }
 


### PR DESCRIPTION
`eslint-plugin-perfectionist@5.11.0` (published 2026-08-31T09:02Z) tightened its sort rules; the plugin floats in our dependency range, so with no lockfile every fresh install now fails `lint:ts` on files that were clean when they merged:

- `src/features/Acceptance/Viewer/AcceptanceDecision.tsx` — `simple-import-sort/imports`
- `src/features/Acceptance/Workspace/batchSelection.test.ts` — `simple-import-sort/imports`
- `src/features/Acceptance/Workspace/groupAcceptanceList.ts` — `perfectionist/sort-interfaces`

Canary's own head (`b4c5ff79ff`) currently fails **Code quality check** with exactly these three errors, and every branch's `push`-event CI is red on them.

This is the plain `eslint --fix` output, no manual edits.

#### Test

- [x] Tested locally — `bunx eslint` over the three files reports 0 errors after the fix
- [x] No tests needed
