### PR TITLE
✨ feat(model-switch-panel): pin newly released models to the top

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
@@ -142,7 +142,6 @@ const GenerationListItemRenderer = memo<GenerationListItemRendererProps>(
                 <ModelItemComponent
                   {...item.model}
                   providerId={item.provider.id}
-                  showBadge={false}
                   showPopover={false}
                 />
               </DropdownMenuSubmenuTrigger>
@@ -185,7 +184,6 @@ const GenerationListItemRenderer = memo<GenerationListItemRendererProps>(
                 <ModelItemComponent
                   {...item.data.model}
                   providerId={singleProvider.id}
-                  showBadge={false}
                   showPopover={false}
                 />
               </DropdownMenuSubmenuTrigger>

--- a/src/features/ModelSwitchPanel/components/List/GenerationMultipleProvidersItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationMultipleProvidersItem.tsx
@@ -57,7 +57,6 @@ const GenerationMultipleProvidersItem = memo<GenerationMultipleProvidersItemProp
             <ModelItemComponent
               {...item.data.model}
               providerId={(activeProvider ?? item.data.providers[0]).id}
-              showBadge={false}
               showPopover={false}
             />
           </DropdownMenuSubmenuTrigger>

--- a/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
+++ b/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
 
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
+import { isNewReleaseDate } from '@/utils/time';
 
 import { type GroupMode, type ListItem, type ModelWithProviders } from '../types';
+
+const isNewModel = (releasedAt?: string): boolean => !!releasedAt && isNewReleaseDate(releasedAt);
 
 export const buildListItems = (
   enabledList: EnabledProviderWithModels[],
@@ -70,14 +73,17 @@ export const buildListItems = (
       });
     }
 
-    const sortedModels = sortModelLast
-      ? modelArray.toSorted((a, b) => {
-          const aLast = a.providers.every((provider) => sortModelLast(a.model.id, provider.id));
-          const bLast = b.providers.every((provider) => sortModelLast(b.model.id, provider.id));
-
-          return Number(aLast) - Number(bLast);
-        })
-      : modelArray;
+    const sortedModels = modelArray.toSorted((a, b) => {
+      if (sortModelLast) {
+        const aLast = a.providers.every((provider) => sortModelLast(a.model.id, provider.id));
+        const bLast = b.providers.every((provider) => sortModelLast(b.model.id, provider.id));
+        if (aLast !== bLast) return Number(aLast) - Number(bLast);
+      }
+      const aNew = isNewModel(a.model.releasedAt);
+      const bNew = isNewModel(b.model.releasedAt);
+      if (aNew !== bNew) return aNew ? -1 : 1;
+      return 0;
+    });
 
     return sortedModels.map((data) => ({
       data,
@@ -94,13 +100,18 @@ export const buildListItems = (
         (modelItem) =>
           matchesSearch(modelItem.displayName || modelItem.id) || matchesSearch(providerItem.name),
       );
-      const sortedModels = sortModelLast
-        ? filteredModels.toSorted(
-            (a, b) =>
-              Number(sortModelLast(a.id, providerItem.id)) -
-              Number(sortModelLast(b.id, providerItem.id)),
-          )
-        : filteredModels;
+      const sortedModels = filteredModels.toSorted((a, b) => {
+        if (sortModelLast) {
+          const diff =
+            Number(sortModelLast(a.id, providerItem.id)) -
+            Number(sortModelLast(b.id, providerItem.id));
+          if (diff !== 0) return diff;
+        }
+        const aNew = isNewModel(a.releasedAt);
+        const bNew = isNewModel(b.releasedAt);
+        if (aNew !== bNew) return aNew ? -1 : 1;
+        return 0;
+      });
 
       if (sortedModels.length > 0 || !searchKeyword.trim()) {
         items.push({ provider: providerItem, type: 'group-header' });

--- a/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
+++ b/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
@@ -5,6 +5,11 @@ import { isNewReleaseDate } from '@/utils/time';
 
 import { type GroupMode, type ListItem, type ModelWithProviders } from '../types';
 
+/**
+ * Shares the exact rule behind `NewModelBadge`, so a model is pinned to the top only while its
+ * badge is still visible. Every renderer of this list must keep the badge on — otherwise models
+ * jump ahead with no visible explanation.
+ */
 const isNewModel = (releasedAt?: string): boolean => !!releasedAt && isNewReleaseDate(releasedAt);
 
 export const buildListItems = (


### PR DESCRIPTION
Newly released models (with a fresh `新` badge) are now sorted to the top of the model picker so they get noticed, and automatically fall back to their original position once the badge expires.

- Reuses `isNewReleaseDate(releasedAt, 14 days)` — the exact rule that controls the `NewModelBadge` visibility, so pinning and badge visibility stay in sync with zero extra config.
- Applies to both grouping modes (`byModel` / `byProvider`).
- Preserves the existing `sortModelLast` behavior as a higher-priority tier, so callers that push models to the bottom are unaffected.

| Before | After |
| ------ | ----- |
| New models mixed in with the rest of the provider list | New models pinned to the top of their group until the badge expires |

#### Test

- [x] Tested locally (`bun run check --lint --type --test` on the touched file — all green)
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Fixes LOBE-13648