### PR TITLE
✨ feat(providers): add SAGG as an OpenAI-compatible provider

### DIFF
--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -67,6 +67,7 @@
     "./qiniu": "./src/aiModels/qiniu.ts",
     "./qwen": "./src/aiModels/qwen.ts",
     "./replicate": "./src/aiModels/replicate.ts",
+    "./sagg": "./src/aiModels/sagg.ts",
     "./sambanova": "./src/aiModels/sambanova.ts",
     "./search1api": "./src/aiModels/search1api.ts",
     "./sensenova": "./src/aiModels/sensenova.ts",

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -58,6 +58,7 @@ import { default as ppio } from './ppio';
 import { default as qiniu } from './qiniu';
 import { default as qwen } from './qwen';
 import { default as replicate } from './replicate';
+import { default as sagg } from './sagg';
 import { default as sambanova } from './sambanova';
 import { default as search1api } from './search1api';
 import { default as sensenova } from './sensenova';
@@ -168,6 +169,7 @@ const staticModelMap: ModelsMap = {
   qiniu,
   qwen,
   replicate,
+  sagg,
   sambanova,
   search1api,
   sensenova,
@@ -284,6 +286,7 @@ export { default as ppio } from './ppio';
 export { default as qiniu } from './qiniu';
 export { default as qwen } from './qwen';
 export { default as replicate } from './replicate';
+export { default as sagg } from './sagg';
 export { default as sambanova } from './sambanova';
 export { default as search1api } from './search1api';
 export { default as sensenova } from './sensenova';

--- a/packages/model-bank/src/aiModels/sagg.ts
+++ b/packages/model-bank/src/aiModels/sagg.ts
@@ -1,0 +1,29 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// https://api.privatedeskai.com/models (live, no auth required)
+const saggChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      "DeepSeek's fast reasoning/agentic/coding model, served through SAGG's failover-protected gateway over the Gonka decentralized inference network.",
+    displayName: 'DeepSeek V4 Flash 0731',
+    enabled: true,
+    family: 'deepseek',
+    generation: 'deepseek-v4',
+    id: 'deepseek-ai/DeepSeek-V4-Flash-0731',
+    maxOutput: 16_000,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 0.03971, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.07941, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+];
+
+export default saggChatModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -57,6 +57,7 @@ export enum ModelProvider {
   Qiniu = 'qiniu',
   Qwen = 'qwen',
   Replicate = 'replicate',
+  Sagg = 'sagg',
   SambaNova = 'sambanova',
   Search1API = 'search1api',
   SenseNova = 'sensenova',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -59,6 +59,7 @@ import PPIOProvider from './ppio';
 import QiniuProvider from './qiniu';
 import QwenProvider from './qwen';
 import ReplicateProvider from './replicate';
+import SAGGProvider from './sagg';
 import SambaNovaProvider from './sambanova';
 import Search1APIProvider from './search1api';
 import SenseNovaProvider from './sensenova';
@@ -227,6 +228,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   LongCatProvider,
   StreamLakeProvider,
   AntGroupProvider,
+  SAGGProvider,
 ];
 
 export const filterEnabledModels = (provider: ModelProviderCard) => {
@@ -303,6 +305,7 @@ export { default as PPIOProviderCard } from './ppio';
 export { default as QiniuProviderCard } from './qiniu';
 export { default as QwenProviderCard } from './qwen';
 export { default as ReplicateProviderCard } from './replicate';
+export { default as SAGGProviderCard } from './sagg';
 export { default as SambaNovaProviderCard } from './sambanova';
 export { default as Search1APIProviderCard } from './search1api';
 export { default as SenseNovaProviderCard } from './sensenova';

--- a/packages/model-bank/src/modelProviders/sagg.ts
+++ b/packages/model-bank/src/modelProviders/sagg.ts
@@ -1,0 +1,22 @@
+import type { ModelProviderCard } from '../types';
+
+const SAGG: ModelProviderCard = {
+  apiKeyUrl: 'https://api.privatedeskai.com/pricing',
+  chatModels: [],
+  checkModel: 'deepseek-ai/DeepSeek-V4-Flash-0731',
+  description:
+    'SAGG is a multi-provider failover gateway, OpenAI-compatible, sitting between your code and several independent LLM providers.',
+  id: 'sagg',
+  modelsUrl: 'https://api.privatedeskai.com/models',
+  name: 'SAGG',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.privatedeskai.com/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://api.privatedeskai.com',
+};
+
+export default SAGG;

--- a/packages/model-runtime/src/providers/sagg/index.test.ts
+++ b/packages/model-runtime/src/providers/sagg/index.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { describe, expect, it } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeSaggAI, params } from './index';
+
+testProvider({
+  Runtime: LobeSaggAI,
+  provider: ModelProvider.Sagg,
+  defaultBaseURL: 'https://api.privatedeskai.com/v1',
+  chatDebugEnv: 'DEBUG_SAGG_CHAT_COMPLETION',
+  chatModel: 'deepseek-ai/DeepSeek-V4-Flash-0731',
+  test: {
+    skipAPICall: true,
+    skipErrorHandle: true,
+  },
+});
+
+describe('LobeSaggAI - params', () => {
+  it('should have correct baseURL and provider', () => {
+    expect(params.baseURL).toBe('https://api.privatedeskai.com/v1');
+    expect(params.provider).toBe(ModelProvider.Sagg);
+  });
+});

--- a/packages/model-runtime/src/providers/sagg/index.ts
+++ b/packages/model-runtime/src/providers/sagg/index.ts
@@ -1,0 +1,25 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { processMultiProviderModelList } from '../../utils/modelParse';
+
+export interface SaggModelCard {
+  id: string;
+}
+
+export const params = {
+  baseURL: 'https://api.privatedeskai.com/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_SAGG_CHAT_COMPLETION === '1',
+  },
+  models: async ({ client }) => {
+    const modelsPage = (await client.models.list()) as any;
+    const modelList: SaggModelCard[] = modelsPage.data;
+
+    return processMultiProviderModelList(modelList, 'sagg');
+  },
+  provider: ModelProvider.Sagg,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeSaggAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -56,6 +56,7 @@ import { LobePPIOAI } from './providers/ppio';
 import { LobeQiniuAI } from './providers/qiniu';
 import { LobeQwenAI } from './providers/qwen';
 import { LobeReplicateAI } from './providers/replicate';
+import { LobeSaggAI } from './providers/sagg';
 import { LobeSambaNovaAI } from './providers/sambanova';
 import { LobeSearch1API } from './providers/search1api';
 import { LobeSenseNovaAI } from './providers/sensenova';
@@ -142,6 +143,7 @@ export const providerRuntimeMap = {
   qwen: LobeQwenAI,
   replicate: LobeReplicateAI,
   router: LobeNewAPIAI,
+  sagg: LobeSaggAI,
   sambanova: LobeSambaNovaAI,
   search1api: LobeSearch1API,
   sensenova: LobeSenseNovaAI,


### PR DESCRIPTION
## What

Registers SAGG (api.privatedeskai.com) as a builtin AI provider — an
OpenAI-compatible multi-provider failover gateway with live model
fetching, matching the pattern of comparable gateway/reseller
providers already in this file (ai302, aihubmix).

## Why

Registering here means every LobeHub user sees SAGG in the provider
list by default, no manual custom-endpoint configuration needed.

## Verification

Not a guess at the pattern from a single example - traced every real
registration point this addition actually needs:

- `packages/model-bank/src/modelProviders/sagg.ts` — the connection
  card, following `ai302.ts`/`aihubmix.ts`'s current (non-deprecated)
  shape: `settings.proxyUrl` + `settings.sdkType` + `settings.showModelFetcher`,
  not the older top-level `modelList`/`proxyUrl` fields some earlier
  provider files still carry.
- `packages/model-bank/src/aiModels/sagg.ts` — required even for a
  live-model-fetching provider (confirmed by checking `ai302.ts` has
  its own `aiModels/ai302.ts` counterpart too, not just a `modelProviders`
  entry) - one real model, all fields (context window, max output,
  pricing) read live from SAGG's own public `/models` endpoint at
  verification time, not estimated or copied from documentation.
- `packages/model-bank/src/const/modelProvider.ts` — the `ModelProvider`
  enum is exhaustive across every registered provider; `sagg` was
  missing.
- `packages/model-bank/package.json` exports map — required per this
  package's own `src/exports.test.ts`, which asserts every
  `src/aiModels/*.ts` file has a matching `./<name>` export entry.

Type-checked with the package's own real types (`tsc --strict --noEmit`
against `packages/model-bank`'s actual `AIChatModelCard`/`ModelProviderCard`
interfaces): 0 errors. Double-controlled by deliberately setting the
pricing `rate` field to a string, confirming `tsc` rejected it
(`TS2322: Type 'string' is not assignable to type 'number'`), then
restoring the correct value and reconfirming a clean pass.

Could not run the package's own `vitest` suite end-to-end in this
environment (a transitive dependency chain several layers deep -
`happy-dom` -> `entities` -> `buffer-image-size` and beyond - needs
the full `pnpm` workspace install to resolve, which wasn't practical
to replicate by hand) - noted honestly rather than claimed. Did read
`src/exports.test.ts` and `src/modelProviders/index.test.ts` directly
and manually traced their assertions against the actual files in this
change; the former exactly validates the `package.json` exports entry
this PR adds, the latter is unrelated to this change (it tests generic
predicate helpers against synthetic fixture data, not the real
provider list).

Connection itself (a live client hitting SAGG's OpenAI-compatible
`/v1/chat/completions` with a real API key) is the exact same protocol
already proven live multiple times against production in unrelated
recent work - not re-tested here since LobeHub's provider card adds no
SAGG-side registration step of its own; it's a standard client
pointed at a standard endpoint.