### PR TITLE
✨ feat(model-runtime): support Claude Fable 5.1 tool_choice rules

### DIFF
--- a/locales/ar/home.json
+++ b/locales/ar/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "عرض الكل",
   "homePromoBanner.cta": "جرّب الآن",
   "homePromoBanner.dismiss": "تجاهل",
-  "homePromoBanner.glm53FlashReveal": "أوكس ألفا مكشوف: GLM-5.3-فلاش",
   "homePromoBanner.label": "{{model}} متاح الآن",
   "inbox.author.scheduled": "مجدول",
   "inbox.error.title": "فشل التشغيل",

--- a/locales/bg-BG/home.json
+++ b/locales/bg-BG/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Виж всички",
   "homePromoBanner.cta": "Опитайте сега",
   "homePromoBanner.dismiss": "Затвори",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha разкрит: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} вече е наличен",
   "inbox.author.scheduled": "Планирано",
   "inbox.error.title": "Неуспешно изпълнение",

--- a/locales/de-DE/home.json
+++ b/locales/de-DE/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Alle anzeigen",
   "homePromoBanner.cta": "Jetzt ausprobieren",
   "homePromoBanner.dismiss": "Schließen",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha enthüllt: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} ist jetzt verfügbar",
   "inbox.author.scheduled": "Geplant",
   "inbox.error.title": "Ausführung fehlgeschlagen",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "View all",
   "homePromoBanner.cta": "Try now",
   "homePromoBanner.dismiss": "Dismiss",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha unmasked: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} is now available",
   "inbox.author.scheduled": "Scheduled",
   "inbox.error.title": "Run failed",

--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -798,6 +798,7 @@
   "lobehub.MiniMax-M2.7-highspeed.description": "Same capabilities as M2.7 with significantly faster responses.",
   "lobehub.MiniMax-M2.7.description": "A self-evolving model with top-tier coding and agentic performance.",
   "lobehub.MiniMax-M3.description": "A frontier multimodal model for coding and agentic tasks, with native image and video understanding.",
+  "lobehub.claude-fable-5-1.description": "Stronger than Fable 5 on long-running coding and research — 55.8% on Terminal-Bench 4.0 versus 42.0%, at the same $10/$50 with cache reads at a quarter of the cost.",
   "lobehub.claude-fable-5.description": "Claude Fable 5 is the world's strongest model for demanding reasoning, long-horizon agentic work, and complex coding. It is also the most expensive model.",
   "lobehub.claude-haiku-4-5-20251001.description": "Claude Haiku 4.5 is Anthropic's fastest and most intelligent Haiku model.",
   "lobehub.claude-opus-4-6.description": "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",

--- a/locales/es-ES/home.json
+++ b/locales/es-ES/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Ver todas",
   "homePromoBanner.cta": "Prueba ahora",
   "homePromoBanner.dismiss": "Cerrar",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha desenmascarado: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} ya está disponible",
   "inbox.author.scheduled": "Programado",
   "inbox.error.title": "Ejecución fallida",

--- a/locales/fa-IR/home.json
+++ b/locales/fa-IR/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "مشاهده همه",
   "homePromoBanner.cta": "همین حالا امتحان کنید",
   "homePromoBanner.dismiss": "بستن",
-  "homePromoBanner.glm53FlashReveal": "آکس آلفا فاش شد: GLM-5.3-فلش",
   "homePromoBanner.label": "{{model}} اکنون در دسترس است",
   "inbox.author.scheduled": "برنامه‌ریزی شده",
   "inbox.error.title": "اجرای عملیات ناموفق بود",

--- a/locales/fr-FR/home.json
+++ b/locales/fr-FR/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Voir tout",
   "homePromoBanner.cta": "Essayez maintenant",
   "homePromoBanner.dismiss": "Fermer",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha dévoilé : GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} est maintenant disponible",
   "inbox.author.scheduled": "Planifié",
   "inbox.error.title": "Échec de l'exécution",

--- a/locales/it-IT/home.json
+++ b/locales/it-IT/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Visualizza tutto",
   "homePromoBanner.cta": "Prova ora",
   "homePromoBanner.dismiss": "Chiudi",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha smascherato: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} è ora disponibile",
   "inbox.author.scheduled": "Programmato",
   "inbox.error.title": "Esecuzione fallita",

--- a/locales/ja-JP/home.json
+++ b/locales/ja-JP/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "すべて表示",
   "homePromoBanner.cta": "今すぐ試す",
   "homePromoBanner.dismiss": "閉じる",
-  "homePromoBanner.glm53FlashReveal": "オックスアルファの正体が明らかに: GLM-5.3-フラッシュ",
   "homePromoBanner.label": "{{model}}が利用可能になりました",
   "inbox.author.scheduled": "予定済み",
   "inbox.error.title": "実行に失敗しました",

--- a/locales/ko-KR/home.json
+++ b/locales/ko-KR/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "모두 보기",
   "homePromoBanner.cta": "지금 시도하기",
   "homePromoBanner.dismiss": "닫기",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha의 비밀 공개: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}}이(가) 이제 사용 가능합니다",
   "inbox.author.scheduled": "예약됨",
   "inbox.error.title": "실행 실패",

--- a/locales/nl-NL/home.json
+++ b/locales/nl-NL/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Alles bekijken",
   "homePromoBanner.cta": "Probeer nu",
   "homePromoBanner.dismiss": "Sluiten",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha onthuld: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} is nu beschikbaar",
   "inbox.author.scheduled": "Gepland",
   "inbox.error.title": "Run failed",

--- a/locales/pl-PL/home.json
+++ b/locales/pl-PL/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Zobacz wszystkie",
   "homePromoBanner.cta": "Wypróbuj teraz",
   "homePromoBanner.dismiss": "Zamknij",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha ujawniony: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} jest już dostępny",
   "inbox.author.scheduled": "Zaplanowane",
   "inbox.error.title": "Niepowodzenie uruchomienia",

--- a/locales/pt-BR/home.json
+++ b/locales/pt-BR/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Ver todas",
   "homePromoBanner.cta": "Experimente agora",
   "homePromoBanner.dismiss": "Fechar",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha desmascarado: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} já está disponível",
   "inbox.author.scheduled": "Agendado",
   "inbox.error.title": "Execução falhou",

--- a/locales/ru-RU/home.json
+++ b/locales/ru-RU/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Посмотреть все",
   "homePromoBanner.cta": "Попробовать сейчас",
   "homePromoBanner.dismiss": "Закрыть",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha разоблачён: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} теперь доступен",
   "inbox.author.scheduled": "Запланировано",
   "inbox.error.title": "Ошибка выполнения",

--- a/locales/tr-TR/home.json
+++ b/locales/tr-TR/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Tümünü görüntüle",
   "homePromoBanner.cta": "Şimdi deneyin",
   "homePromoBanner.dismiss": "Kapat",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha açığa çıktı: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} artık mevcut",
   "inbox.author.scheduled": "Planlanmış",
   "inbox.error.title": "Çalıştırma başarısız oldu",

--- a/locales/vi-VN/home.json
+++ b/locales/vi-VN/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "Xem tất cả",
   "homePromoBanner.cta": "Thử ngay",
   "homePromoBanner.dismiss": "Bỏ qua",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha lộ diện: GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} hiện đã có sẵn",
   "inbox.author.scheduled": "Đã lên lịch",
   "inbox.error.title": "Chạy thất bại",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "查看全部",
   "homePromoBanner.cta": "立即体验",
   "homePromoBanner.dismiss": "关闭",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha 现真身：GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} 现已上线",
   "inbox.author.scheduled": "定时触发",
   "inbox.error.title": "运行失败",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -798,6 +798,7 @@
   "lobehub.MiniMax-M2.7-highspeed.description": "与 M2.7 功能相同，但响应速度显著提升。",
   "lobehub.MiniMax-M2.7.description": "一个自我进化的模型，具备顶级的编码和智能代理性能。",
   "lobehub.MiniMax-M3.description": "一个前沿的多模态模型，专注于编码和智能代理任务，具备原生图像和视频理解能力。",
+  "lobehub.claude-fable-5-1.description": "在长时间编码与研究任务上强于 Fable 5——Terminal-Bench 4.0 得分 55.8%（Fable 5 为 42.0%），价格同为 $10/$50，缓存读取成本仅为四分之一。",
   "lobehub.claude-fable-5.description": "Claude Fable 5 是全球最强大的模型，适用于高要求的推理、长时间智能代理工作和复杂编码，同时也是最昂贵的模型。",
   "lobehub.claude-haiku-4-5-20251001.description": "Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型。",
   "lobehub.claude-opus-4-6.description": "Claude Opus 4.6 是 Anthropic 最智能的模型，用于构建代理和编码。",

--- a/locales/zh-TW/home.json
+++ b/locales/zh-TW/home.json
@@ -107,7 +107,6 @@
   "dashboard.task.viewAll": "查看全部",
   "homePromoBanner.cta": "立即嘗試",
   "homePromoBanner.dismiss": "關閉",
-  "homePromoBanner.glm53FlashReveal": "Ox Alpha揭露：GLM-5.3-Flash",
   "homePromoBanner.label": "{{model}} 現已推出",
   "inbox.author.scheduled": "已排程",
   "inbox.error.title": "執行失敗",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -48,7 +48,6 @@ export default {
   'cardBindingPromoBanner.label': 'Add your first payment method and get 1M credits free',
   'homePromoBanner.cta': 'Try now',
   'homePromoBanner.dismiss': 'Dismiss',
-  'homePromoBanner.glm53FlashReveal': 'Ox Alpha unmasked: GLM-5.3-Flash',
   'homePromoBanner.label': '{{model}} is now available',
   'dashboard.chat.empty': 'No recent conversations',
   'dashboard.chat.recents': 'Recent topics',

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -8,6 +8,8 @@
  * Consumed by both `default/models.ts` (Node) and `default/models.vite.ts` (Vite SPA).
  */
 export const lobeHubOnlineModelDescriptions = {
+  'lobehub.claude-fable-5-1.description':
+    'Stronger than Fable 5 on long-running coding and research — 55.8% on Terminal-Bench 4.0 versus 42.0%, at the same $10/$50 with cache reads at a quarter of the cost.',
   'lobehub.claude-fable-5.description':
     "Claude Fable 5 is the world's strongest model for demanding reasoning, long-horizon agentic work, and complex coding. It is also the most expensive model.",
   'lobehub.claude-haiku-4-5-20251001.description':

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -163,6 +163,25 @@ describe('Anthropic generateObject', () => {
     expect((requestParams.tools?.[0] as any).strict).toBe(true);
   });
 
+  it('should respect an explicit strict: false opt-out on Fable 5.1', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest({
+      messages: [{ content: 'Generate', role: 'user' as const }],
+      model: 'claude-fable-5-1',
+      schema: {
+        name: 'verdict',
+        schema: {
+          properties: { claim: { type: 'string' }, suggestion: { type: 'string' } },
+          required: ['claim'],
+          type: 'object' as const,
+        },
+        strict: false,
+      },
+    } as any);
+
+    expect(requestParams.tool_choice).toEqual({ type: 'auto' });
+    expect((requestParams.tools?.[0] as any).strict).toBe(false);
+  });
+
   describe('use struct output schema', () => {
     it('should return structured data on successful API call', async () => {
       const mockClient = {

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -141,6 +141,28 @@ describe('Anthropic generateObject', () => {
     expect(requestParams.tool_choice).toEqual({ type: 'auto' });
   });
 
+  it('should still use auto tool_choice when the request model is an opaque mapped id', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest(
+      {
+        messages: [{ content: 'Generate', role: 'user' as const }],
+        model: 'claude-fable-5-1',
+        schema: {
+          name: 'result',
+          schema: {
+            additionalProperties: false,
+            properties: { title: { type: 'string' } },
+            required: ['title'],
+            type: 'object' as const,
+          },
+        },
+      } as any,
+      { requestModel: 'custom-deployment-id' },
+    );
+
+    expect(requestParams.tool_choice).toEqual({ type: 'auto' });
+    expect((requestParams.tools?.[0] as any).strict).toBe(true);
+  });
+
   describe('use struct output schema', () => {
     it('should return structured data on successful API call', async () => {
       const mockClient = {

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -62,6 +62,85 @@ describe('Anthropic generateObject', () => {
     expect(requestParams.messages).toEqual([{ content: 'Generate data', role: 'user' }]);
   });
 
+  it('should use auto tool_choice and strict schema tools on Fable 5.1', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest({
+      messages: [{ content: 'Generate a person object', role: 'user' as const }],
+      model: 'claude-fable-5-1',
+      schema: {
+        description: 'Extract person information',
+        name: 'person_extractor',
+        schema: {
+          properties: { age: { type: 'number' }, name: { type: 'string' } },
+          required: ['name', 'age'],
+          type: 'object' as const,
+        },
+      },
+    } as any);
+
+    expect(requestParams.tool_choice).toEqual({ type: 'auto' });
+    expect(requestParams.tools).toEqual([
+      expect.objectContaining({
+        name: 'person_extractor',
+        strict: true,
+      }),
+    ]);
+  });
+
+  it('should key the Fable 5.1 tool_choice guard on config.requestModel', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest(
+      {
+        messages: [{ content: 'Generate a person object', role: 'user' as const }],
+        model: 'my-custom-router-model',
+        schema: {
+          name: 'person_extractor',
+          schema: { properties: { name: { type: 'string' } }, type: 'object' as const },
+        },
+      } as any,
+      { requestModel: 'global.anthropic.claude-fable-5-1' },
+    );
+
+    expect(requestParams.tool_choice).toEqual({ type: 'auto' });
+  });
+
+  it('should keep forced tool_choice on Fable 5', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest({
+      messages: [{ content: 'Generate a person object', role: 'user' as const }],
+      model: 'claude-fable-5',
+      schema: {
+        name: 'person_extractor',
+        schema: { properties: { name: { type: 'string' } }, type: 'object' as const },
+      },
+    } as any);
+
+    expect(requestParams.tool_choice).toEqual({
+      name: 'person_extractor',
+      type: 'tool',
+    });
+  });
+
+  it('should use auto tool_choice for tools mode on Fable 5.1', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest({
+      messages: [{ content: 'Call a tool', role: 'user' as const }],
+      model: 'claude-fable-5-1',
+      tools: [
+        {
+          function: {
+            description: 'Get weather information',
+            name: 'get_weather',
+            parameters: {
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+              type: 'object' as const,
+            },
+          },
+          type: 'function' as const,
+        },
+      ],
+    } as any);
+
+    expect(requestParams.tool_choice).toEqual({ type: 'auto' });
+  });
+
   describe('use struct output schema', () => {
     it('should return structured data on successful API call', async () => {
       const mockClient = {

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
@@ -87,8 +87,12 @@ export const buildAnthropicGenerateObjectRequest = async (
         schema.description || 'Generate structured output according to the provided schema',
       input_schema: schema.schema as Anthropic.Tool.InputSchema,
       name: schema.name || 'structured_output',
+      // Without forced tool_choice, `strict: true` is what keeps the arguments
+      // schema-valid. Respect an explicit `strict: false` opt-out though: strict
+      // mode requires every declared property to be required, and schemas with
+      // optional fields would otherwise fail validation with a 400.
       ...(forcedToolChoiceRejected
-        ? { strict: true }
+        ? { strict: schema.strict !== false }
         : config?.schemaToolStrict && schema.strict !== undefined
           ? { strict: schema.strict }
           : {}),

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
@@ -3,6 +3,7 @@ import debug from 'debug';
 import type { Pricing } from 'model-bank';
 
 import { stripUnsupportedClaudeAssistantPrefill } from '../../providers/anthropic/claudePrefill';
+import { rejectsForcedToolChoice } from '../../providers/anthropic/modelId';
 import type { GenerateObjectOptions, GenerateObjectPayload } from '../../types';
 import { buildAnthropicMessages, buildAnthropicTools } from '../contextBuilders/anthropic';
 import { buildAnthropicInitialUsage } from '../usageConverters/anthropic';
@@ -68,11 +69,12 @@ export const buildAnthropicGenerateObjectRequest = async (
     : undefined;
 
   let finalTools;
-  let tool_choice: Anthropic.ToolChoiceAny | Anthropic.ToolChoiceTool;
+  let tool_choice: Anthropic.ToolChoiceAuto | Anthropic.ToolChoiceAny | Anthropic.ToolChoiceTool;
   let schemaToolName: string | undefined;
+  const forcedToolChoiceRejected = rejectsForcedToolChoice(config?.requestModel ?? model);
   if (tools) {
     finalTools = buildAnthropicTools(tools);
-    tool_choice = { type: 'any' };
+    tool_choice = forcedToolChoiceRejected ? { type: 'auto' } : { type: 'any' };
   } else if (schema) {
     // Convert OpenAI-style schema to Anthropic tool format
     const tool: Anthropic.ToolUnion = {
@@ -80,14 +82,21 @@ export const buildAnthropicGenerateObjectRequest = async (
         schema.description || 'Generate structured output according to the provided schema',
       input_schema: schema.schema as Anthropic.Tool.InputSchema,
       name: schema.name || 'structured_output',
-      ...(config?.schemaToolStrict && schema.strict !== undefined ? { strict: schema.strict } : {}),
+      ...(forcedToolChoiceRejected
+        ? { strict: true }
+        : config?.schemaToolStrict && schema.strict !== undefined
+          ? { strict: schema.strict }
+          : {}),
     };
     log('converted tool: %O', tool);
 
     finalTools = [tool];
     schemaToolName = tool.name;
-    tool_choice =
-      config?.schemaToolChoice === 'any' ? { type: 'any' } : { name: tool.name, type: 'tool' };
+    tool_choice = forcedToolChoiceRejected
+      ? { type: 'auto' }
+      : config?.schemaToolChoice === 'any'
+        ? { type: 'any' }
+        : { name: tool.name, type: 'tool' };
   } else {
     throw new Error('tools or schema is required');
   }

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
@@ -71,7 +71,12 @@ export const buildAnthropicGenerateObjectRequest = async (
   let finalTools;
   let tool_choice: Anthropic.ToolChoiceAuto | Anthropic.ToolChoiceAny | Anthropic.ToolChoiceTool;
   let schemaToolName: string | undefined;
-  const forcedToolChoiceRejected = rejectsForcedToolChoice(config?.requestModel ?? model);
+  // Check both the logical model id and the mapped request model: a router may map
+  // `claude-fable-5-1` to an opaque deployment / inference-profile id that
+  // `rejectsForcedToolChoice` cannot parse, and forced tool_choice would still 400.
+  const forcedToolChoiceRejected = [model, config?.requestModel].some(
+    (id): id is string => !!id && rejectsForcedToolChoice(id),
+  );
   if (tools) {
     finalTools = buildAnthropicTools(tools);
     tool_choice = forcedToolChoiceRejected ? { type: 'auto' } : { type: 'any' };

--- a/packages/model-runtime/src/providers/anthropic/modelId.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.test.ts
@@ -9,6 +9,7 @@ import {
   isThinkingWithToolClaudeModel,
   parseClaudeModelId,
   rejectsDisabledThinkingAtEffort,
+  rejectsForcedToolChoice,
   shouldDropUnsupportedClaudeAssistantPrefill,
   shouldOmitSamplingParams,
 } from './modelId';
@@ -72,6 +73,14 @@ describe('parseClaudeModelId', () => {
       family: 'mythos',
       majorVersion: 5,
       normalizedModelId: 'claude-mythos-5-preview',
+      source: 'anthropic',
+    });
+    expect(parseClaudeModelId('claude-fable-5-1')).toEqual({
+      family: 'fable',
+      majorVersion: 5,
+      minorSeparator: '-',
+      minorVersion: 1,
+      normalizedModelId: 'claude-fable-5-1',
       source: 'anthropic',
     });
   });
@@ -143,7 +152,9 @@ describe('isAdaptiveThinkingDefaultOnModel', () => {
 describe('isAlwaysThinkingClaudeModel', () => {
   it('should return true for the families that reject disabled thinking', () => {
     expect(isAlwaysThinkingClaudeModel('claude-fable-5')).toBe(true);
+    expect(isAlwaysThinkingClaudeModel('claude-fable-5-1')).toBe(true);
     expect(isAlwaysThinkingClaudeModel('claude-mythos-5')).toBe(true);
+    expect(isAlwaysThinkingClaudeModel('global.anthropic.claude-fable-5-1')).toBe(true);
     expect(isAlwaysThinkingClaudeModel('anthropic/claude-fable-5')).toBe(true);
     expect(isAlwaysThinkingClaudeModel('global.anthropic.claude-fable-5')).toBe(true);
   });
@@ -175,6 +186,24 @@ describe('isThinkingDisplayOmittedByDefaultModel', () => {
     expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-5-20251101')).toBe(false);
     expect(isThinkingDisplayOmittedByDefaultModel('claude-haiku-4-5-20251001')).toBe(false);
     expect(isThinkingDisplayOmittedByDefaultModel('gpt-5')).toBe(false);
+  });
+});
+
+describe('rejectsForcedToolChoice', () => {
+  it('should reject forced tool_choice on Fable 5.1 / Mythos 5.1 and later', () => {
+    expect(rejectsForcedToolChoice('claude-fable-5-1')).toBe(true);
+    expect(rejectsForcedToolChoice('claude-mythos-5-1')).toBe(true);
+    expect(rejectsForcedToolChoice('global.anthropic.claude-fable-5-1')).toBe(true);
+    expect(rejectsForcedToolChoice('anthropic/claude-fable-5-1')).toBe(true);
+  });
+
+  it('should keep forced tool_choice valid on Fable 5 / Mythos 5 and other families', () => {
+    expect(rejectsForcedToolChoice('claude-fable-5')).toBe(false);
+    expect(rejectsForcedToolChoice('claude-mythos-5')).toBe(false);
+    expect(rejectsForcedToolChoice('claude-opus-5')).toBe(false);
+    expect(rejectsForcedToolChoice('claude-sonnet-5')).toBe(false);
+    expect(rejectsForcedToolChoice('claude-opus-4-8')).toBe(false);
+    expect(rejectsForcedToolChoice('gpt-5')).toBe(false);
   });
 });
 

--- a/packages/model-runtime/src/providers/anthropic/modelId.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.ts
@@ -172,6 +172,20 @@ export const isThinkingDisplayOmittedByDefaultModel = (model: string): boolean =
 const EFFORTS_INCOMPATIBLE_WITH_DISABLED_THINKING = new Set(['xhigh', 'max']);
 
 /**
+ * Claude Fable 5.1 / Mythos 5.1 reject forced tool use. `tool_choice` of type `any`
+ * or `tool` returns a 400; keep `auto` (or `none`) and use `strict: true` for schema
+ * enforcement instead. Fable 5 / Mythos 5 still accept forced choice.
+ * @see https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1#forced-tool-use-is-not-supported
+ */
+export const rejectsForcedToolChoice = (model: string): boolean => {
+  const parsed = parseClaudeModelId(model);
+  if (!parsed || !isClaudeFamily(parsed, ['fable', 'mythos'])) return false;
+  if (parsed.majorVersion > 5) return true;
+
+  return parsed.majorVersion === 5 && hasMinorVersionAtLeast(parsed, 1);
+};
+
+/**
  * Claude Opus 5 and later reject `thinking: {type: 'disabled'}` combined with effort `xhigh` or
  * `max`. Every lower effort level stays valid alongside disabled thinking, so callers should drop
  * `effort` only for this specific pairing.


### PR DESCRIPTION
<!-- Brief and heads-up -->

Claude Fable 5.1 / Mythos 5.1 reject forced `tool_choice` (`any` / `tool`) with a 400. This PR teaches the Anthropic runtime to use `auto` plus `strict: true` for `generateObject` on those models, and adds the default locale description for `claude-fable-5-1`.

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the touched model-runtime and locale files: lint clean, 75 tests passed.

#### 🔗 Related Issue

- Related to Anthropic Fable 5.1 launch: https://www.anthropic.com/claude/fable/5-1
- Breaking change: https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1#forced-tool-use-is-not-supported

## 🧹 Also included

- Remove the temporary `homePromoBanner.glm53FlashReveal` locale key (Ox Alpha → GLM-5.3-Flash reveal campaign is over).