### PR TITLE
✨ feat: add Gemini 3.8 Flash and fix React artifact preview

### DIFF
--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -836,6 +836,7 @@
   "lobehub.gemini-3.5-flash.description": "Gemini's most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
   "lobehub.gemini-3.6-flash.description": "Gemini 3.6 Flash balances speed with intelligence for strong agentic, coding, and multimodal performance with improved token efficiency.",
   "lobehub.gemini-3.7-flash.description": "Gemini 3.7 Flash is Google's most capable Flash model, built for complex coding, agentic workflows, and reliable multi-step execution.",
+  "lobehub.gemini-3.8-flash.description": "Google's most intelligent Flash model, tuned for long-horizon coding and autonomous agents — faster first token and less verbose than 3.7 Flash at the same price.",
   "lobehub.glm-5.1.description": "Zai's latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. Excels at long-horizon tasks with autonomous work up to 8 hours, an ideal foundation for Autonomous Agents and long-horizon Coding Agents.",
   "lobehub.glm-5.2.description": "GLM-5.2 is the first open-source model to approach the performance of the latest-generation Claude Opus released in the same period.",
   "lobehub.glm-5.3-flash.description": "The first GLM-5 that can see — stronger than GLM-5.2, coding that approaches Opus 4.8, at about one-tenth the flagship price.",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -836,6 +836,7 @@
   "lobehub.gemini-3.5-flash.description": "Gemini 的最智能模型，专为速度而设计，结合前沿智能与卓越的搜索和基础能力。",
   "lobehub.gemini-3.6-flash.description": "Gemini 3.6 Flash 在速度与智能之间实现平衡，适用于强大的智能代理、编码和多模态性能，并提高了令牌效率。",
   "lobehub.gemini-3.7-flash.description": "Gemini 3.7 Flash 是 Google 最强的 Flash 模型，面向复杂编程、智能体工作流和可靠的多步执行。",
+  "lobehub.gemini-3.8-flash.description": "Google 最聪明的 Flash 模型，专为长程编程和自主智能体调优——首字更快、输出更精简，价格与 3.7 Flash 持平。",
   "lobehub.glm-5.1.description": "Zai 的最新旗舰模型，在整体和编码能力上与 Claude Opus 4.6 对齐。擅长长时间任务，支持长达 8 小时的自主工作，是自主代理和长时间编码代理的理想基础。",
   "lobehub.glm-5.2.description": "GLM-5.2 是首个接近同期发布的最新一代 Claude Opus 性能的开源模型。",
   "lobehub.glm-5.3-flash.description": "GLM-5 系列第一款能看图的模型。比 GLM-5.2 更强，编码逼近 Opus 4.8，价格却只有旗舰的十分之一。",

--- a/packages/artifact-template/src/index.ts
+++ b/packages/artifact-template/src/index.ts
@@ -90,9 +90,15 @@ export const REACT_ARTIFACT_DEFAULT_DEPENDENCIES: Record<string, string> = {
 export const REACT_ARTIFACT_DEFAULT_DEV_DEPENDENCIES: Record<string, string> = {
   '@types/react': 'latest',
   '@types/react-dom': 'latest',
-  '@vitejs/plugin-react': 'latest',
+  // The preview runs inside Sandpack's Nodebox, which emulates Node 16 and cannot load
+  // native bindings. Vite 5+ requires Node 18/20+ and Vite 8 bundles rolldown (native),
+  // so `latest` breaks the sandbox ("Cannot find native binding", "Vite requires Node.js
+  // 20.19+"). Mirror the pins of Sandpack's own `vite-react-ts` template: Vite 4 plus
+  // `esbuild-wasm`, which Nodebox substitutes for the native esbuild binary.
+  '@vitejs/plugin-react': '^4.3.4',
+  'esbuild-wasm': '^0.17.12',
   'typescript': 'latest',
-  'vite': 'latest',
+  'vite': '4.2.0',
 };
 
 export const REACT_ARTIFACT_TAILWIND_CDN = 'https://cdn.tailwindcss.com';

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -78,6 +78,8 @@ export const lobeHubOnlineModelDescriptions = {
     'Gemini 3.6 Flash balances speed with intelligence for strong agentic, coding, and multimodal performance with improved token efficiency.',
   'lobehub.gemini-3.7-flash.description':
     "Gemini 3.7 Flash is Google's most capable Flash model, built for complex coding, agentic workflows, and reliable multi-step execution.",
+  'lobehub.gemini-3.8-flash.description':
+    "Google's most intelligent Flash model, tuned for long-horizon coding and autonomous agents — faster first token and less verbose than 3.7 Flash at the same price.",
   'lobehub.glm-5.1.description':
     "Zai's latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. Excels at long-horizon tasks with autonomous work up to 8 hours, an ideal foundation for Autonomous Agents and long-horizon Coding Agents.",
   'lobehub.glm-5.2.description':

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -64,6 +64,26 @@ describe('applyModelExtendParams', () => {
     expect(result.thinkingLevel).toBe('medium');
   });
 
+  it('defaults Gemini 3.8 Flash thinkingLevel to medium (thinkingLevel3)', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({}),
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      model: 'gemini-3.8-flash',
+    });
+
+    expect(result.thinkingLevel).toBe('medium');
+  });
+
+  it('honors an explicit Gemini 3.8 Flash thinkingLevel3 value', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ thinkingLevel3: 'low' }),
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      model: 'gemini-3.8-flash',
+    });
+
+    expect(result.thinkingLevel).toBe('low');
+  });
+
   it('honors an explicit Gemini 3.7 Flash thinkingLevel3 value', () => {
     const result = applyModelExtendParams({
       chatConfig: chatConfig({ thinkingLevel3: 'high' }),
@@ -402,6 +422,10 @@ describe('resolveDefaultThinkingLevelForModel', () => {
     );
     expect(resolveDefaultThinkingLevelForModel('gemini-3.7-flash')).toBe('medium');
     expect(resolveDefaultThinkingLevelForModel('gemini-3.7-flash', 'thinkingLevel3')).toBe(
+      'medium',
+    );
+    expect(resolveDefaultThinkingLevelForModel('gemini-3.8-flash')).toBe('medium');
+    expect(resolveDefaultThinkingLevelForModel('gemini-3.8-flash', 'thinkingLevel3')).toBe(
       'medium',
     );
     expect(resolveDefaultThinkingLevelForModel('gemini-flash-lite-latest')).toBe('minimal');

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -110,6 +110,10 @@ const MODEL_THINKING_LEVEL_DEFAULTS: Partial<
     thinkingLevel: 'medium',
     thinkingLevel3: 'medium',
   },
+  'gemini-3.8-flash': {
+    thinkingLevel: 'medium',
+    thinkingLevel3: 'medium',
+  },
   'gemini-3.5-flash': {
     thinkingLevel: 'medium',
   },


### PR DESCRIPTION
Adds runtime coverage + locale descriptions for Gemini 3.8 Flash (released 2026-09-02), and fixes the React artifact preview, which currently fails to boot in Sandpack.

#### Gemini 3.8 Flash

- `modelExtendParams.ts`: default `thinkingLevel3` to `medium` for `gemini-3.8-flash`, matching Google's API default. The model only accepts `low` / `medium` / `high` (`minimal` returns an error), same as 3.7 Flash, so it reuses the `thinkingLevel3` slider.
- Locale: add `lobehub.gemini-3.8-flash.description` (en-US + hand-written zh-CN).
- No Google runtime change needed: sampling-param stripping and assistant-prefill removal are already version-gated (`>= 3.6`).

#### React artifact preview fix

`packages/artifact-template` used `vite: 'latest'`, so the sandbox resolved to Vite 8, which bundles rolldown (native binding) and fails with `Cannot find native binding ... Unsupported architecture on Linux: x32`. Vite 5–7 also fail because Sandpack's Nodebox emulates Node 16 (`Vite requires Node.js 20.19+`) and needs `esbuild-wasm` instead of native esbuild.

Pinned to the same set Sandpack's own `vite-react-ts` template uses: `vite 4.2.0` + `@vitejs/plugin-react ^4.3.4` + `esbuild-wasm ^0.17.12`. The template is also used by the site-publishing build (real Node), where Vite 4 works fine and the extra `esbuild-wasm` devDependency is harmless.

| Before | After |
| ------ | ----- |
| Preview stuck at `[3/3] Running "vite"` with native-binding error | React + shadcn + lucide artifact renders and is interactive |

#### Test

- [x] Tested locally — Gemini 3.8 Flash chat/billing verified; React artifact (shadcn + lucide hello world) renders in Sandpack
- [x] Added/updated tests — `modelExtendParams.test.ts`

#### 🔗 Related Issue

- Gemini 3.8 Flash docs: https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
- Pricing: https://ai.google.dev/gemini-api/docs/pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)