### PR TITLE
✨ feat(model-runtime): classify 9 error patterns from 2026-09 triage

### DIFF
--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -505,3 +505,60 @@ describe('matchErrorPattern — gateway user/upstream residues by category', () 
     ).toBe(AgentRuntimeErrorType.InvalidVertexCredentials);
   });
 });
+
+describe('2026-09 triage harvest (production residue)', () => {
+  // Real messages sampled from `agent_operations` rows that landed in the
+  // UpstreamHttpError / bare-500 / bare-403 residue over 30 days. Every pattern
+  // here was audited to match zero `provider = 'lobehub'` rows first — first-party
+  // provider errors are our own bugs and must stay visible.
+  const cases: [string, string][] = [
+    ['Sorry, your account balance is insufficient', AgentRuntimeErrorType.InsufficientQuota],
+    [
+      '403 {"error":{"type":"Aihubmix_api_error","message":"Your account balance is insufficient. Please recharge your account to continue using the API."}}',
+      AgentRuntimeErrorType.InsufficientQuota,
+    ],
+    [
+      'LLM stream error: You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.',
+      AgentRuntimeErrorType.InsufficientQuota,
+    ],
+    [
+      '404 Model "gpt-5.6-luna" is not supported by any configured account in this group',
+      AgentRuntimeErrorType.ModelNotFound,
+    ],
+    [
+      'This model models/gemini-2.5-pro is no longer available to new users. Please update your code to use a newer model.',
+      AgentRuntimeErrorType.ModelNotFound,
+    ],
+    [
+      '404 This model is only available through the Batch API. Use the /api/beta/batches endpoint instead.',
+      AgentRuntimeErrorType.CapabilityNotSupported,
+    ],
+    [
+      '400 当前模型或商家不支持请求中的能力。 原因：请求使用了当前渠道不支持的能力，例如图片、PDF、tools、response_format、thinking 或特定协议能力。',
+      AgentRuntimeErrorType.CapabilityNotSupported,
+    ],
+    [
+      '400 data: {"error":{"code":"data_inspection_failed","param":null,"message":"Input text data may contain inappropriate content."}}',
+      AgentRuntimeErrorType.ContentModeration,
+    ],
+    [
+      'LLM stream error: provider temporarily unavailable. Error id: glm-7f67a83c5d74',
+      AgentRuntimeErrorType.ProviderServiceUnavailable,
+    ],
+    [
+      'The bound service account is deleted or disabled. The service account bound to the API key is unavailable.',
+      AgentRuntimeErrorType.InvalidProviderAPIKey,
+    ],
+  ];
+
+  it.each(cases)('classifies %j', (message, expected) => {
+    expect(matchErrorPattern({ message })?.code).toBe(expected);
+    expect(isUserSideError(undefined, message)).toBe(true);
+  });
+
+  it('keeps first-party lobehub failures unclassified so they stay visible', () => {
+    // The bare `Forbidden` body behind 2.4k lobehub-provider rows must NOT be
+    // swept into a user-side code by any pattern added here.
+    expect(matchErrorPattern({ message: 'Forbidden', provider: 'lobehub' })).toBeUndefined();
+  });
+});

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -401,6 +401,18 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('The free quota has been exhausted'),
   },
 
+  // Harvested from the UpstreamHttpError / bare-500 residue (2026-09 triage):
+  // BYOK proxies phrase balance exhaustion without the `, please recharge` tail
+  // that the narrower pattern above requires.
+  {
+    code: AgentRuntimeErrorType.InsufficientQuota,
+    match: sub('account balance is insufficient', { caseInsensitive: true }),
+  },
+  {
+    code: AgentRuntimeErrorType.InsufficientQuota,
+    match: sub('no credits remaining'),
+  },
+
   // ─────────────────────────────────────────────────────────────────────────
   // RateLimitExceeded — short-window rate limit (transient, retryable)
   // ─────────────────────────────────────────────────────────────────────────
@@ -559,6 +571,12 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('服务器问题调试中') },
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('undergoing an upgrade') },
+
+  {
+    code: AgentRuntimeErrorType.ProviderServiceUnavailable,
+    match: sub('provider temporarily unavailable. Error id:'),
+    note: 'Aggregator proxies wrap a transient upstream outage in a bare 500.',
+  },
 
   // ─────────────────────────────────────────────────────────────────────────
   // ProviderNetworkError — connection / timeout
@@ -727,6 +745,17 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('Unknown Model, please check the model code'),
   },
 
+  {
+    code: AgentRuntimeErrorType.ModelNotFound,
+    match: sub('is not supported by any configured account'),
+    note: 'Router/aggregator has no account able to serve the requested model.',
+  },
+  {
+    code: AgentRuntimeErrorType.ModelNotFound,
+    match: sub('is no longer available to new users'),
+    note: 'Gemini retires a model for accounts that never called it before.',
+  },
+
   // ─────────────────────────────────────────────────────────────────────────
   // InvalidVertexCredentials
   // ─────────────────────────────────────────────────────────────────────────
@@ -780,6 +809,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   {
     code: AgentRuntimeErrorType.InvalidProviderAPIKey,
     match: sub('No active credentials for provider'),
+  },
+
+  {
+    code: AgentRuntimeErrorType.InvalidProviderAPIKey,
+    match: sub('bound service account is deleted or disabled'),
   },
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -897,6 +931,16 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('The model rejected this request. It may not support the input you sent'),
   },
 
+  {
+    code: AgentRuntimeErrorType.CapabilityNotSupported,
+    match: sub('only available through the Batch API'),
+  },
+  {
+    code: AgentRuntimeErrorType.CapabilityNotSupported,
+    match: sub('不支持请求中的能力'),
+    note: 'Chinese aggregators reject unsupported image / PDF / tools / thinking capabilities.',
+  },
+
   // ─────────────────────────────────────────────────────────────────────────
   // ContentModeration
   // ─────────────────────────────────────────────────────────────────────────
@@ -947,6 +991,12 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     code: AgentRuntimeErrorType.ContentModeration,
     match: sub('Output data may contain inappropriate content'),
     note: 'sensenova output-side',
+  },
+
+  {
+    code: AgentRuntimeErrorType.ContentModeration,
+    match: sub('data_inspection_failed'),
+    note: 'Alibaba/Qwen content-safety rejection, delivered as a JSON error code.',
   },
 
   // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Full triage of 30 days of `agent_operations` error rows. After removing the unambiguously user-side types (balance, quota, key, local Ollama…), the remaining "attribution" surface is **4.27%** of all ops, split into an **ambiguous** bucket (2.57% — errors parked in `UpstreamHttpError` / bare `500` / bare `403` because the message was never recognised) and a **platform-suspect** bucket (1.70%).

This PR handles the part of the ambiguous bucket that is genuinely user-side or upstream-transient: 9 new message patterns covering ~577 rows / 30 days.

| Pattern | → code | rows/30d |
| --- | --- | ---: |
| `account balance is insufficient` (ci) | InsufficientQuota | 122 |
| `no credits remaining` | InsufficientQuota | 34 |
| `is not supported by any configured account` | ModelNotFound | 147 |
| `is no longer available to new users` | ModelNotFound | 43 |
| `only available through the Batch API` | CapabilityNotSupported | 23 |
| `不支持请求中的能力` | CapabilityNotSupported | 42 |
| `data_inspection_failed` | ContentModeration | 67 |
| `provider temporarily unavailable. Error id:` | ProviderServiceUnavailable | 95 |
| `bound service account is deleted or disabled` | InvalidProviderAPIKey | 11 |

The two `InsufficientQuota` entries exist because the current pattern requires the `, please recharge` tail; the aggregators seen in production phrase it as `Sorry, your account balance is insufficient` or `... is insufficient. Please recharge ...`, neither of which matched.

#### 📝 补充信息 | Additional Information

**First-party safety.** Every candidate was audited against production before inclusion: each matches **0 rows where `provider = 'lobehub'`** (SQL aggregate over 30 days), and all 400 distinct real lobehub-provider error messages from the same window were replayed against the new substrings with zero hits. First-party provider errors are our own bugs and must stay visible, so a regression test pins that the bare `Forbidden` body behind the largest lobehub cluster stays unclassified.

**Deliberately excluded** (found in the same sweep, but not pattern material):

- Context-window / payload-size rejections (`Prompt exceeds max length`, `exceed context window (`, `"status":"Payload Too Large"`) — the harness should preflight/compress these, so filtering them would delete the signal.
- Harness request-shape rejections (`reasoning.mode` is not supported, `reasoning_content` must be passed back, tool-schema unmarshal failures, `Invalid request: text content is empty`) — our bug, needs a code fix.
- Anything with lobehub-provider rows: the bare `403 Forbidden` cluster (2,396 rows / 873 users, zero diagnostic content), `Stealth Ox Alpha` retirement 404s (a model-bank cleanup), Gemini `SAFETY` / `PROHIBITED_CONTENT` bodies still surfacing as bare `500`, and `t.choices is not iterable` (defensive-parsing crash).

Tests: `packages/model-runtime` errors suite — 169 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)