### PR TITLE
🐛 fix(device-gateway): stop a hung handshake from parking the device client offline

### DIFF
--- a/packages/device-gateway-client/src/client.test.ts
+++ b/packages/device-gateway-client/src/client.test.ts
@@ -4,6 +4,10 @@ import { GatewayClient } from './client';
 
 // Flag to control mock WS behavior
 let mockWsShouldThrow = false;
+// When set, the socket never opens — the real-world black-holed TLS handshake,
+// which raises no event at all rather than an error.
+let mockWsShouldHang = false;
+const mockWsInstances: { options?: unknown; url: string }[] = [];
 
 // Mock ws module — must use dynamic import for EventEmitter to avoid hoisting issues
 vi.mock('ws', async () => {
@@ -23,6 +27,11 @@ vi.mock('ws', async () => {
       if (mockWsShouldThrow) {
         mockWsShouldThrow = false;
         throw new Error('connection refused');
+      }
+      mockWsInstances.push(this);
+      if (mockWsShouldHang) {
+        this.readyState = 0; // CONNECTING, and it stays there
+        return;
       }
       // Simulate async open
       setTimeout(() => this.emit('open'), 0);
@@ -49,6 +58,8 @@ describe('GatewayClient', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    mockWsShouldHang = false;
+    mockWsInstances.length = 0;
     client = new GatewayClient({
       autoReconnect: false,
       deviceId: 'test-device-id',
@@ -184,9 +195,84 @@ describe('GatewayClient', () => {
       c.connect();
       const ws = (c as any).ws;
       expect(ws.options).toEqual({
+        handshakeTimeout: 15_000,
         headers: { 'User-Agent': 'LobeHub Desktop/1.2.3' },
       });
       c.disconnect();
+    });
+  });
+
+  describe('connect watchdog', () => {
+    const makeClient = (connectTimeoutMs = 15_000) =>
+      new GatewayClient({
+        autoReconnect: true,
+        connectTimeoutMs,
+        deviceId: 'test-device-id',
+        gatewayUrl: 'https://gateway.test.com',
+        serverUrl: 'https://app.test.com',
+        token: 'test-token',
+        tokenType: 'apiKey',
+        userId: 'test-user',
+      });
+
+    it('bounds the handshake inside ws itself', () => {
+      client.connect();
+
+      expect(mockWsInstances.at(-1)?.options).toMatchObject({ handshakeTimeout: 15_000 });
+    });
+
+    it('retries when the handshake hangs without raising an event', () => {
+      // A black-holed TLS handshake emits no open/error/close, so nothing ever
+      // called scheduleReconnect: the daemon reported `connecting` while the
+      // device sat offline for 15+ minutes, and the run silently fell through
+      // to the cloud sandbox.
+      mockWsShouldHang = true;
+      const hung = makeClient(1000);
+      hung.connect();
+
+      expect(hung.connectionStatus).toBe('connecting');
+      expect(mockWsInstances).toHaveLength(1);
+
+      vi.advanceTimersByTime(1000);
+      expect(hung.connectionStatus).toBe('reconnecting');
+
+      // ...and the backoff actually produces a fresh attempt.
+      mockWsShouldHang = false;
+      vi.advanceTimersByTime(1000);
+      expect(mockWsInstances.length).toBeGreaterThan(1);
+
+      hung.disconnect();
+    });
+
+    it('retries when the socket opens but auth never comes back', async () => {
+      // `startHeartbeat` only runs on auth_success, so a lost auth reply left
+      // the client parked in `authenticating` with no watchdog of any kind.
+      const stalled = makeClient(1000);
+      stalled.connect();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(stalled.connectionStatus).toBe('authenticating');
+
+      vi.advanceTimersByTime(1000);
+      expect(stalled.connectionStatus).toBe('reconnecting');
+
+      stalled.disconnect();
+    });
+
+    it('disarms once authenticated', async () => {
+      const connected = makeClient(1000);
+      connected.connect();
+      await vi.advanceTimersByTimeAsync(0);
+      mockWsInstances.at(-1);
+      connected['handleMessage'](JSON.stringify({ type: 'auth_success' }));
+      expect(connected.connectionStatus).toBe('connected');
+
+      const attemptsBefore = mockWsInstances.length;
+      vi.advanceTimersByTime(10_000);
+
+      expect(connected.connectionStatus).toBe('connected');
+      expect(mockWsInstances).toHaveLength(attemptsBefore);
+
+      connected.disconnect();
     });
   });
 

--- a/packages/device-gateway-client/src/client.ts
+++ b/packages/device-gateway-client/src/client.ts
@@ -28,6 +28,13 @@ const HEARTBEAT_INTERVAL = 30_000; // 30s
 const INITIAL_RECONNECT_DELAY = 1000; // 1s
 const MAX_RECONNECT_DELAY = 30_000; // 30s
 const MAX_MISSED_HEARTBEATS = 3; // Force reconnect after 3 missed acks
+/**
+ * Budget for the whole pre-connected window: TCP + TLS + HTTP upgrade AND the
+ * `auth_success` reply. Neither phase raises an event of its own when it simply
+ * hangs, so without a deadline the client waits on the OS TCP timeout — observed
+ * stalling a reconnect for 15+ minutes while the device sat offline.
+ */
+const CONNECT_TIMEOUT = 15_000; // 15s
 
 // ─── Logger Interface ───
 
@@ -62,6 +69,11 @@ export interface GatewayClientOptions {
    * replace its own previous socket should pass a persisted value.
    */
   connectionId?: string;
+  /**
+   * How long to wait for a connection to become fully authenticated before
+   * abandoning it and retrying (default: 15s).
+   */
+  connectTimeoutMs?: number;
   deviceId?: string;
   gatewayUrl?: string;
   logger?: GatewayClientLogger;
@@ -83,6 +95,7 @@ export class GatewayClient extends EventEmitter {
   private ws: WebSocket | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private connectWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelay = INITIAL_RECONNECT_DELAY;
   private missedHeartbeats = 0;
   private status: ConnectionStatus = 'disconnected';
@@ -99,6 +112,7 @@ export class GatewayClient extends EventEmitter {
   private serverUrl?: string;
   private logger: GatewayClientLogger;
   private autoReconnect: boolean;
+  private connectTimeoutMs: number;
 
   constructor(options: GatewayClientOptions) {
     super();
@@ -114,6 +128,7 @@ export class GatewayClient extends EventEmitter {
     this.workspaceId = options.workspaceId;
     this.logger = options.logger || noopLogger;
     this.autoReconnect = options.autoReconnect ?? true;
+    this.connectTimeoutMs = options.connectTimeoutMs ?? CONNECT_TIMEOUT;
   }
 
   // ─── Public API ───
@@ -227,7 +242,14 @@ export class GatewayClient extends EventEmitter {
       const wsUrl = this.buildWsUrl();
       this.logger.debug(`Connecting to: ${wsUrl}`);
 
-      const wsOptions = this.userAgent ? { headers: { 'User-Agent': this.userAgent } } : undefined;
+      // `handshakeTimeout` bounds TCP+TLS+upgrade inside `ws` itself, which turns
+      // a black-holed handshake into a normal error/close pair. The watchdog
+      // below is the belt to that suspenders: it also covers the phase `ws`
+      // knows nothing about — an opened socket whose `auth_success` never lands.
+      const wsOptions = {
+        handshakeTimeout: this.connectTimeoutMs,
+        ...(this.userAgent ? { headers: { 'User-Agent': this.userAgent } } : {}),
+      };
       const ws = new WebSocket(wsUrl, wsOptions);
 
       ws.on('open', this.handleOpen);
@@ -236,6 +258,7 @@ export class GatewayClient extends EventEmitter {
       ws.on('error', this.handleError);
 
       this.ws = ws;
+      this.startConnectWatchdog();
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.logger.error('Failed to create WebSocket:', msg);
@@ -314,6 +337,7 @@ export class GatewayClient extends EventEmitter {
       switch (message.type) {
         case 'auth_success': {
           this.logger.info('Authentication successful');
+          this.clearConnectWatchdog();
           this.setStatus('connected');
           this.startHeartbeat();
           this.emit('connected');
@@ -377,6 +401,10 @@ export class GatewayClient extends EventEmitter {
   private handleClose = (code: number, reason: Buffer) => {
     this.logger.info(`WebSocket closed: code=${code} reason=${reason.toString()}`);
     this.stopHeartbeat();
+    // `handshakeTimeout` closes the socket on its own, so the watchdog must be
+    // disarmed here or it would fire later and force a SECOND reconnect on top
+    // of the one this close already scheduled.
+    this.clearConnectWatchdog();
     this.ws = null;
 
     if (!this.intentionalDisconnect && this.autoReconnect) {
@@ -401,17 +429,7 @@ export class GatewayClient extends EventEmitter {
     this.heartbeatTimer = setInterval(() => {
       this.missedHeartbeats++;
       if (this.missedHeartbeats > MAX_MISSED_HEARTBEATS) {
-        this.logger.warn(`Missed ${this.missedHeartbeats} heartbeat acks, forcing reconnect`);
-        this.closeWebSocket();
-        // Listeners are detached in closeWebSocket; handleClose won't run — drive reconnect here
-        this.stopHeartbeat();
-        if (this.autoReconnect) {
-          this.setStatus('reconnecting');
-          this.scheduleReconnect();
-        } else {
-          this.setStatus('disconnected');
-          this.emit('disconnected');
-        }
+        this.forceReconnect(`Missed ${this.missedHeartbeats} heartbeat acks, forcing reconnect`);
         return;
       }
       this.sendMessage({ type: 'heartbeat' });
@@ -422,6 +440,45 @@ export class GatewayClient extends EventEmitter {
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
+    }
+  }
+
+  // ─── Connect watchdog ───
+
+  private startConnectWatchdog() {
+    this.clearConnectWatchdog();
+    this.connectWatchdogTimer = setTimeout(() => {
+      this.connectWatchdogTimer = null;
+      this.forceReconnect(
+        `No authenticated connection within ${this.connectTimeoutMs}ms (status: ${this.status}), forcing reconnect`,
+      );
+    }, this.connectTimeoutMs);
+  }
+
+  private clearConnectWatchdog() {
+    if (this.connectWatchdogTimer) {
+      clearTimeout(this.connectWatchdogTimer);
+      this.connectWatchdogTimer = null;
+    }
+  }
+
+  /**
+   * Abandon the current socket and drive the retry ourselves. `closeWebSocket`
+   * detaches our listeners, so `handleClose` will NOT run — every forced path
+   * has to schedule the next attempt itself or the client goes quiet for good.
+   */
+  private forceReconnect(reason: string) {
+    this.logger.warn(reason);
+    this.closeWebSocket();
+    this.stopHeartbeat();
+    this.clearConnectWatchdog();
+
+    if (this.autoReconnect) {
+      this.setStatus('reconnecting');
+      this.scheduleReconnect();
+    } else {
+      this.setStatus('disconnected');
+      this.emit('disconnected');
     }
   }
 
@@ -506,6 +563,7 @@ export class GatewayClient extends EventEmitter {
   private cleanup() {
     this.stopHeartbeat();
     this.clearReconnectTimer();
+    this.clearConnectWatchdog();
     this.closeWebSocket();
   }
 }


### PR DESCRIPTION
#### The bug

`GatewayClient.doConnect` created the socket with **no deadline of any kind**:

```ts
const ws = new WebSocket(wsUrl, wsOptions);
ws.on('open', …); ws.on('message', …); ws.on('close', …); ws.on('error', …);
```

Four listeners, and a black-holed TLS handshake raises **none** of them. No `open`, no `error`, no `close` — so `scheduleReconnect()` was never called and the client sat in `connecting` until the OS TCP timeout eventually fired. The exponential backoff is no defence here: it only runs once a close is *observed*, which is precisely what never happens.

This is not theoretical. From one daemon log in a single evening, measuring each `Attempting reconnect` to its next event:

```
1046.8s  after 2026-09-01T22:50:10Z    ← 17.4 min
 921.1s  after 2026-09-01T19:46:45Z    ← 15.4 min
   3.0s  …every other reconnect
```

Two multi-minute stalls; every healthy reconnect in the same log recovered in under 3s. On that link the daemon dropped 2–5 times per hour, so the failure mode was hit repeatedly.

The device is genuinely offline for that entire window, and it is not a cosmetic problem: a server-side run bound to that device finds it absent from the gateway pool, `resolveExecutionPlan` returns `bound-device-offline`, and `execAgent` silently degrades to the cloud sandbox. A long-running agent Work restarted from scratch in `/workspace` because of it.

#### The fix

- **`handshakeTimeout` passed to `ws`** — bounds TCP + TLS + HTTP upgrade inside the library, turning a stalled handshake into an ordinary `error`+`close` pair that takes the existing backoff path.
- **A connect watchdog** covering the whole pre-connected window. This is the belt to that suspenders, and it covers a phase `ws` knows nothing about: a socket that *opened* but whose `auth_success` never arrives. That case parked the client in `authenticating` with **no liveness check at all**, because `startHeartbeat()` only runs on auth success.

Both are cleared on auth success, on close (so `handshakeTimeout` cannot race the watchdog into a double reconnect), and in `cleanup()`.

Also extracts `forceReconnect()` for the paths that tear the socket down themselves. `closeWebSocket()` detaches our listeners, so `handleClose` cannot run and each such path must schedule the retry itself — the missed-heartbeat branch already open-coded exactly this, and now shares it.

Default is 15s, overridable via the new `connectTimeoutMs` option. Worst case during a sustained outage becomes a retry every ~15–45s instead of a 15-minute silence.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

The `ws` mock gained a `mockWsShouldHang` mode that never emits any event — the real-world black hole, as opposed to the existing `mockWsShouldThrow` which models a synchronous refusal.

- `bounds the handshake inside ws itself`
- `retries when the handshake hangs without raising an event` — asserts `connecting` → `reconnecting` at the deadline, then that the backoff produces a genuinely fresh socket
- `retries when the socket opens but auth never comes back`
- `disarms once authenticated` — advancing well past the deadline must not disturb a live connection

The first three fail on the pre-fix source. One existing assertion updated: `ws.options` now always carries `handshakeTimeout`, and it is still asserted exactly rather than loosened, so stray options can't slip in.

`bun run check` clean: lint + 51 tests passed.

#### 🔗 Related Issue

N/A — found while diagnosing why a production Goal run kept losing its bound device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)