### PR TITLE
🐛 fix(model-runtime): stop provider diagnostics from crashing on a malformed choices field

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/providerDiagnostics.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/providerDiagnostics.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  initializeOpenAIDiagnostics,
+  recordOpenAIChatCompletionChunk,
+  recordOpenAIChatCompletionResponse,
+} from './providerDiagnostics';
+
+const createDiagnostics = () =>
+  initializeOpenAIDiagnostics({
+    apiMode: 'chatCompletion',
+    diagnostics: {} as any,
+    endpoint: 'https://example.test/v1/chat/completions',
+    payload: {},
+    sentAt: Date.now(),
+  })!;
+
+describe('providerDiagnostics choices guard', () => {
+  // OpenAI-compatible proxies send keep-alive / usage-only / error frames whose
+  // `choices` is absent or null. Diagnostics is observability — it must never be
+  // what fails the request.
+  const malformed = [
+    ['absent', {}],
+    ['null', { choices: null }],
+    ['an object', { choices: { 0: {} } }],
+    ['a string', { choices: '' }],
+  ] as const;
+
+  it.each(malformed)('survives a stream chunk whose choices is %s', (_label, shape) => {
+    const diagnostics = createDiagnostics();
+
+    expect(() =>
+      recordOpenAIChatCompletionChunk(diagnostics, { id: 'c1', ...shape } as any),
+    ).not.toThrow();
+  });
+
+  it.each(malformed)('survives a completion whose choices is %s', async (_label, shape) => {
+    const diagnostics = createDiagnostics();
+
+    await expect(
+      recordOpenAIChatCompletionResponse(diagnostics, { id: 'c1', ...shape } as any),
+    ).resolves.not.toThrow();
+  });
+
+  it('still records content from a well-formed chunk', () => {
+    const diagnostics = createDiagnostics();
+
+    recordOpenAIChatCompletionChunk(diagnostics, {
+      choices: [{ delta: { content: 'hello' }, index: 0 }],
+      id: 'c1',
+    } as any);
+
+    expect(diagnostics.textChars).toBe(5);
+    expect(diagnostics.hasNonWhitespaceText).toBe(true);
+  });
+});

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/providerDiagnostics.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/providerDiagnostics.ts
@@ -206,7 +206,11 @@ export const recordOpenAIChatCompletionChunk = (
     type: chunk.object || 'chat.completion.chunk',
   };
 
-  for (const choice of chunk.choices) {
+  // OpenAI-compatible upstreams routinely omit `choices` or send `null` on
+  // keep-alive / usage-only / error frames, even though the SDK type says
+  // otherwise. This is diagnostics — it must never be the thing that fails the
+  // request. (`tool_calls` below is already guarded the same way.)
+  for (const choice of Array.isArray(chunk.choices) ? chunk.choices : []) {
     const delta = choice.delta as typeof choice.delta & {
       reasoning?: string;
       reasoning_content?: string;
@@ -387,7 +391,7 @@ export const recordOpenAIChatCompletionResponse = async (
   const event: Omit<ProviderResponseEventDiagnostics, 'index'> = {
     type: completion.object,
   };
-  for (const choice of completion.choices) {
+  for (const choice of Array.isArray(completion.choices) ? completion.choices : []) {
     const message = choice.message as typeof choice.message & {
       reasoning?: string;
       reasoning_content?: string;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`recordOpenAIChatCompletionChunk` and `recordOpenAIChatCompletionResponse` iterate `choices` directly. The SDK type says it is always an array, but OpenAI-compatible upstreams routinely send frames where it is absent, `null`, or not an array at all (keep-alive, usage-only, and error frames). When that happens the loop throws `TypeError: t.choices is not iterable` — and because this runs inside the diagnostics path, an observability helper ends up failing the user's request.

`tool_calls` a few lines below is already written as `?? []`, so the missing guard on `choices` reads as an oversight rather than an intentional invariant.

Both loops now skip a non-array `choices` instead of throwing.

#### 📝 补充信息 | Additional Information

Live in production: 59 occurrences across 15 users in the last 30 days, 26 of them in the last 7 — all on user-configured (BYOK) providers, which is consistent with third-party proxies being looser about the response shape than first-party endpoints.

Tests: 9 new cases covering absent / `null` / object / string `choices` on both entry points, plus a positive case asserting a well-formed chunk is still recorded. Verified they fail against the unpatched source (6 of 9). Full `openaiCompatibleFactory` suite — 173 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)