### PR TITLE
🐛 fix(model-runtime): ask Fable 5.1 to call the tool when tool_choice falls back to auto

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -84,6 +84,34 @@ describe('Anthropic generateObject', () => {
         strict: true,
       }),
     ]);
+    // auto tool_choice cannot force the call, so the prompt must ask for it
+    expect(requestParams.system).toEqual([
+      {
+        text: 'You must respond by calling the `person_extractor` tool. Do not reply with plain text.',
+        type: 'text',
+      },
+    ]);
+  });
+
+  it('should append the tool-use instruction after an existing system prompt on Fable 5.1', async () => {
+    const { requestParams } = await buildAnthropicGenerateObjectRequest({
+      messages: [
+        { content: 'You are an extractor.', role: 'system' as const },
+        { content: 'Generate a person object', role: 'user' as const },
+      ],
+      model: 'claude-fable-5-1',
+      schema: {
+        name: 'person_extractor',
+        schema: { properties: { name: { type: 'string' } }, type: 'object' as const },
+      },
+    } as any);
+
+    expect(requestParams.system).toEqual([
+      {
+        text: 'You are an extractor.\n\nYou must respond by calling the `person_extractor` tool. Do not reply with plain text.',
+        type: 'text',
+      },
+    ]);
   });
 
   it('should key the Fable 5.1 tool_choice guard on config.requestModel', async () => {
@@ -116,6 +144,8 @@ describe('Anthropic generateObject', () => {
       name: 'person_extractor',
       type: 'tool',
     });
+    // forced tool_choice still works here, so no prompt instruction is injected
+    expect(requestParams.system).toBeUndefined();
   });
 
   it('should use auto tool_choice for tools mode on Fable 5.1', async () => {
@@ -139,6 +169,12 @@ describe('Anthropic generateObject', () => {
     } as any);
 
     expect(requestParams.tool_choice).toEqual({ type: 'auto' });
+    expect(requestParams.system).toEqual([
+      {
+        text: 'You must respond by calling one of the provided tools. Do not reply with plain text.',
+        type: 'text',
+      },
+    ]);
   });
 
   it('should still use auto tool_choice when the request model is an opaque mapped id', async () => {

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
@@ -59,15 +59,6 @@ export const buildAnthropicGenerateObjectRequest = async (
 
   log('converted %d messages to Anthropic format', anthropicMessages.length);
 
-  const systemPrompts = systemPromptText
-    ? [
-        {
-          text: systemPromptText,
-          type: 'text' as const,
-        },
-      ]
-    : undefined;
-
   let finalTools;
   let tool_choice: Anthropic.ToolChoiceAuto | Anthropic.ToolChoiceAny | Anthropic.ToolChoiceTool;
   let schemaToolName: string | undefined;
@@ -77,9 +68,19 @@ export const buildAnthropicGenerateObjectRequest = async (
   const forcedToolChoiceRejected = [model, config?.requestModel].some(
     (id): id is string => !!id && rejectsForcedToolChoice(id),
   );
+  // With `tool_choice: auto` nothing forces the model to call a tool, so the
+  // official migration guide asks callers to state the requirement in the prompt.
+  // Without it the model may answer in plain text and the parser silently returns
+  // `undefined` / `[]` to callers that expect structured output.
+  // https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1#forced-tool-use-is-not-supported
+  let toolUseInstruction: string | undefined;
   if (tools) {
     finalTools = buildAnthropicTools(tools);
     tool_choice = forcedToolChoiceRejected ? { type: 'auto' } : { type: 'any' };
+    if (forcedToolChoiceRejected) {
+      toolUseInstruction =
+        'You must respond by calling one of the provided tools. Do not reply with plain text.';
+    }
   } else if (schema) {
     // Convert OpenAI-style schema to Anthropic tool format
     const tool: Anthropic.ToolUnion = {
@@ -106,9 +107,22 @@ export const buildAnthropicGenerateObjectRequest = async (
       : config?.schemaToolChoice === 'any'
         ? { type: 'any' }
         : { name: tool.name, type: 'tool' };
+    if (forcedToolChoiceRejected) {
+      toolUseInstruction = `You must respond by calling the \`${tool.name}\` tool. Do not reply with plain text.`;
+    }
   } else {
     throw new Error('tools or schema is required');
   }
+
+  const systemPrompts =
+    systemPromptText || toolUseInstruction
+      ? [
+          {
+            text: [systemPromptText, toolUseInstruction].filter(Boolean).join('\n\n'),
+            type: 'text' as const,
+          },
+        ]
+      : undefined;
 
   return {
     requestParams: {


### PR DESCRIPTION
## Why

Claude Fable 5.1 / Mythos 5.1 reject forced `tool_choice` (`any` / `tool` → 400), so #19016 switched `generateObject` to `auto` for those models. With `auto` nothing forces a tool call: the model may answer in plain text, `parseAnthropicGenerateObjectResponse` returns `undefined` (schema mode) or `[]` (tools mode), and callers silently get an empty result.

The [official migration guide](https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1#forced-tool-use-is-not-supported) recommends `auto` + an explicit prompt instruction to call the tool.

## What

When `rejectsForcedToolChoice` matches the model / request model:

- schema mode: append ``You must respond by calling the `<toolName>` tool. Do not reply with plain text.`` to the system prompt
- tools mode: append `You must respond by calling one of the provided tools. Do not reply with plain text.`

The instruction is appended after the caller's own system prompt (or becomes the system prompt when none exists). Non-Fable-5.1 models are untouched.

## Tests

- new / extended unit tests in `generateObject.test.ts` covering schema mode, tools mode, existing system prompt concatenation, and no injection on `claude-fable-5`

Linear: LOBE-13732

🤖 Generated with [Claude Code](https://claude.com/claude-code)