### PR TITLE
✨ feat(goal): fullscreen exploration map hosts the drill-down portal; resolve problem nodes on achieve

### DIFF
--- a/apps/server/src/services/goal/decideNextMove.ts
+++ b/apps/server/src/services/goal/decideNextMove.ts
@@ -13,7 +13,7 @@ export { GOAL_ACCEPTANCE_TASK_TITLE } from '@lobechat/const/goal';
 export const LEASE_EXPIRED_ERROR = 'Goal Work operation lease expired.';
 export const VERIFICATION_FAILED_ERROR = 'Delivery did not pass verification.';
 
-const TERMINAL_NODE_STATUSES = new Set(['resolved', 'rejected', 'retired']);
+export const TERMINAL_NODE_STATUSES = new Set(['resolved', 'rejected', 'retired']);
 
 export interface FrontierSelection {
   /** Every eligible task node, best first — the trace-shaped view. */

--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -795,7 +795,13 @@ describe('GoalService', () => {
       message: 'Goal-level acceptance passed',
       outcome: 'achieved',
     });
-    expect((await service.graph(graph.goal.id)).goal.status).toBe('achieved');
+    const finalGraph = await service.graph(graph.goal.id);
+    expect(finalGraph.goal.status).toBe('achieved');
+    // The verdict closes the map too: the seeded problem node has no other
+    // resolution path, and must not read "active" on an achieved goal.
+    expect(finalGraph.nodes.find((node) => node.kind === 'problem')).toMatchObject({
+      status: 'resolved',
+    });
   });
 
   it('does not mark a required goal achieved when only its initial Work is complete', async () => {

--- a/apps/server/src/services/goal/index.ts
+++ b/apps/server/src/services/goal/index.ts
@@ -39,6 +39,7 @@ import {
   GOAL_ACCEPTANCE_TASK_TITLE,
   type GoalMove,
   selectFrontier,
+  TERMINAL_NODE_STATUSES,
 } from './decideNextMove';
 import {
   resolveMaxConcurrentTasks,
@@ -782,6 +783,14 @@ export class GoalService {
     const goalId = graph.goal.id;
 
     if (move.outcome === 'achieved') {
+      // The map must agree with the verdict: only task nodes get resolved as
+      // Work completes, so without this the seeded problem nodes would read
+      // "active / unanswered" forever on an achieved goal.
+      for (const node of graph.nodes) {
+        if (node.kind !== 'problem' || TERMINAL_NODE_STATUSES.has(node.status)) continue;
+        await this.coordinatorGraph.updateNodeStatus(goalId, node.id, 'resolved', 'Goal achieved');
+        effects.push({ detail: 'resolved', nodeId: node.id, type: 'node_status' });
+      }
       await this.transitionStatus(graph.goal, 'achieved', 'Goal-level acceptance passed');
       effects.push({ type: 'goal_status', detail: 'achieved' });
       return { goalId, message: move.message, outcome: 'achieved' };

--- a/src/features/AgentGoals/GoalDetailPage.tsx
+++ b/src/features/AgentGoals/GoalDetailPage.tsx
@@ -117,6 +117,10 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
   const openGoalMetric = useChatStore((s) => s.openGoalMetric);
   const clearPortalStack = useChatStore((s) => s.clearPortalStack);
 
+  // While the exploration map runs fullscreen its overlay carries the portal
+  // panel; ours unmounts so exactly one PortalContent is alive at a time.
+  const [graphFullscreen, setGraphFullscreen] = useState(false);
+
   // Same per-view width grammar as the conversation portal, but remembered
   // under the 'goal' scope: resizing here never affects the chat surface.
   const { maxWidth, minWidth, updateWidth, width } = usePortalPanelWidth(currentViewType, 'goal');
@@ -274,7 +278,11 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
               )}
             </Flexbox>
 
-            <ProcessControl goalId={goal.id} />
+            <ProcessControl
+              goalId={goal.id}
+              graphFullscreen={graphFullscreen}
+              onGraphFullscreenChange={setGraphFullscreen}
+            />
           </WideScreenContainer>
         </Flexbox>
       </Flexbox>
@@ -285,7 +293,7 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
           open, the panel hosts the conversation with the goal's responsible
           agent so a user can just ask about progress. */}
       <RightPanel
-        expand={showPortal || (chatOpen && !!agentId)}
+        expand={(showPortal || (chatOpen && !!agentId)) && !graphFullscreen}
         maxWidth={maxWidth}
         minWidth={minWidth}
         width={width}
@@ -295,7 +303,7 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
           setChatOpen(next);
         }}
       >
-        {showPortal ? (
+        {graphFullscreen ? null : showPortal ? (
           <PortalContent />
         ) : agentId ? (
           <GoalChat agentId={agentId} goalId={goalId} onCollapse={() => setChatOpen(false)} />

--- a/src/features/AgentGoals/ProcessControl/Graph/index.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/index.tsx
@@ -21,6 +21,12 @@ import { Maximize2, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { PortalContent } from '@/features/Portal/router';
+import { usePortalPanelWidth } from '@/features/Portal/usePortalPanelWidth';
+import RightPanel from '@/features/RightPanel';
+import { useChatStore } from '@/store/chat';
+import { chatPortalSelectors } from '@/store/chat/selectors';
+
 import type { GoalGraphView, GoalNodeView } from '../goalGraphViewModel';
 import { KindDot } from '../shared';
 import GraphNodeView, { GhostNodeView, type GraphNodeData } from './GraphNode';
@@ -29,7 +35,8 @@ import { layoutGraph, NODE_WIDTH } from './layout';
 /**
  * The exploration map. Two views: 当前阶段 (what got the goal here plus what the
  * next advance unlocks) and 全图. Edges carry their relation as a label so the
- * map reads without a legend; fullscreen is a real overlay, not a taller box.
+ * map reads without a legend; fullscreen is a real overlay, not a taller box,
+ * and carries its own right-hand portal panel so node drill-down keeps working.
  */
 
 const styles = createStaticStyles(({ css }) => ({
@@ -111,14 +118,33 @@ const styles = createStaticStyles(({ css }) => ({
     position: fixed;
     z-index: 1000;
     inset: 0;
+
+    display: flex;
+    flex-direction: row;
+
     background: ${cssVar.colorBgLayout};
+  `,
+  /* The corner cards anchor to the canvas area, not the whole overlay, so the
+     portal panel opening on the right never slides under them. */
+  overlayMain: css`
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    height: 100%;
   `,
 }));
 
 type GraphViewMode = 'stage' | 'all';
 
 interface GraphProps {
+  /**
+   * Fullscreen is owned by the page: the overlay replaces the page's Portal
+   * panel with its own, and only the owner can keep exactly one of the two
+   * mounted at a time.
+   */
+  fullscreen: boolean;
   graph: GoalGraphView;
+  onFullscreenChange: (fullscreen: boolean) => void;
   onSelect: (nodeId: string) => void;
   /** The coordinator is still decomposing: show ghost task cards under the problem. */
   planning?: boolean;
@@ -211,200 +237,221 @@ const GHOST_GAP = 32;
 const GHOST_RANK_GAP = 56;
 const GHOST_HEIGHT = 88;
 
-const Canvas = memo<GraphProps & { className: string; interactive: boolean; view: GraphViewMode }>(
-  ({ className, graph, interactive, onSelect, planning, selectedId, view }) => {
-    const { fitView } = useReactFlow();
-    const subtitleOf = useSubtitle();
-    const edgeLabel = useEdgeLabel();
+const Canvas = memo<
+  Pick<GraphProps, 'graph' | 'onSelect' | 'planning' | 'selectedId'> & {
+    className: string;
+    interactive: boolean;
+    /** Bump to refit after the frame around the canvas changes size. */
+    refitKey?: boolean;
+    view: GraphViewMode;
+  }
+>(({ className, graph, interactive, onSelect, planning, refitKey, selectedId, view }) => {
+  const { fitView } = useReactFlow();
+  const subtitleOf = useSubtitle();
+  const edgeLabel = useEdgeLabel();
 
-    const visibleIds = useMemo(
-      () =>
-        view === 'all' ? new Set(graph.nodes.map((item) => item.node.id)) : stageNodeIds(graph),
-      [graph, view],
+  const visibleIds = useMemo(
+    () => (view === 'all' ? new Set(graph.nodes.map((item) => item.node.id)) : stageNodeIds(graph)),
+    [graph, view],
+  );
+  const positions = useMemo(() => {
+    const nodes: GoalGraphNode[] = graph.nodes
+      .filter((item) => visibleIds.has(item.node.id))
+      .map((item) => item.node);
+    const edges = graph.edges.filter(
+      (edge) => visibleIds.has(edge.sourceNodeId) && visibleIds.has(edge.targetNodeId),
     );
-    const positions = useMemo(() => {
-      const nodes: GoalGraphNode[] = graph.nodes
+    return layoutGraph(nodes, edges);
+  }, [graph, visibleIds]);
+
+  const ghosts = useMemo(() => {
+    if (!planning) return [];
+    const problem = graph.nodes.find((item) => item.node.kind === 'problem');
+    const box = problem ? positions[problem.node.id] : undefined;
+    const centerX = box ? box.x + box.width / 2 : 0;
+    const y = box ? box.y + box.height + GHOST_RANK_GAP : 0;
+    const width = NODE_WIDTH.task;
+    const total = width * GHOST_COUNT + GHOST_GAP * (GHOST_COUNT - 1);
+    return Array.from({ length: GHOST_COUNT }, (_, i) => ({
+      id: `goal-ghost-${i}`,
+      sourceId: problem && box ? problem.node.id : undefined,
+      x: centerX - total / 2 + i * (width + GHOST_GAP),
+      y,
+    }));
+  }, [planning, graph, positions]);
+
+  // Inline, the canvas hugs its content: a two-node graph in a fixed 560px
+  // frame is mostly empty margin, and `fitView` then shrinks the nodes to
+  // fill it. Sizing the frame from the layout keeps small graphs at natural
+  // node scale; 560px stays the ceiling so large graphs still zoom out.
+  const inlineHeight = useMemo(() => {
+    const boxes = Object.values(positions);
+    if (boxes.length === 0 && ghosts.length === 0) return 216;
+    const top = Math.min(...boxes.map((box) => box.y), ...ghosts.map((ghost) => ghost.y));
+    const bottom = Math.max(
+      ...boxes.map((box) => box.y + box.height),
+      ...ghosts.map((ghost) => ghost.y + GHOST_HEIGHT),
+    );
+    return Math.min(560, Math.max(216, bottom - top + 72));
+  }, [positions, ghosts]);
+
+  const ghostFlowNodes: FlowNode[] = useMemo(
+    () =>
+      ghosts.map((ghost) => ({
+        data: {},
+        draggable: false,
+        id: ghost.id,
+        position: { x: ghost.x, y: ghost.y },
+        selectable: false,
+        type: 'goalGhost',
+        width: NODE_WIDTH.task,
+      })),
+    [ghosts],
+  );
+
+  const flowNodes: FlowNode[] = useMemo(
+    () =>
+      graph.nodes
         .filter((item) => visibleIds.has(item.node.id))
-        .map((item) => item.node);
-      const edges = graph.edges.filter(
-        (edge) => visibleIds.has(edge.sourceNodeId) && visibleIds.has(edge.targetNodeId),
-      );
-      return layoutGraph(nodes, edges);
-    }, [graph, visibleIds]);
+        .map((item) => {
+          const box = positions[item.node.id];
+          const isGate = item.node.kind === 'decision' && item.node.status === 'waiting';
+          const data: GraphNodeData = {
+            // Not started and still blocked — it is context, not the story.
+            dim: item.node.status === 'proposed' && item.blockers.length > 0,
+            isGate,
+            running: item.node.status === 'active' && !item.isStale,
+            selected: selectedId === item.node.id,
+            stale: item.isStale,
+            subtitle: subtitleOf(item),
+            view: item,
+          };
+          return {
+            data,
+            draggable: false,
+            id: item.node.id,
+            position: { x: box?.x ?? 0, y: box?.y ?? 0 },
+            type: 'goalNode',
+            width: NODE_WIDTH[item.node.kind],
+          } satisfies FlowNode;
+        }),
+    [graph, visibleIds, positions, selectedId, subtitleOf],
+  );
 
-    const ghosts = useMemo(() => {
-      if (!planning) return [];
-      const problem = graph.nodes.find((item) => item.node.kind === 'problem');
-      const box = problem ? positions[problem.node.id] : undefined;
-      const centerX = box ? box.x + box.width / 2 : 0;
-      const y = box ? box.y + box.height + GHOST_RANK_GAP : 0;
-      const width = NODE_WIDTH.task;
-      const total = width * GHOST_COUNT + GHOST_GAP * (GHOST_COUNT - 1);
-      return Array.from({ length: GHOST_COUNT }, (_, i) => ({
-        id: `goal-ghost-${i}`,
-        sourceId: problem && box ? problem.node.id : undefined,
-        x: centerX - total / 2 + i * (width + GHOST_GAP),
-        y,
-      }));
-    }, [planning, graph, positions]);
-
-    // Inline, the canvas hugs its content: a two-node graph in a fixed 560px
-    // frame is mostly empty margin, and `fitView` then shrinks the nodes to
-    // fill it. Sizing the frame from the layout keeps small graphs at natural
-    // node scale; 560px stays the ceiling so large graphs still zoom out.
-    const inlineHeight = useMemo(() => {
-      const boxes = Object.values(positions);
-      if (boxes.length === 0 && ghosts.length === 0) return 216;
-      const top = Math.min(...boxes.map((box) => box.y), ...ghosts.map((ghost) => ghost.y));
-      const bottom = Math.max(
-        ...boxes.map((box) => box.y + box.height),
-        ...ghosts.map((ghost) => ghost.y + GHOST_HEIGHT),
-      );
-      return Math.min(560, Math.max(216, bottom - top + 72));
-    }, [positions, ghosts]);
-
-    const ghostFlowNodes: FlowNode[] = useMemo(
-      () =>
-        ghosts.map((ghost) => ({
-          data: {},
-          draggable: false,
-          id: ghost.id,
-          position: { x: ghost.x, y: ghost.y },
-          selectable: false,
-          type: 'goalGhost',
-          width: NODE_WIDTH.task,
-        })),
-      [ghosts],
-    );
-
-    const flowNodes: FlowNode[] = useMemo(
-      () =>
-        graph.nodes
-          .filter((item) => visibleIds.has(item.node.id))
-          .map((item) => {
-            const box = positions[item.node.id];
-            const isGate = item.node.kind === 'decision' && item.node.status === 'waiting';
-            const data: GraphNodeData = {
-              // Not started and still blocked — it is context, not the story.
-              dim: item.node.status === 'proposed' && item.blockers.length > 0,
-              isGate,
-              running: item.node.status === 'active' && !item.isStale,
-              selected: selectedId === item.node.id,
-              stale: item.isStale,
-              subtitle: subtitleOf(item),
-              view: item,
-            };
-            return {
-              data,
-              draggable: false,
-              id: item.node.id,
-              position: { x: box?.x ?? 0, y: box?.y ?? 0 },
-              type: 'goalNode',
-              width: NODE_WIDTH[item.node.kind],
-            } satisfies FlowNode;
-          }),
-      [graph, visibleIds, positions, selectedId, subtitleOf],
-    );
-
-    const flowEdges: FlowEdge[] = useMemo(
-      () =>
-        graph.edges
-          .filter((edge) => visibleIds.has(edge.sourceNodeId) && visibleIds.has(edge.targetNodeId))
-          .map((edge) => {
-            const [source, target] = orient(edge);
-            const hot = selectedId === edge.sourceNodeId || selectedId === edge.targetNodeId;
-            return {
-              className: cx(edge.kind === 'depends_on' && 'goal-dep', hot && 'goal-hot'),
-              id: edge.id,
-              label: edgeLabel(edge.kind),
-              labelShowBg: true,
-              markerEnd: {
-                color: cssVar.colorBorder,
-                height: 12,
-                type: MarkerType.ArrowClosed,
-                width: 12,
-              },
-              source,
-              target,
-              type: 'default',
-            } satisfies FlowEdge;
-          }),
-      [graph, visibleIds, selectedId, edgeLabel],
-    );
-
-    const ghostFlowEdges: FlowEdge[] = useMemo(
-      () =>
-        ghosts
-          .filter((ghost) => ghost.sourceId)
-          .map((ghost) => ({
-            animated: true,
-            id: `${ghost.id}-edge`,
-            source: ghost.sourceId!,
-            target: ghost.id,
+  const flowEdges: FlowEdge[] = useMemo(
+    () =>
+      graph.edges
+        .filter((edge) => visibleIds.has(edge.sourceNodeId) && visibleIds.has(edge.targetNodeId))
+        .map((edge) => {
+          const [source, target] = orient(edge);
+          const hot = selectedId === edge.sourceNodeId || selectedId === edge.targetNodeId;
+          return {
+            className: cx(edge.kind === 'depends_on' && 'goal-dep', hot && 'goal-hot'),
+            id: edge.id,
+            label: edgeLabel(edge.kind),
+            labelShowBg: true,
+            markerEnd: {
+              color: cssVar.colorBorder,
+              height: 12,
+              type: MarkerType.ArrowClosed,
+              width: 12,
+            },
+            source,
+            target,
             type: 'default',
-          })),
-      [ghosts],
+          } satisfies FlowEdge;
+        }),
+    [graph, visibleIds, selectedId, edgeLabel],
+  );
+
+  const ghostFlowEdges: FlowEdge[] = useMemo(
+    () =>
+      ghosts
+        .filter((ghost) => ghost.sourceId)
+        .map((ghost) => ({
+          animated: true,
+          id: `${ghost.id}-edge`,
+          source: ghost.sourceId!,
+          target: ghost.id,
+          type: 'default',
+        })),
+    [ghosts],
+  );
+
+  const allNodes = useMemo(() => [...flowNodes, ...ghostFlowNodes], [flowNodes, ghostFlowNodes]);
+  const allEdges = useMemo(() => [...flowEdges, ...ghostFlowEdges], [flowEdges, ghostFlowEdges]);
+
+  useEffect(() => {
+    const timer = setTimeout(
+      () => fitView({ duration: 200, maxZoom: 1, minZoom: 0.6, padding: 0.12 }),
+      30,
     );
+    return () => clearTimeout(timer);
+  }, [view, allNodes.length, fitView]);
 
-    const allNodes = useMemo(() => [...flowNodes, ...ghostFlowNodes], [flowNodes, ghostFlowNodes]);
-    const allEdges = useMemo(() => [...flowEdges, ...ghostFlowEdges], [flowEdges, ghostFlowEdges]);
+  // The portal panel borrows width from the canvas; wait out its slide
+  // animation before refitting, or the fit is computed mid-transition.
+  useEffect(() => {
+    if (refitKey === undefined) return;
+    const timer = setTimeout(
+      () => fitView({ duration: 200, maxZoom: 1, minZoom: 0.6, padding: 0.12 }),
+      280,
+    );
+    return () => clearTimeout(timer);
+  }, [refitKey, fitView]);
 
-    useEffect(() => {
-      const timer = setTimeout(
-        () => fitView({ duration: 200, maxZoom: 1, minZoom: 0.6, padding: 0.12 }),
-        30,
-      );
-      return () => clearTimeout(timer);
-    }, [view, allNodes.length, fitView]);
-
-    return (
-      <div className={className} style={interactive ? undefined : { height: inlineHeight }}>
-        {/* Inline, the map is a picture: it settles on `fitView` and stays
+  return (
+    <div className={className} style={interactive ? undefined : { height: inlineHeight }}>
+      {/* Inline, the map is a picture: it settles on `fitView` and stays
             there. Panning or zooming it inside a scrolling page moves the graph
             under the cursor while the page moves too, and leaves no way back to
             the framing the layout chose. Fullscreen is where it is navigable. */}
-        <ReactFlow
-          fitView
-          edges={allEdges}
-          maxZoom={interactive ? 1.5 : 1}
-          minZoom={0.3}
-          nodeTypes={nodeTypes}
-          nodes={allNodes}
-          nodesConnectable={false}
-          nodesDraggable={false}
-          panOnDrag={interactive}
-          // Fullscreen reads like Figma on a trackpad: two-finger scroll pans
-          // and pinch (ctrl+wheel) zooms. Wheel-to-zoom is off — on a mouse,
-          // zooming stays on pinch/double-click and the +/- controls.
-          panOnScroll={interactive}
-          preventScrolling={interactive}
-          proOptions={{ hideAttribution: true }}
-          zoomOnDoubleClick={interactive}
-          zoomOnPinch={interactive}
-          zoomOnScroll={false}
-          onNodeClick={(_, node) => {
-            if (node.type !== 'goalGhost') onSelect(node.id);
-          }}
-        >
-          <Background
-            color={cssVar.colorBorderSecondary}
-            gap={18}
-            size={1}
-            variant={BackgroundVariant.Dots}
-          />
-          {interactive && <Controls position={'bottom-right'} showInteractive={false} />}
-        </ReactFlow>
-      </div>
-    );
-  },
-);
+      <ReactFlow
+        fitView
+        edges={allEdges}
+        maxZoom={interactive ? 1.5 : 1}
+        minZoom={0.3}
+        nodeTypes={nodeTypes}
+        nodes={allNodes}
+        nodesConnectable={false}
+        nodesDraggable={false}
+        panOnDrag={interactive}
+        // Fullscreen reads like Figma on a trackpad: two-finger scroll pans
+        // and pinch (ctrl+wheel) zooms. Wheel-to-zoom is off — on a mouse,
+        // zooming stays on pinch/double-click and the +/- controls.
+        panOnScroll={interactive}
+        preventScrolling={interactive}
+        proOptions={{ hideAttribution: true }}
+        zoomOnDoubleClick={interactive}
+        zoomOnPinch={interactive}
+        zoomOnScroll={false}
+        onNodeClick={(_, node) => {
+          if (node.type !== 'goalGhost') onSelect(node.id);
+        }}
+      >
+        <Background
+          color={cssVar.colorBorderSecondary}
+          gap={18}
+          size={1}
+          variant={BackgroundVariant.Dots}
+        />
+        {interactive && <Controls position={'bottom-right'} showInteractive={false} />}
+      </ReactFlow>
+    </div>
+  );
+});
 
 Canvas.displayName = 'GoalGraphCanvas';
 
-const Graph = memo<GraphProps>((props) => {
+const Graph = memo<GraphProps>(({ fullscreen, onFullscreenChange, ...props }) => {
   const { t } = useTranslation('chat');
   const [view, setView] = useState<GraphViewMode>('stage');
-  const [fullscreen, setFullscreen] = useState(false);
+  const showPortal = useChatStore(chatPortalSelectors.showPortal);
+  const currentViewType = useChatStore(chatPortalSelectors.currentViewType);
+  const clearPortalStack = useChatStore((s) => s.clearPortalStack);
+  // Same 'goal' width scope as the page's panel, so the drill-down keeps its
+  // size when it moves between the page and the fullscreen overlay.
+  const { maxWidth, minWidth, updateWidth, width } = usePortalPanelWidth(currentViewType, 'goal');
 
   const titleAndViews = (
     <>
@@ -437,23 +484,46 @@ const Graph = memo<GraphProps>((props) => {
       icon={fullscreen ? X : Maximize2}
       size={'small'}
       title={fullscreen ? t('goalProcess.graph.exitFullscreen') : t('goalProcess.graph.fullscreen')}
-      onClick={() => setFullscreen(!fullscreen)}
+      onClick={() => onFullscreenChange(!fullscreen)}
     />
   );
 
   if (fullscreen)
     return (
       <div className={styles.overlay}>
-        <ReactFlowProvider>
-          <Canvas {...props} interactive className={cx(styles.canvas, styles.full)} view={view} />
-        </ReactFlowProvider>
-        {/* Corner cards float over the canvas — the map owns the whole screen
-            and panned content stays visible between them. */}
-        <div className={cx(styles.float, styles.floatLeft)}>{titleAndViews}</div>
-        <div className={cx(styles.float, styles.floatRight)}>
-          {legend}
-          {toggle}
+        <div className={styles.overlayMain}>
+          <ReactFlowProvider>
+            <Canvas
+              {...props}
+              interactive
+              className={cx(styles.canvas, styles.full)}
+              refitKey={showPortal}
+              view={view}
+            />
+          </ReactFlowProvider>
+          {/* Corner cards float over the canvas — the map owns the whole screen
+              and panned content stays visible between them. */}
+          <div className={cx(styles.float, styles.floatLeft)}>{titleAndViews}</div>
+          <div className={cx(styles.float, styles.floatRight)}>
+            {legend}
+            {toggle}
+          </div>
         </div>
+        {/* The overlay covers the page's portal panel, so it carries its own:
+            clicking a node keeps the same drill-down chain without leaving the
+            map. The page unmounts its copy while we are fullscreen. */}
+        <RightPanel
+          expand={showPortal}
+          maxWidth={maxWidth}
+          minWidth={minWidth}
+          width={width}
+          onSizeChange={(size) => updateWidth(size?.width)}
+          onExpandChange={(next) => {
+            if (!next) clearPortalStack();
+          }}
+        >
+          <PortalContent />
+        </RightPanel>
       </div>
     );
 

--- a/src/features/AgentGoals/ProcessControl/index.tsx
+++ b/src/features/AgentGoals/ProcessControl/index.tsx
@@ -34,150 +34,162 @@ const styles = createStaticStyles(({ css }) => ({
 interface ProcessControlProps {
   /** The `goals` row id — not the carrier task's identifier. */
   goalId: string;
+  /** Owned by the page so it can swap its portal panel for the overlay's. */
+  graphFullscreen: boolean;
+  onGraphFullscreenChange: (fullscreen: boolean) => void;
 }
 
-const ProcessControl = memo<ProcessControlProps>(({ goalId }) => {
-  const { t } = useTranslation('chat');
-  const { allowed: canEdit } = usePermission('create_content');
-  const [selectedId, setSelectedId] = useState<string>();
+const ProcessControl = memo<ProcessControlProps>(
+  ({ goalId, graphFullscreen, onGraphFullscreenChange }) => {
+    const { t } = useTranslation('chat');
+    const { allowed: canEdit } = usePermission('create_content');
+    const [selectedId, setSelectedId] = useState<string>();
 
-  const useFetchGoalGraph = useGoalStore((s) => s.useFetchGoalGraph);
-  const decideGoal = useGoalStore((s) => s.decideGoal);
-  const refreshGoalGraph = useGoalStore((s) => s.refreshGoalGraph);
-  const openTaskDetail = useChatStore((s) => s.openTaskDetail);
-  const openGoalNode = useChatStore((s) => s.openGoalNode);
-  useFetchGoalGraph(goalId);
-  const snapshot = useGoalStore(goalSelectors.goalGraph(goalId));
+    const useFetchGoalGraph = useGoalStore((s) => s.useFetchGoalGraph);
+    const decideGoal = useGoalStore((s) => s.decideGoal);
+    const refreshGoalGraph = useGoalStore((s) => s.refreshGoalGraph);
+    const openTaskDetail = useChatStore((s) => s.openTaskDetail);
+    const openGoalNode = useChatStore((s) => s.openGoalNode);
+    useFetchGoalGraph(goalId);
+    const snapshot = useGoalStore(goalSelectors.goalGraph(goalId));
 
-  const graph = useMemo(() => (snapshot ? buildGoalGraphView(snapshot) : undefined), [snapshot]);
+    const graph = useMemo(() => (snapshot ? buildGoalGraphView(snapshot) : undefined), [snapshot]);
 
-  const actions: FrontierActions = useMemo(
-    () => ({
-      addTask: async (title: string, description?: string) => {
-        await goalService.addNode({ description, id: goalId, kind: 'task', title });
-        await refreshGoalGraph(goalId);
+    const actions: FrontierActions = useMemo(
+      () => ({
+        addTask: async (title: string, description?: string) => {
+          await goalService.addNode({ description, id: goalId, kind: 'task', title });
+          await refreshGoalGraph(goalId);
+        },
+        decide: (decisionId, optionId, resolution) =>
+          void decideGoal(goalId, { decisionId, optionId, resolution }),
+      }),
+      [decideGoal, goalId, refreshGoalGraph],
+    );
+
+    // Every click funnels here: keep the map highlight (spatial continuity) and
+    // open the drill-down — a dispatched Work goes straight to its Task detail,
+    // everything else opens the node view. This is the chain the page was
+    // missing: node → task → topic conversation.
+    const select = useCallback(
+      (nodeId: string) => {
+        setSelectedId(nodeId);
+        const taskId = graph?.byId[nodeId]?.node.taskId;
+        if (taskId) openTaskDetail(taskId);
+        else openGoalNode(goalId, nodeId);
       },
-      decide: (decisionId, optionId, resolution) =>
-        void decideGoal(goalId, { decisionId, optionId, resolution }),
-    }),
-    [decideGoal, goalId, refreshGoalGraph],
-  );
+      [goalId, graph, openGoalNode, openTaskDetail],
+    );
 
-  // Every click funnels here: keep the map highlight (spatial continuity) and
-  // open the drill-down — a dispatched Work goes straight to its Task detail,
-  // everything else opens the node view. This is the chain the page was
-  // missing: node → task → topic conversation.
-  const select = useCallback(
-    (nodeId: string) => {
-      setSelectedId(nodeId);
-      const taskId = graph?.byId[nodeId]?.node.taskId;
-      if (taskId) openTaskDetail(taskId);
-      else openGoalNode(goalId, nodeId);
-    },
-    [goalId, graph, openGoalNode, openTaskDetail],
-  );
+    // Task-carried goals share the `goals` table but never grow a graph. Nothing
+    // to control here, so the page keeps its original shape.
+    if (!graph || graph.nodes.length === 0) return null;
 
-  // Task-carried goals share the `goals` table but never grow a graph. Nothing
-  // to control here, so the page keeps its original shape.
-  if (!graph || graph.nodes.length === 0) return null;
+    // The coordinator is decomposing the problem into tasks. `running` with zero
+    // Works counts too: the decomposition claim flips the status before the
+    // planner returns, and a re-plan after all Works were removed is the same
+    // state. The surfaces below promise the incoming structure instead of
+    // reading as an empty goal — the graph poll fills them in as nodes land.
+    const planning =
+      ['planning', 'running'].includes(graph.goal.status) &&
+      !graph.nodes.some((view) => view.node.kind === 'task');
+    // Presence of the acceptance block (not a non-empty list) keeps the section
+    // mounted: removing the last criterion must leave the add control reachable,
+    // while legacy prose-only goals (no acceptance config at all) show nothing.
+    const acceptanceConfig = graph.goal.config?.acceptance;
+    const criteriaIds = acceptanceConfig?.criteriaIds ?? [];
+    // A closed goal cannot move: the coordinator returns immediately for these,
+    // and a Work added here would sit `proposed` forever. Stop offering actions
+    // that cannot land. The goal otherwise advances entirely on its own — the
+    // only legitimate human control over its pace is pause/resume.
+    const closed = ['achieved', 'canceled', 'failed'].includes(graph.goal.status);
+    const canAct = canEdit && !closed;
 
-  // The coordinator is decomposing the problem into tasks. `running` with zero
-  // Works counts too: the decomposition claim flips the status before the
-  // planner returns, and a re-plan after all Works were removed is the same
-  // state. The surfaces below promise the incoming structure instead of
-  // reading as an empty goal — the graph poll fills them in as nodes land.
-  const planning =
-    ['planning', 'running'].includes(graph.goal.status) &&
-    !graph.nodes.some((view) => view.node.kind === 'task');
-  // Presence of the acceptance block (not a non-empty list) keeps the section
-  // mounted: removing the last criterion must leave the add control reachable,
-  // while legacy prose-only goals (no acceptance config at all) show nothing.
-  const acceptanceConfig = graph.goal.config?.acceptance;
-  const criteriaIds = acceptanceConfig?.criteriaIds ?? [];
-  // A closed goal cannot move: the coordinator returns immediately for these,
-  // and a Work added here would sit `proposed` forever. Stop offering actions
-  // that cannot land. The goal otherwise advances entirely on its own — the
-  // only legitimate human control over its pace is pause/resume.
-  const closed = ['achieved', 'canceled', 'failed'].includes(graph.goal.status);
-  const canAct = canEdit && !closed;
+    return (
+      <Flexbox gap={20}>
+        <Flexbox gap={12}>
+          <Frontier
+            actions={actions}
+            canEdit={canAct}
+            graph={graph}
+            planning={planning}
+            onSelect={select}
+          />
+        </Flexbox>
 
-  return (
-    <Flexbox gap={20}>
-      <Flexbox gap={12}>
-        <Frontier
-          actions={actions}
-          canEdit={canAct}
+        <Graph
+          fullscreen={graphFullscreen}
           graph={graph}
           planning={planning}
+          selectedId={selectedId}
+          onFullscreenChange={onGraphFullscreenChange}
           onSelect={select}
         />
-      </Flexbox>
 
-      <Graph graph={graph} planning={planning} selectedId={selectedId} onSelect={select} />
-
-      <Accordion defaultExpandedKeys={['findings', 'activity']} gap={0}>
-        {/* The structured acceptance standard the terminal goal acceptance is
+        <Accordion defaultExpandedKeys={['findings', 'activity']} gap={0}>
+          {/* The structured acceptance standard the terminal goal acceptance is
             gated on. Collapsed by default — reference material, like the task
             detail's 交付验收 section. Prose-only legacy goals have none. */}
-        {!!acceptanceConfig && (
+          {!!acceptanceConfig && (
+            <AccordionItem
+              itemKey={'acceptance'}
+              paddingBlock={6}
+              paddingInline={0}
+              title={
+                <Flexbox horizontal align={'center'} gap={8}>
+                  <Text fontSize={14} weight={600}>
+                    {t('goalAcceptance.title')}
+                  </Text>
+                  {criteriaIds.length > 0 && <Tag size={'small'}>{criteriaIds.length}</Tag>}
+                  <Text fontSize={12} type={'secondary'}>
+                    {t('goalAcceptance.gateHint')}
+                  </Text>
+                </Flexbox>
+              }
+            >
+              <Flexbox className={styles.section}>
+                <GoalAcceptanceCriteria criteriaIds={criteriaIds} goalId={goalId} />
+              </Flexbox>
+            </AccordionItem>
+          )}
           <AccordionItem
-            itemKey={'acceptance'}
+            itemKey={'findings'}
             paddingBlock={6}
             paddingInline={0}
             title={
               <Flexbox horizontal align={'center'} gap={8}>
                 <Text fontSize={14} weight={600}>
-                  {t('goalAcceptance.title')}
+                  {t('goalProcess.findings.title')}
                 </Text>
-                {criteriaIds.length > 0 && <Tag size={'small'}>{criteriaIds.length}</Tag>}
-                <Text fontSize={12} type={'secondary'}>
-                  {t('goalAcceptance.gateHint')}
+                {graph.findings.length > 0 && <Tag size={'small'}>{graph.findings.length}</Tag>}
+              </Flexbox>
+            }
+          >
+            <Flexbox className={styles.section}>
+              <Findings graph={graph} onSelect={select} />
+            </Flexbox>
+          </AccordionItem>
+          <AccordionItem
+            itemKey={'activity'}
+            paddingBlock={6}
+            paddingInline={0}
+            title={
+              <Flexbox horizontal align={'center'} gap={8}>
+                <Text fontSize={14} weight={600}>
+                  {t('goalProcess.activity.title')}
                 </Text>
               </Flexbox>
             }
           >
             <Flexbox className={styles.section}>
-              <GoalAcceptanceCriteria criteriaIds={criteriaIds} goalId={goalId} />
+              <Activity graph={graph} onSelect={select} />
             </Flexbox>
           </AccordionItem>
-        )}
-        <AccordionItem
-          itemKey={'findings'}
-          paddingBlock={6}
-          paddingInline={0}
-          title={
-            <Flexbox horizontal align={'center'} gap={8}>
-              <Text fontSize={14} weight={600}>
-                {t('goalProcess.findings.title')}
-              </Text>
-              {graph.findings.length > 0 && <Tag size={'small'}>{graph.findings.length}</Tag>}
-            </Flexbox>
-          }
-        >
-          <Flexbox className={styles.section}>
-            <Findings graph={graph} onSelect={select} />
-          </Flexbox>
-        </AccordionItem>
-        <AccordionItem
-          itemKey={'activity'}
-          paddingBlock={6}
-          paddingInline={0}
-          title={
-            <Flexbox horizontal align={'center'} gap={8}>
-              <Text fontSize={14} weight={600}>
-                {t('goalProcess.activity.title')}
-              </Text>
-            </Flexbox>
-          }
-        >
-          <Flexbox className={styles.section}>
-            <Activity graph={graph} onSelect={select} />
-          </Flexbox>
-        </AccordionItem>
-      </Accordion>
-    </Flexbox>
-  );
-});
+        </Accordion>
+      </Flexbox>
+    );
+  },
+);
 
 ProcessControl.displayName = 'GoalProcessControl';
 


### PR DESCRIPTION
Two gaps found while inspecting Goal Graphs on the goal detail page.

**1. Clicking a node in the fullscreen exploration map showed nothing**

The click already funnels into the drill-down chain (`openGoalNode` / `openTaskDetail`), but the fullscreen overlay is `position: fixed; inset: 0; z-index: 1000`, so the page's right-hand portal panel opened invisibly underneath it. The overlay now hosts its own `RightPanel + PortalContent` on the right side, sharing the page panel's `'goal'` width scope so the drill-down keeps its size when it moves between surfaces. Fullscreen state is lifted to `GoalDetailPage`, which unmounts its own portal (and goal chat) while the overlay is up — exactly one `PortalContent` is alive at a time, and on exit the same view stack reopens seamlessly in the page panel. The canvas refits after the panel's slide animation so the graph re-centers in the remaining space.

**2. An achieved goal's root problem node still read 进行中 / 待回答**

The coordinator only ever resolves **task** nodes (`consumeCompletedTask`); the root problem node seeded `active` at goal creation had no resolution path at all, so the map of every achieved goal kept an "in progress / unanswered" root forever. The achieved transition in `settleTerminalAcceptance` now closes every open problem node (`resolved`, reason "Goal achieved") and pushes a `node_status` effect into the trace. Forward-only by design — existing achieved goals are not backfilled.

#### Test

- [x] Added/updated tests

Extended the achieved-path integration test to assert the seeded problem node ends `resolved`; verified it fails without the fix (`active` ≠ `resolved`) and passes with it. Full goal service suite (74 tests) green; lint clean; type-check shows no errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)