### PR TITLE
🐛 fix(ci): select size baselines from tested lineage

### DIFF
--- a/.github/scripts/find-size-baseline.cjs
+++ b/.github/scripts/find-size-baseline.cjs
@@ -1,16 +1,26 @@
 /**
- * Find the most recent successful `canary` push run of a workflow that
- * contains a given size-baseline artifact, and return its run id (or '' when
- * none exists). Used with actions/download-artifact's `run-id` input:
+ * Find the most recent successful `canary` push run whose commit is an ancestor
+ * of the code being measured and contains a given size-baseline artifact. Return
+ * its run id (or '' when none exists). Used with actions/download-artifact's
+ * `run-id` input:
  *
  *   const finder = require('<workspace>/.github/scripts/find-size-baseline.js');
- *   return await finder({ github, context, workflowId: 'e2e.yml', artifactName: 'bundle-size-baseline-web' });
+ *   return await finder({ github, context, workflowId: 'e2e.yml', artifactName: 'bundle-size-baseline-web', targetSha: context.sha });
  *
  * The returned string becomes the step's `result` output (empty string = no
  * baseline yet, callers should skip the download step and let the gate degrade
  * to a warning).
  */
-const findSizeBaseline = async ({ github, context, workflowId, artifactName, artifactPrefix }) => {
+const findSizeBaseline = async ({
+  github,
+  context,
+  workflowId,
+  artifactName,
+  artifactPrefix,
+  targetSha,
+}) => {
+  if (!targetSha) throw new Error('targetSha is required to select a lineage-safe baseline');
+
   const { data } = await github.rest.actions.listWorkflowRuns({
     branch: 'canary',
     event: 'push',
@@ -22,6 +32,22 @@ const findSizeBaseline = async ({ github, context, workflowId, artifactName, art
   });
 
   for (const run of data.workflow_runs) {
+    const { data: comparison } = await github.request(
+      'GET /repos/{owner}/{repo}/compare/{basehead}',
+      {
+        basehead: `${run.head_sha}...${targetSha}`,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+      },
+    );
+
+    if (comparison.status !== 'ahead' && comparison.status !== 'identical') {
+      console.log(
+        `Skipping canary run ${run.id} (${run.head_sha}): not an ancestor of ${targetSha} (${comparison.status})`,
+      );
+      continue;
+    }
+
     const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
       owner: context.repo.owner,
       per_page: 100,

--- a/.github/scripts/find-size-baseline.test.cjs
+++ b/.github/scripts/find-size-baseline.test.cjs
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const findSizeBaseline = require('./find-size-baseline.cjs');
+
+test('selects the newest baseline in the target commit lineage', async () => {
+  const artifactRunIds = [];
+  const github = {
+    request: async (_route, { basehead }) => ({
+      data: { status: basehead.startsWith('future...') ? 'diverged' : 'ahead' },
+    }),
+    rest: {
+      actions: {
+        listWorkflowRunArtifacts: async ({ run_id }) => {
+          artifactRunIds.push(run_id);
+          return { data: { artifacts: [{ name: 'baseline' }] } };
+        },
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              { created_at: 'later', head_sha: 'future', id: 300 },
+              { created_at: 'earlier', head_sha: 'base', id: 200 },
+            ],
+          },
+        }),
+      },
+    },
+  };
+
+  const result = await findSizeBaseline({
+    artifactName: 'baseline',
+    context: { repo: { owner: 'lobehub', repo: 'lobehub' } },
+    github,
+    targetSha: 'head',
+    workflowId: 'e2e.yml',
+  });
+
+  assert.equal(result, '200');
+  assert.deepEqual(artifactRunIds, [200]);
+});

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,7 @@ jobs:
           SKIP_LINT: '1'
 
       # ===== Bundle size gate (web dist) =====
-      # Baseline: artifact uploaded by the latest successful canary push run of this workflow.
+      # Baseline: artifact from the latest successful canary commit in the tested SHA's lineage.
       - name: Find latest canary baseline run
         if: env.SIZE_GATE_ENABLED == 'true'
         id: baseline_run
@@ -104,7 +104,13 @@ jobs:
           result-encoding: string
           script: |
             const finder = require('${{ github.workspace }}/.github/scripts/find-size-baseline.cjs');
-            return await finder({ github, context, workflowId: 'e2e.yml', artifactName: 'bundle-size-baseline-web' });
+            return await finder({
+              github,
+              context,
+              workflowId: 'e2e.yml',
+              artifactName: 'bundle-size-baseline-web',
+              targetSha: context.payload.pull_request?.head.sha ?? context.sha,
+            });
 
       - name: Download web dist size baseline
         if: env.SIZE_GATE_ENABLED == 'true' && steps.baseline_run.outputs.result != ''
@@ -141,7 +147,13 @@ jobs:
           result-encoding: string
           script: |
             const finder = require('${{ github.workspace }}/.github/scripts/find-size-baseline.cjs');
-            return await finder({ github, context, workflowId: 'e2e.yml', artifactName: 'bundle-size-baseline-entry-graph' });
+            return await finder({
+              github,
+              context,
+              workflowId: 'e2e.yml',
+              artifactName: 'bundle-size-baseline-entry-graph',
+              targetSha: context.payload.pull_request?.head.sha ?? context.sha,
+            });
 
       - name: Download entry-graph baseline
         if: env.SIZE_GATE_ENABLED == 'true' && steps.entry_graph_baseline_run.outputs.result != ''

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -251,7 +251,7 @@ jobs:
           pattern: asar-size-*
           merge-multiple: true
 
-      # 基线:release-desktop-canary 最近一次成功 run 上传的 asar-size-baseline-* artifacts
+      # 基线:被测 merge SHA 祖先中最近一次成功的 release-desktop-canary run
       - name: Find latest canary baseline run
         id: baseline_run
         uses: actions/github-script@v8
@@ -260,7 +260,13 @@ jobs:
           result-encoding: string
           script: |
             const finder = require('${{ github.workspace }}/.github/scripts/find-size-baseline.cjs');
-            return await finder({ github, context, workflowId: 'release-desktop-canary.yml', artifactPrefix: 'asar-size-baseline-' });
+            return await finder({
+              github,
+              context,
+              workflowId: 'release-desktop-canary.yml',
+              artifactPrefix: 'asar-size-baseline-',
+              targetSha: context.sha,
+            });
 
       - name: Download ASAR size baselines
         if: steps.baseline_run.outputs.result != ''


### PR DESCRIPTION
Prevent bundle and entry-graph gates from comparing a feature build with a newer, unrelated canary artifact.

For #19049, the job built head `ac1cb12` but selected baseline `9c81af8`. That canary commit was not an ancestor of the tested head, so the gate reported the intervening Skeleton refactor as newly reachable chunks.

This change:

- requires every baseline lookup to identify the exact SHA being measured;
- skips successful canary runs whose commit is not an ancestor of that SHA;
- wires E2E gates to their explicitly checked-out head SHA;
- wires the Desktop ASAR gate to its checked-out PR merge SHA;
- keeps the existing warning fallback when no recent ancestral artifact exists.

| Before | After |
| ------ | ----- |
| The latest successful canary artifact was selected even when its commit diverged from the tested head. | The newest successful canary artifact in the tested commit's lineage is selected. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `node --test .github/scripts/find-size-baseline.test.cjs .github/scripts/bundle-size-gate.test.cjs` — 3 passed
- `bun run check .github/scripts/find-size-baseline.cjs .github/scripts/find-size-baseline.test.cjs .github/workflows/e2e.yml .github/workflows/pr-build-desktop.yml` — lint clean
- `actionlint` parsed both workflows; remaining findings are pre-existing warnings outside the changed lines.
- Live lineage check for #19049: `9c81af8` and `74d434f` are `diverged`; `df001d1` is `ahead` and its run contains both required web baseline artifacts.

#### 🔗 Related Issue

Related to #19049
