### PR TITLE
🐛 fix(local-system): recover from broken Windows shells

### DIFF
--- a/packages/local-file-shell/src/shell/__tests__/runner.spawn-options.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/runner.spawn-options.test.ts
@@ -1,4 +1,5 @@
 import type * as ChildProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ShellProcessManager } from '../process-manager';
 import { runCommand } from '../runner';
+import { resetShellDetectionCache } from '../utils';
 
 const spawnSpy = vi.hoisted(() => vi.fn());
 
@@ -17,6 +19,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 describe('runCommand spawn options', () => {
+  const realPlatform = process.platform;
   let processManager: ShellProcessManager;
   let tmpDir: string;
 
@@ -29,6 +32,9 @@ describe('runCommand spawn options', () => {
   afterEach(() => {
     processManager.cleanupAll();
     fs.rmSync(tmpDir, { force: true, recursive: true });
+    Object.defineProperty(process, 'platform', { configurable: true, value: realPlatform });
+    resetShellDetectionCache();
+    vi.restoreAllMocks();
   });
 
   it('should hide the console window spawned for the shell on Windows', async () => {
@@ -37,5 +43,71 @@ describe('runCommand spawn options', () => {
     expect(result.success).toBe(true);
     expect(spawnSpy).toHaveBeenCalledTimes(1);
     expect(spawnSpy.mock.calls[0][2]).toMatchObject({ windowsHide: true });
+  });
+
+  it('should report an inaccessible working directory before spawning a shell', async () => {
+    const cwd = path.join(tmpDir, 'renamed-workspace');
+
+    const result = await runCommand({ command: 'echo hidden', cwd }, { processManager });
+
+    expect(result).toEqual({
+      error: expect.stringContaining(`Working directory is not accessible: ${cwd}`),
+      success: false,
+    });
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should retry once with the next Windows shell after a spawn ENOENT', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+    const originalPath = process.env.PATH;
+    const originalSystemRoot = process.env.SystemRoot;
+    const pwshDir = '/fake/tools/pwsh';
+    const pwshPath = path.join(pwshDir, 'pwsh.exe');
+    const powershellPath = path.join(
+      'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe',
+    );
+    process.env.PATH = pwshDir;
+    process.env.SystemRoot = 'C:\\Windows';
+    vi.spyOn(fs.promises, 'lstat').mockImplementation(async (candidate) => {
+      if ([pwshPath, powershellPath].includes(candidate.toString())) return {} as fs.Stats;
+      throw new Error('ENOENT');
+    });
+
+    const failed = new EventEmitter() as ChildProcess.ChildProcess;
+    Object.assign(failed, { exitCode: null, kill: vi.fn(), pid: undefined, signalCode: null });
+    const succeeded = new EventEmitter() as ChildProcess.ChildProcess;
+    Object.assign(succeeded, { exitCode: null, kill: vi.fn(), pid: undefined, signalCode: null });
+    spawnSpy
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          failed.emit('error', new Error('spawn pwsh.exe ENOENT'));
+          failed.emit('close', 1);
+        });
+        return failed;
+      })
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          succeeded.emit('exit', 0);
+          succeeded.emit('close', 0);
+        });
+        return succeeded;
+      });
+
+    try {
+      const result = await runCommand({ command: 'echo recovered' }, { processManager });
+
+      expect(result.success).toBe(true);
+      expect(result.exit_code).toBe(0);
+      expect(spawnSpy).toHaveBeenCalledTimes(2);
+      expect(spawnSpy.mock.calls[0][0]).toBe(pwshPath);
+      expect(spawnSpy.mock.calls[1][0]).toBe(powershellPath);
+    } finally {
+      process.env.PATH = originalPath;
+      process.env.SystemRoot = originalSystemRoot;
+    }
   });
 });

--- a/packages/local-file-shell/src/shell/__tests__/runner.spawn-options.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/runner.spawn-options.test.ts
@@ -46,6 +46,7 @@ describe('runCommand spawn options', () => {
   });
 
   it('should report an inaccessible working directory before spawning a shell', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
     const cwd = path.join(tmpDir, 'renamed-workspace');
 
     const result = await runCommand({ command: 'echo hidden', cwd }, { processManager });
@@ -102,6 +103,60 @@ describe('runCommand spawn options', () => {
 
       expect(result.success).toBe(true);
       expect(result.exit_code).toBe(0);
+      expect(spawnSpy).toHaveBeenCalledTimes(2);
+      expect(spawnSpy.mock.calls[0][0]).toBe(pwshPath);
+      expect(spawnSpy.mock.calls[1][0]).toBe(powershellPath);
+    } finally {
+      process.env.PATH = originalPath;
+      process.env.SystemRoot = originalSystemRoot;
+    }
+  });
+
+  it('should quarantine a background shell that exits with DLL init failure', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+    const originalPath = process.env.PATH;
+    const originalSystemRoot = process.env.SystemRoot;
+    const pwshDir = '/fake/tools/pwsh';
+    const pwshPath = path.join(pwshDir, 'pwsh.exe');
+    const powershellPath = path.join(
+      'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe',
+    );
+    process.env.PATH = pwshDir;
+    process.env.SystemRoot = 'C:\\Windows';
+    vi.spyOn(fs.promises, 'lstat').mockImplementation(async (candidate) => {
+      if ([pwshPath, powershellPath].includes(candidate.toString())) return {} as fs.Stats;
+      throw new Error('ENOENT');
+    });
+
+    const failed = new EventEmitter() as ChildProcess.ChildProcess;
+    Object.assign(failed, { exitCode: null, kill: vi.fn(), pid: undefined, signalCode: null });
+    const succeeded = new EventEmitter() as ChildProcess.ChildProcess;
+    Object.assign(succeeded, { exitCode: null, kill: vi.fn(), pid: undefined, signalCode: null });
+    spawnSpy
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          failed.emit('exit', 0xc000_0142);
+          failed.emit('close', 0xc000_0142);
+        });
+        return failed;
+      })
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          succeeded.emit('exit', 0);
+          succeeded.emit('close', 0);
+        });
+        return succeeded;
+      });
+
+    try {
+      await runCommand({ command: 'echo first', run_in_background: true }, { processManager });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await runCommand({ command: 'echo second' }, { processManager });
+
       expect(spawnSpy).toHaveBeenCalledTimes(2);
       expect(spawnSpy.mock.calls[0][0]).toBe(pwshPath);
       expect(spawnSpy.mock.calls[1][0]).toBe(powershellPath);

--- a/packages/local-file-shell/src/shell/__tests__/utils.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   findGitBash,
   getShellConfig,
+  markWindowsShellUnhealthy,
   normalizeEnvVarRefs,
   resetShellDetectionCache,
   setWindowsShellPreference,
@@ -157,6 +158,26 @@ describe('getShellConfig', () => {
     expect(callsAfterFirst).toBeGreaterThan(0);
     // Second call must not touch the filesystem again.
     expect(lstatSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('should skip a shell marked unhealthy and detect the next candidate', async () => {
+    setPlatform('win32');
+    const pwshDir = '/fake/tools/pwsh';
+    const pwshPath = path.join(pwshDir, 'pwsh.exe');
+    const powershellPath = path.join(
+      'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe',
+    );
+    process.env.PATH = pwshDir;
+    process.env.SystemRoot = 'C:\\Windows';
+    mockExisting(pwshPath, powershellPath);
+
+    expect((await getShellConfig('echo one')).cmd).toBe(pwshPath);
+    markWindowsShellUnhealthy(pwshPath);
+    expect((await getShellConfig('echo two')).cmd).toBe(powershellPath);
   });
 
   it('should share a single detection run between concurrent first calls', async () => {

--- a/packages/local-file-shell/src/shell/__tests__/utils.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/utils.test.ts
@@ -180,6 +180,24 @@ describe('getShellConfig', () => {
     expect((await getShellConfig('echo two')).cmd).toBe(powershellPath);
   });
 
+  it('should fall back to cmd after Windows PowerShell is marked unhealthy', async () => {
+    setPlatform('win32');
+    process.env.PATH = 'C:\\Tools';
+    process.env.SystemRoot = 'C:\\Windows';
+    const powershellPath = path.join(
+      'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe',
+    );
+    mockExisting(powershellPath);
+
+    expect((await getShellConfig('echo one')).cmd).toBe(powershellPath);
+    markWindowsShellUnhealthy(powershellPath);
+    expect(await getShellConfig('echo two')).toEqual({ args: ['/c', 'echo two'], cmd: 'cmd.exe' });
+  });
+
   it('should share a single detection run between concurrent first calls', async () => {
     setPlatform('win32');
     const pwshDir = '/fake/tools/pwsh';

--- a/packages/local-file-shell/src/shell/runner.ts
+++ b/packages/local-file-shell/src/shell/runner.ts
@@ -67,7 +67,7 @@ export async function runCommand(
   // Node reports a missing working directory as a spawn ENOENT for the shell
   // executable, which sends users looking for a PowerShell installation issue
   // that does not exist. Fail before shell detection with the actual cause.
-  if (cwd) {
+  if (process.platform === 'win32' && cwd) {
     try {
       const cwdStat = await fs.promises.stat(cwd);
       if (!cwdStat.isDirectory()) {
@@ -155,6 +155,9 @@ export async function runCommand(
     childProcess.on('exit', (code) => {
       logger?.debug(`${logPrefix} Process exited`, { code, shellId });
       shellProcess.exitCode = code ?? 0;
+      if (process.platform === 'win32' && !sandboxPolicy && code === WINDOWS_DLL_INIT_FAILED) {
+        markWindowsShellUnhealthy(shellConfig.cmd);
+      }
     });
 
     childProcess.on('error', (error) => {
@@ -208,7 +211,6 @@ export async function runCommand(
     // retry exactly once with the next shell in the detection chain.
     if (
       process.platform === 'win32' &&
-      !run_in_background &&
       !sandboxPolicy &&
       !shellFallbackAttempted &&
       isWindowsShellSpawnFailure(result)

--- a/packages/local-file-shell/src/shell/runner.ts
+++ b/packages/local-file-shell/src/shell/runner.ts
@@ -1,11 +1,17 @@
 import { spawn } from 'node:child_process';
+import fs from 'node:fs';
 
 import type { SandboxPolicy } from '@lobechat/device-sandbox';
 
 import type { RunCommandParams, RunCommandResult } from '../types';
 import type { ShellOutputFiles, ShellProcess, ShellProcessManager } from './process-manager';
 import { DEFAULT_OBSERVATION_TIMEOUT_MS } from './process-manager';
-import { detectWindowsShell, getShellConfig, normalizeEnvVarRefs } from './utils';
+import {
+  detectWindowsShell,
+  getShellConfig,
+  markWindowsShellUnhealthy,
+  normalizeEnvVarRefs,
+} from './utils';
 
 export interface RunCommandOptions {
   logger?: {
@@ -28,7 +34,14 @@ export interface RunCommandOptions {
   onSandboxUnavailable?: (error: Error) => void;
   processManager: ShellProcessManager;
   sandboxPolicy?: SandboxPolicy;
+  /** @internal Prevents a launch fallback from recursively retrying forever. */
+  shellFallbackAttempted?: boolean;
 }
+
+const WINDOWS_DLL_INIT_FAILED = 0xc000_0142;
+
+const isWindowsShellSpawnFailure = (result: RunCommandResult): boolean =>
+  result.error !== undefined && /\b(?:EACCES|ENOENT)\b/.test(result.error);
 
 export async function runCommand(
   {
@@ -39,10 +52,32 @@ export async function runCommand(
     run_in_background,
     timeout = DEFAULT_OBSERVATION_TIMEOUT_MS,
   }: RunCommandParams,
-  { processManager, logger, onSandboxUnavailable, sandboxPolicy }: RunCommandOptions,
+  {
+    processManager,
+    logger,
+    onSandboxUnavailable,
+    sandboxPolicy,
+    shellFallbackAttempted = false,
+  }: RunCommandOptions,
 ): Promise<RunCommandResult> {
   if (!command) {
     return { error: 'command is required', success: false };
+  }
+
+  // Node reports a missing working directory as a spawn ENOENT for the shell
+  // executable, which sends users looking for a PowerShell installation issue
+  // that does not exist. Fail before shell detection with the actual cause.
+  if (cwd) {
+    try {
+      const cwdStat = await fs.promises.stat(cwd);
+      if (!cwdStat.isDirectory()) {
+        return { error: `Working directory is not a directory: ${cwd}`, success: false };
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const suffix = code ? ` (${code})` : '';
+      return { error: `Working directory is not accessible: ${cwd}${suffix}`, success: false };
+    }
   }
 
   const logPrefix = `[runCommand: ${description || command.slice(0, 50)}]`;
@@ -124,6 +159,13 @@ export async function runCommand(
 
     childProcess.on('error', (error) => {
       logger?.error(`${logPrefix} Command failed:`, error);
+      if (
+        process.platform === 'win32' &&
+        !sandboxPolicy &&
+        /\b(?:EACCES|ENOENT)\b/.test(error.message)
+      ) {
+        markWindowsShellUnhealthy(shellConfig.cmd);
+      }
       const cwdContext = cwd ? ` (working directory: ${cwd})` : '';
       shellProcess.spawnError = new Error(
         `Failed to start command${cwdContext}: ${error.message}`,
@@ -155,11 +197,51 @@ export async function runCommand(
       timeout,
     });
 
-    return {
+    const result: RunCommandResult = {
       ...observation,
       sandboxed,
       shell_id: shellId,
     };
+
+    // A stale Store alias or removed PowerShell installation fails at spawn, so
+    // the user script definitely did not start. Quarantine that executable and
+    // retry exactly once with the next shell in the detection chain.
+    if (
+      process.platform === 'win32' &&
+      !run_in_background &&
+      !sandboxPolicy &&
+      !shellFallbackAttempted &&
+      isWindowsShellSpawnFailure(result)
+    ) {
+      markWindowsShellUnhealthy(shellConfig.cmd);
+      logger?.info?.(`${logPrefix} Retrying with the next available Windows shell`, {
+        failedShell: shellConfig.cmd,
+      });
+      return runCommand(
+        { command, cwd, description, env: extraEnv, run_in_background, timeout },
+        {
+          logger,
+          onSandboxUnavailable,
+          processManager,
+          sandboxPolicy,
+          shellFallbackAttempted: true,
+        },
+      );
+    }
+
+    // 0xC0000142 normally means PowerShell itself could not initialise its
+    // DLLs. Do not replay the current command, though: a user program can also
+    // return that native status after earlier statements produced side effects.
+    // Quarantining the shell makes the *next* agent retry use the fallback.
+    if (
+      process.platform === 'win32' &&
+      !sandboxPolicy &&
+      result.exit_code === WINDOWS_DLL_INIT_FAILED
+    ) {
+      markWindowsShellUnhealthy(shellConfig.cmd);
+    }
+
+    return result;
   } catch (error) {
     releaseSandbox?.();
     if (outputFiles) processManager.closeOutputFiles(outputFiles);

--- a/packages/local-file-shell/src/shell/utils.ts
+++ b/packages/local-file-shell/src/shell/utils.ts
@@ -217,7 +217,7 @@ const findWindowsPowerShell = async (): Promise<string | undefined> => {
     'v1.0',
     'powershell.exe',
   );
-  return (await executableExists(candidate)) ? candidate : undefined;
+  return firstExisting([candidate]);
 };
 
 /**

--- a/packages/local-file-shell/src/shell/utils.ts
+++ b/packages/local-file-shell/src/shell/utils.ts
@@ -120,11 +120,20 @@ const executableExists = async (candidate: string): Promise<boolean> => {
   }
 };
 
+/**
+ * Shell executables that existed during detection but failed before a user
+ * command could start. Keep them out of the fallback chain for the lifetime of
+ * this process; desktop restart is the natural point at which a repaired Store
+ * alias / PowerShell installation should be reconsidered.
+ */
+const unhealthyWindowsShells = new Set<string>();
+
 /** Return the first candidate that exists, preserving the list's priority order. */
 const firstExisting = async (candidates: string[]): Promise<string | undefined> => {
-  const results = await Promise.all(candidates.map((candidate) => executableExists(candidate)));
+  const eligible = candidates.filter((candidate) => !unhealthyWindowsShells.has(candidate));
+  const results = await Promise.all(eligible.map((candidate) => executableExists(candidate)));
   const index = results.indexOf(true);
-  return index === -1 ? undefined : candidates[index];
+  return index === -1 ? undefined : eligible[index];
 };
 
 /**
@@ -236,6 +245,18 @@ let windowsShellPreference: WindowsShellPreference = 'auto';
  * @internal for tests only — production code should rely on the cache.
  */
 export const resetShellDetectionCache = (): void => {
+  cachedWindowsShell = undefined;
+  unhealthyWindowsShells.clear();
+};
+
+/**
+ * Remove a Windows shell from future detection after a proven launch failure.
+ * This is deliberately narrower than reacting to an arbitrary non-zero command
+ * exit: only the runner, which can distinguish spawn / process-init failures,
+ * should call it.
+ */
+export const markWindowsShellUnhealthy = (shellPath: string): void => {
+  unhealthyWindowsShells.add(shellPath);
   cachedWindowsShell = undefined;
 };
 


### PR DESCRIPTION
Fixes two Windows Local System failure modes surfaced by recent agent vent reports:

- Validate the requested working directory before spawning, so a renamed/deleted workspace is reported as the real cause instead of a misleading `powershell.exe ENOENT`.
- Quarantine a shell executable after a proven spawn `ENOENT`/`EACCES`, invalidate the detection cache, and retry the command once with the next candidate in the existing `pwsh -> Windows PowerShell -> cmd` chain.
- Quarantine PowerShell after `0xC0000142` (`STATUS_DLL_INIT_FAILED`) so the next agent retry uses a fallback, without automatically replaying a command that may have produced side effects.
- Keep background failures recoverable by invalidating the cached shell even when the original call has already returned.

No UI changes.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `vitest` targeted shell suites: 43 tests passed
- ESLint passed for all four changed files
- Prettier and the repository pre-commit lint-staged checks passed
- Full `bun run type-check` could not be evaluated cleanly from the isolated worktree because reusing the main checkout dependency tree caused cross-worktree module/React type resolution; targeted tests and lint are clean.

#### 🔗 Related Issue

Surfaced by agent vent reports for Windows PowerShell `ENOENT`, stale working directories, and `0xC0000142` process initialization failures.