### PR TITLE
✅ test: pin the polling regression with a fixed-count case

### DIFF
--- a/packages/agent-runtime/src/utils/toolCallRepeatGuard.test.ts
+++ b/packages/agent-runtime/src/utils/toolCallRepeatGuard.test.ts
@@ -16,6 +16,22 @@ const createToolCall = (argumentsValue: string): ChatToolPayload => ({
 });
 
 describe('toolCallRepeatGuard', () => {
+  // Deliberately hardcoded (not derived from TOOL_CALL_REPEAT_LIMIT): a
+  // fixed-argument polling loop — same jobId polled until the job finishes —
+  // must survive well past the old limit of 5. Reverting the limit makes this
+  // fail, which the self-referential tests below cannot do.
+  it('lets a fixed-argument polling loop run to 19 calls and blocks the 20th', () => {
+    let guard: ReturnType<typeof updateToolCallRepeatGuard> | undefined;
+
+    for (let index = 0; index < 19; index++) {
+      guard = updateToolCallRepeatGuard(guard, [createToolCall('{"jobId":"job-1"}')]);
+      expect(hasRepeatedToolCall(guard)).toBe(false);
+    }
+
+    guard = updateToolCallRepeatGuard(guard, [createToolCall('{"jobId":"job-1"}')]);
+    expect(hasRepeatedToolCall(guard)).toBe(true);
+  });
+
   it('allows limit-1 consecutive calls and blocks the next with canonically equivalent arguments', () => {
     let guard: ReturnType<typeof updateToolCallRepeatGuard> | undefined;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

Follow-up to #18989, addressing the Codex P2 there: the existing tests derive their iteration counts from `TOOL_CALL_REPEAT_LIMIT`, so they are self-referential — if the limit is ever reverted to 5 they still pass and the polling regression goes undetected.

Adds one deliberately hardcoded case: a fixed-argument polling loop (same jobId) runs 19 identical calls without tripping the guard and is blocked on the 20th. Reverting the limit makes this test fail.

#### 📝 补充信息 | Additional Information

None — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)