### PR TITLE
🐛 fix(hetero): reuse CLI detection cache on launch

### DIFF
--- a/apps/desktop/src/main/controllers/BinaryCtr.ts
+++ b/apps/desktop/src/main/controllers/BinaryCtr.ts
@@ -5,7 +5,10 @@ import type {
   ClaudeAuthStatus,
   DetectHeterogeneousAgentCommandParams,
 } from '@lobechat/electron-client-ipc';
-import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
+import {
+  getHeterogeneousAgentConfigOrThrow,
+  isRemoteHeterogeneousType,
+} from '@lobechat/heterogeneous-agents';
 import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
 
 import type { BinaryCategory, BinaryStatus } from '@/core/infrastructure/BinaryManager';
@@ -49,9 +52,18 @@ export default class BinaryCtr extends ControllerModule {
       return resolveRemotePlatformCommand(params.agentType);
     }
 
+    const defaultCommand = getHeterogeneousAgentConfigOrThrow(params.agentType).defaultCommand;
+    if (params.command === defaultCommand) {
+      // Keep the explicit Rescan result in the same manager entry that launch
+      // preflight reads. This refreshes both the login-shell PATH and stale
+      // negative/positive binary status in one operation.
+      return this.manager.detect(defaultCommand, true);
+    }
+
     // This is the Connect Agent Rescan path, and it bypasses `BinaryManager`
-    // entirely — a user pressing Rescan after installing a CLI has to see the
-    // PATH that installer wrote, not the one cached at first scan.
+    // for custom commands, which have no registered manager entry. A user
+    // pressing Rescan after installing one still has to see the PATH that its
+    // installer wrote, not the one cached at first scan.
     invalidateLoginShellPathCache();
 
     return detectHeterogeneousCliCommand(params.agentType, params.command);

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -791,7 +791,11 @@ export default class HeterogeneousAgentCtr {
     const command = this.resolveSessionCommand(session);
     const status =
       command === defaultCommand
-        ? await this.app.binaryManager?.detect?.(defaultCommand, true)
+        ? // Normal launches must reuse the successful binary/PATH detection.
+          // Forcing here invalidates the login-shell PATH cache on every message,
+          // putting a slow interactive shell back on the critical path. Explicit
+          // Rescan actions remain responsible for force-refreshing the cache.
+          await this.app.binaryManager?.detect?.(defaultCommand)
         : await detectHeterogeneousCliCommand(session.agentType, command);
 
     if (!status || status.available) {

--- a/apps/desktop/src/main/controllers/__tests__/BinaryCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/BinaryCtr.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { App } from '@/core/App';
+import { BinaryManager, type BinaryStatus } from '@/core/infrastructure/BinaryManager';
+
+import BinaryCtr from '../BinaryCtr';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
+describe('BinaryCtr', () => {
+  let cacheRoot: string;
+
+  beforeEach(async () => {
+    cacheRoot = await mkdtemp(path.join(os.tmpdir(), 'lobehub-binary-ctr-'));
+    const { app } = await import('electron');
+    vi.mocked(app.getPath).mockReturnValue(cacheRoot);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(cacheRoot, { force: true, recursive: true });
+  });
+
+  it('hands a refreshed default CLI status to the immediate launch preflight', async () => {
+    let detectedStatus: BinaryStatus = { available: false };
+    const detectSpec = vi.fn(async () => detectedStatus);
+    const manager = new BinaryManager({} as App);
+    manager.register({ detect: detectSpec, name: 'codex' }, 'cli-agents');
+
+    // Seed the same stale negative entry that a launch would otherwise reuse.
+    await expect(manager.detect('codex')).resolves.toMatchObject({ available: false });
+
+    detectedStatus = {
+      available: true,
+      path: '/Users/test/.local/bin/codex',
+      version: '1.2.3',
+    };
+    const controller = new BinaryCtr({ binaryManager: manager } as App);
+
+    await expect(
+      controller.detectHeterogeneousAgentCommand({ agentType: 'codex', command: 'codex' }),
+    ).resolves.toMatchObject(detectedStatus);
+
+    // HeterogeneousAgent launch calls this non-forced path. It must receive the
+    // rescan result without probing again or falling back to the stale entry.
+    await expect(manager.detect('codex')).resolves.toMatchObject(detectedStatus);
+    expect(detectSpec).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -2347,7 +2347,7 @@ describe('HeterogeneousAgentCtr', () => {
         ctr.sendPrompt({ operationId: 'op-test', prompt: 'hello', sessionId }),
       ).rejects.toThrow('Codex CLI was not found');
 
-      expect(detect).toHaveBeenCalledWith('codex', true);
+      expect(detect).toHaveBeenCalledWith('codex');
       expect(spawnCalls).toHaveLength(0);
     });
 
@@ -2535,7 +2535,7 @@ describe('HeterogeneousAgentCtr', () => {
       ).rejects.toThrow('Codex CLI was not found');
 
       expect(statSync).toHaveBeenCalledWith(FAKE_DESKTOP_PATH, expect.anything());
-      expect(detect).toHaveBeenCalledWith('codex', true);
+      expect(detect).toHaveBeenCalledWith('codex');
     });
 
     it('reports a missing working directory instead of claiming the Codex CLI is missing', async () => {
@@ -2580,7 +2580,7 @@ describe('HeterogeneousAgentCtr', () => {
         ctr.sendPrompt({ operationId: 'op-test', prompt: 'hello', sessionId }),
       ).rejects.toThrow('Claude Code CLI was not found');
 
-      expect(detect).toHaveBeenCalledWith('claude', true);
+      expect(detect).toHaveBeenCalledWith('claude');
       expect(spawnCalls).toHaveLength(0);
     });
 
@@ -2600,7 +2600,7 @@ describe('HeterogeneousAgentCtr', () => {
         ctr.sendPrompt({ operationId: 'op-test', prompt: 'hello', sessionId }),
       ).rejects.toThrow('CodeBuddy CLI was not found');
 
-      expect(detect).toHaveBeenCalledWith('codebuddy', true);
+      expect(detect).toHaveBeenCalledWith('codebuddy');
       expect(spawnCalls).toHaveLength(0);
     });
 
@@ -2617,7 +2617,7 @@ describe('HeterogeneousAgentCtr', () => {
         ctr.sendPrompt({ operationId: 'op-test', prompt: 'hello', sessionId }),
       ).rejects.toThrow('Amp CLI was not found');
 
-      expect(detect).toHaveBeenCalledWith('amp', true);
+      expect(detect).toHaveBeenCalledWith('amp');
       expect(spawnCalls).toHaveLength(0);
     });
 
@@ -2637,7 +2637,7 @@ describe('HeterogeneousAgentCtr', () => {
         ctr.sendPrompt({ operationId: 'op-test', prompt: 'hello', sessionId }),
       ).rejects.toThrow('OpenCode CLI was not found');
 
-      expect(detect).toHaveBeenCalledWith('opencode', true);
+      expect(detect).toHaveBeenCalledWith('opencode');
       expect(spawnCalls).toHaveLength(0);
     });
 


### PR DESCRIPTION
## Summary

- stop forcing binary re-detection before every heterogeneous-agent launch
- reuse the successful CLI and login-shell PATH cache during normal sends and retries
- make explicit default-CLI rescans refresh the same BinaryManager entry consumed by launch preflight
- keep custom-command rescans on the direct detector path

## Root cause

The launch preflight called `BinaryManager.detect(command, true)`. After #18983, `force=true` invalidates the login-shell PATH cache, so every message spawned a fresh interactive login shell. Slow shell startup under load could repeatedly exceed the timeout even though the CLI was installed.

The first revision stopped forcing launch detection, but exposed a cache-coherence gap: Connect Agent rescans bypassed BinaryManager, so launch could immediately reuse an old negative, version, or path. Default-command rescans now force-refresh the manager entry itself.

## Tests

- added a rescan-to-launch regression covering stale negative → install → explicit rescan → immediate cached launch preflight
- 124 focused desktop controller tests passed
- lint clean
