### PR TITLE
✨ feat: add project acceptance workspace

### DIFF
--- a/apps/server/src/routers/lambda/acceptance.ts
+++ b/apps/server/src/routers/lambda/acceptance.ts
@@ -592,6 +592,7 @@ export const acceptanceRouter = router({
         .object({
           filter: z.enum(['active', 'all', 'completed']).optional(),
           limit: z.number().int().min(1).max(200).optional(),
+          projectId: z.string().optional(),
           q: z.string().max(200).optional(),
         })
         .optional(),
@@ -613,6 +614,7 @@ export const acceptanceRouter = router({
           cursor: z.string().optional(),
           filter: z.enum(['active', 'all', 'completed']).optional(),
           limit: z.number().int().min(1).max(100).optional(),
+          projectId: z.string().optional(),
         })
         .optional(),
     )
@@ -621,6 +623,7 @@ export const acceptanceRouter = router({
         cursor: input?.cursor,
         filter: input?.filter,
         limit: input?.limit,
+        projectId: input?.projectId,
       }),
     ),
 

--- a/apps/server/src/services/verify/__tests__/acceptanceListSearch.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceListSearch.test.ts
@@ -76,4 +76,21 @@ describe('AcceptanceService.listWithSubjects', () => {
     expect(mocks.resolveDocuments).toHaveBeenCalledOnce();
     expect(result.map(({ id }: { id: string }) => id)).toEqual(['older']);
   });
+
+  it('scopes the candidate query to a project', async () => {
+    const query = vi.fn().mockResolvedValue([]);
+    const service = new AcceptanceService({} as any, 'user-1') as any;
+    service.acceptanceModel = { query };
+    service.latestCheckCounts = vi.fn().mockResolvedValue(new Map());
+    service.resolveProjects = vi.fn().mockResolvedValue(new Map());
+
+    await service.listWithSubjects({ filter: 'all', projectId: 'project-1' });
+
+    expect(query).toHaveBeenCalledWith({
+      limit: 50,
+      projectId: 'project-1',
+      statuses: undefined,
+      unbounded: false,
+    });
+  });
 });

--- a/apps/server/src/services/verify/acceptanceService.ts
+++ b/apps/server/src/services/verify/acceptanceService.ts
@@ -1148,6 +1148,7 @@ export class AcceptanceService {
     options: {
       filter?: 'active' | 'all' | 'completed';
       limit?: number;
+      projectId?: string;
       q?: string;
     } = {},
   ) => {
@@ -1162,6 +1163,7 @@ export class AcceptanceService {
       limit: normalizedQuery ? undefined : limit,
       statuses,
       unbounded: Boolean(normalizedQuery),
+      ...(options.projectId ? { projectId: options.projectId } : {}),
     });
     const subjects = await this.resolveSubjects(candidates);
     const withSubjects = candidates.map((row) => ({
@@ -1203,11 +1205,13 @@ export class AcceptanceService {
     cursor?: string;
     filter?: AcceptanceListFilter;
     limit?: number;
+    projectId?: string;
   }) => {
     const { items, nextCursor } = await this.acceptanceModel.queryPage({
       cursor: options.cursor,
       limit: options.limit,
       statuses: statusesForFilter(options.filter ?? 'all'),
+      ...(options.projectId ? { projectId: options.projectId } : {}),
     });
 
     const subjects = await this.resolveSubjects(items);

--- a/packages/database/src/models/__tests__/acceptance.test.ts
+++ b/packages/database/src/models/__tests__/acceptance.test.ts
@@ -213,6 +213,25 @@ describe('AcceptanceModel', () => {
     await expect(model.listStatusesBySubjects('task', [topicId])).resolves.toEqual([]);
   });
 
+  it('filters flat and paged lists by project before applying limits', async () => {
+    const projectModel = new ProjectModel(serverDB, userId);
+    const alpha = await projectModel.create({ identifier: 'ALPHA', name: 'Alpha project' });
+    const beta = await projectModel.create({ identifier: 'BETA', name: 'Beta project' });
+    const model = new AcceptanceModel(serverDB, userId);
+
+    await model.create({ projectId: alpha.id, subjectId: 'alpha-1', subjectType: 'standalone' });
+    await model.create({ projectId: beta.id, subjectId: 'beta-1', subjectType: 'standalone' });
+    await model.create({ projectId: alpha.id, subjectId: 'alpha-2', subjectType: 'standalone' });
+
+    const alphaRows = await model.query({ projectId: alpha.id });
+    expect(alphaRows.map(({ subjectId }) => subjectId).sort()).toEqual(['alpha-1', 'alpha-2']);
+    expect(alphaRows.every(({ projectId }) => projectId === alpha.id)).toBe(true);
+    await expect(model.queryPage({ limit: 1, projectId: alpha.id })).resolves.toMatchObject({
+      items: [expect.objectContaining({ projectId: alpha.id })],
+      nextCursor: expect.any(String),
+    });
+  });
+
   it('updateStatus stamps completedAt only on user-terminal statuses', async () => {
     const model = new AcceptanceModel(serverDB, userId);
     const row = await model.ensureForSubject('topic', topicId);

--- a/packages/database/src/models/acceptance.ts
+++ b/packages/database/src/models/acceptance.ts
@@ -211,17 +211,23 @@ export class AcceptanceModel {
 
   /** Acceptances for the current user/workspace, newest first. */
   query = async (
-    options: { limit?: number; statuses?: AcceptanceStatus[]; unbounded?: boolean } = {},
+    options: {
+      limit?: number;
+      projectId?: string;
+      statuses?: AcceptanceStatus[];
+      unbounded?: boolean;
+    } = {},
   ) => {
-    const { statuses, unbounded } = options;
+    const { projectId, statuses, unbounded } = options;
     const limit = unbounded ? undefined : (options.limit ?? 50);
+    const conditions = [this.ownership()];
+    if (projectId) conditions.push(eq(acceptances.projectId, projectId));
+    if (statuses && statuses.length > 0) conditions.push(inArray(acceptances.status, statuses));
+
     return this.db.query.acceptances.findMany({
       limit,
       orderBy: [desc(acceptances.createdAt)],
-      where:
-        statuses && statuses.length > 0
-          ? and(this.ownership(), inArray(acceptances.status, statuses))
-          : this.ownership(),
+      where: and(...conditions),
     });
   };
 
@@ -235,12 +241,19 @@ export class AcceptanceModel {
   queryPage = async ({
     cursor,
     limit = 30,
+    projectId,
     statuses,
-  }: { cursor?: string; limit?: number; statuses?: AcceptanceStatus[] } = {}): Promise<{
+  }: {
+    cursor?: string;
+    limit?: number;
+    projectId?: string;
+    statuses?: AcceptanceStatus[];
+  } = {}): Promise<{
     items: AcceptanceItem[];
     nextCursor: string | null;
   }> => {
     const conditions = [this.ownership()];
+    if (projectId) conditions.push(eq(acceptances.projectId, projectId));
     if (statuses && statuses.length > 0) conditions.push(inArray(acceptances.status, statuses));
 
     // Millisecond-truncated createdAt — the precision the cursor round-trips

--- a/src/features/Acceptance/Workspace/AcceptanceListPanel.tsx
+++ b/src/features/Acceptance/Workspace/AcceptanceListPanel.tsx
@@ -280,6 +280,7 @@ interface AcceptanceListPanelProps extends ReportPanelExpand {
    * it offers, the multi-select toggle included.
    */
   projectActionItems?: (projectId?: string) => DropdownItem[];
+  projectId?: string;
 }
 
 /**
@@ -288,7 +289,7 @@ interface AcceptanceListPanelProps extends ReportPanelExpand {
  * same persisted panel-width preference so the two surfaces read as one family.
  */
 const AcceptanceListPanel = memo<AcceptanceListPanelProps>(
-  ({ expand, headerLeading, isNarrow, projectActionItems, setExpand }) => {
+  ({ expand, headerLeading, isNarrow, projectActionItems, projectId, setExpand }) => {
     const { t } = useTranslation('verify');
     const navigate = useNavigate();
     const { acceptanceId } = useParams<{ acceptanceId: string }>();
@@ -315,7 +316,11 @@ const AcceptanceListPanel = memo<AcceptanceListPanelProps>(
     // hands off to the flat read, which resolves every subject title across the
     // WHOLE owned set — a paged search would only ever match what had scrolled
     // in, and would report an exhausted list while the match sat on page four.
-    const search = useAcceptanceList(searching, { filter, q: debouncedQuery || undefined });
+    const search = useAcceptanceList(searching, {
+      filter,
+      projectId,
+      q: debouncedQuery || undefined,
+    });
     const {
       hasMore,
       isLoadingInitial,
@@ -323,7 +328,7 @@ const AcceptanceListPanel = memo<AcceptanceListPanelProps>(
       items: pagedItems,
       loadMore,
       ...pagedRest
-    } = useAcceptanceListInfinite(searching ? null : filter);
+    } = useAcceptanceListInfinite(searching ? null : filter, projectId);
 
     const items = searching ? (search.data ?? []) : pagedItems;
     const error = searching ? search.error : pagedRest.error;
@@ -335,6 +340,7 @@ const AcceptanceListPanel = memo<AcceptanceListPanelProps>(
     // filter is hiding anything at all (see acceptanceListEmptyVariant).
     const allProbe = useAcceptanceList(!error && !isLoading && items.length === 0, {
       filter: 'all',
+      projectId,
     });
     const emptyVariant = acceptanceListEmptyVariant({
       allListEmpty: allProbe.data ? allProbe.data.length === 0 : undefined,
@@ -829,8 +835,8 @@ const AcceptanceListPanel = memo<AcceptanceListPanelProps>(
                         action={
                           groupMode === 'project' && projectActionItems ? (
                             <DropdownMenu
-                              placement={'bottomRight'}
                               items={projectActionItems(group.projectName ? group.key : undefined)}
+                              placement={'bottomRight'}
                             >
                               <ActionIcon
                                 icon={MoreHorizontal}

--- a/src/features/Acceptance/Workspace/index.tsx
+++ b/src/features/Acceptance/Workspace/index.tsx
@@ -76,7 +76,11 @@ export const shouldShowAcceptanceOnboarding = ({
 }: AcceptanceOnboardingState) =>
   enabled && !hasDeepLink && !isLoading && !error && data?.length === 0;
 
-const AcceptanceWorkspace = memo(() => {
+interface AcceptanceWorkspaceProps {
+  projectId?: string;
+}
+
+const AcceptanceWorkspace = memo<AcceptanceWorkspaceProps>(({ projectId }) => {
   const { t } = useTranslation('verify');
   const panel = useReportPanelExpand();
   const projectActionItems = useAcceptanceProjectActionItems();
@@ -90,10 +94,11 @@ const AcceptanceWorkspace = memo(() => {
     isLoading,
   } = useAcceptanceList(showList, {
     filter: 'all',
+    projectId,
   });
   const isFirstUse = shouldShowAcceptanceOnboarding({
     data: allAcceptances,
-    enabled: showList,
+    enabled: showList && !projectId,
     error,
     hasDeepLink: Boolean(acceptanceId),
     isLoading,
@@ -111,7 +116,13 @@ const AcceptanceWorkspace = memo(() => {
   return (
     <Flexbox horizontal height={'100dvh'} style={{ overflow: 'hidden' }} width={'100%'}>
       <RouteMetaBridge />
-      {showList && <AcceptanceListPanel {...panel} projectActionItems={projectActionItems} />}
+      {showList && (
+        <AcceptanceListPanel
+          {...panel}
+          projectActionItems={projectActionItems}
+          projectId={projectId}
+        />
+      )}
       <div className={styles.main}>
         {showList && !panel.expand && (
           <button

--- a/src/features/Acceptance/hooks.test.ts
+++ b/src/features/Acceptance/hooks.test.ts
@@ -10,6 +10,7 @@ import { verifyService } from '@/services/verify';
 import {
   getAcceptanceBySubjectRefreshInterval,
   useAcceptanceBySubject,
+  useAcceptanceList,
   useRubrics,
   useVerifyReportBundle,
   useVerifyReportSummariesInfinite,
@@ -70,6 +71,22 @@ describe('Verify data hooks', () => {
 
     await waitFor(() => expect(result.current.data).toEqual({ id: 'acceptance-1' }));
     expect(getAcceptanceBySubject).toHaveBeenCalledWith('task', 'T-231');
+  });
+
+  it('forwards the project scope to the acceptance list service', async () => {
+    const listAcceptances = vi.spyOn(verifyService, 'listAcceptances').mockResolvedValue([]);
+
+    renderHook(() => useAcceptanceList(true, { filter: 'all', projectId: 'project-1' }), {
+      wrapper: createSWRWrapper(new Map()),
+    });
+
+    await waitFor(() => expect(listAcceptances).toHaveBeenCalledOnce());
+    expect(listAcceptances).toHaveBeenCalledWith({
+      filter: 'all',
+      limit: undefined,
+      projectId: 'project-1',
+      q: undefined,
+    });
   });
 
   it('polls fastest before an acceptance exists, then keeps it live until it settles', () => {

--- a/src/features/Acceptance/hooks.ts
+++ b/src/features/Acceptance/hooks.ts
@@ -99,16 +99,20 @@ export const useAcceptanceList = (
   options?: {
     filter?: 'active' | 'all' | 'completed';
     limit?: number;
+    projectId?: string;
     q?: string;
     revalidateOnMount?: boolean;
   },
 ) =>
   useClientDataSWR(
-    enabled ? verifyKeys.acceptances(options?.limit, options?.q, options?.filter) : null,
+    enabled
+      ? verifyKeys.acceptances(options?.limit, options?.q, options?.filter, options?.projectId)
+      : null,
     () =>
       verifyService.listAcceptances({
         filter: options?.filter,
         limit: options?.limit,
+        projectId: options?.projectId,
         q: options?.q,
       }),
     {
@@ -126,7 +130,10 @@ export const useAcceptanceList = (
  * loaded depth collapses back to one page rather than cascading a refetch of as
  * many pages as the previous view had open.
  */
-export const useAcceptanceListInfinite = (filter: AcceptanceListFilter | null) => {
+export const useAcceptanceListInfinite = (
+  filter: AcceptanceListFilter | null,
+  projectId?: string,
+) => {
   const workspaceId = useActiveWorkspaceId();
 
   const getKey = useCallback(
@@ -136,26 +143,28 @@ export const useAcceptanceListInfinite = (filter: AcceptanceListFilter | null) =
       return verifyKeys.acceptancePage(
         workspaceId ?? undefined,
         filter,
+        projectId,
         previous?.nextCursor ?? undefined,
       );
     },
-    [filter, workspaceId],
+    [filter, projectId, workspaceId],
   );
 
   const { data, error, isLoading, mutate, setSize, size } = useSWRInfinite(
     getKey,
-    ([, , , cursor]: readonly [string, string, string, string]) =>
+    ([, , , scopedProjectId, cursor]: readonly [string, string, string, string, string]) =>
       verifyService.listAcceptancePage({
         cursor: cursor || undefined,
         filter: filter ?? undefined,
         limit: ACCEPTANCE_PAGE_SIZE,
+        projectId: scopedProjectId || undefined,
       }),
     { ...VERIFY_REPORT_SWR_CONFIG, revalidateFirstPage: false },
   );
 
   useEffect(() => {
     setSize(1);
-  }, [filter, workspaceId, setSize]);
+  }, [filter, projectId, workspaceId, setSize]);
 
   const loadMore = useCallback(() => {
     void setSize((s) => s + 1);

--- a/src/features/Projects/Acceptance/index.tsx
+++ b/src/features/Projects/Acceptance/index.tsx
@@ -1,163 +1,28 @@
 'use client';
 
-import type { ProjectCompletionDecision, ProjectStatus } from '@lobechat/types';
-import { Block, Empty, Flexbox, Icon } from '@lobehub/ui';
-import { Button, Text, toast } from '@lobehub/ui/base-ui';
-import { BadgeCheckIcon, Clock3Icon } from 'lucide-react';
-import { memo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Center } from '@lobehub/ui';
 
 import AsyncError from '@/components/AsyncError';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
-import NavHeader from '@/features/NavHeader';
-import WideScreenContainer from '@/features/WideScreenContainer';
+import { AcceptanceWorkspace } from '@/features/Acceptance';
 import { useActiveRouteParams } from '@/hooks/useActiveRouteParams';
-import { projectService } from '@/services/project';
 import { useCurrentProjectDetail, useProjectStore } from '@/store/project';
 
-import { getProjectAcceptanceActions, type ProjectAcceptanceAction } from './actions';
-import { openRejectProjectModal } from './RejectModal';
-
-const PROJECT_STATUS_KEYS: Record<ProjectStatus, `acceptance.status.${ProjectStatus}`> = {
-  active: 'acceptance.status.active',
-  archived: 'acceptance.status.archived',
-  backlog: 'acceptance.status.backlog',
-  canceled: 'acceptance.status.canceled',
-  completed: 'acceptance.status.completed',
-  paused: 'acceptance.status.paused',
-  reviewing: 'acceptance.status.reviewing',
-};
-
-const PROJECT_DECISION_KEYS: Record<
-  ProjectCompletionDecision,
-  `acceptance.decision.${ProjectCompletionDecision}`
-> = {
-  accepted: 'acceptance.decision.accepted',
-  rejected: 'acceptance.decision.rejected',
-};
-
-const ProjectAcceptance = memo(() => {
-  const { t } = useTranslation('project');
+const ProjectAcceptance = () => {
   const { projectId } = useActiveRouteParams<{ projectId: string }>();
-  const reference = projectId ?? '';
-  const detail = useCurrentProjectDetail(reference);
-  const detailSWR = useProjectStore((s) => s.useFetchProjectDetail)(projectId);
-  const [loadingAction, setLoadingAction] = useState<ProjectAcceptanceAction>();
+  const detail = useCurrentProjectDetail(projectId);
+  const detailSWR = useProjectStore((state) => state.useFetchProjectDetail)(projectId);
 
   if (detailSWR.error)
     return <AsyncError error={detailSWR.error} variant={'page'} onRetry={detailSWR.mutate} />;
   if (!detail)
     return (
-      <Flexbox align={'center'} flex={1} justify={'center'}>
+      <Center height={'100%'} width={'100%'}>
         <NeuralNetworkLoading />
-      </Flexbox>
+      </Center>
     );
 
-  const id = detail.project.id;
-
-  const actions = getProjectAcceptanceActions(detail.project.status);
-  const completionReviews = detail.completionReviews ?? [];
-  const execute = async (action: Exclude<ProjectAcceptanceAction, 'reject'>) => {
-    setLoadingAction(action);
-    try {
-      if (action === 'start') await projectService.updateStatus(id, 'active');
-      if (action === 'requestCompletion') await projectService.requestCompletion(id);
-      if (action === 'accept') await projectService.acceptCompletion(id);
-      if (action === 'reopen') await projectService.reopen(id);
-      await detailSWR.mutate();
-      toast.success(t(`acceptance.success.${action}`));
-    } catch {
-      toast.error(t('acceptance.operationFailed'));
-    } finally {
-      setLoadingAction(undefined);
-    }
-  };
-
-  const reject = () =>
-    openRejectProjectModal(async (comment) => {
-      await projectService.rejectCompletion(id, comment);
-      await detailSWR.mutate();
-      toast.success(t('acceptance.success.reject'));
-    });
-
-  return (
-    <Flexbox flex={1} height={'100%'}>
-      <NavHeader left={<Text weight={600}>{t('acceptance.title')}</Text>} />
-      <WideScreenContainer
-        flex={1}
-        gap={20}
-        paddingBlock={24}
-        wrapperStyle={{ flex: 1, overflowY: 'auto' }}
-      >
-        <Flexbox gap={4}>
-          <Text fontSize={24} weight={650}>
-            {t('acceptance.title')}
-          </Text>
-          <Text type={'secondary'}>{t('acceptance.description')}</Text>
-        </Flexbox>
-        <Block padding={20} variant={'filled'}>
-          <Flexbox horizontal align={'center'} gap={16} justify={'space-between'} wrap={'wrap'}>
-            <Flexbox horizontal align={'center'} gap={12}>
-              <Icon icon={BadgeCheckIcon} size={24} />
-              <Flexbox gap={2}>
-                <Text weight={600}>{t('acceptance.currentStatus')}</Text>
-                <Text type={'secondary'}>{t(PROJECT_STATUS_KEYS[detail.project.status])}</Text>
-              </Flexbox>
-            </Flexbox>
-            <Flexbox horizontal gap={8}>
-              {actions.map((action) => (
-                <Button
-                  key={action}
-                  loading={loadingAction === action}
-                  type={
-                    action === 'accept' || action === 'requestCompletion' ? 'primary' : undefined
-                  }
-                  onClick={() => (action === 'reject' ? reject() : void execute(action))}
-                >
-                  {t(`acceptance.actions.${action}`)}
-                </Button>
-              ))}
-            </Flexbox>
-          </Flexbox>
-        </Block>
-        <Flexbox gap={10}>
-          <Text fontSize={16} weight={600}>
-            {t('acceptance.history')}
-          </Text>
-          {completionReviews.length === 0 ? (
-            <Block padding={32} variant={'outlined'}>
-              <Empty
-                description={t('acceptance.emptyDescription')}
-                title={t('acceptance.emptyTitle')}
-              />
-            </Block>
-          ) : (
-            completionReviews.map((review) => (
-              <Block
-                horizontal
-                align={'flex-start'}
-                gap={12}
-                key={review.id}
-                padding={16}
-                variant={'outlined'}
-              >
-                <Icon icon={Clock3Icon} />
-                <Flexbox gap={4}>
-                  <Text weight={600}>
-                    {t('acceptance.round', { round: review.round })} ·{' '}
-                    {t(PROJECT_DECISION_KEYS[review.decision])}
-                  </Text>
-                  {review.comment && <Text type={'secondary'}>{review.comment}</Text>}
-                </Flexbox>
-              </Block>
-            ))
-          )}
-        </Flexbox>
-      </WideScreenContainer>
-    </Flexbox>
-  );
-});
-
-ProjectAcceptance.displayName = 'ProjectAcceptance';
+  return <AcceptanceWorkspace projectId={detail.project.id} />;
+};
 
 export default ProjectAcceptance;

--- a/src/features/Projects/Layout/Sidebar.tsx
+++ b/src/features/Projects/Layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { ListTodoIcon, TargetIcon } from 'lucide-react';
+import { ClipboardCheckIcon, ListTodoIcon, TargetIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
@@ -14,7 +14,7 @@ import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwar
 import { useActiveRouteParams } from '@/hooks/useActiveRouteParams';
 import { useCurrentProjectDetail, useProjectStore } from '@/store/project';
 
-import { getProjectGoalsPath, getProjectTasksPath } from './navigation';
+import { getProjectAcceptancePath, getProjectGoalsPath, getProjectTasksPath } from './navigation';
 import ProjectHeader from './ProjectHeader';
 
 const ProjectSidebarContent = memo(() => {
@@ -26,6 +26,7 @@ const ProjectSidebarContent = memo(() => {
   const detailSWR = useProjectStore((s) => s.useFetchProjectDetail)(projectId);
   const projectTasksPath = getProjectTasksPath(projectId!);
   const projectGoalsPath = getProjectGoalsPath(projectId!);
+  const projectAcceptancePath = getProjectAcceptancePath(projectId!);
 
   const header = <ProjectHeader project={detail?.project} />;
 
@@ -53,6 +54,12 @@ const ProjectSidebarContent = memo(() => {
             icon={TargetIcon}
             title={t('sections.goals')}
             onClick={() => navigate(projectGoalsPath)}
+          />
+          <NavItem
+            active={pathname === projectAcceptancePath}
+            icon={ClipboardCheckIcon}
+            title={t('sections.acceptance')}
+            onClick={() => navigate(projectAcceptancePath)}
           />
         </Flexbox>
       }

--- a/src/libs/swr/keys.test.ts
+++ b/src/libs/swr/keys.test.ts
@@ -9,6 +9,7 @@ import {
   recentKeys,
   resourceKeys,
   taskKeys,
+  verifyKeys,
   workKeys,
 } from './keys';
 import { CACHE_TIERS } from './localStorageProvider';
@@ -70,6 +71,15 @@ describe('isAcceptanceListKey', () => {
       true,
     );
     expect(isAcceptanceListKey(['verify:acceptanceBundle', 'acceptance-1'])).toBe(false);
+  });
+
+  it('keeps project-scoped acceptance feeds in separate cache entries', () => {
+    expect(verifyKeys.acceptances(undefined, undefined, 'all', 'project-1')).not.toEqual(
+      verifyKeys.acceptances(undefined, undefined, 'all', 'project-2'),
+    );
+    expect(verifyKeys.acceptancePage('workspace-1', 'all', 'project-1')).not.toEqual(
+      verifyKeys.acceptancePage('workspace-1', 'all', 'project-2'),
+    );
   });
 });
 

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -1082,20 +1082,25 @@ export const verifyKeys = {
    */
   acceptancePage: def(
     'verify:acceptancePage',
-    (workspaceId: string | undefined, filter: string, cursor?: string) => [
+    (workspaceId: string | undefined, filter: string, projectId?: string, cursor?: string) => [
       'verify:acceptancePage',
       workspaceId ?? '',
       filter,
+      projectId ?? '',
       cursor ?? '',
     ],
   ),
   /** Query inputs are part of the key so server-side list filtering never reuses stale rows. */
-  acceptances: def('verify:acceptances', (limit?: number, q?: string, filter?: string) => [
+  acceptances: def(
     'verify:acceptances',
-    String(limit ?? ''),
-    q ?? '',
-    filter ?? '',
-  ]),
+    (limit?: number, q?: string, filter?: string, projectId?: string) => [
+      'verify:acceptances',
+      String(limit ?? ''),
+      q ?? '',
+      filter ?? '',
+      projectId ?? '',
+    ],
+  ),
   criteria: def('verify:criteria', () => ['verify:criteria']),
   instruction: def('verify:instruction', (documentId: string) => [
     'verify:instruction',

--- a/src/services/verify.ts
+++ b/src/services/verify.ts
@@ -182,11 +182,19 @@ export class VerifyService {
     filter?: 'active' | 'all' | 'completed';
     /** Widen the recency window (server-capped) — the merge picker asks for more. */
     limit?: number;
+    projectId?: string;
     q?: string;
     quiet?: boolean;
   }): Promise<AcceptanceListItem[]> =>
     lambdaClient.acceptance.list.query(
-      options ? { filter: options.filter, limit: options.limit, q: options.q } : undefined,
+      options
+        ? {
+            filter: options.filter,
+            limit: options.limit,
+            projectId: options.projectId,
+            q: options.q,
+          }
+        : undefined,
       options?.quiet ? { context: { showNotification: false } } : undefined,
     );
 
@@ -195,6 +203,7 @@ export class VerifyService {
     cursor?: string;
     filter?: AcceptanceListFilter;
     limit?: number;
+    projectId?: string;
   }): Promise<AcceptanceListPage> => lambdaClient.acceptance.listPage.query(params);
 
   /**

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -42,6 +42,7 @@ import MemorySkeleton from '@/components/Skeleton/Memory';
 import ResourceHomeSkeleton from '@/components/Skeleton/ResourceHome';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import { createSurfaceSkeleton } from '@/components/Skeleton/Surface';
+import { acceptanceRouteMeta } from '@/features/Acceptance/routeMeta';
 import { agentDocumentRouteMeta } from '@/features/AgentDocumentPage/routeMeta';
 import { goalDetailRouteMeta, goalsRouteMeta } from '@/features/AgentGoals/routeMeta';
 import AgentRouteSwitch from '@/features/AgentRoute/AgentRouteSwitch';
@@ -1016,6 +1017,23 @@ export const sharedMainAreaChildren: RouteObject[] = [
         ),
         handle: { meta: goalsRouteMeta },
         path: 'goals',
+      },
+      {
+        children: [
+          {
+            element: dynamicElement(
+              () => import('@/routes/(main)/acceptance/empty'),
+              'Desktop > Project Acceptance > Empty',
+            ),
+            index: true,
+          },
+        ],
+        element: dynamicLayout(
+          () => import('@/routes/(main)/project/[projectId]/acceptance'),
+          'Desktop > Project Acceptance',
+        ),
+        handle: { meta: acceptanceRouteMeta },
+        path: 'acceptance',
       },
     ],
     element: dynamicLayout(

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -186,7 +186,7 @@ describe('desktop router shared definition', () => {
   });
 
   it.each(mainAreaVariants)(
-    '%s exposes projects as task and goal containers only',
+    '%s exposes project task, goal, and acceptance workspaces',
     (_, factory) => {
       const projectRoute = factory().find((route) => route.path === 'project/:projectId');
       const projectIndexRoute = projectRoute?.children?.find((route) => route.index);
@@ -194,7 +194,7 @@ describe('desktop router shared definition', () => {
         ?.map((route) => route.path)
         .filter((routePath): routePath is string => Boolean(routePath));
 
-      expect(projectPaths).toEqual(['tasks', 'goals']);
+      expect(projectPaths).toEqual(['tasks', 'goals', 'acceptance']);
       expect(
         (projectIndexRoute?.element as ReactElement<{ to: string }> | undefined)?.props.to,
       ).toBe('tasks');


### PR DESCRIPTION
## Summary

- add an Acceptance tab to the Project sidebar and register the shared desktop route
- reuse the canonical Acceptance master-detail workspace inside Project
- scope flat and paginated Acceptance queries by project ID across DB, service, router, client, and SWR keys
- keep project empty states in context instead of showing the global first-use onboarding

## Verification

- `bun run check <16 changed files>` — lint clean, 92 tests passed
- `bun run check --type` — types clean
- browser-verified the Project Acceptance tab, project-scoped list, and detail empty state