### PR TITLE
💄 style(chat): say agent session, not Claude Code, in the switch-cwd dialog

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -909,7 +909,7 @@
   "heteroAgent.resumeReset.cwdChanged": "Working directory changed. Previous Claude Code session can only be resumed from its original directory, so a new conversation has started.",
   "heteroAgent.resumeReset.resumeFailed": "The saved Codex thread could not be resumed safely, so a new conversation has started for this topic.",
   "heteroAgent.switchCwd.cancel": "Cancel",
-  "heteroAgent.switchCwd.content": "Claude Code sessions are pinned to a working directory. Switching will start a new session for this topic — chat messages stay, but the previous session context cannot be resumed.",
+  "heteroAgent.switchCwd.content": "Agent sessions are pinned to a working directory. Switching will start a new session for this topic — chat messages stay, but the previous session context cannot be resumed.",
   "heteroAgent.switchCwd.ok": "Switch and start new session",
   "heteroAgent.switchCwd.title": "Switch working directory?",
   "hideForYou": "Direct message content is hidden. Please enable 'Show Direct Message Content' in settings to view.",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -909,7 +909,7 @@
   "heteroAgent.resumeReset.cwdChanged": "工作目录已切换，之前的 Claude Code 会话只能在原目录下继续，已开始新对话。",
   "heteroAgent.resumeReset.resumeFailed": "已保存的 Codex 线程无法安全恢复，当前话题已自动开启新会话。",
   "heteroAgent.switchCwd.cancel": "取消",
-  "heteroAgent.switchCwd.content": "Claude Code 会话会绑定到具体的工作目录。切换后将为当前话题开启一个新会话——消息记录会保留，但之前会话的上下文无法恢复。",
+  "heteroAgent.switchCwd.content": "Agent 会话会绑定到具体的工作目录。切换后将为当前话题开启一个新会话——消息记录会保留，但之前会话的上下文无法恢复。",
   "heteroAgent.switchCwd.ok": "切换并开启新会话",
   "heteroAgent.switchCwd.title": "切换工作目录？",
   "hideForYou": "私信内容已隐藏。可在设置中开启「显示私信内容」查看",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -522,7 +522,7 @@ export default {
     'The saved Codex thread could not be resumed safely, so a new conversation has started for this topic.',
   'heteroAgent.switchCwd.cancel': 'Cancel',
   'heteroAgent.switchCwd.content':
-    'Claude Code sessions are pinned to a working directory. Switching will start a new session for this topic — chat messages stay, but the previous session context cannot be resumed.',
+    'Agent sessions are pinned to a working directory. Switching will start a new session for this topic — chat messages stay, but the previous session context cannot be resumed.',
   'heteroAgent.switchCwd.ok': 'Switch and start new session',
   'heteroAgent.switchCwd.title': 'Switch working directory?',
   'heteroAgent.cloudNotConfigured.action': 'Configure',


### PR DESCRIPTION
The switch-working-directory confirmation named Claude Code, but the dialog is shared by every heterogeneous agent (Claude Code, Codex, Cursor, …). The copy now says "Agent 会话 / Agent sessions" instead.

| Before | After |
| ------ | ----- |
| Claude Code 会话会绑定到具体的工作目录。… | Agent 会话会绑定到具体的工作目录。… |

#### Test

- [x] No tests needed — locale copy only

🤖 Generated with [Claude Code](https://claude.com/claude-code)