### PR TITLE
🐛 fix(goal): stop re-dispatching a delivered Work while verification is judging

### DIFF
--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -31,6 +31,7 @@ import { TaskService } from '../task';
 import { TaskRunnerService } from '../taskRunner';
 import { GoalCriteriaGeneratorService } from './criteriaGenerator';
 import { GoalService } from './index';
+import { VERIFY_SETTLE_GRACE_MS } from './recoveryPolicy';
 import type { GoalTickObservation } from './traceObservation';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -141,6 +142,120 @@ describe('GoalService', () => {
     expect(released.outcome).toBe('advanced');
     expect((await taskModel.findById(created.taskId!))?.status).toBe('backlog');
     runSpy.mockRestore();
+  });
+
+  it('does not re-dispatch a delivered Work while verification is still judging', async () => {
+    // A verify-bound Work keeps its task `running` with a completed topic until
+    // the verify run settles, and that judgment routinely outlives the
+    // operation lease. Treating the window as a dead claim released the task
+    // back to backlog, and the next advance paid for a ghost attempt that the
+    // verify settle path then canceled.
+    const runSpy = vi.spyOn(TaskRunnerService.prototype, 'runTask').mockResolvedValue({} as never);
+    const service = new GoalService(serverDB, userId);
+    const taskModel = new TaskModel(serverDB, userId);
+    const graph = await service.create({
+      config: { recovery: { operationLeaseTimeoutMs: 60_000 } },
+      title: 'Deliveries wait for verification',
+      work: ['Deliver and wait'],
+    });
+    const created = await service.tick(graph.goal.id);
+    await serverDB.insert(taskTopics).values({
+      operationId: 'op-delivered',
+      seq: 1,
+      status: 'completed',
+      taskId: created.taskId!,
+      userId,
+    });
+    await taskModel.updateStatus(created.taskId!, 'running');
+    await serverDB
+      .update(tasks)
+      .set({ updatedAt: new Date(Date.now() - 10 * 60 * 1000) })
+      .where(eq(tasks.id, created.taskId!));
+
+    const waiting = await service.tick(graph.goal.id);
+
+    expect(waiting).toMatchObject({
+      message: expect.stringContaining('waiting for verification'),
+      outcome: 'waiting_external',
+      taskId: created.taskId,
+    });
+    expect((await taskModel.findById(created.taskId!))?.status).toBe('running');
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it('reclaims a delivered Work once the verification grace window lapses', async () => {
+    // The hold-off above cannot be unconditional: a verify run that died
+    // silently would otherwise strand the goal forever, which is exactly the
+    // failure mode the sweep exists to break.
+    const service = new GoalService(serverDB, userId);
+    const taskModel = new TaskModel(serverDB, userId);
+    const graph = await service.create({
+      config: { recovery: { operationLeaseTimeoutMs: 60_000 } },
+      title: 'Dead verification is reclaimed',
+      work: ['Deliver into silence'],
+    });
+    const created = await service.tick(graph.goal.id);
+    await serverDB.insert(taskTopics).values({
+      createdAt: new Date(Date.now() - VERIFY_SETTLE_GRACE_MS - 60_000),
+      operationId: 'op-delivered-stale',
+      seq: 1,
+      status: 'completed',
+      taskId: created.taskId!,
+      userId,
+    });
+    await taskModel.updateStatus(created.taskId!, 'running');
+    await serverDB
+      .update(tasks)
+      .set({ updatedAt: new Date(Date.now() - 10 * 60 * 1000) })
+      .where(eq(tasks.id, created.taskId!));
+
+    const released = await service.tick(graph.goal.id);
+
+    expect(released.outcome).toBe('advanced');
+    expect((await taskModel.findById(created.taskId!))?.status).toBe('backlog');
+  });
+
+  it('synthesizes the finding from the delivered topic, not a canceled retry', async () => {
+    // When verification accepts a delivery, the settle path cancels the ghost
+    // retry it superseded — leaving the canceled, handoff-less topic as the
+    // newest row. Reading blindly by seq produced findings titled
+    // "Completed: <work>" with no description.
+    const service = new GoalService(serverDB, userId);
+    const taskModel = new TaskModel(serverDB, userId);
+    const graph = await service.create({ title: 'Consume the delivery', work: ['Deliver me'] });
+    const created = await service.tick(graph.goal.id);
+    await serverDB.insert(taskTopics).values([
+      {
+        handoff: {
+          content: 'Delivered content with the full run summary.',
+          summary: 'Delivered summary',
+          title: 'Delivered title',
+        },
+        operationId: 'op-delivered',
+        seq: 1,
+        status: 'completed',
+        taskId: created.taskId!,
+        userId,
+      },
+      {
+        operationId: 'op-ghost-retry',
+        seq: 2,
+        status: 'canceled',
+        taskId: created.taskId!,
+        userId,
+      },
+    ]);
+    await taskModel.updateStatus(created.taskId!, 'completed');
+
+    await service.tick(graph.goal.id);
+
+    const finding = (await service.graph(graph.goal.id)).nodes.find(
+      (node) => node.kind === 'finding',
+    );
+    expect(finding).toMatchObject({
+      description: 'Delivered content with the full run summary.',
+      title: 'Delivered title',
+    });
   });
 
   it('leaves a fresh dispatch claim alone', async () => {

--- a/apps/server/src/services/goal/index.ts
+++ b/apps/server/src/services/goal/index.ts
@@ -42,6 +42,7 @@ import {
   resolveMaxConcurrentTasks,
   resolveOperationLeaseTimeout,
   resolveTaskMaxSteps,
+  VERIFY_SETTLE_GRACE_MS,
 } from './recoveryPolicy';
 import { TaskRecoveryCoordinator } from './taskRecoveryCoordinator';
 import {
@@ -972,6 +973,29 @@ export class GoalService {
     const staleBefore = new Date(Date.now() - resolveOperationLeaseTimeout(graph.goal));
 
     if (!operationId || !topicId) {
+      // No running topic covers two very different shapes. A verify-bound Work
+      // that delivered keeps its task `running` with a *completed* topic until
+      // the verify run settles, and that judgment — a full agent run — outlives
+      // the operation lease routinely. Re-dispatching there pays for a duplicate
+      // attempt the verify settle path will cancel, and the canceled retry then
+      // becomes the newest topic and shadows the delivered one. Hold off while
+      // the delivery is fresh; past the grace window, fall through to the
+      // release below so a verify run that died silently cannot strand the
+      // goal forever.
+      const [lastTopic] = await this.taskTopicModel.findWithHandoff(task.id, 1);
+      if (lastTopic?.status === 'completed') {
+        const deliveredAt = lastTopic.completedAt ?? lastTopic.createdAt;
+        if (new Date(deliveredAt).getTime() >= Date.now() - VERIFY_SETTLE_GRACE_MS) {
+          return {
+            goalId: graph.goal.id,
+            message: `Task ${task.identifier} delivered; waiting for verification to settle`,
+            nodeId,
+            outcome: 'waiting_external',
+            taskId: task.id,
+          };
+        }
+      }
+
       // A task claimed for dispatch but with no run behind it. Normally this is
       // the sliver between the claim and `runTask` creating the topic; if the
       // worker died in there it is permanent, and every later advance would
@@ -1214,7 +1238,16 @@ export class GoalService {
     const existingFinding = graph.edges.some(
       (edge) => edge.sourceNodeId === nodeId && edge.kind === 'produces',
     );
-    const [latest] = await this.taskTopicModel.findWithHandoff(taskId, 1);
+    // The newest row by seq can be a retry that was canceled when verification
+    // accepted an earlier delivery — the settle path cancels the in-flight
+    // attempt it superseded. The finding must be synthesized from the run that
+    // actually delivered, so prefer the newest completed topic (with a handoff
+    // when one exists) over whatever happens to be last.
+    const recent = await this.taskTopicModel.findWithHandoff(taskId, 10);
+    const latest =
+      recent.find((topic) => topic.status === 'completed' && topic.handoff) ??
+      recent.find((topic) => topic.status === 'completed') ??
+      recent[0];
     const completedWork = await this.workModel.registerTask({
       changeType: 'updated',
       rootOperationId: latest?.operationId,

--- a/apps/server/src/services/goal/recoveryPolicy.ts
+++ b/apps/server/src/services/goal/recoveryPolicy.ts
@@ -14,6 +14,15 @@ const DEFAULT_OPERATION_LEASE_TIMEOUT_MS = 5 * 60 * 1000;
 // so a transient missed write cannot reclaim a healthy operation.
 export const MIN_OPERATION_LEASE_TIMEOUT_MS = 3 * 60 * 1000;
 
+/**
+ * How long a delivered Work may sit with verification pending before the
+ * coordinator treats the delivery as abandoned and re-dispatches. The verify
+ * judge is a full agent run — tens of minutes on a large delivery — so this
+ * sits far above the operation lease, which is scaled to heartbeat gaps, not
+ * judgments.
+ */
+export const VERIFY_SETTLE_GRACE_MS = 60 * 60 * 1000;
+
 /** How many attempts one Work gets before the coordinator opens a decision gate. */
 export const resolveTaskAttemptBudget = (goal: GoalItem): number => {
   const configured = goal.config?.recovery?.maxAttemptsPerTask;


### PR DESCRIPTION
A verify-bound Work keeps its task `running` with a *completed* topic until the verify run settles — and that judgment is a full agent run that routinely outlives the 5-minute operation lease. The coordinator's recovery path read this window as a dead dispatch claim (no running topic → "worker died before the run existed"), released the task back to backlog, and the next advance dispatched a ghost retry that the verify settle path then canceled.

Observed on a real goal (`goal_wnVHLXCgE9Dt`, 5 Works, fully autonomous run): 3 of 5 Works hit the window. Chain of consequences:

- **Findings lost their content.** `consumeCompletedTask` reads the newest topic by `seq`; after the ghost retry that is the *canceled, handoff-less* topic, so findings came out titled `Completed: <work>` with `description: null` while the real delivery summary sat one row below. The work-version `rootOperationId` also pointed at the canceled op.
- **Acceptances stuck at `planned`.** Each ghost retry instantiated a verification round that never runs, so the acceptance never left `planned` even though round 1 had passed.
- A duplicate dispatch was paid for and then canceled.

#### Fix

- `recoverAbandonedTask`: when there is no running topic, check the latest topic first. If it is `completed` and fresher than `VERIFY_SETTLE_GRACE_MS` (1h), report `waiting_external` ("delivered; waiting for verification to settle") and touch nothing. Past the grace window it falls through to the existing release path, so a verify run that dies silently still cannot strand the goal — the sweep safety net keeps its teeth.
- `consumeCompletedTask`: synthesize the finding from the newest **completed** topic (preferring one with a handoff) instead of the newest row by seq, so a canceled trailing retry can no longer shadow the delivery.

#### Test

- [x] Tested locally
- [x] Added/updated tests

3 regression tests in `apps/server/src/services/goal/index.test.ts`:

1. delivered Work inside the grace window → `waiting_external`, task stays `running`, no dispatch
2. delivered Work past the grace window → released to backlog (the safety net still fires)
3. finding synthesis picks the completed topic's handoff over a newer canceled retry

Reverting the `index.ts` changes reproduces the production symptom exactly (`Completed: <work>` + null description). `bun run check` on the touched files: lint clean, 42 tests passed; full type-check clean.

#### 🔗 Related Issue

Related to LOBE-13597 (surfaced while auditing the goal run described there; this defect is outside the four gaps and prerequisite to relying on findings as graph content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)