### PR TITLE
🐛 fix: pass workspaceId to cloud-sandbox MarketService

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/cloudSandbox.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/cloudSandbox.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
   return {
     createSandboxService: vi.fn(),
     FakeSandboxService,
+    MarketService: vi.fn(() => ({})),
     preprocessLhCommand: vi.fn(),
     sandboxService: new FakeSandboxService(),
   };
@@ -21,7 +22,7 @@ vi.mock('@/server/services/file', () => ({
 }));
 
 vi.mock('@/server/services/market', () => ({
-  MarketService: vi.fn(() => ({})),
+  MarketService: mocks.MarketService,
 }));
 
 vi.mock('@/server/services/sandbox', () => ({
@@ -84,6 +85,22 @@ describe('cloudSandboxRuntime', () => {
       expect.objectContaining({
         command:
           'lh() { LOBEHUB_WORKSPACE_ID=\'ws-42\' npx -y @lobehub/cli "$@"; }\nlh agent edit agt_1 -t x',
+      }),
+    );
+  });
+
+  // `injectCredsToSandbox` (the `creds` runtime) threads `workspaceId` into its
+  // MarketService, which routes workspace requests to an `org-<id>` sandbox
+  // session on the market backend. If this runtime's MarketService omits
+  // `workspaceId`, its shell calls resolve to the personal session instead —
+  // a different sandbox than the one credentials were just injected into.
+  it('scopes its MarketService to the request workspace', async () => {
+    const { cloudSandboxRuntime } = await import('../cloudSandbox');
+    await cloudSandboxRuntime.factory(buildContext({ workspaceId: 'ws-42' }));
+
+    expect(mocks.MarketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userInfo: { userId: 'user-1', workspaceId: 'ws-42' },
       }),
     );
   });

--- a/apps/server/src/services/toolExecution/serverRuntimes/cloudSandbox.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/cloudSandbox.ts
@@ -83,7 +83,7 @@ export const cloudSandboxRuntime: ServerRuntimeRegistration = {
 
     const marketService = new MarketService({
       accessToken,
-      userInfo: { userId: context.userId },
+      userInfo: { userId: context.userId, workspaceId: context.workspaceId },
     });
     const fileService = new FileService(context.serverDB, context.userId, context.workspaceId);
     const sandboxService = createSandboxService({


### PR DESCRIPTION
<!-- Brief and heads-up -->

`injectCredsToSandbox` (the `creds` server runtime) threads `workspaceId` into its `MarketService`, which causes the market backend to route workspace-scoped requests into an `org-<ownerAccountId>` sandbox session. The `cloud-sandbox` server runtime (`runCommand`/`execScript`, i.e. where the agent's shell actually executes) built its `MarketService` without `workspaceId`, so its calls resolved to the *personal* sandbox session instead.

For workspace-scoped credential injection this means: `injectCredsToSandbox` reports success and writes `~/.creds/env` into the workspace's sandbox session, but every subsequent `runCommand`/`execScript` call executes in a different sandbox session where that file was never created — silently breaking credential injection with no surfaced error. Personal (non-workspace) requests happen to resolve both runtimes to the same session, so the bug never manifests there.

Fix: pass `workspaceId: context.workspaceId` into the `cloud-sandbox` runtime's `MarketService` construction, aligning it with the `creds` runtime.

#### Key Decisions / Non-goals

- Root cause is isolated to `cloudSandboxRuntime`'s `MarketService` construction; the market-backend session-resolution logic (`resolveSessionUserId`, `resolveActingAccount`) and the `injectForSkill`/browser-executor gaps noted in adjacent code comments are out of scope for this PR.

#### Test

- [x] Added/updated tests
- [ ] Tested locally (blocked by unrelated local vitest setup issue resolving `@/locales/default/chat`; verified via lint/prettier pre-commit hooks + code inspection)

Added a regression test asserting the `cloud-sandbox` runtime's `MarketService` is constructed with the request's `workspaceId`, so its shell tool calls resolve into the same AgentCore sandbox session that `injectCredsToSandbox` writes credentials into.

#### 🔗 Related Issue

None