### PR TITLE
🐛 fix(shell): handle asynchronous process tree kill errors

### DIFF
--- a/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
@@ -5,9 +5,14 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import treeKill from 'tree-kill';
 
 import type { ShellProcess } from '../process-manager';
 import { ShellProcessManager } from '../process-manager';
+
+vi.mock('tree-kill', () => ({ default: vi.fn() }));
+
+const treeKillMock = vi.mocked(treeKill);
 
 function createMockProcess(exitCode: number | null = null, pid?: number): ChildProcess {
   const process = new EventEmitter() as ChildProcess;
@@ -50,6 +55,18 @@ describe('ShellProcessManager', () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobehub-shell-process-manager-'));
+    treeKillMock.mockReset();
+    treeKillMock.mockImplementation((pid, signalOrCallback, callback) => {
+      const signal = typeof signalOrCallback === 'function' ? 'SIGKILL' : signalOrCallback;
+      const onComplete = typeof signalOrCallback === 'function' ? signalOrCallback : callback;
+
+      try {
+        process.kill(pid, signal);
+        onComplete?.();
+      } catch (error) {
+        onComplete?.(error);
+      }
+    });
     manager = new ShellProcessManager(tmpDir);
   });
 
@@ -321,6 +338,18 @@ describe('ShellProcessManager', () => {
   });
 
   describe('kill', () => {
+    it('should contain asynchronous process-tree kill errors', () => {
+      treeKillMock.mockImplementation((_pid, _signal, callback) => {
+        callback?.(Object.assign(new Error('kill EPERM'), { code: 'EPERM' }));
+      });
+
+      const process = createMockProcess(null, 12_345);
+      manager.register('test-1', createShellProcess(manager, 'test-1', process));
+
+      expect(() => manager.kill('test-1')).not.toThrow();
+      expect(treeKillMock).toHaveBeenCalledWith(12_345, 'SIGKILL', expect.any(Function));
+    });
+
     it('should kill process successfully', () => {
       const process = createMockProcess();
       manager.register('test-1', createShellProcess(manager, 'test-1', process));

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import treeKill from 'tree-kill';
 
+import { createLogger } from '../logger';
 import type { GetCommandOutputParams, GetCommandOutputResult, KillCommandResult } from '../types';
 import { decodeClixml } from './clixml';
 import { buildOutputPreview } from './utils';
@@ -17,6 +18,7 @@ const OUTPUT_PREVIEW_TOTAL_MAX_BYTES = 22 * 1024;
 const OUTPUT_PREVIEW_STREAM_MAX_BYTES = 18 * 1024;
 const OUTPUT_PREVIEW_SECONDARY_MIN_BYTES = 4 * 1024;
 const KILL_SIGNAL: NodeJS.Signals = 'SIGKILL';
+const logger = createLogger('shell:process-manager');
 
 export interface ShellOutputFile {
   fd: number;
@@ -320,7 +322,14 @@ const killProcessTree = (childProcess: ChildProcess): void => {
   const { pid } = childProcess;
 
   if (pid) {
-    treeKill(pid, KILL_SIGNAL);
+    // tree-kill discovers descendants asynchronously. Without a callback,
+    // errors from process.kill (for example EPERM for root-owned children on
+    // Linux) are thrown outside the caller's try/catch and can crash Electron.
+    treeKill(pid, KILL_SIGNAL, (error) => {
+      if (error) {
+        logger.warn(`Failed to kill process tree for pid ${pid}:`, error);
+      }
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

- Pass an error callback to `tree-kill` when terminating process trees.
- Prevent asynchronous `EPERM` errors from root-owned descendants from becoming uncaught Electron main-process exceptions.
- Log asynchronous termination failures and add regression coverage.

## Related Issue

Fixes #18976

## Verification

- `pnpm exec vitest run src/shell/__tests__/process-manager.test.ts` (24 passed)
- `bun run check packages/local-file-shell/src/shell/process-manager.ts packages/local-file-shell/src/shell/__tests__/process-manager.test.ts` tests passed (24); lint is blocked by the repository dependency error `@lobehub/ui` not exporting `./eslint`.
