### PR TITLE
🐛 fix(model-runtime): route grok-4.6 through xAI

### DIFF
--- a/packages/model-runtime/src/providers/newapi/index.test.ts
+++ b/packages/model-runtime/src/providers/newapi/index.test.ts
@@ -805,6 +805,18 @@ describe('NewAPI Runtime - 100% Branch Coverage', () => {
       expect(Array.isArray(routers[2].models)).toBe(true);
     });
 
+    it('should route grok-4.6 through the xai router', () => {
+      mockDetectModelProvider.mockImplementation((id: string) => {
+        if (id.includes('grok')) return 'xai';
+        return 'openai';
+      });
+
+      const options = { apiKey: 'test', baseURL: 'https://custom.com' };
+      const routers = params.routers(options, { model: 'grok-4.6' });
+
+      expect(routers[2].models).toContain('grok-4.6');
+    });
+
     it('should handle missing baseURL by using empty string', () => {
       const options = { apiKey: 'test' }; // No baseURL
       const routers = params.routers(options);

--- a/packages/model-runtime/src/providers/newapi/index.ts
+++ b/packages/model-runtime/src/providers/newapi/index.ts
@@ -215,8 +215,10 @@ export const params = {
       },
       {
         apiType: 'xai',
-        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-          (id) => detectModelProvider(id) === 'xai',
+        models: resolveProviderRouteModels(
+          'xai',
+          LOBE_DEFAULT_MODEL_LIST,
+          runtimeContext?.model,
         ),
         options: {
           ...options,


### PR DESCRIPTION
<!-- Brief and heads-up -->

## Description

`grok-4.6` was falling through the NewAPI xAI route, which sent the request through the OpenAI fallback before xAI-specific pruning could run.

## Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

## Related Issue

Fixes #18885