### PR TITLE
🐛 fix(web): gate desktop-only electron SWR hooks off-web

### DIFF
--- a/src/store/electron/actions/__tests__/webSuspenseGuard.test.ts
+++ b/src/store/electron/actions/__tests__/webSuspenseGuard.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { Component, createElement, type ReactNode, Suspense } from 'react';
+import { SWRConfig } from 'swr';
+import { describe, expect, it } from 'vitest';
+
+import { type ElectronStore, useElectronStore } from '@/store/electron';
+
+/**
+ * Regression: on web (non-desktop) these SWR hooks used to call the Electron
+ * IPC unconditionally. The fetch always rejected with "electronAPI.invoke not
+ * found", which was silent until layouts adopted `SWRConfig { suspense: true }`
+ * — then the rejection was thrown during render and the route boundary
+ * replaced the whole page with a load-failure screen (/settings/devices,
+ * /settings/proxy). The keys must be null off-desktop so no fetch starts.
+ */
+
+class Boundary extends Component<{ children: ReactNode }, { error?: Error }> {
+  state: { error?: Error } = {};
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    return this.state.error ? `boundary: ${this.state.error.message}` : this.props.children;
+  }
+}
+
+const desktopOnlySwrHooks = [
+  'useFetchGatewayDeviceInfo',
+  'useFetchGatewayStatus',
+  'useFetchDesktopHotkeys',
+  'useGetProxySettings',
+  'useDataSyncConfig',
+] as const;
+
+describe('desktop-only SWR hooks under a suspense SWRConfig on web', () => {
+  it.each(desktopOnlySwrHooks)('%s neither fetches nor throws', async (hookName) => {
+    const rendered: string[] = [];
+
+    renderHook(
+      () => {
+        const useHook = useElectronStore((s) => s[hookName] as ElectronStore[typeof hookName]);
+        useHook();
+        rendered.push(hookName);
+      },
+      {
+        wrapper: ({ children }) =>
+          createElement(
+            SWRConfig,
+            { value: { provider: () => new Map(), suspense: true } },
+            createElement(Boundary, undefined, createElement(Suspense, undefined, children)),
+          ),
+      },
+    );
+
+    // Before the fix the hook suspended on the doomed IPC fetch, the rejection
+    // hit the boundary, and the hook body never (re)rendered to completion.
+    await waitFor(() => expect(rendered.length).toBeGreaterThan(0));
+  });
+});

--- a/src/store/electron/actions/gateway.ts
+++ b/src/store/electron/actions/gateway.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import type { GatewayConnectionStatus } from '@lobechat/electron-client-ipc';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
@@ -55,7 +56,10 @@ export class ElectronGatewayActionImpl {
 
   useFetchGatewayDeviceInfo = (): SWRResponse<GatewayDeviceInfo> => {
     return useSWR<GatewayDeviceInfo>(
-      electronKeys.gatewayDeviceInfo(),
+      // Desktop-only IPC: on web there is no electronAPI, and under a
+      // suspense-mode SWRConfig a rejected fetch throws into the route
+      // boundary instead of staying in `error` — so never fetch off-desktop.
+      isDesktop ? electronKeys.gatewayDeviceInfo() : null,
       async () => gatewayConnectionService.getDeviceInfo() as Promise<GatewayDeviceInfo>,
       {
         onSuccess: (data) => {
@@ -67,7 +71,7 @@ export class ElectronGatewayActionImpl {
 
   useFetchGatewayStatus = (): SWRResponse<{ status: GatewayConnectionStatus }> => {
     return useSWR<{ status: GatewayConnectionStatus }>(
-      'electron:getGatewayConnectionStatus',
+      isDesktop ? 'electron:getGatewayConnectionStatus' : null,
       async () => gatewayConnectionService.getConnectionStatus(),
       {
         onSuccess: (data) => {

--- a/src/store/electron/actions/settings.ts
+++ b/src/store/electron/actions/settings.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import {
   type NetworkProxySettings,
   type ShortcutUpdateResult,
@@ -76,7 +77,10 @@ export class ElectronSettingsActionImpl {
 
   useFetchDesktopHotkeys = (): SWRResponse => {
     return useSWR<Record<string, string>>(
-      electronKeys.desktopHotkeys(),
+      // Desktop-only IPC: on web there is no electronAPI, and under a
+      // suspense-mode SWRConfig a rejected fetch throws into the route
+      // boundary instead of staying in `error` — so never fetch off-desktop.
+      isDesktop ? electronKeys.desktopHotkeys() : null,
       async () => desktopSettingsService.getDesktopHotkeys(),
       {
         onSuccess: (data) => {
@@ -90,7 +94,7 @@ export class ElectronSettingsActionImpl {
 
   useGetAppTrayVisible = (enabled = true): SWRResponse => {
     return useSWR<boolean>(
-      enabled ? electronKeys.appTrayVisible() : null,
+      enabled && isDesktop ? electronKeys.appTrayVisible() : null,
       async () => desktopSettingsService.getAppTrayVisible(),
       {
         onSuccess: (data) => {
@@ -104,7 +108,7 @@ export class ElectronSettingsActionImpl {
 
   useGetProxySettings = (): SWRResponse => {
     return useSWR<NetworkProxySettings>(
-      electronKeys.proxySettings(),
+      isDesktop ? electronKeys.proxySettings() : null,
       async () => desktopSettingsService.getProxySettings(),
       {
         onSuccess: (data) => {

--- a/src/store/electron/actions/sync.ts
+++ b/src/store/electron/actions/sync.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import { type DataSyncConfig } from '@lobechat/electron-client-ipc';
 import isEqual from 'fast-deep-equal';
 import { type SWRResponse } from 'swr';
@@ -110,7 +111,10 @@ export class ElectronRemoteServerActionImpl {
 
   useDataSyncConfig = (): SWRResponse => {
     return useSWR<DataSyncConfig>(
-      electronKeys.remoteServerConfig(),
+      // Desktop-only IPC: on web there is no electronAPI, and under a
+      // suspense-mode SWRConfig a rejected fetch throws into the route
+      // boundary instead of staying in `error` — so never fetch off-desktop.
+      isDesktop ? electronKeys.remoteServerConfig() : null,
       async () => {
         try {
           return await remoteServerService.getRemoteServerConfig();


### PR DESCRIPTION
### Problem

On web, `app.lobehub.com/settings/devices` and `/settings/proxy` crash to a full-page "加载失败 / load failed" screen.

The six electron-IPC SWR hooks in `src/store/electron/actions` (`useFetchGatewayDeviceInfo`, `useFetchGatewayStatus`, `useFetchDesktopHotkeys`, `useGetProxySettings`, `useGetAppTrayVisible`, `useDataSyncConfig`) fetched unconditionally, and on web the fetcher always rejects with `electronAPI.invoke not found` (`ensureElectronIpc`). This had been silently failing for months, but since the skeleton refactor wrapped settings/resource/group/etc. layouts in `SWRConfig { suspense: true }`, a rejected SWR fetch is thrown during render and caught by `SuspenseRouteBoundary`, replacing the whole route with the failure screen.

Confirmed blast radius on web:

- `/settings/devices` — `DeviceManager` (production crash, screenshot below)
- `/settings/proxy` — `ProxyForm` (tab is registered in the web `componentMap`, URL-reachable)
- ChatInput `HeteroDeviceSwitcher` / `ModelCatalogSelector` under the suspense-wrapped group layout — same latent crash

### Fix

Gate every desktop-only SWR key on `isDesktop` at the store layer (key = `null` off-desktop, so the fetch never starts). This fixes all call sites at once and also stops web from firing doomed IPC requests on every mount. It is correct regardless of whether the blanket suspense config stays.

#### Test

Regression test `webSuspenseGuard.test.ts` renders each hook under `SWRConfig { suspense: true }` in a web-like env (no `electronAPI`): 4/5 cases crash into the error boundary before the fix, all pass after.

- [x] Tested locally
- [x] Added/updated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)