### PR TITLE
✨ feat(chat): load pre-window history with a round cursor

### DIFF
--- a/apps/server/src/routers/lambda/message.ts
+++ b/apps/server/src/routers/lambda/message.ts
@@ -398,6 +398,10 @@ export const messageRouter = router({
     .input(
       z.object({
         agentId: z.string().nullish(),
+        // Round-cursor for loading older history: only rows strictly older than
+        // this (createdAt, id) tuple, round-aligned like page 0. See
+        // `QueryMessageParams.before`.
+        before: z.object({ createdAt: z.date(), id: z.string() }).optional(),
         current: z.number().optional(),
         groupId: z.string().nullish(),
         // Opt-in for `file` work summaries in the payload. Absent → the legacy

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -661,6 +661,204 @@ describe('MessageModel Query Tests', () => {
       });
     });
 
+    describe('round-cursor before pages (LOBE-13716)', () => {
+      // Like seedRounds, but with a per-round step count so one round can dwarf
+      // the page size — the shape that amplifies the round-start trim.
+      const seedVariableRounds = async (topicId: string, stepsPerRound: number[]) => {
+        await serverDB.insert(topics).values([{ id: topicId, userId }]);
+        const rows: any[] = [];
+        let seq = 0;
+        let prevId: string | null = null;
+        stepsPerRound.forEach((steps, index) => {
+          const r = index + 1;
+          const uid = `${topicId}-u${r}`;
+          rows.push({
+            id: uid,
+            userId,
+            topicId,
+            role: 'user',
+            parentId: prevId,
+            content: `q${r}`,
+            createdAt: new Date(2023, 0, 1, 0, seq),
+          });
+          seq += 1;
+          prevId = uid;
+          for (let step = 1; step <= steps; step += 1) {
+            const sid = `${topicId}-a${r}-${step}`;
+            rows.push({
+              id: sid,
+              userId,
+              topicId,
+              role: 'assistant',
+              parentId: prevId,
+              content: `a${r}.${step}`,
+              createdAt: new Date(2023, 0, 1, 0, seq),
+            });
+            seq += 1;
+            prevId = sid;
+          }
+        });
+        await serverDB.insert(messages).values(rows);
+        return { allIds: rows.map((row) => row.id as string) };
+      };
+
+      const cursorOf = (message: { createdAt: Date | number | string; id: string }) => ({
+        createdAt: new Date(message.createdAt),
+        id: message.id,
+      });
+
+      it('reproduces the amplified trim: a giant mid-topic round shrinks page 0 to the last round', async () => {
+        const topicId = 't-lobe13716-repro';
+        // Rounds of 4 / 12 / 4 messages; page size 10. The newest 10 rows cut
+        // into the giant round 2, and the round-start trim jumps all the way to
+        // round 3 — page 0 keeps only 4 of the 20 messages.
+        await seedVariableRounds(topicId, [3, 11, 3]);
+
+        const page0 = await messageModel.query({ topicId, pageSize: 10 });
+
+        expect(page0).toHaveLength(4);
+        expect(page0[0].id).toBe(`${topicId}-u3`);
+        expect(page0.at(-1)!.id).toBe(`${topicId}-a3-3`);
+      });
+
+      it('walks the full history through before cursors with no gaps or duplicates', async () => {
+        const topicId = 't-lobe13716-walk';
+        const { allIds } = await seedVariableRounds(topicId, [3, 11, 3]);
+
+        const pageSize = 10;
+        const page0 = await messageModel.query({ topicId, pageSize });
+
+        // Page 1: the giant round's tail. A full page with no user message in
+        // view is kept whole (oversized-round guard), mid-round top and all.
+        const page1 = await messageModel.query({
+          topicId,
+          pageSize,
+          before: cursorOf(page0[0]),
+        });
+        expect(page1).toHaveLength(10);
+        // Contiguous join: page 1's newest row is the parent of page 0's oldest.
+        expect(page0[0].parentId).toBe(page1.at(-1)!.id);
+
+        // Page 2: everything left (6 rows < pageSize) — no trim on a partial page.
+        const page2 = await messageModel.query({
+          topicId,
+          pageSize,
+          before: cursorOf(page1[0]),
+        });
+        expect(page2).toHaveLength(6);
+        expect(page2[0].id).toBe(`${topicId}-u1`);
+        expect(page1[0].parentId).toBe(page2.at(-1)!.id);
+
+        // The three pages reassemble the exact full transcript, in order.
+        const walked = [...page2, ...page1, ...page0].map((m) => m.id);
+        expect(walked).toEqual(allIds);
+
+        // Walking past the beginning returns an empty page (the client's
+        // exhaustion signal alongside `page.length < pageSize`).
+        const page3 = await messageModel.query({
+          topicId,
+          pageSize,
+          before: cursorOf(page2[0]),
+        });
+        expect(page3).toHaveLength(0);
+      });
+
+      it('breaks createdAt ties by id so equal-timestamp rows are neither skipped nor duplicated', async () => {
+        const topicId = 't-lobe13716-tie';
+        await serverDB.insert(topics).values([{ id: topicId, userId }]);
+        const createdAt = new Date(2023, 0, 1, 0, 0);
+        await serverDB.insert(messages).values([
+          { id: `${topicId}-m1`, userId, topicId, role: 'user', content: 'q', createdAt },
+          { id: `${topicId}-m2`, userId, topicId, role: 'assistant', content: 'a1', createdAt },
+          { id: `${topicId}-m3`, userId, topicId, role: 'assistant', content: 'a2', createdAt },
+        ]);
+
+        const page0 = await messageModel.query({ topicId, pageSize: 2 });
+        expect(page0.map((m) => m.id)).toEqual([`${topicId}-m2`, `${topicId}-m3`]);
+
+        const page1 = await messageModel.query({
+          topicId,
+          pageSize: 2,
+          before: cursorOf(page0[0]),
+        });
+        expect(page1.map((m) => m.id)).toEqual([`${topicId}-m1`]);
+      });
+
+      it('windows group nodes to the before page instead of refetching the whole topic', async () => {
+        const topicId = 't-lobe13716-group';
+        await seedVariableRounds(topicId, [3, 11, 3]);
+
+        // One group inside the first before page's time window (minute 7.5) and
+        // one inside page 0's window (minute 18.5), each with a hidden member.
+        await serverDB.insert(messageGroups).values([
+          {
+            id: `${topicId}-g-old`,
+            content: 'old summary',
+            type: MessageGroupType.Compression,
+            topicId,
+            userId,
+            createdAt: new Date(2023, 0, 1, 0, 7, 30),
+          },
+          {
+            id: `${topicId}-g-new`,
+            content: 'new summary',
+            type: MessageGroupType.Compression,
+            topicId,
+            userId,
+            createdAt: new Date(2023, 0, 1, 0, 18, 30),
+          },
+        ]);
+        await serverDB.insert(messages).values([
+          {
+            id: `${topicId}-gm-old`,
+            userId,
+            topicId,
+            role: 'assistant',
+            content: 'grouped old',
+            messageGroupId: `${topicId}-g-old`,
+            createdAt: new Date(2023, 0, 1, 0, 7, 15),
+          },
+          {
+            id: `${topicId}-gm-new`,
+            userId,
+            topicId,
+            role: 'assistant',
+            content: 'grouped new',
+            messageGroupId: `${topicId}-g-new`,
+            createdAt: new Date(2023, 0, 1, 0, 18, 15),
+          },
+        ]);
+
+        const pageSize = 10;
+        const page0 = await messageModel.query({ topicId, pageSize });
+        // Page 0 keeps its existing behavior: every group node of the topic.
+        expect(page0.filter((m) => m.id.startsWith(`${topicId}-g-`)).map((m) => m.id)).toEqual([
+          `${topicId}-g-old`,
+          `${topicId}-g-new`,
+        ]);
+
+        const mainline = page0.find((m) => !m.id.startsWith(`${topicId}-g-`));
+        const page1 = await messageModel.query({
+          topicId,
+          pageSize,
+          before: cursorOf(mainline!),
+        });
+        const page1GroupIds = page1
+          .filter((m) => m.id.startsWith(`${topicId}-g-`))
+          .map((m) => m.id);
+        // Only the group inside this page's time window — not the whole topic's.
+        expect(page1GroupIds).toEqual([`${topicId}-g-old`]);
+
+        const page1Mainline = page1.find((m) => !m.id.startsWith(`${topicId}-g-`));
+        const page2 = await messageModel.query({
+          topicId,
+          pageSize,
+          before: cursorOf(page1Mainline!),
+        });
+        expect(page2.some((m) => m.id.startsWith(`${topicId}-g-`))).toBe(false);
+      });
+    });
+
     describe('query with messageQueries', () => {
       it('should include ragQuery, ragQueryId and ragRawQuery in query results', async () => {
         // Create test data

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -58,6 +58,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   lte,
   ne,
   not,
@@ -185,6 +186,11 @@ export interface QueryMessagesOptions {
    * true }`).
    */
   allowShareVisitor?: boolean;
+  /**
+   * Round-cursor for loading older history (see `QueryMessageParams.before`):
+   * only rows strictly older than this `(createdAt, id)` tuple are fetched.
+   */
+  before?: { createdAt: Date; id: string };
   /**
    * Current page number (0-indexed)
    */
@@ -1043,6 +1049,7 @@ export class MessageModel {
   query = async (
     {
       agentId,
+      before,
       current = 0,
       includeFileWorks,
       pageSize = 1000,
@@ -1141,6 +1148,7 @@ export class MessageModel {
       const threadScopeCondition = topicId ? this.matchTopic(topicId) : agentCondition;
       const messageItems = await this.queryWithWhere({
         allowShareVisitor: effectiveIncludeVisitor,
+        before,
         current,
         includeFileWorks,
         pageSize,
@@ -1169,6 +1177,7 @@ export class MessageModel {
 
       const messageItems = await this.queryWithWhere({
         allowShareVisitor: effectiveIncludeVisitor,
+        before,
         current,
         includeFileWorks,
         pageSize,
@@ -1201,6 +1210,7 @@ export class MessageModel {
 
     const messageItems = await this.queryWithWhere({
       allowShareVisitor: effectiveIncludeVisitor,
+      before,
       current,
       includeFileWorks,
       pageSize,
@@ -1369,6 +1379,7 @@ export class MessageModel {
   queryWithWhere = async (options: QueryMessagesOptions = {}): Promise<UIChatMessage[]> => {
     const {
       where,
+      before,
       current = 0,
       includeFileWorks,
       pageSize = 1000,
@@ -1384,6 +1395,16 @@ export class MessageModel {
     // instance's `includeShareVisitor` so either widens the scope.
     const scope =
       allowShareVisitor || this.includeShareVisitor ? this.workspaceScope() : this.ownership();
+
+    // Round-cursor paging: only rows strictly older than the `(createdAt, id)`
+    // tuple. The id tie-break mirrors the sort order below, so rows sharing a
+    // createdAt with the cursor are neither skipped nor duplicated.
+    const beforeCondition = before
+      ? or(
+          lt(messages.createdAt, before.createdAt),
+          and(eq(messages.createdAt, before.createdAt), lt(messages.id, before.id)),
+        )
+      : undefined;
 
     // 1. get basic messages with joins, excluding messages that belong to MessageGroups
     const result = await runTimedStage(
@@ -1460,6 +1481,7 @@ export class MessageModel {
               // Filter out messages that belong to MessageGroups
               isNull(messages.messageGroupId),
               where,
+              beforeCondition,
             ),
           )
           .leftJoin(messagePlugins, eq(messagePlugins.id, messages.id))
@@ -1494,15 +1516,14 @@ export class MessageModel {
     // round with no user message in view is kept whole (the proper fix for those
     // is lazy step loading). Thread queries pass no `topicId` and are untouched.
     //
-    // Scope: this only serves the single "most recent page" load (`current === 0`),
-    // which is the only page the chat read path ever requests — `current`/`pageSize`
-    // offset paging is dead code here (the very premise of). The trim is
-    // deliberately NOT offset-exact: the rows it drops from page 0 also fall outside
-    // page 1's `offset = pageSize` window, so a hypothetical offset walk would skip
-    // them. That is acceptable because nothing offset-walks this path; loading older
-    // history is round-cursor based (see the follow-up), which supersedes offset
-    // paging entirely and closes that gap by construction.
-    if (topicId && current === 0 && result.length >= pageSize) {
+    // Scope: this serves the single "most recent page" load (`current === 0`)
+    // and the round-cursor `before` pages that walk older history — the only
+    // shapes the chat read path requests; `current`/`pageSize` offset paging is
+    // dead code here (the very premise of). The trim is deliberately NOT
+    // offset-exact: rows dropped from one page reappear at the TOP of the next
+    // `before` page (its cursor is the trimmed page's oldest kept row), so the
+    // round-cursor walk loses nothing by construction.
+    if (topicId && (current === 0 || before) && result.length >= pageSize) {
       const firstRoundStart = result.findIndex((message) => message.role === 'user');
       if (firstRoundStart > 0) result.splice(0, firstRoundStart);
     }
@@ -1512,6 +1533,7 @@ export class MessageModel {
     const messageGroupNodesPromise = this.queryMessageGroupNodesForPage({
       allowShareVisitor: allowShareVisitor || this.includeShareVisitor,
       current,
+      hasBeforeCursor: !!before,
       postProcessUrl,
       result,
       timing,
@@ -1686,6 +1708,7 @@ export class MessageModel {
   private queryMessageGroupNodesForPage = async ({
     allowShareVisitor,
     current,
+    hasBeforeCursor,
     postProcessUrl,
     result,
     timing,
@@ -1702,6 +1725,13 @@ export class MessageModel {
      */
     allowShareVisitor?: boolean;
     current: number;
+    /**
+     * The page was fetched with a round-cursor (`before`): scope group nodes to
+     * the page's time window instead of the whole topic — page 0 already
+     * returned every group node, so an unwindowed fetch here would only
+     * duplicate them.
+     */
+    hasBeforeCursor?: boolean;
     postProcessUrl?: (
       path: string | null,
       file: { fileType: string; id?: string | null },
@@ -1713,7 +1743,7 @@ export class MessageModel {
     if (!topicId) return [];
 
     if (result.length === 0) {
-      if (current !== 0) return [];
+      if (current !== 0 || hasBeforeCursor) return [];
 
       return runTimedStage(
         timing,
@@ -1726,7 +1756,7 @@ export class MessageModel {
       );
     }
 
-    if (current === 0) {
+    if (current === 0 && !hasBeforeCursor) {
       return runTimedStage(
         timing,
         'db.message.queryWithWhere.messageGroups',

--- a/packages/types/src/message/db/params.ts
+++ b/packages/types/src/message/db/params.ts
@@ -24,6 +24,13 @@ import type { UIChatMessage } from '../ui';
 
 export interface QueryMessageParams {
   agentId?: string | null;
+  /**
+   * Round-cursor for loading older history: only rows strictly older than this
+   * `(createdAt, id)` tuple are returned, newest-first windowed like the main
+   * page. Callers pass the oldest already-loaded mainline message so pages join
+   * contiguously; offset paging (`current`) is unused by the chat read path.
+   */
+  before?: { createdAt: Date; id: string };
   current?: number;
   groupId?: string | null;
   /**

--- a/src/features/Conversation/ChatList/components/VirtualizedList.tsx
+++ b/src/features/Conversation/ChatList/components/VirtualizedList.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Icon } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
+import { LoaderCircle } from 'lucide-react';
 import type { KeyboardEvent, PointerEvent, ReactElement, ReactNode } from 'react';
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { VListHandle } from 'virtua';
@@ -36,6 +38,10 @@ const DebugInspector = lazy(() => import('./AutoScroll/DebugInspector'));
 const CONVERSATION_FOOTER_ID = '__conversation_footer__';
 const CONVERSATION_HEADER_ID = '__conversation_header__';
 const USER_SCROLL_INTENT_TTL_MS = 500;
+// User-scrolled distance from the very top (px) under which one round-aligned
+// page of pre-window history is fetched (LOBE-13716). The action self-guards
+// against duplicate loads, so firing per scroll event is safe.
+const EARLIER_HISTORY_TRIGGER_PX = 200;
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' ']);
 
 interface VirtualizedListProps {
@@ -109,6 +115,8 @@ const VirtualizedList = memo<VirtualizedListProps>(
     const isSelectionMode = useConversationStore(messageStateSelectors.isSelectionMode);
 
     // Store actions
+    const loadEarlierMessages = useConversationStore((s) => s.loadEarlierMessages);
+    const isLoadingEarlierMessages = useConversationStore((s) => s.isLoadingEarlierMessages);
     const registerVirtuaScrollMethods = useConversationStore((s) => s.registerVirtuaScrollMethods);
     const setScrollState = useConversationStore((s) => s.setScrollState);
     const resetVisibleItems = useConversationStore((s) => s.resetVisibleItems);
@@ -173,6 +181,12 @@ const VirtualizedList = memo<VirtualizedListProps>(
         const hasUserScrollIntent =
           Date.now() - lastUserScrollIntentAtRef.current <= USER_SCROLL_INTENT_TTL_MS;
         onScrollOffset(ref.scrollOffset, hasUserScrollIntent);
+
+        // Near the top under a real user scroll (programmatic mount/restore
+        // scrolls carry no intent): fetch one page of pre-window history.
+        if (hasUserScrollIntent && ref.scrollOffset < EARLIER_HISTORY_TRIGGER_PX) {
+          void loadEarlierMessages();
+        }
       }
 
       // Check if at bottom
@@ -192,7 +206,15 @@ const VirtualizedList = memo<VirtualizedListProps>(
       scrollEndTimerRef.current = setTimeout(() => {
         setScrollState({ isScrolling: false });
       }, 150);
-    }, [activeIndex, checkAtBottom, onScrollOffset, recordScroll, setActiveIndex, setScrollState]);
+    }, [
+      activeIndex,
+      checkAtBottom,
+      loadEarlierMessages,
+      onScrollOffset,
+      recordScroll,
+      setActiveIndex,
+      setScrollState,
+    ]);
 
     const handleScrollEnd = useCallback(() => {
       setScrollState({ isScrolling: false });
@@ -290,6 +312,22 @@ const VirtualizedList = memo<VirtualizedListProps>(
       [footerSlot, headerSlot, listData],
     );
 
+    // Prepend detection for virtua: when pre-window history loads, the former
+    // first message moves down the list. Passing `shift` for exactly that
+    // render keeps the viewport anchored on the rows the user was reading
+    // instead of snapping to the (new) top. Removals and topic switches drop
+    // the previous first id from the list entirely and stay unshifted.
+    const firstMessageId = listData[0] as string | undefined;
+    const prevFirstMessageIdRef = useRef(firstMessageId);
+    const prevFirstMessageId = prevFirstMessageIdRef.current;
+    const shift =
+      prevFirstMessageId !== undefined &&
+      firstMessageId !== prevFirstMessageId &&
+      listData.includes(prevFirstMessageId);
+    useEffect(() => {
+      prevFirstMessageIdRef.current = firstMessageId;
+    });
+
     const keepMountedIndicesWithSlots = useMemo(
       () => (headerSlot ? keepMountedIndices.map((index) => index + 1) : keepMountedIndices),
       [headerSlot, keepMountedIndices],
@@ -315,6 +353,23 @@ const VirtualizedList = memo<VirtualizedListProps>(
       >
         {/* Pinned to the list viewport top; only renders while multi-selecting */}
         <MessageForwardSelectToHere />
+        {/* Pre-window history page in flight (LOBE-13716) */}
+        {isLoadingEarlierMessages && (
+          <div
+            style={{
+              display: 'flex',
+              insetInlineStart: 0,
+              justifyContent: 'center',
+              pointerEvents: 'none',
+              position: 'absolute',
+              top: 8,
+              width: '100%',
+              zIndex: 10,
+            }}
+          >
+            <Icon spin icon={LoaderCircle} />
+          </div>
+        )}
         {/* Debug Inspector - placed outside VList so it won't be recycled by the virtual list */}
         {devDockMounted && (
           <Suspense fallback={null}>
@@ -326,6 +381,7 @@ const VirtualizedList = memo<VirtualizedListProps>(
           data={dataWithSlots}
           keepMounted={keepMountedIndicesWithSlots}
           ref={virtuaRef}
+          shift={shift}
           style={{ height: '100%', overflowAnchor: 'none', paddingBottom }}
           onScroll={handleScroll}
           onScrollEnd={handleScrollEnd}

--- a/src/features/Conversation/store/initialState.ts
+++ b/src/features/Conversation/store/initialState.ts
@@ -90,6 +90,7 @@ export const createEphemeralResetState = (): Partial<State> => ({
   heteroOverloadRetryAttempts: {},
   heteroOverloadWaitOpIds: {},
   inputMessage: '',
+  isLoadingEarlierMessages: false,
   isScrolling: false,
   messageEditingIds: [],
   messageLoadingIds: [],

--- a/src/features/Conversation/store/selectors.test.ts
+++ b/src/features/Conversation/store/selectors.test.ts
@@ -37,6 +37,7 @@ const createMockState = (overrides: Partial<State> = {}): State => ({
   dbMessages: [],
   displayMessages: [],
   hooks: {},
+  isLoadingEarlierMessages: false,
   messagesInit: false,
   operationState: DEFAULT_OPERATION_STATE,
   skipFetch: false,

--- a/src/features/Conversation/store/slices/data/action.test.ts
+++ b/src/features/Conversation/store/slices/data/action.test.ts
@@ -13,6 +13,7 @@ import { useChatStore } from '@/store/chat';
 import { LOCAL_MESSAGE_SCOPE } from '@/store/chat/utils/localMessages';
 
 import { createStore } from '../../index';
+import { createEphemeralResetState } from '../../initialState';
 import { dataSelectors } from './selectors';
 
 // Mock conversation-flow parse function
@@ -299,7 +300,9 @@ describe('DataSlice', () => {
       });
       store.getState().replaceMessages(windowMessages);
       vi.mocked(messageService.getEarlierMessages).mockImplementationOnce(async () => {
+        // Mimic the real switch path (StoreUpdater): ephemeral reset + context.
         store.setState({
+          ...createEphemeralResetState(),
           context: { agentId: 'agent-earlier', topicId: 'topic-earlier-other', threadId: null },
         } as any);
         return earlierPage;
@@ -309,6 +312,44 @@ describe('DataSlice', () => {
 
       expect(store.getState().dbMessages.map((m) => m.id)).toEqual(['u2', 'a2']);
       expect(store.getState().isLoadingEarlierMessages).toBe(false);
+    });
+
+    it('swallows a failed page fetch, resets the flag, and allows a retry', async () => {
+      const store = createStore({
+        context: { agentId: 'agent-earlier', topicId: 'topic-earlier-4', threadId: null },
+      });
+      store.getState().replaceMessages(windowMessages);
+      vi.mocked(messageService.getEarlierMessages)
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValueOnce(earlierPage);
+
+      await expect(store.getState().loadEarlierMessages()).resolves.toBeUndefined();
+      expect(store.getState().isLoadingEarlierMessages).toBe(false);
+
+      await store.getState().loadEarlierMessages();
+
+      expect(messageService.getEarlierMessages).toHaveBeenCalledTimes(2);
+      expect(store.getState().dbMessages.map((m) => m.id)).toEqual(['u1', 'a1', 'u2', 'a2']);
+    });
+
+    it('does not clear the loading flag of the next conversation on late settle', async () => {
+      const store = createStore({
+        context: { agentId: 'agent-earlier', topicId: 'topic-earlier-5', threadId: null },
+      });
+      store.getState().replaceMessages(windowMessages);
+      vi.mocked(messageService.getEarlierMessages).mockImplementationOnce(async () => {
+        store.setState({
+          ...createEphemeralResetState(),
+          context: { agentId: 'agent-earlier', topicId: 'topic-earlier-next', threadId: null },
+        } as any);
+        // The next conversation starts its own page load while ours is in flight.
+        store.setState({ isLoadingEarlierMessages: true });
+        return earlierPage;
+      });
+
+      await store.getState().loadEarlierMessages();
+
+      expect(store.getState().isLoadingEarlierMessages).toBe(true);
     });
   });
 

--- a/src/features/Conversation/store/slices/data/action.test.ts
+++ b/src/features/Conversation/store/slices/data/action.test.ts
@@ -1,6 +1,6 @@
 import type { UIChatMessage } from '@lobechat/types';
 import { act, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useClientDataSWRWithSync } from '@/libs/swr';
 import { messageService } from '@/services/message';
@@ -31,6 +31,7 @@ vi.mock('@lobechat/conversation-flow', () => ({
 // Mock messageService
 vi.mock('@/services/message', () => ({
   messageService: {
+    getEarlierMessages: vi.fn(),
     getMessages: vi.fn(),
     updateMessageMetadata: vi.fn().mockResolvedValue({ success: true, messages: [] }),
   },
@@ -243,6 +244,71 @@ describe('DataSlice', () => {
       const metadata = state.displayMessages[0].metadata as any;
       expect(metadata?.expanded).toBe(true);
       expect(metadata?.someOtherField).toBe('preserved');
+    });
+  });
+
+  describe('loadEarlierMessages', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      clearMessageListClientCacheState();
+    });
+
+    const windowMessages: UIChatMessage[] = [
+      { id: 'u2', content: 'q2', role: 'user', createdAt: 1000, updatedAt: 1000 } as any,
+      { id: 'a2', content: 'a2', role: 'assistant', createdAt: 2000, updatedAt: 2000 } as any,
+    ];
+    const earlierPage: UIChatMessage[] = [
+      { id: 'u1', content: 'q1', role: 'user', createdAt: 100, updatedAt: 100 } as any,
+      { id: 'a1', content: 'a1', role: 'assistant', createdAt: 200, updatedAt: 200 } as any,
+    ];
+
+    it('prepends the fetched round page below the live window rows', async () => {
+      const store = createStore({
+        context: { agentId: 'agent-earlier', topicId: 'topic-earlier-1', threadId: null },
+      });
+      store.getState().replaceMessages(windowMessages);
+      vi.mocked(messageService.getEarlierMessages).mockResolvedValueOnce(earlierPage);
+
+      await store.getState().loadEarlierMessages();
+
+      expect(messageService.getEarlierMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'agent-earlier', topicId: 'topic-earlier-1' }),
+        { createdAt: new Date(1000), id: 'u2' },
+      );
+      expect(store.getState().dbMessages.map((m) => m.id)).toEqual(['u1', 'a1', 'u2', 'a2']);
+      expect(store.getState().isLoadingEarlierMessages).toBe(false);
+    });
+
+    it('stops fetching once a page comes back empty (beginning reached)', async () => {
+      const store = createStore({
+        context: { agentId: 'agent-earlier', topicId: 'topic-earlier-2', threadId: null },
+      });
+      store.getState().replaceMessages(windowMessages);
+      vi.mocked(messageService.getEarlierMessages).mockResolvedValue([]);
+
+      await store.getState().loadEarlierMessages();
+      await store.getState().loadEarlierMessages();
+
+      expect(messageService.getEarlierMessages).toHaveBeenCalledTimes(1);
+      expect(store.getState().dbMessages.map((m) => m.id)).toEqual(['u2', 'a2']);
+    });
+
+    it('drops a page that resolves after the store switched conversations', async () => {
+      const store = createStore({
+        context: { agentId: 'agent-earlier', topicId: 'topic-earlier-3', threadId: null },
+      });
+      store.getState().replaceMessages(windowMessages);
+      vi.mocked(messageService.getEarlierMessages).mockImplementationOnce(async () => {
+        store.setState({
+          context: { agentId: 'agent-earlier', topicId: 'topic-earlier-other', threadId: null },
+        } as any);
+        return earlierPage;
+      });
+
+      await store.getState().loadEarlierMessages();
+
+      expect(store.getState().dbMessages.map((m) => m.id)).toEqual(['u2', 'a2']);
+      expect(store.getState().isLoadingEarlierMessages).toBe(false);
     });
   });
 

--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -7,7 +7,9 @@ import { type StateCreator } from 'zustand/vanilla';
 import { useClientDataSWRWithSync } from '@/libs/swr';
 import { messageService } from '@/services/message';
 import {
+  getEarlierHistoryStatus,
   getMessageListFetchPolicy,
+  loadEarlierMessagePage,
   messageListKey,
   runMessageListQuery,
 } from '@/services/message/cache';
@@ -74,6 +76,14 @@ export interface DataAction {
    * This method updates the frontend state without persisting to database
    */
   internal_dispatchMessage: (payload: MessageDispatch) => void;
+
+  /**
+   * Load one round-aligned page of history older than the server's
+   * newest-first window (LOBE-13716) and prepend it to the transcript.
+   * Self-guarding: no-ops while a page is in flight, once the beginning has
+   * been reached, or when the conversation has no server-backed messages yet.
+   */
+  loadEarlierMessages: () => Promise<void>;
 
   /**
    * Replace all messages with new data
@@ -186,6 +196,43 @@ export const dataSlice: StateCreator<
 
     // Sync changes to external store (ChatStore)
     get().onMessagesChange?.(newDbMessages, get().context);
+  },
+
+  loadEarlierMessages: async () => {
+    const context = get().context;
+    if (!context.agentId || !context.topicId) return;
+    const status = getEarlierHistoryStatus(context);
+    if (status.loading || status.exhausted) return;
+
+    set({ isLoadingEarlierMessages: true }, false, 'loadEarlierMessages/start');
+    try {
+      const merged = await loadEarlierMessagePage(context, get().dbMessages, (before) =>
+        messageService.getEarlierMessages(
+          {
+            agentId: context.agentId,
+            groupId: context.groupId,
+            threadId: context.threadId,
+            topicId: context.topicId,
+            topicShareId: context.topicShareId,
+          },
+          before,
+        ),
+      );
+      // `undefined` → nothing to prepend (no cursor, already loading, or the
+      // beginning was reached — the exhausted flag lives in the cache layer).
+      if (!merged) return;
+      // The user may have switched conversations while the page was in flight.
+      if (!isSameConversationContext(context, get().context)) return;
+
+      log(
+        '[loadEarlierMessages] prepended | contextKey=%s | mergedCount=%d',
+        messageMapKey(context),
+        merged.length,
+      );
+      get().replaceMessages(merged, { expectedContext: context });
+    } finally {
+      set({ isLoadingEarlierMessages: false }, false, 'loadEarlierMessages/end');
+    }
   },
 
   replaceMessages: (messages, options) => {

--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -230,8 +230,17 @@ export const dataSlice: StateCreator<
         merged.length,
       );
       get().replaceMessages(merged, { expectedContext: context });
+    } catch (error) {
+      // The list fires this without awaiting; a swallowed failure resets the
+      // flags below, so the next near-top scroll simply retries the page.
+      log('[loadEarlierMessages] failed | contextKey=%s | %O', messageMapKey(context), error);
     } finally {
-      set({ isLoadingEarlierMessages: false }, false, 'loadEarlierMessages/end');
+      // The flag is conversation-wide state: after a context switch it belongs
+      // to the new conversation (reset by createEphemeralResetState), so a
+      // late settle from the previous one must not clear it.
+      if (isSameConversationContext(context, get().context)) {
+        set({ isLoadingEarlierMessages: false }, false, 'loadEarlierMessages/end');
+      }
     }
   },
 

--- a/src/features/Conversation/store/slices/data/initialState.ts
+++ b/src/features/Conversation/store/slices/data/initialState.ts
@@ -14,6 +14,12 @@ export interface DataState {
   displayMessages: UIChatMessage[];
 
   /**
+   * A round-cursor fetch for history older than the server's newest-first
+   * window is in flight (LOBE-13716). Drives the top-of-list loading hint.
+   */
+  isLoadingEarlierMessages: boolean;
+
+  /**
    * Whether messages have been initialized
    */
   messagesInit: boolean;
@@ -27,5 +33,6 @@ export interface DataState {
 export const dataInitialState: DataState = {
   dbMessages: [],
   displayMessages: [],
+  isLoadingEarlierMessages: false,
   messagesInit: false,
 };

--- a/src/services/message/cache.test.ts
+++ b/src/services/message/cache.test.ts
@@ -345,4 +345,29 @@ describe('earlier history (round-cursor pages, LOBE-13716)', () => {
     const revalidated = await runMessageListQuery(context, async () => window);
     expect(revalidated).toBe(window);
   });
+
+  it('evicts the least-recently-used identity once the earlier-history cache is full', async () => {
+    const window = [message('u2', 10, 'user')];
+    const oldest = { ...context, topicId: 'topic-evicted' };
+    // Exhaust the first identity, then flood the cache with 30 more.
+    await loadEarlierMessagePage(oldest, window, async () => []);
+    expect(getEarlierHistoryStatus(oldest).exhausted).toBe(true);
+
+    for (let i = 0; i < 30; i++) {
+      await loadEarlierMessagePage({ ...context, topicId: `topic-fill-${i}` }, window, async () => [
+        message('u1', 1, 'user'),
+      ]);
+    }
+
+    // The exhausted marker was evicted with the entry: the identity fetches again.
+    expect(getEarlierHistoryStatus(oldest).exhausted).toBe(false);
+    const fetcher = vi.fn().mockResolvedValue([]);
+    await loadEarlierMessagePage(oldest, window, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // The most recent identity survives: its cached page still re-attaches.
+    const survivor = { ...context, topicId: 'topic-fill-29' };
+    const revalidated = await runMessageListQuery(survivor, async () => window);
+    expect(ids(revalidated)).toEqual(['u1', 'u2']);
+  });
 });

--- a/src/services/message/cache.test.ts
+++ b/src/services/message/cache.test.ts
@@ -5,9 +5,11 @@ import { MESSAGE_CACHE_VERSION } from '@/libs/swr/keys';
 
 import {
   clearMessageListClientCacheState,
+  getEarlierHistoryStatus,
   getMessageListFetchPolicy,
   invalidateMessageListClientState,
   isMessageListServerVerified,
+  loadEarlierMessagePage,
   MESSAGE_LIST_VERIFICATION_INTERVAL,
   messageListKey,
   runMessageListQuery,
@@ -243,5 +245,104 @@ describe('message list client cache', () => {
 
     expect(isMessageListServerVerified({ agentId: 'agent-1', topicId: 'topic-0' })).toBe(false);
     expect(isMessageListServerVerified({ agentId: 'agent-1', topicId: 'topic-500' })).toBe(true);
+  });
+});
+
+describe('earlier history (round-cursor pages, LOBE-13716)', () => {
+  const message = (id: string, createdAt: number, role = 'assistant') =>
+    ({ content: id, createdAt, id, role, updatedAt: createdAt }) as unknown as UIChatMessage;
+
+  const ids = (list: UIChatMessage[] | undefined) => list?.map((item) => item.id);
+
+  it('fetches a page older than the oldest mainline row and returns the merged transcript', async () => {
+    const window = [message('u2', 10, 'user'), message('a2', 11)];
+    const fetcher = vi.fn().mockResolvedValue([message('u1', 1, 'user'), message('a1', 2)]);
+
+    const merged = await loadEarlierMessagePage(context, window, fetcher);
+
+    expect(fetcher).toHaveBeenCalledWith({ createdAt: new Date(10), id: 'u2' });
+    expect(ids(merged)).toEqual(['u1', 'a1', 'u2', 'a2']);
+  });
+
+  it('never uses a synthetic group node as the round cursor', async () => {
+    const window = [message('group-1', 5, 'compressedGroup'), message('u2', 10, 'user')];
+    const fetcher = vi.fn().mockResolvedValue([message('u1', 1, 'user')]);
+
+    await loadEarlierMessagePage(context, window, fetcher);
+
+    expect(fetcher).toHaveBeenCalledWith({ createdAt: new Date(10), id: 'u2' });
+  });
+
+  it('re-attaches loaded history to later revalidations of the same identity', async () => {
+    const window = [message('u2', 10, 'user'), message('a2', 11)];
+    await loadEarlierMessagePage(context, window, async () => [message('u1', 1, 'user')]);
+
+    const revalidated = await runMessageListQuery(context, async () => window);
+
+    expect(ids(revalidated)).toEqual(['u1', 'u2', 'a2']);
+  });
+
+  it('drops cached pages when the fresh window slid past the join point', async () => {
+    const window = [message('u2', 10, 'user'), message('a2', 11)];
+    await loadEarlierMessagePage(context, window, async () => [message('u1', 1, 'user')]);
+
+    // The window moved forward: u2 (the join point) fell out of it. Merging
+    // would leave an invisible gap, so the transcript collapses to the window.
+    const slidWindow = [message('u3', 20, 'user'), message('a3', 21)];
+    const revalidated = await runMessageListQuery(context, async () => slidWindow);
+
+    expect(revalidated).toBe(slidWindow);
+  });
+
+  it('deduplicates rows the fresh window already contains', async () => {
+    const window = [message('u2', 10, 'user'), message('a2', 11)];
+    await loadEarlierMessagePage(context, window, async () => [
+      message('u1', 1, 'user'),
+      message('a1', 2),
+    ]);
+
+    // A later window that reaches further back overlaps the cached page.
+    const extendedWindow = [message('a1', 2), message('u2', 10, 'user'), message('a2', 11)];
+    const revalidated = await runMessageListQuery(context, async () => extendedWindow);
+
+    expect(ids(revalidated)).toEqual(['u1', 'a1', 'u2', 'a2']);
+  });
+
+  it('marks the identity exhausted only on an empty page and stops fetching', async () => {
+    const window = [message('u1', 10, 'user')];
+    const fetcher = vi.fn().mockResolvedValue([]);
+
+    const merged = await loadEarlierMessagePage(context, window, fetcher);
+
+    expect(merged).toBeUndefined();
+    expect(getEarlierHistoryStatus(context).exhausted).toBe(true);
+
+    await loadEarlierMessagePage(context, window, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a second load while one page is in flight', async () => {
+    const window = [message('u2', 10, 'user')];
+    const firstPage = deferred<UIChatMessage[]>();
+    const fetcher = vi.fn().mockReturnValue(firstPage.promise);
+
+    const first = loadEarlierMessagePage(context, window, fetcher);
+    const second = await loadEarlierMessagePage(context, window, fetcher);
+
+    expect(second).toBeUndefined();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    firstPage.resolve([message('u1', 1, 'user')]);
+    expect(ids(await first)).toEqual(['u1', 'u2']);
+  });
+
+  it('clears cached history on invalidation so stale rows cannot resurrect', async () => {
+    const window = [message('u2', 10, 'user')];
+    await loadEarlierMessagePage(context, window, async () => [message('u1', 1, 'user')]);
+
+    invalidateMessageListClientState(() => true);
+
+    const revalidated = await runMessageListQuery(context, async () => window);
+    expect(revalidated).toBe(window);
   });
 });

--- a/src/services/message/cache.ts
+++ b/src/services/message/cache.ts
@@ -56,6 +56,28 @@ interface EarlierHistoryState {
 
 const earlierHistoryStates = new Map<string, EarlierHistoryState>();
 
+/**
+ * Each entry can hold thousands of full message rows, so the cap is much
+ * tighter than `MAX_MESSAGE_LIST_CLIENT_STATES`. Insertion order doubles as
+ * recency: `touchEarlierHistoryState` re-appends on every merge, and pruning
+ * evicts the least-recently-merged identities that are not mid-fetch.
+ */
+const MAX_EARLIER_HISTORY_STATES = 30;
+
+const touchEarlierHistoryState = (identity: string, state: EarlierHistoryState) => {
+  earlierHistoryStates.delete(identity);
+  earlierHistoryStates.set(identity, state);
+};
+
+const pruneEarlierHistoryStates = () => {
+  if (earlierHistoryStates.size <= MAX_EARLIER_HISTORY_STATES) return;
+  for (const [identity, state] of earlierHistoryStates.entries()) {
+    if (earlierHistoryStates.size <= MAX_EARLIER_HISTORY_STATES) return;
+    if (state.loading) continue;
+    earlierHistoryStates.delete(identity);
+  }
+};
+
 /** Synthetic MessageGroup nodes are injected by the query, not DB rows — they
  *  can never serve as a round cursor. */
 const isSyntheticGroupNode = (message: UIChatMessage) =>
@@ -78,6 +100,7 @@ const mergeEarlierHistory = (identity: string, fresh: UIChatMessage[]): UIChatMe
 
   const freshIds = new Set(fresh.map((message) => message.id));
   const prefix = state.messages.filter((message) => !freshIds.has(message.id));
+  touchEarlierHistoryState(identity, state);
   // Stable sort: group nodes carried by the fresh window can predate the whole
   // prefix, and rows inside each list keep their relative order.
   return [...prefix, ...fresh].sort(byCreatedAtAscending);
@@ -115,7 +138,8 @@ export const loadEarlierMessagePage = async (
     messages: [],
   };
   state.loading = true;
-  earlierHistoryStates.set(identity, state);
+  touchEarlierHistoryState(identity, state);
+  pruneEarlierHistoryStates();
 
   try {
     const page = await fetcher({ createdAt: new Date(cursor.createdAt), id: cursor.id });

--- a/src/services/message/cache.ts
+++ b/src/services/message/cache.ts
@@ -30,6 +30,115 @@ interface MessageListClientState {
 
 const messageListClientStates = new Map<string, MessageListClientState>();
 
+/**
+ * Client-held pages of history OLDER than the server's newest-first window
+ * (LOBE-13716). The chat read path only ever fetches the newest round-aligned
+ * page; when the user walks back past it, the older pages are fetched once via
+ * a round cursor and kept here so every later revalidation of the same
+ * identity re-merges them instead of collapsing the view back to the window.
+ */
+interface EarlierHistoryState {
+  /**
+   * The oldest mainline row of the live window when history was first
+   * extended — the join point. A fresh window that no longer contains this id
+   * has slid past the cached pages (a gap), so the cache is dropped rather
+   * than merged.
+   */
+  anchorId: string;
+  cacheScope: string;
+  context: CanonicalMessageListContext;
+  /** A `before` page came back empty: the very beginning has been reached. */
+  exhausted: boolean;
+  loading: boolean;
+  /** Ascending rows strictly older than `anchorId`. */
+  messages: UIChatMessage[];
+}
+
+const earlierHistoryStates = new Map<string, EarlierHistoryState>();
+
+/** Synthetic MessageGroup nodes are injected by the query, not DB rows — they
+ *  can never serve as a round cursor. */
+const isSyntheticGroupNode = (message: UIChatMessage) =>
+  message.role === 'compressedGroup' || message.role === 'compareGroup';
+
+const byCreatedAtAscending = (a: UIChatMessage, b: UIChatMessage) =>
+  new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+
+const mergeEarlierHistory = (identity: string, fresh: UIChatMessage[]): UIChatMessage[] => {
+  const state = earlierHistoryStates.get(identity);
+  if (!state || state.messages.length === 0) return fresh;
+
+  if (!fresh.some((message) => message.id === state.anchorId)) {
+    // The window slid past the join point — merging would hide an invisible
+    // gap in the middle of the transcript. Collapse back to the window; the
+    // user can walk back again from the new boundary.
+    earlierHistoryStates.delete(identity);
+    return fresh;
+  }
+
+  const freshIds = new Set(fresh.map((message) => message.id));
+  const prefix = state.messages.filter((message) => !freshIds.has(message.id));
+  // Stable sort: group nodes carried by the fresh window can predate the whole
+  // prefix, and rows inside each list keep their relative order.
+  return [...prefix, ...fresh].sort(byCreatedAtAscending);
+};
+
+export const getEarlierHistoryStatus = (context: MessageListQueryContext) => {
+  const state = earlierHistoryStates.get(getMessageListCacheIdentity(context));
+  return { exhausted: state?.exhausted ?? false, loading: state?.loading ?? false };
+};
+
+/**
+ * Fetch one round-aligned page of history older than the oldest mainline row
+ * of `currentMessages`, remember it for future revalidation merges, and return
+ * the full merged transcript — or `undefined` when there is nothing to do
+ * (no cursor, already loading, or the beginning was reached).
+ */
+export const loadEarlierMessagePage = async (
+  context: MessageListQueryContext,
+  currentMessages: UIChatMessage[],
+  fetcher: (before: { createdAt: Date; id: string }) => Promise<UIChatMessage[]>,
+): Promise<UIChatMessage[] | undefined> => {
+  const identity = getMessageListCacheIdentity(context);
+  const existing = earlierHistoryStates.get(identity);
+  if (existing?.exhausted || existing?.loading) return undefined;
+
+  const cursor = currentMessages.find((message) => !isSyntheticGroupNode(message));
+  if (!cursor) return undefined;
+
+  const state: EarlierHistoryState = existing ?? {
+    anchorId: cursor.id,
+    cacheScope: getCacheScope(),
+    context: normalizeMessageListQueryContext(context),
+    exhausted: false,
+    loading: false,
+    messages: [],
+  };
+  state.loading = true;
+  earlierHistoryStates.set(identity, state);
+
+  try {
+    const page = await fetcher({ createdAt: new Date(cursor.createdAt), id: cursor.id });
+
+    if (page.length === 0) {
+      // `length < pageSize` is NOT a reliable end signal — the round-start trim
+      // legitimately shortens full pages — so only an empty page marks the top.
+      state.exhausted = true;
+      return undefined;
+    }
+
+    const pageIds = new Set(page.map((message) => message.id));
+    state.messages = [
+      ...page,
+      ...state.messages.filter((message) => !pageIds.has(message.id)),
+    ].sort(byCreatedAtAscending);
+
+    return mergeEarlierHistory(identity, currentMessages);
+  } finally {
+    state.loading = false;
+  }
+};
+
 export const messageListKey = (context: MessageListQueryContext) => messageKeys.list(context);
 
 export const getMessageListCacheIdentity = (
@@ -139,7 +248,10 @@ const startCurrentGenerationQuery = (
       state.verifiedAt = Date.now();
       touchState(state);
       pruneClientStates();
-      return messages;
+      // Re-attach client-held older history (loaded via round cursor) so a
+      // revalidation doesn't collapse an extended transcript back to the
+      // newest-first window.
+      return mergeEarlierHistory(state.identity, messages);
     })
     .finally(() => {
       state.activeRequestGenerations.delete(requestGeneration);
@@ -185,8 +297,18 @@ export const invalidateMessageListClientState = (
     state.generation += 1;
     state.verifiedAt = undefined;
   }
+
+  // A force refresh signals the persisted rows may have changed (edits or
+  // deletes can target rounds inside the extended range). Cached older pages
+  // could resurrect stale rows through the merge, so drop them; the user can
+  // walk back again from the refreshed window.
+  for (const [identity, state] of earlierHistoryStates.entries()) {
+    if (state.cacheScope !== cacheScope || !predicate(state.context)) continue;
+    earlierHistoryStates.delete(identity);
+  }
 };
 
 export const clearMessageListClientCacheState = () => {
   messageListClientStates.clear();
+  earlierHistoryStates.clear();
 };

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -176,6 +176,25 @@ export class MessageService {
     return data as unknown as UIChatMessage[];
   };
 
+  /**
+   * Load one round-aligned page of history strictly OLDER than `before` (the
+   * oldest already-loaded mainline message). Intentionally outside the
+   * `runMessageListQuery` client-cache policy: older pages are additive and
+   * merged by the earlier-history layer in `services/message/cache`.
+   */
+  getEarlierMessages = async (
+    params: MessageReadQueryContext,
+    before: { createdAt: Date; id: string },
+  ): Promise<UIChatMessage[]> => {
+    const data = await lambdaClient.message.getMessages.query({
+      ...params,
+      before,
+      includeFileWorks: true,
+    });
+
+    return data as unknown as UIChatMessage[];
+  };
+
   diagnoseTopic = async (params: { agentId?: string | null; topicId: string }) => {
     return lambdaClient.message.diagnoseTopic.query(params);
   };


### PR DESCRIPTION
## 背景

排查 `tpc_atAzJuBAB5iY` 时发现:该 topic 数据库里有 1183 条消息、parentId 森林完整、无 historySummary,但聊天页顶部只显示最后 307 条,前 876 条完全不可见。

根因是读路径的两层裁剪叠加:

1. `MessageModel.query` 只取最新 1000 条(`desc + limit` 后 reverse),多出的 183 条永远不发给前端。
2. 满页时下边界会对齐到 round 起点——窗口内第一条 mainline `user` 消息。该 topic 只有 3 条 user 消息,第二轮单轮 855 条,窗口边界落在轮中间,裁剪直接跳到第三条 user 消息。855 条的巨型 round 把"少 183 条"放大成了"少 876 条"。

1000 条上限自建库起就存在;#17313 把 `asc + limit` 翻成 newest-first,截断方向从"丢最新"改成"丢最旧"——当前行为是那个设计的预期结果,但配套的历史加载一直没落地(`message.ts` 注释里预告的 round-cursor follow-up)。本 PR 补上它。

## 改动

**DB 层** — `MessageModel.query` / `queryWithWhere` 接受 `before: {createdAt, id}`,返回严格早于该 tuple 的 round 对齐页。id tie-break 与排序一致,时间戳并列的行既不会跳过也不会重复。裁剪从一页丢掉的行会出现在下一页顶部(下一页的 cursor 正是本页保留的最老行),所以整个走查无损。

**Group 节点** — `before` 页按页时间窗取 group node,不再全量重取。此前 page 0 已返回全部节点,不加窗会让每一页都重复它们。

**客户端缓存** — 按 cache identity 记住已加载的旧页,revalidate 时重新拼接,避免刷新把展开的历史打回窗口。两种情况丢弃缓存:窗口滑过 join 点(中间会出现不可见的断层)、显式失效(编辑/删除可能命中已加载区间,合并会复活陈旧行)。

**UI** — 用户滚动到接近顶部时拉一页(仅在有真实滚动意图时触发,挂载/恢复位置的程序化滚动不算),virtua 的 `shift` 保持视口锚定在用户正在读的行上,顶部显示加载指示。

## 测试

DB 层 4 个:先复现问题(3 轮 4/12/4 条、pageSize 10,page 0 被裁到只剩 4 条),再验证 cursor 走查完整重建全量 transcript 且无重复、走到头返回空页、时间戳并列按 id 断开、group node 按页加窗。

回退修复验证过 regression 有效:去掉 cursor 条件后 3 个用例失败(第 4 个是刻意记录 bug 现状的复现用例,前后都通过)。

缓存层 7 个(合并、去重、滑窗丢弃、exhausted、并发防抖、失效清理)+ store action 3 个(prepend、空页停止、切会话丢弃迟到结果)。

`bun run check` 全绿:12 文件 lint clean、199 测试通过;类型检查在本 PR 文件范围内无报错。

Closes LOBE-13716

🤖 Generated with [Claude Code](https://claude.com/claude-code)