### PR TITLE
🐛 fix(local-system): allow reading large PDFs

### DIFF
--- a/packages/local-file-shell/src/file/__tests__/file.test.ts
+++ b/packages/local-file-shell/src/file/__tests__/file.test.ts
@@ -168,6 +168,34 @@ describe('file operations', () => {
       expect(result.charCount).toBe(0);
     });
 
+    it('should parse PDFs larger than the text file size cap', async () => {
+      const filePath = path.join(tmpDir, 'large.pdf');
+      const objects = [
+        '<< /Type /Catalog /Pages 2 0 R >>',
+        '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+        '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+        '<< /Length 45 >>\nstream\nBT /F1 12 Tf 72 720 Td (Large PDF works) Tj ET\nendstream',
+        '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+        `<< /Length ${10 * 1024 * 1024} >>\nstream\n${' '.repeat(10 * 1024 * 1024)}\nendstream`,
+      ];
+      let pdf = '%PDF-1.4\n';
+      const offsets = objects.map((object, index) => {
+        const offset = Buffer.byteLength(pdf);
+        pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+        return offset;
+      });
+      const xrefOffset = Buffer.byteLength(pdf);
+      pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+      pdf += offsets.map((offset) => `${offset.toString().padStart(10, '0')} 00000 n \n`).join('');
+      pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+      await writeFile(filePath, pdf);
+
+      const result = await readLocalFile({ path: filePath });
+
+      expect(result.content).toContain('Large PDF works');
+      expect(result.content).not.toContain('too large');
+    });
+
     it('should still read normal source files of allowed extensions', async () => {
       const filePath = path.join(tmpDir, 'app.cjs');
       await writeFile(filePath, "module.exports = { hello: 'world' };\n");

--- a/packages/local-file-shell/src/file/__tests__/file.test.ts
+++ b/packages/local-file-shell/src/file/__tests__/file.test.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, truncate, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -194,6 +194,19 @@ describe('file operations', () => {
 
       expect(result.content).toContain('Large PDF works');
       expect(result.content).not.toContain('too large');
+    });
+
+    it('should reject PDFs larger than the PDF size cap before parsing', async () => {
+      const filePath = path.join(tmpDir, 'oversized.pdf');
+      await writeFile(filePath, 'not actually a PDF');
+      await truncate(filePath, 50 * 1024 * 1024 + 1);
+
+      const result = await readLocalFile({ path: filePath });
+
+      expect(result.content).toContain('too large');
+      expect(result.content).toContain(`limit ${50 * 1024 * 1024}`);
+      expect(result.content).toContain('split it into multiple documents');
+      expect(result.charCount).toBe(0);
     });
 
     it('should still read normal source files of allowed extensions', async () => {

--- a/packages/local-file-shell/src/file/read.ts
+++ b/packages/local-file-shell/src/file/read.ts
@@ -13,6 +13,8 @@ import { resolveAgainstCwd } from './expandTilde';
 
 /** Hard cap on file size we will read into memory at all (10MB). */
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+/** PDFs are commonly image-heavy, but pdfjs still loads the entire source into memory. */
+const MAX_PDF_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 /** Cap on the total chars returned to the agent. */
 const MAX_OUTPUT_CHARS = 500_000;
 /** Cap on chars per line. Keeps a single 27KB base64 line from blowing up the response. */
@@ -67,12 +69,15 @@ export async function readLocalFile({
 
   const extension = path.extname(filePath).toLowerCase().replace('.', '');
 
-  // PDFs are parsed into text by pdfjs and remain bounded by the output caps below.
-  // Their source size is often dominated by embedded images and does not reflect text volume.
-  if (extension !== 'pdf' && stats.size > MAX_FILE_SIZE_BYTES) {
+  const maxFileSize = extension === 'pdf' ? MAX_PDF_FILE_SIZE_BYTES : MAX_FILE_SIZE_BYTES;
+  if (stats.size > maxFileSize) {
+    const suggestion =
+      extension === 'pdf'
+        ? 'Use a smaller PDF or split it into multiple documents.'
+        : 'Use grep / shell tools to inspect specific parts.';
     return buildErrorResult(
       filePath,
-      `Error: File is too large to read (${stats.size} bytes, limit ${MAX_FILE_SIZE_BYTES}). Use grep / shell tools to inspect specific parts.`,
+      `Error: File is too large to read (${stats.size} bytes, limit ${maxFileSize}). ${suggestion}`,
     );
   }
 

--- a/packages/local-file-shell/src/file/read.ts
+++ b/packages/local-file-shell/src/file/read.ts
@@ -65,14 +65,17 @@ export async function readLocalFile({
     return buildErrorResult(filePath, 'This is a directory and cannot be read as plain text.');
   }
 
-  if (stats.size > MAX_FILE_SIZE_BYTES) {
+  const extension = path.extname(filePath).toLowerCase().replace('.', '');
+
+  // PDFs are parsed into text by pdfjs and remain bounded by the output caps below.
+  // Their source size is often dominated by embedded images and does not reflect text volume.
+  if (extension !== 'pdf' && stats.size > MAX_FILE_SIZE_BYTES) {
     return buildErrorResult(
       filePath,
       `Error: File is too large to read (${stats.size} bytes, limit ${MAX_FILE_SIZE_BYTES}). Use grep / shell tools to inspect specific parts.`,
     );
   }
 
-  const extension = path.extname(filePath).toLowerCase().replace('.', '');
   if (extension && !isReadableFileType(extension)) {
     return buildErrorResult(
       filePath,


### PR DESCRIPTION
### Summary

- allow PDF files above the generic 10 MiB source-size guard
- retain a dedicated 50 MiB PDF input cap before pdf.js reads the file into memory
- keep the existing parsed-output and per-line limits in place
- add regression coverage for both accepted large PDFs and rejected oversized PDF inputs

### Test plan

- `bun run check packages/local-file-shell/src/file/read.ts packages/local-file-shell/src/file/__tests__/file.test.ts`
- 67 related tests passed