### PR TITLE
🔥 refactor(agentTasks): drop run summary/output labels on TopicCard

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1613,8 +1613,6 @@
   "taskDetail.replyInThread": "Reply in this thread",
   "taskDetail.replyPlaceholder": "Reply in this thread...",
   "taskDetail.rerunTask": "Re-run task",
-  "taskDetail.run.outputLabel": "Run output",
-  "taskDetail.run.summaryLabel": "Run summary",
   "taskDetail.runAll": "Run all",
   "taskDetail.runAll.cancel": "Cancel",
   "taskDetail.runAll.confirm": "Run {{count}} subtask(s)",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1613,8 +1613,6 @@
   "taskDetail.replyInThread": "在此对话中回复",
   "taskDetail.replyPlaceholder": "在此对话中回复…",
   "taskDetail.rerunTask": "重新运行",
-  "taskDetail.run.outputLabel": "运行输出",
-  "taskDetail.run.summaryLabel": "运行摘要",
   "taskDetail.runAll": "全部运行",
   "taskDetail.runAll.cancel": "取消",
   "taskDetail.runAll.confirm": "运行 {{count}} 个子任务",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1635,8 +1635,6 @@ export default {
   'taskDetail.topicMenu.stopConfirm.content':
     'The current run will be canceled. Generated messages are kept and you can re-run the task later.',
   'taskDetail.topicMenu.stopConfirm.title': 'Stop Run?',
-  'taskDetail.run.outputLabel': 'Run output',
-  'taskDetail.run.summaryLabel': 'Run summary',
   'taskDetail.runTrigger.goal': 'Goal loop',
   'taskDetail.runTrigger.heartbeat': 'Heartbeat',
   'taskDetail.runTrigger.schedule': 'Scheduled',

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -360,29 +360,15 @@ const TopicCard = memo<TopicCardProps>(({ activity, defaultExpanded = true }) =>
 
       {hasBody && bodyExpanded && (
         <Flexbox gap={8} paddingInline={4}>
-          {/* Both blocks carry a label naming what they are — an unlabeled blob
-              of model output reads as page noise, not as the run's record. */}
           {activity.summary && (
-            <Flexbox gap={2}>
-              <Text fontSize={12} style={{ color: cssVar.colorTextTertiary }}>
-                {t('taskDetail.run.summaryLabel')}
-              </Text>
-              <Text
-                fontSize={13}
-                style={{ color: cssVar.colorTextDescription, whiteSpace: 'pre-wrap' }}
-              >
-                {activity.summary}
-              </Text>
-            </Flexbox>
+            <Text
+              fontSize={13}
+              style={{ color: cssVar.colorTextDescription, whiteSpace: 'pre-wrap' }}
+            >
+              {activity.summary}
+            </Text>
           )}
-          {activity.content && (
-            <Flexbox gap={2}>
-              <Text fontSize={12} style={{ color: cssVar.colorTextTertiary }}>
-                {t('taskDetail.run.outputLabel')}
-              </Text>
-              <RunContent content={activity.content} />
-            </Flexbox>
-          )}
+          {activity.content && <RunContent content={activity.content} />}
           {/* The verdict's evidence, next to the delivery it judged — reading
               one should never require leaving for the acceptance page. */}
           {activity.verify && (


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Run card shows two tertiary captions "运行摘要 / Run summary" and "运行输出 / Run output" above the summary text and run output | Summary text and run output render directly, without the caption rows |

#### Description of Change

The expanded run card in the Agent Task detail labeled its summary and output blocks with two 12px tertiary captions ("Run summary" / "Run output"). The card header already carries the run's metadata (status icon, #seq, trigger tag, duration), so these caption rows read as visual noise rather than structure — the content blocks don't need to announce what they are.

This removes the two captions from `TopicCard`, simplifies the block structure (the outer `Flexbox gap={8}` already provides the spacing), and deletes the now-unused `taskDetail.run.summaryLabel` / `taskDetail.run.outputLabel` keys from `packages/locales/src/default/chat.ts`, `locales/en-US/chat.json` and `locales/zh-CN/chat.json`.

Other locales are left to the daily auto-i18n workflow.

#### Test

- [x] Tested locally — `bun run check` on the changed files: lint clean, TopicCard related tests (4) passed
- [x] No new tests needed — the captions had no test coverage; the existing `TopicCard.test.tsx` (link clickability) still passes
- [ ] Added/updated tests

#### 🔗 Related Issue

None — UI polish reported via internal review.