### PR TITLE
🐛 fix(device-gateway): stop laundering a failed device read into "none online"

### DIFF
--- a/apps/server/src/services/deviceGateway/__tests__/index.test.ts
+++ b/apps/server/src/services/deviceGateway/__tests__/index.test.ts
@@ -201,6 +201,42 @@ describe('DeviceGateway', () => {
       ]);
     });
 
+    it('absorbs a transient failure instead of reporting an empty pool', async () => {
+      // The online set decides which devices a run may reach, so one dropped
+      // connection must not read as "every device is offline".
+      mockEnv.DEVICE_GATEWAY_URL = 'https://gateway.example.com';
+      mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
+      const connectedAt = Date.parse('2025-01-15T10:30:00Z');
+      mockClient.queryDeviceList
+        .mockRejectedValueOnce(new Error('fetch failed'))
+        .mockResolvedValueOnce([
+          { connectedAt, deviceId: 'dev-1', hostname: 'my-laptop', platform: 'darwin' },
+        ]);
+
+      const result = await new DeviceGateway().queryDeviceList('user-1');
+
+      expect(mockClient.queryDeviceList).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ deviceId: 'dev-1', online: true });
+    });
+
+    it('reports the fallback out loud when the gateway stays unreachable', async () => {
+      // The old bare `catch {}` made this failure invisible: a device-bound run
+      // degraded to the cloud sandbox with no breadcrumb in any log.
+      mockEnv.DEVICE_GATEWAY_URL = 'https://gateway.example.com';
+      mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
+      mockClient.queryDeviceList.mockRejectedValue(new Error('fetch failed'));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await new DeviceGateway().queryDeviceList('user-1', 'ws-1');
+
+      expect(result).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('queryDeviceList'),
+        expect.objectContaining({ error: 'fetch failed', userId: 'user-1', workspaceId: 'ws-1' }),
+      );
+    });
+
     it('should return empty array on error', async () => {
       mockEnv.DEVICE_GATEWAY_URL = 'https://gateway.example.com';
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -85,8 +85,48 @@ const assertPathsWithinWorkspace = (
 
 export type { DeviceAttachment, DeviceStatusResult, DeviceSystemInfo };
 
+/** One extra attempt for a device read; see `readDevices`. */
+const DEVICE_READ_ATTEMPTS = 2;
+const DEVICE_READ_RETRY_DELAY_MS = 250;
+
 export class DeviceGateway {
   private client: GatewayHttpClient | null = null;
+
+  /**
+   * Run a device READ, retrying once and reporting the fallback out loud.
+   *
+   * These reads decide which devices a run may reach, and the fallback value is
+   * indistinguishable from a legitimately empty pool: a single dropped
+   * connection therefore reads as "every device is offline", which sends a
+   * device-bound run to the cloud sandbox instead. Retrying absorbs the blip,
+   * and the warning leaves the breadcrumb that was missing entirely — the old
+   * bare `catch {}` made this failure invisible in every log.
+   */
+  private async readDevices<T>(
+    label: string,
+    context: { userId: string; workspaceId?: string },
+    read: () => Promise<T>,
+    fallback: T,
+  ): Promise<T> {
+    for (let attempt = 1; attempt <= DEVICE_READ_ATTEMPTS; attempt++) {
+      try {
+        return await read();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (attempt < DEVICE_READ_ATTEMPTS) {
+          await new Promise((resolve) => setTimeout(resolve, DEVICE_READ_RETRY_DELAY_MS));
+          continue;
+        }
+        console.warn(`[DeviceGateway] ${label} failed; treating the online set as empty`, {
+          attempts: attempt,
+          error: message,
+          userId: context.userId,
+          workspaceId: context.workspaceId,
+        });
+      }
+    }
+    return fallback;
+  }
 
   get isConfigured(): boolean {
     return !!gatewayEnv.DEVICE_GATEWAY_URL;
@@ -96,11 +136,12 @@ export class DeviceGateway {
     const client = this.getClient();
     if (!client) return { deviceCount: 0, online: false };
 
-    try {
-      return await client.queryDeviceStatus(userId, workspaceId);
-    } catch {
-      return { deviceCount: 0, online: false };
-    }
+    return this.readDevices(
+      'queryDeviceStatus',
+      { userId, workspaceId },
+      () => client.queryDeviceStatus(userId, workspaceId),
+      { deviceCount: 0, online: false },
+    );
   }
 
   // Pass a `workspaceId` to address a workspace-owned device pool (the gateway
@@ -109,40 +150,43 @@ export class DeviceGateway {
     const client = this.getClient();
     if (!client) return [];
 
-    try {
-      const devices = await client.queryDeviceList(userId, workspaceId);
-      // The gateway already dedupes to one entry per physical device, with its
-      // live connections nested as `channels`. Map to the runtime shape; every
-      // returned device has at least one channel, so it's online.
-      return devices.map((d) => ({
-        // `channels` may be absent if the gateway worker deploy lags behind the
-        // server (separate Cloudflare deploy); tolerate the legacy flat shape.
-        //
-        // Sorted newest-first because every consumer reads `channels[0]` as
-        // "this device's current connection" — the settings row's
-        // "Connected {time}", a ghost row's `lastSeen`, its hostname/platform
-        // fallback — while `sortDevicesByActivity` ranks by the FRESHEST
-        // channel. The gateway promises no order, so leaving it raw lets a
-        // multi-channel device rank by one connection and get labelled with
-        // another. Normalising here (the single entry point both `listDevices`
-        // and `getScopedOnlineDevices` pull channels through) makes
-        // `channels[0]` mean the same thing everywhere.
-        channels: (d.channels ?? [])
-          .map((c) => ({
-            channel: c.channel,
-            connectedAt: new Date(c.connectedAt).toISOString(),
-            connectionId: c.connectionId,
-          }))
-          .sort((a, b) => Date.parse(b.connectedAt) - Date.parse(a.connectedAt)),
-        deviceId: d.deviceId,
-        hostname: d.hostname,
-        lastSeen: new Date(d.connectedAt).toISOString(),
-        online: true,
-        platform: d.platform,
-      }));
-    } catch {
-      return [];
-    }
+    return this.readDevices(
+      'queryDeviceList',
+      { userId, workspaceId },
+      async () => {
+        const devices = await client.queryDeviceList(userId, workspaceId);
+        // The gateway already dedupes to one entry per physical device, with its
+        // live connections nested as `channels`. Map to the runtime shape; every
+        // returned device has at least one channel, so it's online.
+        return devices.map((d) => ({
+          // `channels` may be absent if the gateway worker deploy lags behind the
+          // server (separate Cloudflare deploy); tolerate the legacy flat shape.
+          //
+          // Sorted newest-first because every consumer reads `channels[0]` as
+          // "this device's current connection" — the settings row's
+          // "Connected {time}", a ghost row's `lastSeen`, its hostname/platform
+          // fallback — while `sortDevicesByActivity` ranks by the FRESHEST
+          // channel. The gateway promises no order, so leaving it raw lets a
+          // multi-channel device rank by one connection and get labelled with
+          // another. Normalising here (the single entry point both `listDevices`
+          // and `getScopedOnlineDevices` pull channels through) makes
+          // `channels[0]` mean the same thing everywhere.
+          channels: (d.channels ?? [])
+            .map((c) => ({
+              channel: c.channel,
+              connectedAt: new Date(c.connectedAt).toISOString(),
+              connectionId: c.connectionId,
+            }))
+            .sort((a, b) => Date.parse(b.connectedAt) - Date.parse(a.connectedAt)),
+          deviceId: d.deviceId,
+          hostname: d.hostname,
+          lastSeen: new Date(d.connectedAt).toISOString(),
+          online: true,
+          platform: d.platform,
+        }));
+      },
+      [],
+    );
   }
 
   async queryDeviceSystemInfo(

--- a/packages/device-gateway-client/src/http.test.ts
+++ b/packages/device-gateway-client/src/http.test.ts
@@ -59,12 +59,13 @@ describe('GatewayHttpClient', () => {
       );
     });
 
-    it('should return defaults on non-ok response', async () => {
+    it('surfaces a non-ok response instead of reporting nothing online', async () => {
+      // Previously returned `{ deviceCount: 0, online: false }`, which is
+      // indistinguishable from a genuinely empty pool — the caller could not
+      // tell "no devices" from "the gateway never answered".
       mockFetch({ ok: false, status: 500 });
 
-      const result = await client.queryDeviceStatus('user-1');
-
-      expect(result).toEqual({ deviceCount: 0, online: false });
+      await expect(client.queryDeviceStatus('user-1')).rejects.toThrow('responded 500');
     });
 
     it('should handle missing fields in response', async () => {
@@ -94,12 +95,23 @@ describe('GatewayHttpClient', () => {
       expect(result).toEqual(devices);
     });
 
-    it('should return empty array on non-ok response', async () => {
-      mockFetch({ ok: false });
+    it('surfaces a non-ok response instead of reporting an empty pool', async () => {
+      // The empty array used to be returned for a 5xx too, so a gateway blip
+      // became an authoritative "every device is offline" for the run that
+      // asked — which is what silently rerouted device-bound work elsewhere.
+      mockFetch({ ok: false, status: 503 });
 
-      const result = await client.queryDeviceList('user-1');
+      await expect(client.queryDeviceList('user-1')).rejects.toThrow('responded 503');
+    });
 
-      expect(result).toEqual([]);
+    it('bounds the read with a timeout', async () => {
+      mockFetch({ json: vi.fn().mockResolvedValue({ devices: [] }), ok: true });
+
+      await client.queryDeviceList('user-1');
+
+      // `post` applies no deadline unless asked, so an unanswered read would
+      // otherwise hang for as long as the socket stays open.
+      expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({ signal: expect.anything() });
     });
 
     it('should return empty array when devices is not an array', async () => {

--- a/packages/device-gateway-client/src/http.ts
+++ b/packages/device-gateway-client/src/http.ts
@@ -6,6 +6,12 @@ import type {
 } from './types';
 
 const DEFAULT_GATEWAY_TOOL_CALL_TIMEOUT_MS = 30_000;
+/**
+ * Device *reads* are on the critical path of every routing decision, and `post`
+ * has no deadline of its own — an unanswered read would otherwise hang for as
+ * long as the socket stays open.
+ */
+const DEVICE_QUERY_TIMEOUT_MS = 10_000;
 const HTTP_CALL_TIMEOUT_PADDING_MS = 30_000;
 
 export interface DeviceStatusResult {
@@ -47,8 +53,15 @@ export class GatewayHttpClient {
   }
 
   async queryDeviceStatus(userId: string, workspaceId?: string): Promise<DeviceStatusResult> {
-    const res = await this.post('/api/device/status', { userId, workspaceId });
-    if (!res.ok) return { deviceCount: 0, online: false };
+    const res = await this.post(
+      '/api/device/status',
+      { userId, workspaceId },
+      { timeout: DEVICE_QUERY_TIMEOUT_MS },
+    );
+    // A gateway that answered with an error did not tell us "nothing is
+    // online" — it told us nothing. Reporting the two as the same value is how
+    // a transient 5xx became an authoritative "all devices offline" downstream.
+    if (!res.ok) throw new Error(`Device gateway /api/device/status responded ${res.status}`);
 
     const data = await res.json();
     return {
@@ -58,8 +71,14 @@ export class GatewayHttpClient {
   }
 
   async queryDeviceList(userId: string, workspaceId?: string): Promise<GatewayDevice[]> {
-    const res = await this.post('/api/device/devices', { userId, workspaceId });
-    if (!res.ok) return [];
+    const res = await this.post(
+      '/api/device/devices',
+      { userId, workspaceId },
+      { timeout: DEVICE_QUERY_TIMEOUT_MS },
+    );
+    // See `queryDeviceStatus`: an errored read is an UNKNOWN online set, and
+    // only the caller can decide what to do about that.
+    if (!res.ok) throw new Error(`Device gateway /api/device/devices responded ${res.status}`);
 
     const data = await res.json();
     return Array.isArray(data.devices) ? data.devices : [];


### PR DESCRIPTION
#### The bug

Two stacked layers turned any failure to *read* the device list into a confident, silent "no devices are online":

```ts
// packages/device-gateway-client/src/http.ts
if (!res.ok) return [];        // a 5xx never even threw

// apps/server/src/services/deviceGateway/index.ts
catch { return []; }           // no log, no retry, no trace
```

The gateway is the **authoritative** source for which devices a run may reach — `getScopedOnlineDevices` says so in its own doc comment. That empty array flows straight into `online: !!live`, then into `resolveExecutionPlan`, which concludes `bound-device-offline` and lets `execAgent` degrade the run to the cloud sandbox.

So a device that was connected the entire time looked offline, and **nothing anywhere recorded that the read had failed**. I hit this driving a real Goal: an agent Work node abandoned the user's machine mid-goal and rebuilt the whole project from scratch in `/workspace`, and the only trace was the agent's own note that "本地设备离线".

The asymmetry is the tell — `getScopedOnlineDevices` deliberately fails **closed** on a DB error:

> `null` (lookup failed) fails CLOSED: without the hidden set we can't tell a genuine ghost from someone's private device

…while the one call it calls authoritative failed **open**.

#### The fix

- `queryDeviceList` / `queryDeviceStatus` **throw** on a non-ok response instead of returning the empty default, so the failure reaches a layer that is allowed to decide what it means. Previously a 5xx did not even reach the service's `catch`.
- Both reads get a **10s timeout**. `post` applies none by default, so an unanswered read hung for as long as the socket stayed open — the server-side twin of the client hang in #19021.
- The service wraps both in `readDevices`: **one retry** to absorb a blip, and a `console.warn` carrying `userId` / `workspaceId` / `error` whenever it does fall back.

#### Deliberately *not* changed

The fallback value stays the same, so no caller changes behaviour on a sustained outage — the read is now merely retried and audible rather than silent. `GatewayHttpClient` is only constructed inside `DeviceGateway`, so the new throw is fully contained (verified by grep).

That leaves the second half of the problem open, and it is a product decision rather than a bug fix: **when the online set is genuinely unknown, should a device-bound run fail loudly instead of silently running in the cloud sandbox?** Today `bound-device-offline` is already treated as "locked, don't hop to another machine", yet exec still degrades to the sandbox — those two intentions contradict each other. Worth deciding separately; happy to follow up once someone picks a side.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New:

- `surfaces a non-ok response instead of reporting nothing online`
- `surfaces a non-ok response instead of reporting an empty pool`
- `bounds the read with a timeout`
- `absorbs a transient failure instead of reporting an empty pool` — first call rejects, second succeeds, devices still returned
- `reports the fallback out loud when the gateway stays unreachable` — asserts the warning and its context

All five fail on the pre-fix source. Two existing tests (`should return defaults on non-ok response`, `should return empty array on non-ok response`) asserted the old fail-open contract and are inverted here — that inversion *is* the fix, so they are rewritten rather than deleted, with the reason in the test body.

`bun run check` clean: lint + 91 tests passed. Type-check clean for the touched files.

#### 🔗 Related Issue

Related to #19021 — same incident, opposite end of the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)