### PR TITLE
💄 style(model-bank): add GLM-5.3-Flash, V4 Flash Vision Exp, Fable 5.1

### DIFF
--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -277,7 +277,7 @@ describe('Google Gemini 3.1 Flash Image models', () => {
 });
 
 describe('vendor provider cards', () => {
-  it('advertises native image and video input for GLM-5.3-Flash', () => {
+  it('advertises native search, image and video input for GLM-5.3-Flash', () => {
     // Without `video: true` the chat pipeline falls back to media analysis instead of sending
     // video to the model natively, even though the official card lists video input.
     const glm53Flash = LOBE_DEFAULT_MODEL_LIST.find(
@@ -285,7 +285,8 @@ describe('vendor provider cards', () => {
     );
 
     expect(glm53Flash?.abilities).toEqual(
-      expect.objectContaining({ reasoning: true, video: true, vision: true }),
+      expect.objectContaining({ reasoning: true, search: true, video: true, vision: true }),
     );
+    expect(glm53Flash?.settings?.searchImpl).toBe('params');
   });
 });

--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -275,3 +275,17 @@ describe('Google Gemini 3.1 Flash Image models', () => {
     );
   });
 });
+
+describe('vendor provider cards', () => {
+  it('advertises native image and video input for GLM-5.3-Flash', () => {
+    // Without `video: true` the chat pipeline falls back to media analysis instead of sending
+    // video to the model natively, even though the official card lists video input.
+    const glm53Flash = LOBE_DEFAULT_MODEL_LIST.find(
+      (m) => m.providerId === 'zhipu' && m.id === 'glm-5.3-flash',
+    );
+
+    expect(glm53Flash?.abilities).toEqual(
+      expect.objectContaining({ reasoning: true, video: true, vision: true }),
+    );
+  });
+});

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -15,7 +15,7 @@ const anthropicChatModels: AIChatModelCard[] = [
     displayName: 'Claude Fable 5.1',
     enabled: true,
     family: 'claude-mythos',
-    generation: 'mythos-5-1',
+    generation: 'mythos-5.1',
     id: 'claude-fable-5-1',
     knowledgeCutoff: '2026-06',
     maxOutput: 128_000,

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -11,6 +11,43 @@ const anthropicChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      "Claude Fable 5.1 is Anthropic's most capable generally available model. It outperforms Fable 5 on long-running coding and research at the same base price, with cache reads at a quarter of the cost.",
+    displayName: 'Claude Fable 5.1',
+    enabled: true,
+    family: 'claude-mythos',
+    generation: 'mythos-5-1',
+    id: 'claude-fable-5-1',
+    knowledgeCutoff: '2026-06',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 50, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 12.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-09-01',
+    // Adaptive thinking is always on and cannot be disabled (400 on `thinking.type: disabled`),
+    // so the `enableAdaptiveThinking` toggle from Fable 5 is intentionally omitted.
+    // https://platform.claude.com/docs/en/models/fable-5-1/migration-guide
+    settings: {
+      disabledParams: ['temperature', 'top_p'],
+      extendParams: ['disableContextCaching', 'opus47Effort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       "Claude Fable 5 is Anthropic's strongest model — a new tier above Opus for the most demanding reasoning, agentic work, and coding, at a premium price.",
     displayName: 'Claude Fable 5',
     enabled: true,

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -60,6 +60,36 @@ const deepseekChatModels: AIChatModelCard[] = [
     },
     type: 'chat',
   },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576,
+    description:
+      'DeepSeek V4 Flash Vision Exp is an experimental multimodal model built on V4 Flash. It matches V4 Flash on text and adds native image understanding for visual agent workflows, billed at the same rates.',
+    displayName: 'DeepSeek V4 Flash Vision Exp',
+    enabled: true,
+    family: 'deepseek',
+    generation: 'deepseek-v4',
+    id: 'deepseek-v4-flash-vision-exp',
+    maxOutput: 393_216,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.05, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-08-21',
+    settings: {
+      extendParams: ['deepseekV4GAReasoningEffort'],
+    },
+    type: 'chat',
+  },
 ];
 
 export const allModels = [...deepseekChatModels];

--- a/packages/model-bank/src/aiModels/zhipu.ts
+++ b/packages/model-bank/src/aiModels/zhipu.ts
@@ -44,6 +44,7 @@ const zhipuChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       structuredOutput: true,
+      video: true,
       vision: true,
     },
     contextWindowTokens: 1_048_576,

--- a/packages/model-bank/src/aiModels/zhipu.ts
+++ b/packages/model-bank/src/aiModels/zhipu.ts
@@ -43,6 +43,7 @@ const zhipuChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       structuredOutput: true,
       video: true,
       vision: true,
@@ -69,6 +70,7 @@ const zhipuChatModels: AIChatModelCard[] = [
     releasedAt: '2026-08-26',
     settings: {
       extendParams: ['glm5_3ReasoningEffort', 'preserveThinking'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/zhipu.ts
+++ b/packages/model-bank/src/aiModels/zhipu.ts
@@ -43,6 +43,38 @@ const zhipuChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576,
+    description:
+      'GLM-5.3-Flash is the first natively multimodal GLM-5 model. It inherits the GLM-5.3 text contract with always-on thinking, adds image, video and file understanding, and lands coding quality close to the flagship at roughly one-tenth of the price.',
+    displayName: 'GLM-5.3-Flash',
+    enabled: true,
+    family: 'glm',
+    generation: 'glm-5.3',
+    id: 'glm-5.3-flash',
+    maxOutput: 131_072,
+    // List price; the 50% launch promo ends 2026-09-09, so it is intentionally not encoded here.
+    // https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5.3-flash
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.23, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-08-26',
+    settings: {
+      extendParams: ['glm5_3ReasoningEffort', 'preserveThinking'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
       search: true,
       structuredOutput: true,
     },

--- a/packages/model-bank/src/aiModels/zhipu.ts
+++ b/packages/model-bank/src/aiModels/zhipu.ts
@@ -50,7 +50,7 @@ const zhipuChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576,
     description:
-      'GLM-5.3-Flash is the first natively multimodal GLM-5 model. It inherits the GLM-5.3 text contract with always-on thinking, adds image, video and file understanding, and lands coding quality close to the flagship at roughly one-tenth of the price.',
+      'GLM-5.3-Flash is the first natively multimodal GLM-5 model. It inherits the GLM-5.3 text contract with always-on thinking, adds image and video understanding, and lands coding quality close to the flagship at roughly one-tenth of the price.',
     displayName: 'GLM-5.3-Flash',
     enabled: true,
     family: 'glm',

--- a/packages/model-bank/src/const/knowledgeCutoff.ts
+++ b/packages/model-bank/src/const/knowledgeCutoff.ts
@@ -18,6 +18,7 @@ export const MODEL_KNOWLEDGE_CUTOFFS: Record<string, string> = {
   'claude-3-opus': '2023-08',
   'claude-3-sonnet': '2023-08',
   'claude-fable-5': '2026-01',
+  'claude-fable-5-1': '2026-06',
   'claude-haiku-4-5': '2025-02',
   'claude-opus-4': '2025-01',
   'claude-opus-4-1': '2025-01',


### PR DESCRIPTION
Add the self-hosted provider cards for three models that were recently launched on the hosted LobeHub provider but were still missing from the official provider files, so users pointing at the vendor API directly can pick them and get correct capabilities (vision, reasoning effort) and pricing.

- **Zhipu `glm-5.3-flash`** (`zhipu.ts`) — first natively multimodal GLM-5 model. CNY list price ¥0.8 / ¥2.8 per 1M, cache read ¥0.23, `vision: true`, `glm5_3ReasoningEffort` + `preserveThinking`. The runtime alias to the GLM-5.3 parameter contract already landed in #18723.
- **DeepSeek `deepseek-v4-flash-vision-exp`** (`deepseek.ts`) — experimental multimodal V4 Flash. Pricing is identical to `deepseek-v4-flash` per the official pricing table; released 2026-08-21.
- **Anthropic `claude-fable-5-1`** (`anthropic.ts` + `knowledgeCutoff.ts`) — $10 / $50 per 1M, cache read $0.25, cache write $12.5, 1M context, 128K output, knowledge cutoff 2026-06.

#### Key Decisions / Non-goals

- **GLM-5.3-Flash uses the list price, not the launch promo.** The 50% launch discount on bigmodel.cn ends 2026-09-09, so encoding it would need a follow-up revert within days. Noted in a code comment.
- **Fable 5.1 drops `enableAdaptiveThinking`.** Adaptive thinking is always on for this model and `thinking.type: disabled` returns a 400 per the migration guide, so the toggle carried over from Fable 5 would be a no-op. The `tool_choice` forced-use restriction is handled at the runtime layer in #19016 and needs nothing on the card.
- **Two-generation rule**: `glm-4.7-flash`, `claude-fable-5` and `deepseek-v4-flash` stay enabled — each is the second-newest generation on its line.
- Non-goal: aggregator cards (aihubmix, bedrock, openrouter, …) are not touched.

#### Test

- [x] `bun run check` on the four files — lint clean, 26 tests passed
- [x] Full `packages/model-bank` vitest run — 89 passed
- [x] No tests needed beyond existing model-bank suites

#### 🔗 Related Issue

Related to #18813 — the DeepSeek card overlaps with #18962 by @seb4ez; keeping this PR as the combined landing for all three, happy to rebase if that one merges first.
