### PR TITLE
🐛 fix(model-runtime): price Anthropic cache writes instead of recording them as zero

### DIFF
--- a/packages/model-runtime/src/core/usageConverters/anthropic.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/anthropic.test.ts
@@ -98,3 +98,60 @@ describe('convertAnthropicUsage', () => {
     expect(usage).toBeUndefined();
   });
 });
+
+describe('convertAnthropicUsage cache-write TTL', () => {
+  const deltaEvent = {
+    type: 'message_delta',
+    usage: { output_tokens: 5 },
+  } as unknown as Anthropic.MessageStreamEvent;
+
+  const streamUsage = {
+    inputCacheMissTokens: 0,
+    inputWriteCacheTokens: 1_000_000,
+    totalInputTokens: 1_000_000,
+    totalOutputTokens: 0,
+  };
+
+  // `pricingParams: ['ttl']` is what every current Anthropic card older than Opus 4.7 uses.
+  const ttlPricing = {
+    units: [
+      {
+        lookup: { prices: { '1h': 6, '5m': 3.75 }, pricingParams: ['ttl'] },
+        name: 'textInput_cacheWrite',
+        strategy: 'lookup',
+        unit: 'millionTokens',
+      },
+    ],
+  } as any;
+
+  it('prices a cache write instead of billing it as zero', () => {
+    const usage = convertAnthropicUsage(deltaEvent, streamUsage, { pricing: ttlPricing } as any);
+
+    // 1M tokens at $3.75/MTok — before the fix the lookup key was unresolved and cost was 0.
+    expect(usage?.cost).toBeCloseTo(3.75, 6);
+  });
+
+  it('lets a caller-supplied ttl win over the default', () => {
+    const usage = convertAnthropicUsage(deltaEvent, streamUsage, {
+      pricing: ttlPricing,
+      pricingOptions: { lookupParams: { ttl: '1h' } },
+    } as any);
+
+    expect(usage?.cost).toBeCloseTo(6, 6);
+  });
+
+  it('keeps other pricingOptions intact', () => {
+    const usage = convertAnthropicUsage(deltaEvent, streamUsage, {
+      pricing: {
+        currency: 'CNY',
+        units: [
+          { name: 'textInput_cacheWrite', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+      },
+      pricingOptions: { usdToCnyRate: 10 },
+    } as any);
+
+    // 1M tokens at CNY 10/MTok converted at the supplied rate, not the built-in one.
+    expect(usage?.cost).toBeCloseTo(1, 6);
+  });
+});

--- a/packages/model-runtime/src/core/usageConverters/anthropic.ts
+++ b/packages/model-runtime/src/core/usageConverters/anthropic.ts
@@ -2,6 +2,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { ModelUsage } from '@lobechat/types';
 
 import type { ChatPayloadForTransformStream } from '../streams/protocol';
+import type { ComputeChatCostOptions } from './utils/computeChatCost';
 import { withUsageCost } from './utils/withUsageCost';
 
 export const buildAnthropicInitialUsage = (
@@ -55,6 +56,21 @@ const mergeDeltaUsage = (
   return base;
 };
 
+/**
+ * Anthropic cards price `textInput_cacheWrite` with a `ttl` lookup (`5m` / `1h`), but the request
+ * builder writes a plain `cache_control: { type: 'ephemeral' }`, which the API stores as a
+ * five-minute cache. Nothing told the pricing layer that, so the lookup key stayed unresolved and
+ * every cache write on those cards was billed as 0.
+ *
+ * Declare the TTL the builder actually uses, while letting a caller-supplied value win.
+ */
+const withCacheWriteTtl = (
+  payload: ChatPayloadForTransformStream | undefined,
+): ComputeChatCostOptions => ({
+  ...payload?.pricingOptions,
+  lookupParams: { ttl: '5m', ...payload?.pricingOptions?.lookupParams },
+});
+
 export const convertAnthropicUsage = (
   messageEvent: Anthropic.MessageStreamEvent,
   streamContextUsage?: ModelUsage,
@@ -66,7 +82,7 @@ export const convertAnthropicUsage = (
     }
     case 'message_delta': {
       const usage = mergeDeltaUsage(streamContextUsage, messageEvent.usage);
-      return usage && withUsageCost(usage, payload?.pricing, payload?.pricingOptions);
+      return usage && withUsageCost(usage, payload?.pricing, withCacheWriteTtl(payload));
     }
     default: {
       return streamContextUsage;


### PR DESCRIPTION
## Problem

Prompt-cache **writes** on an Anthropic model whose card prices `textInput_cacheWrite` with a `ttl` lookup are recorded as costing **$0**. Four current cards are affected — `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5-20251101`, `claude-haiku-4-5-20251001` — so on Sonnet 4.6 and Haiku 4.5 the cache-write component is missing from `usage.cost` entirely. It is not a rounding error: Anthropic bills a cache write at 1.25x the base input rate, and on a cached conversation the first turn is almost all cache write.

## Root cause

- `packages/model-bank/src/aiModels/anthropic.ts` — those four cards price cache writes as   `strategy: 'lookup'` with `pricingParams: ['ttl']` and prices `{ '5m', '1h' }`.

- `packages/model-runtime/src/core/usageConverters/anthropic.ts` — `convertAnthropicUsage` passes   `payload?.pricingOptions` straight through, and nothing on the Anthropic path ever sets a `ttl` lookup param.

- `computeChatCost` → `resolveLookupKey` therefore reports `Missing lookup params: ttl` and  `computeLookupCredits` returns `credits: 0`. The turn still succeeds, so the zero is silent.

The TTL is not actually unknown: `contextBuilders/anthropic.ts` writes a plain `cache_control: { type: 'ephemeral' }` (the file contains no `ttl` at all), which the API stores as a five-minute cache. Verified against the live API — a request with that exact block comes back with `cache_creation: { ephemeral_5m_input_tokens: 2473, ephemeral_1h_input_tokens: 0 }`.

## Fix

Have the Anthropic converter declare the TTL its own request builder uses, defaulting the `ttl` lookup param to `'5m'` while letting a caller-supplied value win, so a future caller that opts into a one-hour cache prices correctly without touching this code again. The alternative — teaching `computeChatCost` to assume `5m` for any unresolved `ttl` — was rejected because it puts provider-specific knowledge into the generic pricing utility, where it would apply to every lookup.

Cards are unchanged: the `1h` price stays in the data, ready for whoever wires the option up.

## Scope and non-goals

- Covers the Anthropic stream path, which `anthropicCompatibleFactory` also runs through, so Bedrock's Claude cards are fixed by the same change.

- **Aggregator and mirror cards are deliberately left alone.** `openrouter.ts` (3) and `aihubmix.ts` (8) carry the same `ttl` lookup shape and reach `convertOpenAIUsage`, which does populate `inputWriteCacheTokens`. The justification here does not transfer to them: it rests on *this* repo's Anthropic request builder writing a plain `cache_control`, whereas an aggregator decides its own cache TTL. Guessing `5m` for them would be the same unverified assumption this PR removes.

#### Test

`packages/model-runtime/src/core/usageConverters/anthropic.test.ts`, 3 cases: a cache write on a ttl-lookup card is now priced instead of zero, a caller-supplied `ttl` still wins, and unrelated `pricingOptions` (`usdToCnyRate`) survive the merge. Run with `cd packages/model-runtime && vitest run src/core/usageConverters` — 155 passed.

- [x] Tested locally

- [x] Added/updated tests

- [ ] No tests needed

- Acceptance: No published report (no LobeHub Cloud account). Completed verification and its limits are documented under Test.

#### 🔗 Related Issue

None — found while auditing self-hosted cost records.

