### PR TITLE
🐛 fix(cli): make `lh goal run` survive transient failures, idle polls and reversed graph edges

### DIFF
--- a/apps/cli/src/commands/goal.test.ts
+++ b/apps/cli/src/commands/goal.test.ts
@@ -146,6 +146,50 @@ describe('goal show command', () => {
     expect(output).not.toContain('undefined');
   });
 
+  it("states an incoming edge from the row owner's side, not the source's", async () => {
+    // Edges read `source <kind> target`, so listing an INCOMING `depends_on` as
+    // `depends_on:<source>` claimed the exact opposite of the graph: it made the
+    // framework node look like it depended on the node that depends on IT, so a
+    // correct plan read as a reversed one.
+    mockClient.goal.graph.query.mockResolvedValue({
+      data: {
+        decisions: [],
+        edges: [
+          {
+            goalId: 'goal-1',
+            id: 'e1',
+            kind: 'decomposes',
+            sourceNodeId: 'problem-node-id',
+            targetNodeId: 'task-node-id',
+          },
+          {
+            goalId: 'goal-1',
+            id: 'e2',
+            kind: 'depends_on',
+            sourceNodeId: 'finding-node-id',
+            targetNodeId: 'task-node-id',
+          },
+        ],
+        events: [],
+        goal: { id: 'goal-1', requirement: null, status: 'review', title: 'Three quotes' },
+        nodes: [
+          node('problem', 'Collect three quotes'),
+          node('task', 'Build the harness'),
+          node('finding', 'Downstream work'),
+        ],
+        workVersions: [],
+      },
+    });
+
+    const output = await render();
+
+    expect(output).toContain('RELATIONS');
+    // The task is part of the problem, and it BLOCKS the node that depends on it.
+    expect(output).toContain('part of problem-');
+    expect(output).toContain('blocks finding-');
+    expect(output).not.toContain('depends_on');
+  });
+
   it('still shows the responsible task id next to its node', async () => {
     mockClient.goal.graph.query.mockResolvedValue({
       data: {

--- a/apps/cli/src/commands/goal.test.ts
+++ b/apps/cli/src/commands/goal.test.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { log } from '../utils/logger';
 import { registerGoalCommand } from './goal';
 
 const { mockClient } = vi.hoisted(() => ({
@@ -84,6 +85,96 @@ describe('goal run command', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ pollCount: 3, waitedMs: 30 });
     expect(result[1]).toMatchObject({ outcome: 'achieved' });
+  });
+});
+
+describe('goal run resilience', () => {
+  let previousExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    previousExitCode = process.exitCode;
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+  });
+
+  const achieved = { goalId: 'goal-1', message: 'Goal achieved', outcome: 'achieved' };
+  // A tRPC rejection carries its verdict on `error.data.code`; a transport
+  // failure (`fetch failed`) has no such envelope at all.
+  const trpcError = (code: string) =>
+    Object.assign(new Error(`${code} from server`), { data: { code } });
+
+  const run = (...args: string[]) =>
+    createProgram().parseAsync(['node', 'test', 'goal', 'run', 'goal-1', ...args]);
+
+  const loggedOutput = () =>
+    vi
+      .mocked(console.log)
+      .mock.calls.map(([value]) => String(value))
+      .join('\n');
+
+  it('rides out a transient tick failure instead of ending the run', async () => {
+    // A single `fetch failed` used to abort the whole loop and leave the goal
+    // stranded mid-flight, which is what forced an external supervisor script.
+    mockClient.goal.tick.mutate
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValueOnce({ data: achieved });
+
+    await run('--poll-ms', '0', '--retry-window-ms', '20');
+
+    expect(mockClient.goal.tick.mutate).toHaveBeenCalledTimes(2);
+    expect(loggedOutput()).toContain('Goal achieved');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('does not retry a verdict about the request itself', async () => {
+    mockClient.goal.tick.mutate.mockRejectedValue(trpcError('NOT_FOUND'));
+
+    await expect(run('--poll-ms', '0', '--retry-window-ms', '5000')).rejects.toThrow('NOT_FOUND');
+
+    expect(mockClient.goal.tick.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up once the retry window is spent', async () => {
+    mockClient.goal.tick.mutate.mockRejectedValue(new Error('fetch failed'));
+
+    await expect(run('--poll-ms', '0', '--retry-window-ms', '20')).rejects.toThrow('fetch failed');
+
+    expect(mockClient.goal.tick.mutate.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('spends the tick budget on progress, not on idle polls', async () => {
+    // Three unchanged `waiting_external` polls sit between two advancing ticks.
+    // The budget of 2 must cover only the advancing pair — counting the polls
+    // stopped healthy goals whose Work simply took a while to finish.
+    mockClient.goal.tick.mutate
+      .mockResolvedValueOnce({ data: waitingResult })
+      .mockResolvedValueOnce({ data: waitingResult })
+      .mockResolvedValueOnce({ data: waitingResult })
+      .mockResolvedValueOnce({ data: waitingResult })
+      .mockResolvedValueOnce({ data: achieved });
+
+    await run('--poll-ms', '0', '--max-ticks', '2');
+
+    expect(mockClient.goal.tick.mutate).toHaveBeenCalledTimes(5);
+    expect(loggedOutput()).toContain('Goal achieved');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('reports an unfinished goal with a non-zero exit code', async () => {
+    // Each tick advances to a different task, so every one spends budget.
+    mockClient.goal.tick.mutate.mockImplementation(async () => ({
+      data: { ...waitingResult, taskId: `task-${mockClient.goal.tick.mutate.mock.calls.length}` },
+    }));
+
+    await run('--poll-ms', '0', '--max-ticks', '2');
+
+    expect(mockClient.goal.tick.mutate).toHaveBeenCalledTimes(2);
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(log.warn)).toHaveBeenCalledWith(expect.stringContaining('unfinished'));
   });
 });
 

--- a/apps/cli/src/commands/goal.ts
+++ b/apps/cli/src/commands/goal.ts
@@ -40,6 +40,71 @@ const inverseEdgeLabel: Record<GoalEdgeKind, string> = {
 
 const terminalOutcomes = new Set(['achieved', 'waiting_human', 'no_progress', 'failed']);
 
+/** Backoff bounds for a transient `goal tick` failure. */
+const TICK_RETRY_BASE_MS = 1000;
+const TICK_RETRY_MAX_MS = 30_000;
+
+/**
+ * tRPC codes that are a verdict about the REQUEST, not about the trip to the
+ * server: retrying them just reproduces the same answer. Everything else —
+ * including a transport failure that never reached tRPC — is treated as a blip
+ * worth surviving, because `goal run` is meant to be left unattended for hours
+ * and a dropped socket must not end the run half-way.
+ */
+const fatalTickCodes = new Set([
+  'BAD_REQUEST',
+  'CONFLICT',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'PARSE_ERROR',
+  'UNAUTHORIZED',
+]);
+
+const trpcErrorCode = (error: unknown): string | undefined => {
+  const value = error as { data?: { code?: string }; shape?: { data?: { code?: string } } };
+  return value?.data?.code ?? value?.shape?.data?.code;
+};
+
+/**
+ * A transport-level failure (`fetch failed`, ECONNRESET, a 502 from a proxy)
+ * carries no tRPC envelope at all, so the ABSENCE of a code is the signal that
+ * the request never got a verdict. Erring towards retry keeps an unrecognised
+ * error shape from killing a multi-hour run.
+ */
+const isRetryableTickError = (error: unknown) => {
+  const code = trpcErrorCode(error);
+  return code === undefined || !fatalTickCodes.has(code);
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run one coordinator tick, riding out transient failures until `retryWindowMs`
+ * of CONSECUTIVE failure has elapsed. The window is wall-clock rather than an
+ * attempt count so a long outage is survivable without making the backoff
+ * pointlessly aggressive; each delay is also clamped to what's left of the
+ * window so the command never sleeps past its own budget (and so a tiny window
+ * stays fast instead of blocking on the first 1s backoff).
+ */
+const tickWithRetry = async <T>(
+  tick: () => Promise<T>,
+  retryWindowMs: number,
+  onRetry: (error: unknown, delayMs: number) => void,
+): Promise<T> => {
+  const deadline = Date.now() + retryWindowMs;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await tick();
+    } catch (error) {
+      const remaining = deadline - Date.now();
+      if (!isRetryableTickError(error) || remaining <= 0) throw error;
+      const delay = Math.min(TICK_RETRY_BASE_MS * 2 ** attempt, TICK_RETRY_MAX_MS, remaining);
+      onRetry(error, delay);
+      await sleep(delay);
+    }
+  }
+};
+
 interface GoalRunTickResult extends GoalTickResult {
   pollCount?: number;
   waitedMs?: number;
@@ -226,39 +291,80 @@ export function registerGoalCommand(program: Command) {
   goal
     .command('run <id>')
     .description('Tick until the goal reaches a stop condition')
-    .option('--max-ticks <n>', 'Safety limit for this CLI invocation', '100')
+    .option(
+      '--max-ticks <n>',
+      'Safety limit on ADVANCING ticks; idle polls of an unchanged waiting state do not count',
+      '100',
+    )
     .option('--poll-ms <ms>', 'Delay while waiting for task execution', '3000')
+    .option(
+      '--retry-window-ms <ms>',
+      'Keep retrying a failing tick for this long before giving up (0 disables retry)',
+      '600000',
+    )
     .option('--json', 'Output tick results as JSON')
-    .action(async (id: string, options: { json?: boolean; maxTicks: string; pollMs: string }) => {
-      const client = await getTrpcClient();
-      const results: GoalRunTickResult[] = [];
-      const maxTicks = Number.parseInt(options.maxTicks, 10);
-      const pollMs = Number.parseInt(options.pollMs, 10);
-      for (let index = 0; index < maxTicks; index++) {
-        const { data } = await client.goal.tick.mutate({ id });
-        const previous = results.at(-1);
-        if (isSameWaitingState(previous, data)) {
-          previous.pollCount = (previous.pollCount ?? 1) + 1;
-          previous.waitedMs = (previous.waitedMs ?? pollMs) + pollMs;
-        } else {
-          results.push(
-            data.outcome === 'waiting_external'
-              ? { ...data, pollCount: 1, waitedMs: pollMs }
-              : data,
+    .action(
+      async (
+        id: string,
+        options: { json?: boolean; maxTicks: string; pollMs: string; retryWindowMs: string },
+      ) => {
+        const client = await getTrpcClient();
+        const results: GoalRunTickResult[] = [];
+        const maxTicks = Number.parseInt(options.maxTicks, 10);
+        const pollMs = Number.parseInt(options.pollMs, 10);
+        const retryWindowMs = Number.parseInt(options.retryWindowMs, 10);
+        // Only ticks that CHANGED something count against the budget. Polling an
+        // unchanged `waiting_external` state is the coordinator idling while a
+        // Work runs — a Work that legitimately takes an hour would otherwise
+        // burn the whole allowance on no-ops and stop a healthy goal half-way.
+        let advancingTicks = 0;
+        let exhaustedBudget = false;
+        for (;;) {
+          // Pinned explicitly: inferring `T` through the callback collapses the
+          // router's return type to `unknown` in the CLI's standalone
+          // type-check, which has no built `@lobechat/types` to resolve against.
+          const { data } = await tickWithRetry<{ data: GoalTickResult }>(
+            () => client.goal.tick.mutate({ id }),
+            retryWindowMs,
+            (error, delayMs) => {
+              if (options.json) return;
+              const message = error instanceof Error ? error.message : String(error);
+              log.warn(`Tick failed (${message}); retrying in ${delayMs}ms`);
+            },
           );
-          if (!options.json) printTick(data);
+          const previous = results.at(-1);
+          const isIdlePoll = isSameWaitingState(previous, data);
+          if (isIdlePoll) {
+            previous.pollCount = (previous.pollCount ?? 1) + 1;
+            previous.waitedMs = (previous.waitedMs ?? pollMs) + pollMs;
+          } else {
+            advancingTicks++;
+            results.push(
+              data.outcome === 'waiting_external'
+                ? { ...data, pollCount: 1, waitedMs: pollMs }
+                : data,
+            );
+            if (!options.json) printTick(data);
+          }
+          if (terminalOutcomes.has(data.outcome)) break;
+          if (!isIdlePoll && advancingTicks >= maxTicks) {
+            exhaustedBudget = true;
+            break;
+          }
+          if (data.outcome === 'waiting_external') await sleep(pollMs);
         }
-        if (terminalOutcomes.has(data.outcome)) break;
-        if (data.outcome === 'waiting_external') {
-          await new Promise((resolve) => setTimeout(resolve, pollMs));
+        if (options.json) outputJson(results);
+        if (exhaustedBudget) {
+          // A half-finished goal must not look like success to a wrapper script:
+          // the whole reason this branch exists is that the run still has work
+          // left, so leave a non-zero code behind for the caller to branch on.
+          process.exitCode = 1;
+          log.warn(
+            `Stopped after ${advancingTicks} advancing ticks (--max-ticks ${maxTicks}); the goal is unfinished. Resume with: lh goal run ${id}`,
+          );
         }
-      }
-      if (options.json) outputJson(results);
-      const last = results.at(-1);
-      if (last && !terminalOutcomes.has(last.outcome)) {
-        log.warn(`Stopped after ${maxTicks} ticks; rerun to continue.`);
-      }
-    });
+      },
+    );
 
   for (const action of ['pause', 'resume'] as const) {
     goal

--- a/apps/cli/src/commands/goal.ts
+++ b/apps/cli/src/commands/goal.ts
@@ -1,4 +1,5 @@
 import type {
+  GoalEdgeKind,
   GoalGraphDecision,
   GoalGraphSnapshot,
   GoalNodeKind,
@@ -21,6 +22,22 @@ const nodeIcon: Record<GoalNodeKind, string> = {
   problem: '◇',
   task: '▣',
 };
+/**
+ * Every edge kind reads `source <kind> target`, so a row listing its INCOMING
+ * edges by kind states the relationship backwards: an incoming `depends_on`
+ * means the other node depends on THIS one, not the reverse. Render the inverse
+ * verb instead, so each entry is a true sentence about the row it sits on.
+ */
+const inverseEdgeLabel: Record<GoalEdgeKind, string> = {
+  contradicts: 'contradicted by',
+  decomposes: 'part of',
+  depends_on: 'blocks',
+  investigates: 'investigated by',
+  leads_to: 'follows',
+  produces: 'produced by',
+  supports: 'supported by',
+};
+
 const terminalOutcomes = new Set(['achieved', 'waiting_human', 'no_progress', 'failed']);
 
 interface GoalRunTickResult extends GoalTickResult {
@@ -45,20 +62,20 @@ function printGraph(graph: GoalGraphSnapshot) {
     incoming.set(edge.targetNodeId, list);
   }
   const rows = graph.nodes.map((node) => {
-    const dependencies = (incoming.get(node.id) ?? [])
-      .map((edge) => `${edge.kind}:${edge.sourceNodeId.slice(0, 8)}`)
+    const relations = (incoming.get(node.id) ?? [])
+      .map((edge) => `${inverseEdgeLabel[edge.kind] ?? edge.kind} ${edge.sourceNodeId.slice(0, 8)}`)
       .join(', ');
     return [
       `${nodeIcon[node.kind]} ${node.kind}`,
       node.status,
       truncate(node.title, 46),
       node.taskId ?? '-',
-      dependencies || '-',
+      relations || '-',
       node.id,
     ];
   });
   console.log();
-  printTable(rows, ['TYPE', 'STATUS', 'TITLE', 'TASK', 'INCOMING', 'NODE ID']);
+  printTable(rows, ['TYPE', 'STATUS', 'TITLE', 'TASK', 'RELATIONS', 'NODE ID']);
 }
 
 function printTick(result: GoalTickResult) {


### PR DESCRIPTION
Three fixes to `lh goal run` / `lh goal graph`, found while driving a real multi-hour Goal to completion on production. Each one independently forced manual intervention on a goal that was otherwise healthy.

#### 1. A transient failure ended the whole run

One `fetch failed` rejected the tick and terminated the loop, stranding the goal mid-flight. On a flaky link this happened repeatedly, and the only workaround was wrapping the command in an external supervisor script.

Ticks now retry inside a wall-clock `--retry-window-ms` (default 10min). Backoff is exponential, capped at 30s, and clamped to the remaining window so the command never sleeps past its own budget.

The interesting part is telling "retry helps" from "retry is pointless". tRPC codes that are a verdict about the request itself (`NOT_FOUND`, `FORBIDDEN`, `BAD_REQUEST`, …) abort immediately — retrying only reproduces the same answer. A transport failure carries **no tRPC envelope at all**, so the *absence* of a code is the signal that the request never got a verdict; treating that as retryable keeps an unrecognised error shape from killing a multi-hour run.

#### 2. Idle polls consumed the tick budget

`--max-ticks` counted every tick, including `waiting_external` polls of an unchanged state — the coordinator idling while a Work runs. A Work that legitimately took an hour burned the entire allowance on no-ops and stopped a healthy goal half-way. In the run that surfaced this, ~200 ticks were spent almost entirely on such polls.

Only ticks that change something count now, reusing the same `isSameWaitingState` predicate that already de-duplicates output. `--max-ticks` therefore bounds *coordinator progress*, not wall time — which is what a safety valve should bound. A genuinely stuck Work stays bounded server-side by the operation lease, `maxRounds` and `maxTotalCost`.

#### 3. An unfinished goal exited 0

A wrapper could not distinguish a finished goal from one that ran out of budget. Exhausting the budget now sets a non-zero exit code and prints the resume command, so `lh goal run <id> || lh goal run <id>` is enough. `waiting_human` remains terminal and exits 0 — a decision gate is a normal stop, not a failure.

#### 4. `goal graph` stated edge relations backwards

Every edge reads `source <kind> target`, but the table listed each row's **incoming** edges as `<kind>:<source>`, asserting the opposite of the graph. An incoming `depends_on` means the other node depends on *this* one, so a correctly ordered plan rendered as a reversed one.

| Before | After |
| ------ | ----- |
| `depends_on:d7e19b50` (reads as "this depends on d7e19b50" — false) | `blocks d7e19b50` |
| `decomposes:a5a493a4` | `part of a5a493a4` |

Column renamed `INCOMING` → `RELATIONS`. The map is typed `Record<GoalEdgeKind, string>` so a future edge kind fails type-check instead of silently printing `undefined` — the same trap `nodeIcon` already documents.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Six regression tests added; all six fail on the pre-fix source and pass after:

- rides out a transient tick failure instead of ending the run
- does not retry a verdict about the request itself (asserts exactly one call)
- gives up once the retry window is spent
- spends the tick budget on progress, not on idle polls
- reports an unfinished goal with a non-zero exit code
- states an incoming edge from the row owner's side, not the source's

`bun run check` is clean (lint + 11 tests). `apps/cli` type-check produces the same error set as pristine `canary` — no new errors.

#### 🔗 Related Issue

N/A — found during manual end-to-end testing of the Goal feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)