### PR TITLE
🐛 fix(vite): forward memberless @lobehub/ui barrel imports as a namespace

### DIFF
--- a/plugins/vite/lobeUiImports.test.ts
+++ b/plugins/vite/lobeUiImports.test.ts
@@ -14,6 +14,8 @@ const fixturePlugin: Plugin = {
       import { ConfigProvider, ErrorBoundary, Flexbox } from '@lobehub/ui';
       import { Button } from '@lobehub/ui/base-ui';
       export { ConfigProvider, ErrorBoundary, Flexbox, Button };
+      export * from '@lobehub/ui/brand';
+      export const loadToast = () => import('@lobehub/ui/base-ui');
     `;
   },
   resolveId(id) {
@@ -73,5 +75,7 @@ describe('lobeUiImports', () => {
     expect(code).not.toMatch(/from ["']react-error-boundary["']/);
     expect(code).not.toMatch(/from ["']@lobehub\/ui["']/);
     expect(code).not.toMatch(/from ["']@lobehub\/ui\/base-ui["']/);
+    expect(code).toContain('@lobehub/ui/es/brand/index');
+    expect(code).toContain('@lobehub/ui/es/base-ui/index');
   });
 });

--- a/plugins/vite/lobeUiImports.ts
+++ b/plugins/vite/lobeUiImports.ts
@@ -73,9 +73,13 @@ const namedExportProxy = (maps: Record<string, Barrel>): Plugin => ({
     if (!id.startsWith(RESOLVED_NAMED_EXPORT_PREFIX)) return;
 
     const [barrel, member] = id.slice(RESOLVED_NAMED_EXPORT_PREFIX.length).split(':');
+    const barrelIndex = `@lobehub/ui/es/${barrel ? `${barrel}/` : ''}index`;
+    // transform-imports rewrites `import()`, `export *` and side-effect imports
+    // with an empty member, so there is no single export to forward.
+    if (!member) return `export * from '${barrelIndex}';`;
+
     const entry = maps[barrel]?.members[member];
-    if (!entry)
-      return `export { ${member} as default } from '@lobehub/ui/es/${barrel ? `${barrel}/` : ''}index';`;
+    if (!entry) return `export { ${member} as default } from '${barrelIndex}';`;
 
     // Bare specifiers such as react-error-boundary are dependencies of
     // @lobehub/ui, not of the app, so they only resolve from the barrel's own


### PR DESCRIPTION
`@rolldown/plugin-transform-imports` rewrites `import('@lobehub/ui/base-ui')`, `export * from '@lobehub/ui'` and side-effect `import '@lobehub/ui'` with an **empty member**, so `lobeUiImports` received `virtual:lobe-ui-named:base-ui:` and emitted `export {  as default } from …`, which rolldown rejects:

```
[PARSE_ERROR] Expected `,` or `}` but found `default`
╭─[ \0virtual:lobe-ui-named:base-ui::1:14 ]
1 │ export {  as default } from '@lobehub/ui/es/base-ui/index';
```

Canary was unaffected only because its barrel dynamic imports live in `*.test.ts`; Cloud hit it on the first `await import('@lobehub/ui/base-ui')` in bundled code (lobehub-biz/lobehub-cloud#1588 worked around it with a static import).

Fix: when the member is empty, forward the whole barrel as a namespace (`export * from '@lobehub/ui/es/<barrel>/index'`). Static named imports keep the deep-import path, so the first-screen closure from #19033 is unchanged.

#### Test

- [x] Tested locally: `bunx vitest run plugins/vite/lobeUiImports.test.ts`
- [x] Added/updated tests: fixture now includes `export * from '@lobehub/ui/brand'` and `import('@lobehub/ui/base-ui')`; the build failed with the PARSE_ERROR above before the fix and passes after

#### 🔗 Related Issue

Fixes LOBE-13759
Related to #19033

https://claude.ai/code/session_013sk2z4PpPbcLRMASm3DST3
