### PR TITLE
[Bug] MCP owner verification and metadata refresh failures should stay in listing triage

### DIFF
--- a/.github/scripts/shared/mcp-submission-classifier.ts
+++ b/.github/scripts/shared/mcp-submission-classifier.ts
@@ -113,10 +113,10 @@ export function classify(title: string, body: string): Classification {
     /\b(?:market-)?cli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|cannot|unable|reject)/s.test(
       text,
     ) ||
-    /(?:fail|error|unable|can'?t|cannot|reject).*(?:add|list|submit|publish|login|connect|claim|verify ownership)/s.test(
+    /(?:fail|error|unable|can'?t|cannot|reject).*(?:add|submit|publish|login|connect|claim|verify ownership)/s.test(
       text,
     ) ||
-    /(?:add|list|submit|publish|login|connect|claim|verify ownership).*(?:fail|error|unable|can'?t|cannot|reject)/s.test(
+    /(?:add|\blist\b|submit|publish|login|connect|claim|verify ownership).*(?:fail|error|unable|can'?t|cannot|reject)/s.test(
       text,
     );
 

--- a/tests/github-scripts/mcpSubmissionClassifier.test.ts
+++ b/tests/github-scripts/mcpSubmissionClassifier.test.ts
@@ -80,6 +80,38 @@ Please rescan the listing.`,
     expect(classification.isSubmission).toBe(false);
   });
 
+  it('still classifies actual market-cli list failures as CLI feedback', () => {
+    const classification = classify(
+      'market-cli list fails for my MCP server',
+      'I ran market-cli list my-server and got Error: request failed.',
+    );
+
+    expect(classification).toMatchObject({
+      isSubmission: false,
+      reason: 'looks like CLI/publishing feedback',
+    });
+  });
+
+  it('classifies owner verification and metadata refresh failures as listing requests', () => {
+    const classification = classify(
+      '[Bug] MCP owner verification and metadata refresh fail: Workflow trigger is not configured',
+      `Both owner verification and metadata refresh fail for our public MCP listing with the same server-side error:
+
+Workflow trigger is not configured
+
+Listing: https://lobehub.com/mcp/sallim-app-korea-realty
+Repository: https://github.com/sallim-app/korea-realty
+
+Could you check the workflow trigger configuration for this marketplace listing and re-enable verification/rescan?`,
+    );
+
+    expect(classification).toMatchObject({
+      isSubmission: true,
+      reason: 'existing marketplace listing rescan/refresh request',
+      repoUrl: 'https://github.com/sallim-app/korea-realty',
+    });
+  });
+
   it('still treats a plain rescan (no CLI failure) as a listing request', () => {
     const classification = classify(
       '[Request] Rescan elecz MCP listing to v1.9.6',


### PR DESCRIPTION
This keeps MCP owner verification and metadata refresh failures on the listing triage path instead of misclassifying them as CLI/publishing feedback.

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #18439

#### Reviewer

@arvinxx @canisminor1990 @nekomeowww