### PR TITLE
🐛 fix(artifact): keep React artifact preview alive for apps over 16 KiB

### DIFF
--- a/packages/artifact-template/src/index.ts
+++ b/packages/artifact-template/src/index.ts
@@ -99,6 +99,54 @@ export const REACT_ARTIFACT_DEFAULT_DEV_DEPENDENCIES: Record<string, string> = {
   'esbuild-wasm': '^0.17.12',
   'typescript': 'latest',
   'vite': '4.2.0',
+  // Babel presets used instead of esbuild for TS/JSX — see `defaultViteConfig` for why.
+  '@babel/preset-react': '^7.26.3',
+  '@babel/preset-typescript': '^7.26.0',
+};
+
+/**
+ * Bare module specifiers that must always be pre-bundled: they are imported by the
+ * bootstrap entry / injected by `@vitejs/plugin-react`, so Vite needs them regardless of
+ * what the artifact itself imports.
+ */
+const REACT_ARTIFACT_CORE_OPTIMIZE_DEPS = [
+  'react',
+  'react-dom',
+  'react-dom/client',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+];
+
+// Static `import`/`export ... from` statements only; dynamic `import()` calls are left to
+// Vite's runtime dependency discovery.
+const IMPORT_SPECIFIER_RE = /\b(?:import|export)\b(?:[^'"]+?\bfrom)?\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Collect the bare package specifiers imported by the artifact source so they can be
+ * listed in `optimizeDeps.include`. Relative and absolute paths are skipped; alias
+ * prefixes are mapped to their real package target.
+ */
+export const collectArtifactBareImports = (appCode: string): string[] => {
+  const specifiers = new Set<string>();
+
+  for (const match of appCode.matchAll(IMPORT_SPECIFIER_RE)) {
+    let specifier = match[1];
+    if (specifier.startsWith('.') || specifier.startsWith('/')) continue;
+
+    for (const [alias, target] of Object.entries(REACT_ARTIFACT_VITE_ALIASES)) {
+      if (specifier === alias || specifier.startsWith(`${alias}/`)) {
+        specifier = target + specifier.slice(alias.length);
+        break;
+      }
+    }
+
+    // Unresolved aliases (e.g. `@/lib/utils`) are not packages.
+    if (specifier.startsWith('@/')) continue;
+
+    specifiers.add(specifier);
+  }
+
+  return [...specifiers];
 };
 
 export const REACT_ARTIFACT_TAILWIND_CDN = 'https://cdn.tailwindcss.com';
@@ -141,12 +189,43 @@ createRoot(container).render(
 );
 `;
 
-const defaultViteConfig = `import react from '@vitejs/plugin-react';
+// Why this config avoids esbuild for the artifact source:
+//
+// In the Sandpack preview, Vite runs inside Nodebox, where `esbuild-wasm` runs as an
+// emulated child process talking to Vite over an emulated stdio pipe. Any single message
+// Vite sends to that child larger than 16 KiB desyncs the esbuild protocol and the
+// service hangs forever — every transform after that times out and the preview stays
+// blank. Two code paths push the raw `App.tsx` through that pipe:
+//   1. the `vite:esbuild` TS/JSX transform plugin, and
+//   2. the dependency scanner (`optimizeDeps.entries` crawl), which feeds entry sources
+//      to esbuild via `onLoad`.
+// Real artifacts easily exceed 16 KiB, so both are switched off: `@vitejs/plugin-react`
+// compiles TS/JSX with Babel in-process, and `optimizeDeps` gets an explicit `include`
+// list (derived from the artifact's imports) with no entry crawl. Pre-bundling itself is
+// safe because esbuild reads `node_modules` and writes output on its own side of the pipe.
+//
+// `esbuild: false` must be re-applied by a trailing plugin because `@vitejs/plugin-react`'s
+// `config()` hook returns an `esbuild: { jsx: ... }` object that overrides the user value.
+const defaultViteConfig = (
+  optimizeDepsInclude: string[],
+) => `import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   base: './',
-  plugins: [react()],
+  esbuild: false,
+  optimizeDeps: {
+    entries: [],
+    include: ${JSON.stringify(optimizeDepsInclude, null, 6)},
+  },
+  plugins: [
+    react({
+      babel: {
+        presets: ['@babel/preset-typescript', ['@babel/preset-react', { runtime: 'automatic' }]],
+      },
+    }),
+    { name: 'lobe-artifact:disable-esbuild', enforce: 'post', config: () => ({ esbuild: false }) },
+  ],
   resolve: {
     alias: ${JSON.stringify(REACT_ARTIFACT_VITE_ALIASES, null, 6)},
   },
@@ -192,8 +271,16 @@ export const buildReactArtifactProject = (
     ...overrides?.packageJson?.devDependencies,
   };
 
+  const resolvedAppCode = overrides?.appCode ?? appCode;
+  const optimizeDepsInclude = [
+    ...new Set([
+      ...REACT_ARTIFACT_CORE_OPTIMIZE_DEPS,
+      ...collectArtifactBareImports(resolvedAppCode),
+    ]),
+  ];
+
   const files: Record<string, string> = {
-    [REACT_ARTIFACT_APP_PATH]: overrides?.appCode ?? appCode,
+    [REACT_ARTIFACT_APP_PATH]: resolvedAppCode,
     [REACT_ARTIFACT_BOOTSTRAP_PATH]: overrides?.entry ?? defaultEntry,
     [REACT_ARTIFACT_INDEX_HTML_PATH]: overrides?.indexHtml ?? defaultIndexHtml(resolvedTitle),
     [REACT_ARTIFACT_PACKAGE_JSON_PATH]: defaultPackageJson(
@@ -201,7 +288,8 @@ export const buildReactArtifactProject = (
       dependencies,
       devDependencies,
     ),
-    [REACT_ARTIFACT_VITE_CONFIG_PATH]: overrides?.viteConfig ?? defaultViteConfig,
+    [REACT_ARTIFACT_VITE_CONFIG_PATH]:
+      overrides?.viteConfig ?? defaultViteConfig(optimizeDepsInclude),
   };
 
   if (extraFiles) {


### PR DESCRIPTION
React artifacts larger than ~16 KiB rendered a blank Sandpack preview (BroadcastChannel timeout on `/index.tsx`), while small hello-world artifacts worked. Follow-up to #19058.

**Root cause.** In the Sandpack preview Vite runs inside Nodebox, where `esbuild-wasm` is an emulated child process on an emulated stdio pipe. Any single message Vite pushes to that child over 16 KiB desyncs the esbuild protocol and the service hangs forever, so every later transform times out. Bisected on `App.tsx` size: 15 306 bytes renders, 17 331 bytes hangs, independent of content (pure comment padding reproduces it). Two paths push the raw `App.tsx` through the pipe: the `vite:esbuild` TS/JSX transform, and the `optimizeDeps` entry scanner (`onLoad`).

**Fix** (in `@lobechat/artifact-template`, shared by the preview and the publish-site build so "previews = publishes" stays true):
- `esbuild: false`, re-applied by a trailing plugin because `@vitejs/plugin-react`'s `config()` hook returns an `esbuild: { jsx }` object that overrides the user value.
- TS/JSX compiled in-process by `@vitejs/plugin-react` with `@babel/preset-typescript` + `@babel/preset-react` (added as devDependencies).
- `optimizeDeps: { entries: [], include: [...] }` — the include list is the React core set plus bare specifiers statically collected from the artifact's `import`/`export … from` statements, so pre-bundling (which stays on esbuild's own side of the pipe) still happens without a scan.

| Before | After |
| ------ | ----- |
| 20 KB snake artifact: blank preview, `/App.tsx` → "Failed to fetch" after 20 s | same artifact renders (title, score, start button); `/App.tsx` 200 in ~4 ms |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified in a standalone Sandpack harness (40 KB comment-padded hello + the real 20 KB snake app) and in the app's artifact portal via agent-browser + raw CDP probes into the cross-origin preview iframe. Small artifacts still render with the new config; dependency pre-bundle completes (`/node_modules/.vite/deps/_metadata.json` 200).

#### Key Decisions / Non-goals

- Same config for preview and publish build: Babel instead of esbuild is slightly slower for the site builder but keeps a single source of truth and identical transform semantics.
- Dynamic `import()` specifiers are not collected; Vite's runtime dependency discovery still covers them (with a reload).
- `typescript: 'latest'` now pulls TypeScript's native platform packages during Nodebox install; not addressed here.