### PR TITLE
docs: add PZERO example for OPENAI_PROXY_URL

### DIFF
--- a/docs/self-hosting/environment-variables/model-provider.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.mdx
@@ -49,6 +49,17 @@ When deploying LobeHub, a rich set of environment variables related to model ser
   `api.openai.com` domain, then you need to add `/v1` to the URL yourself.
 </Callout>
 
+<Callout type={'tip'}>
+  **PZERO** is a prepaid OpenAI-compatible inference service. Example configuration:
+  ```bash
+  OPENAI_PROXY_URL="https://api.pzero.studio/v1"
+  OPENAI_API_KEY="pzero_YOUR_KEY"
+  OPENAI_MODEL_LIST="+deepseek-v4-flash"
+  ```
+  Get a key at [pzero.studio/agents](https://pzero.studio/agents) (sign-in free; min top-up 1 USDC on Base; no starter credits).
+  Public model catalog (no key required): `GET https://api.pzero.studio/v1/models`
+</Callout>
+
 Related discussions:
 
 - [Why is the return value blank after installing Docker, configuring environment variables?](https://github.com/lobehub/lobehub/discussions/623)


### PR DESCRIPTION
Add a PZERO tip callout in the OpenAI provider docs explaining how to configure PZERO as an OpenAI-compatible custom endpoint.

PZERO is a prepaid inference service using OpenAI-compatible API with `pzero_` API keys. This example clarifies the `/v1` suffix requirement and shows the correct environment variable configuration.

Fixes lobehub/lobehub#18773