### PR TITLE
💄 style(home): hide scope toggle from running tasks

### DIFF
--- a/src/features/HomeInbox/hiddenWidgets.test.ts
+++ b/src/features/HomeInbox/hiddenWidgets.test.ts
@@ -124,7 +124,7 @@ describe('hasVisibleRailWidget', () => {
 });
 
 describe('resolveInboxScopeToggleSection', () => {
-  const populated = { needsYouCount: 2, runningCount: 1, unreadCount: 3 };
+  const populated = { needsYouCount: 2, unreadCount: 3 };
 
   it('keeps the scope toggle on needs-you while that widget is visible', () => {
     expect(resolveInboxScopeToggleSection({ ...populated, hiddenWidgets: [] })).toBe('needsYou');
@@ -136,10 +136,10 @@ describe('resolveInboxScopeToggleSection', () => {
     );
   });
 
-  it('falls through to running when both leading widgets are hidden', () => {
+  it('hides the scope toggle when both titled topic widgets are hidden', () => {
     expect(
       resolveInboxScopeToggleSection({ ...populated, hiddenWidgets: ['needsYou', 'unread'] }),
-    ).toBe('running');
+    ).toBeNull();
   });
 
   it('gives up the scope toggle only once every host widget is hidden', () => {
@@ -151,7 +151,7 @@ describe('resolveInboxScopeToggleSection', () => {
     ).toBeNull();
   });
 
-  it('suppresses a section through the task-mode props as well as the hidden set', () => {
+  it('suppresses titled sections through the task-mode props as well as the hidden set', () => {
     expect(
       resolveInboxScopeToggleSection({
         ...populated,
@@ -159,7 +159,7 @@ describe('resolveInboxScopeToggleSection', () => {
         hideNeedsYou: true,
         hideUnread: true,
       }),
-    ).toBe('running');
+    ).toBeNull();
   });
 
   it('still leads with unread in the main column when needs-you is hidden', () => {
@@ -187,7 +187,6 @@ describe('resolveInboxScopeToggleSection', () => {
       resolveInboxScopeToggleSection({
         hiddenWidgets: [],
         needsYouCount: 0,
-        runningCount: 0,
         unreadCount: 4,
       }),
     ).toBe('unread');

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -281,7 +281,6 @@ const HomeInbox = memo<HomeInboxProps>((props) => {
         hideUnread,
         needsYouCount: needsYou.length,
         preferUnread: isMain,
-        runningCount: runningTopics.length,
         unreadCount: unreadTopics.length,
       })
     : null;
@@ -407,14 +406,7 @@ const HomeInbox = memo<HomeInboxProps>((props) => {
   if (!hideRunning && !isRail && runningTopics.length > 0)
     sections.push({
       key: 'running',
-      node: (
-        <RunningTasksCard
-          action={placeToggle('running')}
-          bare={isRail}
-          running={runningTopics}
-          showAuthor={teamView}
-        />
-      ),
+      node: <RunningTasksCard bare={isRail} running={runningTopics} showAuthor={teamView} />,
     });
 
   // A first-load failure of the day feed must not make the whole section

--- a/src/features/HomeInbox/scopeTogglePlacement.test.ts
+++ b/src/features/HomeInbox/scopeTogglePlacement.test.ts
@@ -4,22 +4,17 @@ import { filterTopicsForInboxScope, resolveScopeToggleSection } from './scopeTog
 
 describe('resolveScopeToggleSection', () => {
   it('keeps the team scope control on a rail Needs-you card', () => {
-    expect(
-      resolveScopeToggleSection({ hasNeedsYou: true, hasRunning: false, hasUnread: false }),
-    ).toBe('needsYou');
+    expect(resolveScopeToggleSection({ hasNeedsYou: true, hasUnread: false })).toBe('needsYou');
   });
 
-  it('falls through to the first topic section when no brief needs attention', () => {
-    expect(
-      resolveScopeToggleSection({ hasNeedsYou: false, hasRunning: true, hasUnread: false }),
-    ).toBe('running');
+  it('does not place the team scope control on the running card', () => {
+    expect(resolveScopeToggleSection({ hasNeedsYou: false, hasUnread: false })).toBeNull();
   });
 
   it('places the scope control on unread when the main feed leads with unread', () => {
     expect(
       resolveScopeToggleSection({
         hasNeedsYou: true,
-        hasRunning: false,
         hasUnread: true,
         preferUnread: true,
       }),

--- a/src/features/HomeInbox/scopeTogglePlacement.ts
+++ b/src/features/HomeInbox/scopeTogglePlacement.ts
@@ -1,6 +1,5 @@
 interface ScopeTogglePlacementInput {
   hasNeedsYou: boolean;
-  hasRunning: boolean;
   hasUnread: boolean;
   preferUnread?: boolean;
 }
@@ -8,14 +7,12 @@ interface ScopeTogglePlacementInput {
 /** Place the team scope control on the first section whose contents it governs. */
 export const resolveScopeToggleSection = ({
   hasNeedsYou,
-  hasRunning,
   hasUnread,
   preferUnread,
-}: ScopeTogglePlacementInput): 'needsYou' | 'running' | 'unread' | null => {
+}: ScopeTogglePlacementInput): 'needsYou' | 'unread' | null => {
   if (preferUnread && hasUnread) return 'unread';
   if (hasNeedsYou) return 'needsYou';
   if (hasUnread) return 'unread';
-  if (hasRunning) return 'running';
   return null;
 };
 
@@ -25,7 +22,6 @@ interface InboxScopeTogglePlacementInput {
   hideUnread?: boolean;
   needsYouCount: number;
   preferUnread?: boolean;
-  runningCount: number;
   unreadCount: number;
 }
 
@@ -35,12 +31,10 @@ export const resolveInboxScopeToggleSection = ({
   hideUnread,
   needsYouCount,
   preferUnread,
-  runningCount,
   unreadCount,
-}: InboxScopeTogglePlacementInput): 'needsYou' | 'running' | 'unread' | null =>
+}: InboxScopeTogglePlacementInput): 'needsYou' | 'unread' | null =>
   resolveScopeToggleSection({
     hasNeedsYou: !hideNeedsYou && needsYouCount > 0 && !hiddenWidgets.includes('needsYou'),
-    hasRunning: runningCount > 0 && !hiddenWidgets.includes('running'),
     hasUnread: !hideUnread && unreadCount > 0 && !hiddenWidgets.includes('unread'),
     preferUnread,
   });


### PR DESCRIPTION
## Summary

- hide the Mine / Team scope toggle from the running-tasks card in workspace home
- keep the scope control on titled inbox sections and the Recent topics header
- update scope-placement regression coverage

## Test plan

- `bunx vitest run --silent=passed-only src/features/HomeInbox/scopeTogglePlacement.test.ts src/features/HomeInbox/hiddenWidgets.test.ts` (25 tests passed)
- pre-commit stylelint, ESLint, and Prettier checks passed