### PR TITLE
🐛 fix: raise tool-call repeat limit from 5 to 20

### DIFF
--- a/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
@@ -7,6 +7,7 @@ import type {
   MessageTransport,
   StreamSink,
 } from '../transport';
+import { TOOL_CALL_REPEAT_LIMIT } from '../utils/toolCallRepeatGuard';
 import {
   finalizeCallLlmTurn,
   persistInterruptedCallLlmResult,
@@ -61,13 +62,14 @@ const createOutput = (overrides: Partial<LLMAttemptOutput> = {}): LLMAttemptOutp
 });
 
 describe('callLlmFinalizer', () => {
-  it('blocks the fifth consecutive identical tool call before it can execute', async () => {
+  it('blocks the limit-th consecutive identical tool call before it can execute', async () => {
     const messages = createMessageTransport();
     const stream = createStreamSink();
     const state = AgentRuntime.createInitialState({ operationId: 'operation-1' });
     state.toolCallRepeatGuard = {
       counts: {
-        '["credentials","inject","{\\"keys\\":[\\"github\\"],\\"scope\\":\\"repo\\"}"]': 4,
+        '["credentials","inject","{\\"keys\\":[\\"github\\"],\\"scope\\":\\"repo\\"}"]':
+          TOOL_CALL_REPEAT_LIMIT - 1,
       },
     };
     const output = createOutput({
@@ -108,7 +110,7 @@ describe('callLlmFinalizer', () => {
       payload: {
         hasToolsCalling: false,
         result: {
-          content: 'Stopped after the same tool call was requested 5 consecutive times.',
+          content: `Stopped after the same tool call was requested ${TOOL_CALL_REPEAT_LIMIT} consecutive times.`,
           tool_calls: [],
         },
         toolsCalling: [],
@@ -124,7 +126,7 @@ describe('callLlmFinalizer', () => {
     expect(messages.update).toHaveBeenCalledWith(
       'assistant-5',
       expect.objectContaining({
-        content: 'Stopped after the same tool call was requested 5 consecutive times.',
+        content: `Stopped after the same tool call was requested ${TOOL_CALL_REPEAT_LIMIT} consecutive times.`,
         tools: undefined,
       }),
     );
@@ -136,11 +138,11 @@ describe('callLlmFinalizer', () => {
     );
   });
 
-  it('preserves user cancellation when an aborted stream emits the fifth repeated tool call', async () => {
+  it('preserves user cancellation when an aborted stream emits the limit-th repeated tool call', async () => {
     const state = AgentRuntime.createInitialState({ operationId: 'operation-1' });
     state.toolCallRepeatGuard = {
       counts: {
-        '["credentials","inject","{\\"keys\\":[\\"github\\"]}"]': 4,
+        '["credentials","inject","{\\"keys\\":[\\"github\\"]}"]': TOOL_CALL_REPEAT_LIMIT - 1,
       },
     };
     const toolCalling = {

--- a/packages/agent-runtime/src/utils/toolCallRepeatGuard.test.ts
+++ b/packages/agent-runtime/src/utils/toolCallRepeatGuard.test.ts
@@ -1,7 +1,11 @@
 import type { ChatToolPayload } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
-import { hasRepeatedToolCall, updateToolCallRepeatGuard } from './toolCallRepeatGuard';
+import {
+  hasRepeatedToolCall,
+  TOOL_CALL_REPEAT_LIMIT,
+  updateToolCallRepeatGuard,
+} from './toolCallRepeatGuard';
 
 const createToolCall = (argumentsValue: string): ChatToolPayload => ({
   apiName: 'inject',
@@ -12,10 +16,10 @@ const createToolCall = (argumentsValue: string): ChatToolPayload => ({
 });
 
 describe('toolCallRepeatGuard', () => {
-  it('allows four consecutive calls and blocks the fifth with canonically equivalent arguments', () => {
+  it('allows limit-1 consecutive calls and blocks the next with canonically equivalent arguments', () => {
     let guard: ReturnType<typeof updateToolCallRepeatGuard> | undefined;
 
-    for (let index = 0; index < 4; index++) {
+    for (let index = 0; index < TOOL_CALL_REPEAT_LIMIT - 1; index++) {
       guard = updateToolCallRepeatGuard(guard, [
         createToolCall('{"keys":["github"],"scope":"repo"}'),
       ]);

--- a/packages/agent-runtime/src/utils/toolCallRepeatGuard.ts
+++ b/packages/agent-runtime/src/utils/toolCallRepeatGuard.ts
@@ -2,7 +2,13 @@ import type { ChatToolPayload } from '@lobechat/types';
 
 import type { AgentState } from '../types';
 
-export const TOOL_CALL_REPEAT_LIMIT = 5;
+/**
+ * Consecutive identical calls allowed before the turn is stopped. High enough
+ * that legitimate fixed-argument polling loops (e.g. an MCP job-status check
+ * repeated until the job finishes) don't get cut off, while a model stuck
+ * replaying the same call forever is still caught.
+ */
+export const TOOL_CALL_REPEAT_LIMIT = 20;
 
 const canonicalize = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(canonicalize);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`TOOL_CALL_REPEAT_LIMIT` 从 5 提到 20。5 次的阈值会误伤参数天然完全相同的合法轮询循环——典型场景是 MCP 工具轮询 job status(同一个 jobId 反复查直到任务完成),第 5 次就被 `Stopped after the same tool call was requested 5 consecutive times.` 硬停整个 turn。MCP manifest 目前没有任何 annotation/运行时 API 能声明「轮询型工具」,server 作者即使在服务端做了 45 秒内聚合轮询也绕不开。

20 次仍能兜住真正死循环(模型无限重放同一调用),但给了固定参数轮询足够的余量。测试同步改为引用 `TOOL_CALL_REPEAT_LIMIT` 常量而非硬编码 5,后续调阈值不再需要改测试。

#### 📝 补充信息 | Additional Information

由 agent vent 上报浮出(一位 MCP gateway 作者的反馈)。更彻底的方案(manifest 层轮询豁免声明、或「参数相同且**结果也相同**才计数」)可以另行讨论,本 PR 只做低风险的阈值调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)