### PR TITLE
🐛 fix(acceptance): resolve lint errors from #18897

### DIFF
--- a/src/features/Acceptance/Viewer/AcceptanceDecision.tsx
+++ b/src/features/Acceptance/Viewer/AcceptanceDecision.tsx
@@ -18,8 +18,8 @@ import DecisionBar from './DecisionBar';
 import FeedbackDrawer, { type FeedbackListEntry } from './FeedbackDrawer';
 import { openAcceptModal, openGroupFeedbackModal, openRejectModal } from './modals';
 import { useAcceptanceBundle } from './useAcceptanceBundle';
-import { canReviewAcceptance } from './visibility';
 import { formatAcceptanceCountsText, LIVE_ACCEPTANCE_STATUSES } from './verdict';
+import { canReviewAcceptance } from './visibility';
 
 const AcceptanceDecision = () => {
   const { t } = useTranslation('verify');

--- a/src/features/Acceptance/Workspace/batchSelection.test.ts
+++ b/src/features/Acceptance/Workspace/batchSelection.test.ts
@@ -5,8 +5,8 @@ import type { AcceptanceListItem } from '@/services/verify';
 import {
   ACCEPTANCE_BATCH_CHUNK,
   acceptanceBatchTargets,
-  chunkAcceptanceBatch,
   acceptanceSelectAllState,
+  chunkAcceptanceBatch,
   nextAcceptanceSelectAll,
   toggleAcceptanceSelection,
   visibleAcceptanceSelection,

--- a/src/features/Acceptance/Workspace/groupAcceptanceList.ts
+++ b/src/features/Acceptance/Workspace/groupAcceptanceList.ts
@@ -16,14 +16,14 @@ export const normalizeAcceptanceGroupMode = (value: unknown): AcceptanceGroupMod
 export interface AcceptanceListGroup {
   items: AcceptanceListItem[];
   key: string;
+  /** i18n key under `verify:acceptance.workspace.groups.*` for a fixed bucket. */
+  labelKey: string | null;
   /**
    * Header text that comes from the data itself (a project's name). Fixed
    * buckets carry a `labelKey` instead, so the panel never has to translate a
    * user's project name or hardcode a bucket's wording.
    */
   name: string | null;
-  /** i18n key under `verify:acceptance.workspace.groups.*` for a fixed bucket. */
-  labelKey: string | null;
   projectName: string | null;
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 📝 Description

PR #18897 landed with 3 eslint errors that have been failing the `Code quality check` job in **Release Desktop Canary** on every canary push since (first failure: run 33483570320 at 07:44 UTC today):

- `src/features/Acceptance/Viewer/AcceptanceDecision.tsx` — `simple-import-sort/imports`
- `src/features/Acceptance/Workspace/batchSelection.test.ts` — `simple-import-sort/imports`
- `src/features/Acceptance/Workspace/groupAcceptanceList.ts` — `perfectionist/sort-interfaces` (`labelKey` before `name`)

Pure reordering (eslint autofix + interface field swap), no behavior change. Verified the three files pass eslint locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)