### PR TITLE
⚡️ perf(spa): fold first-screen @lobehub/ui members into vendor-ui-core

### DIFF
--- a/plugins/vite/lobeUiImports.ts
+++ b/plugins/vite/lobeUiImports.ts
@@ -86,8 +86,15 @@ const namedExportProxy = (maps: Record<string, Barrel>): Plugin => ({
 
     return `export { ${entry.imported} as default } from ${JSON.stringify(source)};`;
   },
-  resolveId(id) {
+  resolveId(id, importer) {
     if (!id.startsWith(NAMED_EXPORT_PREFIX)) return;
+
+    const [barrel, member] = id.slice(NAMED_EXPORT_PREFIX.length).split(':');
+    const entry = maps[barrel]?.members[member];
+    // A default export needs no proxy module; pointing straight at the source
+    // avoids one facade chunk per member shared between routes.
+    if (entry?.imported === 'default' && entry.source.startsWith('@lobehub/ui/es/'))
+      return this.resolve(entry.source, importer);
 
     return `\0${id}`;
   },

--- a/plugins/vite/sharedRendererConfig.test.ts
+++ b/plugins/vite/sharedRendererConfig.test.ts
@@ -189,6 +189,19 @@ describe('sharedManualChunks', () => {
   });
 });
 
+describe('isUiCoreModule', () => {
+  it('folds first-screen @lobehub/ui members into vendor-ui-core and leaves heavy ones lazy', () => {
+    const es = '/repo/node_modules/.pnpm/@lobehub+ui@5/node_modules/@lobehub/ui/es/';
+    expect(__testing.isUiCoreModule(`${es}Flex/FlexBasic.mjs`)).toBe(true);
+    expect(__testing.isUiCoreModule(`${es}base-ui/Button/Button.mjs`)).toBe(true);
+    expect(__testing.isUiCoreModule(`${es}hooks/useIsClient.mjs`)).toBe(true);
+    expect(__testing.isUiCoreModule(`${es}Markdown/Markdown.mjs`)).toBe(false);
+    expect(__testing.isUiCoreModule(`${es}hooks/useMarkdown/index.mjs`)).toBe(false);
+    expect(__testing.isUiCoreModule(`${es}base-ui/Select/Select.mjs`)).toBe(false);
+    expect(__testing.isUiCoreModule('/repo/node_modules/antd/es/index.js')).toBe(false);
+  });
+});
+
 describe('sharedChunkFileNames', () => {
   it('routes only the complete deferred model catalog to on-demand assets', () => {
     expect(

--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -319,6 +319,21 @@ interface SharedRolldownOutputOptions {
   strictExecutionOrder?: boolean;
 }
 
+// @lobehub/ui members on the first-screen path of dist/desktop, measured with
+// bundle-size-gate --type entry-graph. lobeUiImports splits the barrel into one
+// module per member; folding the eager ones back into one chunk keeps the heavy
+// members (Markdown, Mermaid, EmojiPicker, Highlighter, Image) on lazy routes.
+const UI_CORE_MEMBER_RE =
+  /^(?:Accordion|ActionIcon|Block|Collapse|ConfigProvider|Flex|FluentEmoji|Grid|Hotkey|Icon|Img|Modal|MotionProvider|Skeleton|Text|ThemeProvider|color|styles|utils|hooks\/use(?:IsClient|NativeButton|TextOverflow)|icons\/lucideExtra|base-ui\/(?:ActionIcon|Avatar|Button|Checkbox|ContextMenu|Modal|Popover|Switch|Text|Toast|Tooltip|controlSize|focusRing|zIndex))(?:\/|\.)/;
+
+const isUiCoreModule = (id: string) => {
+  const member = id.replaceAll('\\', '/').split('/node_modules/@lobehub/ui/es/')[1];
+
+  return Boolean(member && UI_CORE_MEMBER_RE.test(member));
+};
+
+// Rolldown groups also capture their modules' dependencies; a higher priority
+// keeps the explicit groups above (and antd) from being pulled into ui-core.
 export const createSharedRolldownOutput = (options: SharedRolldownOutputOptions = {}) => ({
   chunkFileNames: sharedChunkFileNames,
   strictExecutionOrder: options.strictExecutionOrder ?? true,
@@ -326,7 +341,14 @@ export const createSharedRolldownOutput = (options: SharedRolldownOutputOptions 
     groups: [
       {
         name: (moduleId: string) => sharedManualChunks(moduleId) ?? null,
+        priority: 3,
       },
+      {
+        name: 'vendor-antd',
+        priority: 2,
+        test: /[\\/]node_modules[\\/](?:antd|@ant-design|@rc-component)[\\/]/,
+      },
+      { name: 'vendor-ui-core', priority: 1, test: isUiCoreModule },
     ],
   },
 });
@@ -433,7 +455,4 @@ export const sharedOptimizeDeps = {
 // snapshots. They must still share one LexicalComposerContext at runtime.
 export const sharedRendererDedupe = ['@lobehub/editor', 'react', 'react-dom'];
 
-export const __testing = {
-  sharedChunkFileNames,
-  sharedManualChunks,
-};
+export const __testing = { isUiCoreModule, sharedChunkFileNames, sharedManualChunks };


### PR DESCRIPTION
#19033 split the `@lobehub/ui` barrels into one module per member so heavy members stop leaking into the first-screen graph. The cost was granularity: `dist/desktop` went to 117 first-screen chunks, 57 of them `@lobehub/ui` / `@base-ui/react` fragments of 1–3 modules, plus one facade chunk per re-exported member. This folds the eager members back into one chunk without letting the heavy ones (Markdown, Mermaid, EmojiPicker, Highlighter, Image) back in.

#### What changed

- `sharedRendererConfig.ts`: a `vendor-ui-core` code-splitting group for the `@lobehub/ui/es/*` members measured on the first-screen path (allowlist regex; unlisted members just stay as their own small chunk, so drift is harmless and visible in the entry-graph report).
- Rolldown groups capture their modules' dependencies recursively, so without protection `vendor-ui-core` swallowed antd (2 MB raw) and the explicit `vendor-ui-runtime` group. Groups now carry priorities, and antd gets its own `vendor-antd` group (it was already fully eager as the auto-named `assets/es.js`; this only names it and keeps it cache-separate from `@lobehub/ui`).
- `lobeUiImports.ts`: a member whose barrel export is the source module's `default` is resolved straight to that module instead of through a `virtual:lobe-ui-named:*` proxy, which removes the per-member facade chunks. Named re-exports (`toast`, `createModal`, `ModalFooter`) keep the proxy.

#### Result (entry-graph, gzip of the static import closure)

| Entry | Before | After |
| --- | --- | --- |
| dist/desktop | 117 chunks, 2.269 MB | 67 chunks, 2.262 MB |
| dist/mobile | 87 chunks, 1.99 MB | 50 chunks, 1.99 MB (+3.0 KB) |
| dist/auth | 17 chunks, 624.5 KB | 16 chunks, 627.6 KB |

`vendor-ui-core` is 159 KB gz (`@lobehub/ui` core members, `@base-ui/react`, `antd-style`), `vendor-antd` 392 KB gz, `vendor-ui-runtime` unchanged at 80 KB gz.

The entry-graph gate's name check will flag `vendor/vendor-ui-core.js` and `vendor/vendor-antd.js` as "added to sync graph": they are new names for modules that were already eager (the removed column lists the 36–50 chunks they replace), not lazy chunks promoted to the first screen. The gate has no lazy-chunk baseline to tell the two apart; that is a follow-up for the gate, not changed here.

#### Non-goals

- Grouping the lazy-only parts of `@base-ui/react` (183 modules, ~500 KB raw): they are not first-screen and would grow the closure.
- Electron renderer: `lobeUiImports` is not applied on `platform === 'desktop'`, so nothing changes there.

#### Test

- [x] Tested locally: `vite build` for web / `MOBILE=true` / `AUTH=true` against a build of the base commit, compared with `bundle-size-gate.cjs measure --type entry-graph` + `check`
- [x] Added/updated tests: `plugins/vite/sharedRendererConfig.test.ts` (`isUiCoreModule` allow/deny), `plugins/vite/lobeUiImports.test.ts` still passes

#### 🔗 Related Issue

Fixes LOBE-13760
Related to #19033, #19059

https://claude.ai/code/session_013sk2z4PpPbcLRMASm3DST3
