### PR TITLE
♻️ refactor(skeleton): migrate the remaining legacy Skeleton imports to base-ui

### DIFF
--- a/packages/builtin-tools/src/kimiCode/index.tsx
+++ b/packages/builtin-tools/src/kimiCode/index.tsx
@@ -15,7 +15,8 @@ import {
   shinyTextStyles,
 } from '@lobechat/shared-tool-ui/styles';
 import type { BuiltinInspector, BuiltinInspectorProps, BuiltinRenderProps } from '@lobechat/types';
-import { CodeDiff, Highlighter, Markdown, Skeleton } from '@lobehub/ui';
+import { CodeDiff, Highlighter, Markdown } from '@lobehub/ui';
+import { Skeleton } from '@lobehub/ui/base-ui';
 import { cx } from 'antd-style';
 import path from 'path-browserify-esm';
 import { memo, useMemo } from 'react';
@@ -184,7 +185,7 @@ const ReadRender = memo<BuiltinRenderProps<KimiFileArgs>>(({ args, content }) =>
 ReadRender.displayName = 'KimiCodeReadRender';
 
 const WriteRender = memo<BuiltinRenderProps<KimiFileArgs>>(({ args }) => {
-  if (!args) return <Skeleton active />;
+  if (!args) return <Skeleton.Text rows={4} />;
   if (!args.content) return null;
 
   const extension = path
@@ -214,7 +215,7 @@ const WriteRender = memo<BuiltinRenderProps<KimiFileArgs>>(({ args }) => {
 WriteRender.displayName = 'KimiCodeWriteRender';
 
 const EditRender = memo<BuiltinRenderProps<KimiEditArgs>>(({ args }) => {
-  if (!args) return <Skeleton active />;
+  if (!args) return <Skeleton.Text rows={4} />;
 
   const filePath = args.path ?? '';
   return (

--- a/src/features/PageEditor/DocumentLikes/index.tsx
+++ b/src/features/PageEditor/DocumentLikes/index.tsx
@@ -2,8 +2,8 @@
 
 import type { DocumentLikeSummary } from '@lobechat/types';
 import { useAnalytics } from '@lobehub/analytics/react';
-import { Flexbox, Skeleton } from '@lobehub/ui';
-import { Avatar, Text, toast, Tooltip } from '@lobehub/ui/base-ui';
+import { Flexbox } from '@lobehub/ui';
+import { Avatar, Skeleton, Text, toast, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ThumbsUp } from 'lucide-react';
 import { memo, useCallback, useRef } from 'react';
@@ -230,8 +230,8 @@ const DocumentLikes = memo<{ documentId: string }>(({ documentId }) => {
   if (isLoading && !data)
     return (
       <Flexbox data-document-likes align={'center'} className={styles.section} gap={16}>
-        <Skeleton.Avatar active shape={'circle'} size={BUTTON_SIZE} />
-        <Skeleton.Button active style={{ height: 20, width: 200 }} />
+        <Skeleton.Avatar shape={'circle'} size={BUTTON_SIZE} />
+        <Skeleton height={20} width={200} />
       </Flexbox>
     );
 

--- a/src/features/Settings/appearance/features/Font/index.tsx
+++ b/src/features/Settings/appearance/features/Font/index.tsx
@@ -2,8 +2,8 @@
 
 import { isDesktop } from '@lobechat/const';
 import type { FormGroupItemType } from '@lobehub/ui';
-import { Form, Skeleton } from '@lobehub/ui';
-import { Select } from '@lobehub/ui/base-ui';
+import { Form } from '@lobehub/ui';
+import { Select, Skeleton } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -50,7 +50,7 @@ const FontSettings = memo(() => {
     value: monospaceFontFamily,
   });
 
-  if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
+  if (!isUserStateInit) return <Skeleton.Text rows={5} />;
 
   const font: FormGroupItemType = {
     children: [

--- a/src/routes/(main)/eval/bench/[benchmarkId]/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { Card, Skeleton } from 'antd';
+import { Skeleton } from '@lobehub/ui/base-ui';
+import { Card } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   Activity,
@@ -117,10 +118,14 @@ const BenchmarkDetail = memo(() => {
         {/* Header skeleton */}
         <Flexbox gap={16}>
           <Flexbox horizontal align="start" gap={12}>
-            <Skeleton.Avatar  shape="square" size={40} style={{ borderRadius: cssVar.borderRadiusLG }} />
+            <Skeleton.Avatar
+              shape="square"
+              size={40}
+              style={{ borderRadius: cssVar.borderRadiusLG }}
+            />
             <Flexbox flex={1} gap={8}>
-              <Skeleton.Input  style={{ height: 24, width: 200 }} />
-              <Skeleton.Input  size="small" style={{ height: 14, width: 320 }} />
+              <Skeleton height={24} width={200} />
+              <Skeleton height={14} width={320} />
             </Flexbox>
           </Flexbox>
         </Flexbox>
@@ -140,14 +145,16 @@ const BenchmarkDetail = memo(() => {
             >
               <Flexbox gap={12}>
                 <Flexbox horizontal align="center" gap={8}>
-                  <Skeleton.Avatar  shape="square"
-                  size={36}
-                  style={{ borderRadius: cssVar.borderRadius }} />
-                  <Skeleton.Input  size="small" style={{ height: 14, width: 80 }} />
+                  <Skeleton.Avatar
+                    shape="square"
+                    size={36}
+                    style={{ borderRadius: cssVar.borderRadius }}
+                  />
+                  <Skeleton height={14} width={80} />
                 </Flexbox>
                 <Flexbox gap={4}>
-                  <Skeleton.Input  style={{ height: 24, width: 60 }} />
-                  <Skeleton.Input  size="small" style={{ height: 12, width: 100 }} />
+                  <Skeleton height={24} width={60} />
+                  <Skeleton height={12} width={100} />
                 </Flexbox>
               </Flexbox>
             </Card>
@@ -155,10 +162,10 @@ const BenchmarkDetail = memo(() => {
         </Flexbox>
 
         {/* Section skeletons */}
-        <Skeleton.Input  style={{ height: 16, width: 80 }} />
-        <Skeleton.Input  style={{ height: 64, width: '100%' }} />
-        <Skeleton.Input  style={{ height: 16, width: 80 }} />
-        <Skeleton.Input  style={{ height: 64, width: '100%' }} />
+        <Skeleton height={16} width={80} />
+        <Skeleton height={64} width={'100%'} />
+        <Skeleton height={16} width={80} />
+        <Skeleton height={64} width={'100%'} />
       </Flexbox>
     );
 


### PR DESCRIPTION
Follow-up to #18953. Four call sites still imported the legacy Skeleton from the `@lobehub/ui` root entry or from `antd`; `@lobehub/ui` is adding those names to its eslint restricted-imports ban, so these would turn lint red on the next bump.

- `src/routes/(main)/eval/bench/[benchmarkId]/index.tsx`: antd `Skeleton.Input` / `Skeleton.Avatar` → base-ui `Skeleton` / `Skeleton.Avatar`
- `src/features/PageEditor/DocumentLikes/index.tsx`: `Skeleton.Button` → `Skeleton`
- `src/features/Settings/appearance/features/Font/index.tsx`: `paragraph={{ rows: 5 }}` → `Skeleton.Text rows={5}`
- `packages/builtin-tools/src/kimiCode/index.tsx`: bare `<Skeleton active />` → `Skeleton.Text rows={4}`, same as the other builtin tools

After this, canary has no remaining root-entry or antd Skeleton imports.

https://claude.ai/code/session_01Xzf2rySBQFVuGUHMmTupMg
