### PR TITLE
✨ feat(sandbox): let auto mode offer the cloud sandbox alongside a routed device

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/__tests__/serverCallLlmTooling.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/__tests__/serverCallLlmTooling.test.ts
@@ -1,0 +1,41 @@
+import type { AgentState } from '@lobechat/agent-runtime';
+import { describe, expect, it } from 'vitest';
+
+import { resolveServerCallLlmTooling } from '../serverCallLlmTooling';
+
+const buildState = (metadata?: AgentState['metadata']): AgentState => ({ metadata }) as AgentState;
+
+describe('resolveServerCallLlmTooling', () => {
+  // Regression: `serverCallLlmContextBuilder` needs this to compute
+  // `creds_sandbox_reachable` — `sandbox_enabled` alone (whether the
+  // dedicated Cloud Sandbox tool is offered) doesn't tell it whether
+  // `runCommand`/`execScript` will actually land in that sandbox or on a
+  // routed device, so it must read the same single-track device gate the
+  // rest of the run executors use.
+  it('exposes the active device id when a device is routed for this run', () => {
+    const result = resolveServerCallLlmTooling(
+      { operationId: 'op-1', stepIndex: 0 },
+      buildState({
+        activeDeviceId: 'device-1',
+        executionPlan: { deviceId: 'device-1', kind: 'device' },
+      } as AgentState['metadata']),
+    );
+
+    expect(result.activeDeviceId).toBe('device-1');
+  });
+
+  it('leaves the active device id undefined when no device is routed', () => {
+    const result = resolveServerCallLlmTooling(
+      { operationId: 'op-1', stepIndex: 0 },
+      buildState({ executionPlan: { kind: 'sandbox' } } as AgentState['metadata']),
+    );
+
+    expect(result.activeDeviceId).toBeUndefined();
+  });
+
+  it('leaves the active device id undefined with no metadata at all', () => {
+    const result = resolveServerCallLlmTooling({ operationId: 'op-1', stepIndex: 0 }, buildState());
+
+    expect(result.activeDeviceId).toBeUndefined();
+  });
+});

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -87,7 +87,8 @@ export const buildServerCallLlmContext = async ({
   }
 
   const { operationId, stepIndex } = ctx;
-  const { resolved, resolvedSkills, toolDiscoveryConfig, activeDeviceId } = tooling;
+  const { resolved, resolvedSkills, toolDiscoveryConfig, activeDeviceId, executionTarget } =
+    tooling;
   const contextHints = await resolveServerCallLlmContextHints({
     ctx,
     llmPayload,
@@ -261,16 +262,18 @@ export const buildServerCallLlmContext = async ({
   }
 
   const sandboxEnabled = String(resolved.enabledToolIds.includes('lobe-cloud-sandbox'));
-  // `sandbox_enabled` only tracks whether the dedicated Cloud Sandbox tool is
-  // offered (execution target resolved to exactly 'sandbox'). It's not what
-  // determines whether a credential injected via `injectCredsToSandbox` will
-  // actually be reachable: `lobe-skills`' `runCommand`/`execScript` silently
-  // fall back to that same cloud sandbox session whenever no device is
-  // actively routed for this run (see `skillsRuntime`), independent of
-  // `sandbox_enabled` — e.g. the common no-device web/agent session, or an
-  // `auto` target that didn't end up routing to an online device. Give the
-  // creds tool its own, accurate signal instead of reusing this one.
-  const credsSandboxReachable = String(!activeDeviceId);
+  // `sandbox_enabled` tracks whether the dedicated Cloud Sandbox tool is
+  // offered — true for target 'sandbox', and (so the model can choose sandbox
+  // vs. an auto-routed device per call) for 'auto' too, regardless of whether
+  // a device ended up routed. It's still not the full answer for
+  // `injectCredsToSandbox` reachability: `lobe-skills`' `runCommand`/
+  // `execScript` ALSO silently fall back to that same cloud sandbox session
+  // whenever no device is actively routed, for targets where the dedicated
+  // tool isn't offered at all (e.g. the common no-device 'none' web/agent
+  // session). So a credential is reachable whenever EITHER condition holds:
+  // the dedicated tool is exposed for 'auto' (independent of device routing),
+  // or no device is routed (independent of target).
+  const credsSandboxReachable = String(!activeDeviceId || executionTarget === 'auto');
   let sandboxUploadedFiles = '';
   if (sandboxEnabled === 'true' && ctx.serverDB && ctx.userId && lobehubSkillTopicId) {
     try {

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -87,7 +87,7 @@ export const buildServerCallLlmContext = async ({
   }
 
   const { operationId, stepIndex } = ctx;
-  const { resolved, resolvedSkills, toolDiscoveryConfig } = tooling;
+  const { resolved, resolvedSkills, toolDiscoveryConfig, activeDeviceId } = tooling;
   const contextHints = await resolveServerCallLlmContextHints({
     ctx,
     llmPayload,
@@ -261,6 +261,16 @@ export const buildServerCallLlmContext = async ({
   }
 
   const sandboxEnabled = String(resolved.enabledToolIds.includes('lobe-cloud-sandbox'));
+  // `sandbox_enabled` only tracks whether the dedicated Cloud Sandbox tool is
+  // offered (execution target resolved to exactly 'sandbox'). It's not what
+  // determines whether a credential injected via `injectCredsToSandbox` will
+  // actually be reachable: `lobe-skills`' `runCommand`/`execScript` silently
+  // fall back to that same cloud sandbox session whenever no device is
+  // actively routed for this run (see `skillsRuntime`), independent of
+  // `sandbox_enabled` — e.g. the common no-device web/agent session, or an
+  // `auto` target that didn't end up routing to an online device. Give the
+  // creds tool its own, accurate signal instead of reusing this one.
+  const credsSandboxReachable = String(!activeDeviceId);
   let sandboxUploadedFiles = '';
   if (sandboxEnabled === 'true' && ctx.serverDB && ctx.userId && lobehubSkillTopicId) {
     try {
@@ -597,6 +607,7 @@ export const buildServerCallLlmContext = async ({
       ...lobehubSkillVariables,
       COMPOSIO_SERVICES_LIST: composioServicesListStr,
       CREDS_LIST: credsListStr,
+      creds_sandbox_reachable: credsSandboxReachable,
       language: serverLanguage,
       // Only override the generator's 'en-US' locale fallback when the user info
       // fetch actually resolved a language — an empty string would render blank.

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmTooling.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmTooling.ts
@@ -12,6 +12,8 @@ import {
   ToolResolver,
 } from '@lobechat/context-engine';
 
+import type { ExecutionPlan } from '@/helpers/executionTarget';
+
 import type { RuntimeExecutorContext } from '../context';
 import { buildToolDiscoveryConfig, log } from '../executorHelpers';
 import { resolveRunActiveDeviceId } from '../executors/resolveRunActiveDeviceId';
@@ -28,6 +30,15 @@ export interface ServerCallLlmTooling {
    * offered.
    */
   activeDeviceId?: string;
+  /**
+   * The run's resolved execution target (`local`/`device`/`sandbox`/`auto`/
+   * `none`), straight from `state.metadata.executionPlan.target`. Exposed
+   * alongside `activeDeviceId` because `'auto'` is the one target where a
+   * device can be routed (`activeDeviceId` set) while the cloud sandbox is
+   * *also* reachable — see `AgentToolsEngine`'s `agentModeRules` gate for
+   * `lobe-cloud-sandbox`, which allows it for `'auto'` regardless of routing.
+   */
+  executionTarget?: ExecutionPlan['target'];
   resolved: ResolvedToolSet;
   resolvedSkills?: ResolvedSkillSet;
   toolDiscoveryConfig?: ToolDiscoveryConfig;
@@ -47,6 +58,7 @@ export const resolveServerCallLlmTooling = (
   // `resolveRunActiveDeviceId` swallows the id whenever the plan/policy
   // forbids devices — the same filter the tool executors apply.
   const activeDeviceId = resolveRunActiveDeviceId(state.metadata);
+  const executionTarget = (state.metadata?.executionPlan as ExecutionPlan | undefined)?.target;
   const operationToolSet: OperationToolSet = state.operationToolSet ?? {
     enabledToolIds: [],
     executorMap: state.toolExecutorMap ?? {},
@@ -95,6 +107,7 @@ export const resolveServerCallLlmTooling = (
 
   return {
     activeDeviceId,
+    executionTarget,
     resolved,
     resolvedSkills,
     toolDiscoveryConfig,

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmTooling.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmTooling.ts
@@ -17,6 +17,17 @@ import { buildToolDiscoveryConfig, log } from '../executorHelpers';
 import { resolveRunActiveDeviceId } from '../executors/resolveRunActiveDeviceId';
 
 export interface ServerCallLlmTooling {
+  /**
+   * The device actually routed for this run, if any (same single-track gate
+   * `buildStepToolDelta` uses below). Exposed so callers building prompt
+   * template variables can tell whether `runCommand`/`execScript` will
+   * execute on a device instead of falling back to the cloud sandbox —
+   * `resolved.enabledToolIds.includes('lobe-cloud-sandbox')` alone doesn't
+   * cover it, since Skills' sandbox fallback applies whenever no device is
+   * routed, independent of whether the dedicated Cloud Sandbox tool is
+   * offered.
+   */
+  activeDeviceId?: string;
   resolved: ResolvedToolSet;
   resolvedSkills?: ResolvedSkillSet;
   toolDiscoveryConfig?: ToolDiscoveryConfig;
@@ -83,6 +94,7 @@ export const resolveServerCallLlmTooling = (
     : undefined;
 
   return {
+    activeDeviceId,
     resolved,
     resolvedSkills,
     toolDiscoveryConfig,

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { GroupAgentBuilderManifest } from '@lobechat/builtin-tool-group-agent-builder';
 import { GroupManagementManifest } from '@lobechat/builtin-tool-group-management';
 import { ImageGenerationManifest } from '@lobechat/builtin-tool-image-generation';
@@ -872,6 +873,104 @@ describe('createServerAgentToolsEngine', () => {
       });
 
       expect(result.enabledToolIds).not.toContain(LocalSystemManifest.identifier);
+    });
+  });
+
+  describe('CloudSandbox tool enable rules', () => {
+    it('should enable CloudSandbox when executionTarget is sandbox', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { agencyConfig: { executionTarget: 'sandbox' } },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(CloudSandboxManifest.identifier);
+    });
+
+    it('should disable CloudSandbox when executionTarget is none', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { agencyConfig: { executionTarget: 'none' } },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(CloudSandboxManifest.identifier);
+    });
+
+    it('should disable CloudSandbox when executionTarget is device (explicit device selection)', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { agencyConfig: { executionTarget: 'device' } },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true, deviceOnline: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(CloudSandboxManifest.identifier);
+    });
+
+    // Regression: auto mode lets the model choose per call whether to run in
+    // the cloud sandbox or on the auto-routed device — `injectCredsToSandbox`
+    // has no device branch and always targets the sandbox regardless of
+    // routing — so CloudSandbox must stay offered even once a device has
+    // been auto-activated, not only while none has.
+    it('should enable CloudSandbox when executionTarget is auto and no device is auto-activated', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { agencyConfig: { executionTarget: 'auto' } },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(CloudSandboxManifest.identifier);
+    });
+
+    it('should still enable CloudSandbox when executionTarget is auto and a device HAS been auto-activated', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { agencyConfig: { executionTarget: 'auto' } },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true, deviceOnline: true, autoActivated: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(CloudSandboxManifest.identifier);
     });
   });
 

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -305,7 +305,12 @@ export const createServerAgentToolsEngine = (
     // Always-on builtin tools
     ...Object.fromEntries(alwaysOnToolIds.map((id) => [id, true])),
     // System-level rules (may override user selection for specific tools)
-    [CloudSandboxManifest.identifier]: runtimeMode === 'cloud',
+    // Auto mode lets the model choose per call whether to run in the cloud
+    // sandbox or on the auto-routed device — `injectCredsToSandbox` has no
+    // device branch and always targets the sandbox regardless of routing —
+    // so the dedicated Cloud Sandbox tool is offered here too, not only when
+    // the target is literally 'sandbox'.
+    [CloudSandboxManifest.identifier]: runtimeMode === 'cloud' || executionTarget === 'auto',
     [KnowledgeBaseManifest.identifier]: hasEnabledKnowledgeBases,
     // Local-system: the user must have opted into local runtime
     // (`runtimeMode === 'local'`) AND have an online, auto-activated device

--- a/apps/server/src/services/aiAgent/pipeline/toolDiscovery.ts
+++ b/apps/server/src/services/aiAgent/pipeline/toolDiscovery.ts
@@ -882,12 +882,16 @@ export const discoverTools = async (
     // Effective runtimeMode from the plan's resolved target — same value the
     // engine derives, single derivation point.
     const agentRuntimeMode = executionTargetToRuntimeMode(executionPlan.target);
-    // When sandbox is not the active runtime, remove lobe-cloud-sandbox from the
+    // Mirrors AgentToolsEngine's agentModeRules gate: auto mode lets the model
+    // choose per call whether to run in the cloud sandbox or on the
+    // auto-routed device, so Cloud Sandbox stays allowed there too.
+    const cloudSandboxAllowed = agentRuntimeMode === 'cloud' || executionPlan.target === 'auto';
+    // When sandbox isn't reachable, remove lobe-cloud-sandbox from the
     // manifest map. The initial seed via getEnabledPluginManifests (which includes
     // defaultToolIds) may have already placed it there, and the allowedBuiltinTools
     // loop below only guards the discoverable-builtin append path. Deleting here
     // covers both sources in a single point.
-    if (agentRuntimeMode !== 'cloud') {
+    if (!cloudSandboxAllowed) {
       delete toolManifestMap[CloudSandboxManifest.identifier];
     }
     // Same single-point deletion for the device tools: a `none` / `sandbox`
@@ -904,10 +908,9 @@ export const discoverTools = async (
     }
     for (const tool of allowedBuiltinTools) {
       if (!isManifestIngestAllowed(tool.identifier)) continue;
-      // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves
-      // to 'cloud' (i.e. executionTarget='sandbox').
-      if (tool.identifier === CloudSandboxManifest.identifier && agentRuntimeMode !== 'cloud')
-        continue;
+      // lobe-cloud-sandbox is only activator-discoverable when the sandbox is
+      // reachable (executionTarget='sandbox', or 'auto' — see cloudSandboxAllowed above).
+      if (tool.identifier === CloudSandboxManifest.identifier && !cloudSandboxAllowed) continue;
       // device tools are only activator-discoverable in device-capable sessions
       if (stripDeviceTools && isDeviceToolIdentifier(tool.identifier)) continue;
       if (tool.discoverable !== false && !toolManifestMap[tool.identifier]) {

--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -71,7 +71,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 **Decision flow:**
 1. **If ANY trigger condition above is met** → Immediately activate \`lobe-creds\`
 2. Check if the required credential already exists using the credentials list in context
-3. If credential exists → use \`getPlaintextCred\` or \`injectCredsToSandbox\` (for sandbox execution)
+3. If credential exists and the sandbox is reachable → use \`injectCredsToSandbox\` (see \`<credential_usage_by_runtime>\` below)
 4. If credential doesn't exist:
    - For LobeHub OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
    - For Composio-managed services (Slack, Google Drive, Airtable, Jira, etc.)
@@ -84,16 +84,16 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 **Important:**
 - Never ask users to paste API keys directly in chat — always use \`lobe-creds\` to store them securely
 
-**Credential Usage by Runtime (sandbox mode: {{sandbox_enabled}}):**
+<credential_usage_by_runtime>
+**Cloud sandbox reachable for credential injection: {{creds_sandbox_reachable}}.** This is about whether \`runCommand\`/\`execScript\` will actually execute in the cloud sandbox this run — not whether the dedicated Cloud Sandbox tool happens to be present, which can be \`true\` at the same time a device is also routed (auto mode).
 
-When sandbox mode is true (\`lobe-cloud-sandbox\` present, \`injectCredsToSandbox\` available):
-- Environment-based credentials (oauth, kv-env, kv-header) → \`~/.creds/env\` — use \`runCommand\` with \`bash -c "source ~/.creds/env && your_command"\`
-- File-based credentials → \`~/.creds/files/{key}/{filename}\` — use file path directly in your code
+When \`{{creds_sandbox_reachable}}\` is \`true\`:
+- Use \`injectCredsToSandbox\` before running code that needs credentials. Injected credentials become automatically available as environment variables in every \`runCommand\`/\`execScript\` call — you do NOT need to \`source\` any file yourself. See the \`lobe-creds\` system prompt's \`<sandbox_integration>\` section for the full contract.
 
-When sandbox mode is false (\`lobe-cloud-sandbox\` does not exist in this session — do not look for it or offer to activate it):
-- Use \`getPlaintextCred\` to retrieve values, then pass as inline env vars in \`runCommand\`
-- Example: \`runCommand({ command: "GITHUB_TOKEN='xxx' gh repo list" })\`
-- File credentials: use \`getPlaintextCred\` to get the file path from the response state
+When \`{{creds_sandbox_reachable}}\` is \`false\` (this run is routed to a device):
+- Do NOT call \`injectCredsToSandbox\` — it would still report success, but it writes into a cloud sandbox nothing in this run actually executes in.
+- There is currently no tool exposed to read a saved credential's plaintext value for inline use on a device-routed run. Tell the user this credential can't be used in this run rather than inventing a workaround.
+</credential_usage_by_runtime>
 </credentials_management>
 
 <best_practices>

--- a/packages/builtin-tool-cloud-sandbox/src/systemRole.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/systemRole.ts
@@ -10,10 +10,10 @@ export const systemPrompt = `You have access to a Cloud Sandbox that provides a 
 - Sessions may expire after inactivity; files will be recreated if needed
 - The sandbox has its own isolated file system starting at the root directory
 - Commands will time out after 120 seconds by default
-- **Default shell is /bin/sh** (typically dash or ash), NOT bash. The \`source\` command may not work as expected. If you need bash-specific features or \`source\`, wrap your command with bash: \`bash -c "source ~/.creds/env && your_command"\`
+- **Default shell is /bin/sh** (typically dash or ash), NOT bash. Some commands may need bash-specific features — wrap with \`bash -c "your_command"\` if needed.
 
-**Credential Injection Locations:**
-- Environment-based credentials (oauth, kv-env, kv-header) are written to \`~/.creds/env\`
+**Credential Injection:**
+- Credentials injected via \`injectCredsToSandbox\` are automatically available as environment variables in every \`runCommand\`/\`execScript\` call — do NOT \`source\` anything yourself, and do not try to locate or read a credential file. \`~/.creds/env\` is a reference-only listing of which keys were injected (masked values, comment lines) — it is not a real environment file.
 - File-based credentials are extracted to \`~/.creds/files/{key}/{filename}\`
 </sandbox_environment>
 

--- a/packages/builtin-tool-creds/src/manifest.ts
+++ b/packages/builtin-tool-creds/src/manifest.ts
@@ -44,7 +44,7 @@ export const CredsManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Inject credentials into the cloud sandbox environment as environment variables. Only useful when this run is not routed to a device — check "Cloud sandbox reachable for credential injection" in the session context before calling this; do NOT call it on desktop/local or when a device is routed.',
+        'Inject credentials into the cloud sandbox environment as environment variables. Only useful when the sandbox is reachable this run — check "Cloud sandbox reachable for credential injection" in the session context before calling this. A routed device does not by itself rule this out: in auto mode the cloud sandbox stays reachable alongside a routed device, so the session-context value is the source of truth, not device-routing status alone.',
       name: CredsApiName.injectCredsToSandbox,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-creds/src/manifest.ts
+++ b/packages/builtin-tool-creds/src/manifest.ts
@@ -44,7 +44,7 @@ export const CredsManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Inject credentials into the sandbox environment as environment variables. Only available when sandbox mode is enabled — do NOT call this on desktop/local.',
+        'Inject credentials into the cloud sandbox environment as environment variables. Only useful when this run is not routed to a device — check "Cloud sandbox reachable for credential injection" in the session context before calling this; do NOT call it on desktop/local or when a device is routed.',
       name: CredsApiName.injectCredsToSandbox,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -73,6 +73,8 @@ When suggesting to save, always:
 
 Don't confuse this with \`sandbox_enabled\` (current value: {{sandbox_enabled}}) above — that only tracks whether the dedicated Cloud Sandbox tool is offered. Your \`runCommand\`/\`execScript\` calls (Skills) also execute in that same cloud sandbox session whenever this run isn't routed to a device, regardless of \`sandbox_enabled\` — that's the case \`{{creds_sandbox_reachable}}\` actually tracks, and it's what determines whether an injected credential will be reachable.
 
+One case needs care: if a device IS routed for this run but \`{{creds_sandbox_reachable}}\` is still \`true\` (auto mode), Skills' own \`runCommand\` refuses to run in the sandbox — use the dedicated Cloud Sandbox tool's \`runCommand\`/\`execScript\` instead to actually reach the credential.
+
 When \`{{creds_sandbox_reachable}}\` is \`true\` and you need to run code that requires credentials:
 1. Check if the required credential is in the available credentials list
 2. Use \`injectCredsToSandbox\` to inject the credential before running code

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -4,6 +4,7 @@ export const systemPrompt = `You have access to a LobeHub Credentials Tool. This
 Current user: {{username}}
 Session date: {{session_date}}
 Sandbox mode: {{sandbox_enabled}}
+Cloud sandbox reachable for credential injection: {{creds_sandbox_reachable}}
 </session_context>
 
 <available_credentials>
@@ -20,13 +21,13 @@ Sandbox mode: {{sandbox_enabled}}
 <core_responsibilities>
 1. **Awareness**: Know what credentials the user has configured and suggest relevant ones when needed.
 2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in LobeHub.
-3. **Runtime Integration**: When sandbox mode is enabled, use \`injectCredsToSandbox\` to inject credentials into the sandbox environment.
+3. **Runtime Integration**: When the cloud sandbox is reachable (\`{{creds_sandbox_reachable}}\`), use \`injectCredsToSandbox\` to inject credentials into the sandbox environment before running code that needs them.
 4. **Ownership disclosure**: In a workspace, some listed credentials are tagged \`[shared by <name>]\` (a teammate's own credential they chose to share) or \`[workspace credential]\` (owned by the workspace itself). Never present a shared credential as if it belongs to the workspace or to you — when it's relevant, tell the user whose credential is actually being used.
 </core_responsibilities>
 
 <tooling>
 - **initiateOAuthConnect**: Start OAuth authorization flow for third-party services. Returns an authorization URL for the user to click.
-- **injectCredsToSandbox**: Inject credentials into the sandbox environment. Only available when sandbox mode is enabled.
+- **injectCredsToSandbox**: Inject credentials into the cloud sandbox environment. Only useful when \`{{creds_sandbox_reachable}}\` is \`true\` — see \`<sandbox_integration>\` for why this differs from \`sandbox_enabled\`.
 - **saveCreds**: Save new credentials securely. Use when user wants to store sensitive information.
   - Parameters: \`key\` (unique identifier, lowercase with hyphens), \`name\` (display name), \`type\` ("kv-env" or "kv-header"), \`values\` (object of key-value pairs, NOT a string), \`description\` (optional)
   - Example: \`saveCreds({ key: "openai", name: "OpenAI API Key", type: "kv-env", values: { "OPENAI_API_KEY": "sk-xxx" } })\`
@@ -68,13 +69,17 @@ When suggesting to save, always:
 </credential_saving_triggers>
 
 <sandbox_integration>
-**Only applies when sandbox mode is enabled (current value: {{sandbox_enabled}}).**
+**Only applies when the cloud sandbox is reachable this run (current value: {{creds_sandbox_reachable}}).**
 
-When sandbox mode is enabled and you need to run code that requires credentials:
+Don't confuse this with \`sandbox_enabled\` (current value: {{sandbox_enabled}}) above — that only tracks whether the dedicated Cloud Sandbox tool is offered. Your \`runCommand\`/\`execScript\` calls (Skills) also execute in that same cloud sandbox session whenever this run isn't routed to a device, regardless of \`sandbox_enabled\` — that's the case \`{{creds_sandbox_reachable}}\` actually tracks, and it's what determines whether an injected credential will be reachable.
+
+When \`{{creds_sandbox_reachable}}\` is \`true\` and you need to run code that requires credentials:
 1. Check if the required credential is in the available credentials list
 2. Use \`injectCredsToSandbox\` to inject the credential before running code
 3. The credential will be available as an environment variable or file in the sandbox
 4. Never pass credential values directly in code - always use environment variables or file paths
+
+When \`{{creds_sandbox_reachable}}\` is \`false\`, this run is routed to a device — \`injectCredsToSandbox\` will still report success, but it writes into a cloud sandbox nothing in this run actually executes in, so the credential is unreachable. Don't call it. There is currently no way to load a saved credential's value onto a device-routed run — tell the user this credential can't be used here and ask them to run the command in a cloud-sandbox context instead, or supply the value themselves for this run.
 
 **Important Notes:**
 - \`executeCode\` runs in an isolated process that may NOT have access to injected environment variables. If your script needs credentials, write the script to a file and use \`runCommand\` to execute it instead.

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -83,10 +83,11 @@ When \`{{creds_sandbox_reachable}}\` is \`false\`, this run is routed to a devic
 
 **Important Notes:**
 - \`executeCode\` runs in an isolated process that may NOT have access to injected environment variables. If your script needs credentials, write the script to a file and use \`runCommand\` to execute it instead.
+- Credentials are already automatically available as environment variables in every command's execution context — do not attempt to locate, cat, or source any credential file yourself. Doing so is unnecessary and will not give you real values.
 
 **Credential Storage Locations:**
-- **Environment-based credentials** (oauth, kv-env, kv-header): Written to \`~/.creds/env\` file
-- **File-based credentials** (file): Extracted to \`~/.creds/files/\` directory
+- **Environment-based credentials** (oauth, kv-env, kv-header): Automatically available as environment variables in every command you run via \`runCommand\`/\`execScript\` — you do NOT need to \`source\` anything yourself, and there is no credential file you need to read, export, or locate. \`~/.creds/env\` is a reference-only listing of which keys were injected, written as comment lines (e.g. \`# API_KEY=8f******vZ\`) — these are NOT real shell variables, the values shown are intentionally masked, and the file cannot be sourced or used for authentication. Never try to read real values from it or manually \`source\` it; seeing masked values there is expected and normal, not an error.
+- **File-based credentials** (file): Extracted to \`~/.creds/files/\` directory; the file path is provided via an automatically-injected environment variable, same as above.
 
 **Environment Variable Naming:**
 - **oauth**: \`{{KEY}}_ACCESS_TOKEN\` (e.g., \`GITHUB_ACCESS_TOKEN\`)


### PR DESCRIPTION
<!-- Brief and heads-up -->

Three commits, all closely related credential/sandbox-reachability work:

1. **`sandbox_enabled` was the wrong signal for `injectCredsToSandbox` reachability.** It only tracks whether the dedicated Cloud Sandbox tool is offered (`executionTarget === 'sandbox'`), but `lobe-skills`' `runCommand`/`execScript` silently fall back to that same cloud sandbox session whenever no device is actively routed, independent of `sandbox_enabled` — e.g. the common no-device web/agent session. That made the model refuse `injectCredsToSandbox` in sessions where it would actually have worked. Added `creds_sandbox_reachable`, derived from the run's already-computed `activeDeviceId` (the single-track device gate the rest of the run executors use), and rewired `lobe-creds`' systemRole.ts and tool manifest description to key off it.

2. **Synced the credential-storage description with the shipped hidden-file split** (market PR lobehub-biz/lobehub-market#418): real values now live in a hidden `~/.creds/.env` the platform auto-sources before every command; `~/.creds/env` is a masked, comment-only reference. `lobe-creds`' systemRole.ts still said credentials were "Written to `~/.creds/env` file", which was letting the model infer it should manually `source` that file — the exact behavior the split was meant to make harmless, but better to stop the model from trying at all.

3. **Product decision: auto mode should offer the cloud sandbox as a co-equal option alongside an auto-routed device, not have the sandbox silently taken off the table the moment a device happens to be online.** `injectCredsToSandbox` has no device branch and always targets the sandbox regardless of routing, so there's no reason auto-routing a device should block it. Relaxed the `lobe-cloud-sandbox` tool-exposure gates (`AgentToolsEngine`'s `agentModeRules`, and the matching physical-deletion + activator-discoverability gates in `toolDiscovery.ts`) to allow `executionTarget === 'auto'` alongside `'sandbox'`, and extended `creds_sandbox_reachable`'s derivation to match. Also fixed `builtin-tool-activator`'s credential-usage guidance, which described sandbox mode as a strict binary ("`lobe-cloud-sandbox` does not exist in this session — do not look for it") and referenced `getPlaintextCred`, a tool that isn't on the `lobe-creds` manifest at all (only `connectComposioService`/`initiateOAuthConnect`/`injectCredsToSandbox`/`saveCreds` are) — a real dead end whenever a session had no reachable sandbox. Fixed the same stale `~/.creds/env` description duplicated in `builtin-tool-cloud-sandbox`'s own systemRole.ts.

#### Key Decisions / Non-goals

- Did **not** relax `skillsRuntime.runCommand`'s existing hard refusal when a device is routed (it still tells the model to use `execScript`/`lobe-local-system` instead). In auto mode, the model now has an independent, dedicated `lobe-cloud-sandbox` tool to reach the sandbox explicitly when it wants to — it doesn't need `lobe-skills.runCommand` itself to also fall through. Keeping that refusal intact avoids touching the safety property it documents ("a prompt-following or hallucinated call can't silently run in the sandbox while the user expects their device") for explicit `device`/`local` selections, and keeps this PR's blast radius to tool *exposure*, not execution routing.
- Did **not** thread an "was this device auto-routed vs. explicitly selected" signal into `packages/builtin-tool-skills/src/resolveManifest.ts`'s per-run manifest preambles (`EXEC_ENV_PREAMBLES`/`EXEC_ENV_FACTS`). Those still describe `device`-routed sessions uniformly regardless of whether routing came from `auto` or an explicit pick. `lobe-cloud-sandbox`'s own systemRole.ts is unconditional about describing itself as sandbox execution, so the model isn't told anything false — it's just a smaller UX polish opportunity, not a correctness gap, and left as a follow-up.
- Did **not** touch the client-side prompt-variable mirror (`src/services/chat/mecha/contextEngineering.ts`'s `sandbox_enabled`, or the analogous `isCloudSandboxEnabled` selector in `chatConfigSelectors.ts`) — per AGENTS.md, Cloud analysis defaults to server runtime + agent gateway, and neither path currently has an `activeDeviceId`-equivalent to mirror `creds_sandbox_reachable` with. Flagging as a known gap if that path turns out to still be load-bearing somewhere.
- Confirmed no billing/quota or client-side device-indicator UI is coupled to `lobe-cloud-sandbox` tool presence — the sandbox session itself (keyed by `(userId, topicId)`) already gets created by `lobe-skills` regardless of whether the dedicated tool is offered, so exposing it in `auto` mode doesn't open a new billing surface, just a second way to reach the same session.

#### 🧪 How to Test

- [ ] Tested locally (blocked by a pre-existing, unrelated local environment gap in this checkout — `src/locales` is entirely missing, breaking the shared vitest setup file for every test in this repo; confirmed via `eslint --fix` + a full, unfiltered `tsc --noEmit -p .` showing zero errors touching any file in this diff, plus manual review)
- [x] Added/updated tests
- [ ] No tests needed

Added:
- `serverCallLlmTooling.test.ts` — asserts `resolveServerCallLlmTooling` passes `activeDeviceId` through correctly (device routed / not routed / no metadata at all).
- `AgentToolsEngine/__tests__/index.test.ts` — new `CloudSandbox tool enable rules` describe block: enabled for `sandbox`, disabled for `none`/explicit `device`, and — the regression case — still enabled for `auto` both with and without a device auto-activated.

#### 🔗 Related Issue

None