### PR TITLE
🐛 fix(model-runtime): classify SubscriptionPlanLimit in the error spec table

### DIFF
--- a/packages/model-runtime/src/errors/specs.ts
+++ b/packages/model-runtime/src/errors/specs.ts
@@ -12,7 +12,8 @@ import type { ErrorAttribution, ErrorCategory, ErrorSeverity } from './taxonomy'
 export type CloudErrorCode =
   | typeof ChatErrorType.FreePlanLimit
   | typeof ChatErrorType.InsufficientBudgetForModel
-  | typeof ChatErrorType.LobeHubModelDeprecated;
+  | typeof ChatErrorType.LobeHubModelDeprecated
+  | typeof ChatErrorType.SubscriptionPlanLimit;
 
 /** Every code the spec table can classify. */
 export type SpecErrorCode = CloudErrorCode | ILobeAgentRuntimeErrorType;
@@ -190,6 +191,18 @@ export const ERROR_CODE_SPECS: SpecMap = {
     retryable: false,
     countAsFailure: false,
     description: 'LobeHub Cloud balance is positive but below the model’s estimated cost.',
+  },
+  [ChatErrorType.SubscriptionPlanLimit]: {
+    code: ChatErrorType.SubscriptionPlanLimit,
+    numericId: 2903,
+    category: 'quota',
+    severity: 'warning',
+    attribution: 'user',
+    httpStatus: 402,
+    retryable: false,
+    countAsFailure: false,
+    description:
+      'LobeHub Cloud paid-plan allowance reached, or the plan tier does not cover the requested model.',
   },
 
   // ─── 3xxx Capacity ────────────────────────────────────────────────────


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`ChatErrorType.SubscriptionPlanLimit` is emitted by the cloud gateway (budget checks in `CostService` / `WorkspaceCostService`), is listed in the runtime's passthrough set, and is rendered by the client's `PlanLimitCard` alongside `FreePlanLimit` and `InsufficientBudgetForModel` — but it is the only one of the three missing from `ERROR_CODE_SPECS`.

Without a spec it has no `attribution`, no `category`, and no `countAsFailure` flag, so it is invisible to every consumer that classifies by spec: it cannot be recognised as a user-side quota outcome and instead falls through as an unclassified failure.

Adds the spec as `numericId: 2903`, mirroring `FreePlanLimit` (2901) — `quota` / `warning` / `attribution: user` / `httpStatus: 402` / `countAsFailure: false`, placed in ascending id order per the table's contract test.

#### 📝 补充信息 | Additional Information

Surfaced while auditing which production error codes land in the unclassified bucket. Tests: `packages/model-runtime` errors suite — 158 passed, including the `numericId` uniqueness / ordering contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)