### PR TITLE
🐛 fix(chat-input): preserve default action lists

### DIFF
--- a/src/features/ChatInput/store/action.test.ts
+++ b/src/features/ChatInput/store/action.test.ts
@@ -16,6 +16,13 @@ describe('ChatInput store actions', () => {
     vi.restoreAllMocks();
   });
 
+  it('keeps action lists usable when a host omits them', () => {
+    const store = createStore({ leftActions: undefined, rightActions: undefined });
+
+    expect(store.getState().leftActions).toEqual([]);
+    expect(store.getState().rightActions).toEqual([]);
+  });
+
   it('clears the autocomplete breaker when dismissing its error', () => {
     const store = createStore();
 

--- a/src/features/ChatInput/store/action.ts
+++ b/src/features/ChatInput/store/action.ts
@@ -41,6 +41,8 @@ const getEffectiveAgentId = (agentId?: string): string => {
 export const store: CreateStore = (publicState) => (set, get) => ({
   ...initialState,
   ...publicState,
+  leftActions: publicState?.leftActions ?? initialState.leftActions,
+  rightActions: publicState?.rightActions ?? initialState.rightActions,
 
   clearInputCompletionError: () => {
     set({ inputCompletionError: undefined, inputCompletionErrorDismissed: false });


### PR DESCRIPTION
## Summary

- preserve the chat input store defaults when a host omits `leftActions` or `rightActions`
- prevent the desktop composer from calling `.flat()` on `undefined`
- add regression coverage for omitted action lists

## Context

Opening **Agents → Create Agent** crashed the Electron renderer after the model selector moved from `leftActions` to `rightActions`. The create modal stopped passing `leftActions`, and the partial store initialization overwrote the default empty array with `undefined`.

## Testing

- `bun run check src/features/ChatInput/store/action.ts src/features/ChatInput/store/action.test.ts`
- 2 files, lint clean, 14 tests passed