### PR TITLE
💄 style(spa): replace app shell skeleton logo with brand text and update loading hint

### DIFF
--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -464,6 +464,7 @@
   "serverVersionOutdated.warning": "Some features may not work properly or behave unexpectedly. Please update your server for the best experience.",
   "setting": "Settings",
   "share": "Share",
+  "stillLoading": "Still loading...",
   "stop": "Stop",
   "switch": "Switch",
   "sync.actions.settings": "Sync Settings",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -464,6 +464,7 @@
   "serverVersionOutdated.warning": "部分功能可能无法正常使用或出现非预期行为。建议更新服务端以获得最佳体验。",
   "setting": "设置",
   "share": "分享",
+  "stillLoading": "仍在加载中…",
   "stop": "停止",
   "switch": "切换",
   "sync.actions.settings": "同步设置",

--- a/packages/locales/src/default/common.ts
+++ b/packages/locales/src/default/common.ts
@@ -475,6 +475,7 @@ export default {
   'layoutInitializing': 'Loading layout...',
   'legal': 'Legal Disclaimer',
   'loading': 'Loading...',
+  'stillLoading': 'Still loading...',
   'mail.business': 'Business Cooperation',
   'mail.support': 'Email Support',
   'deleteHistoryMigrating':

--- a/src/spa/BootShell/AppShellSkeleton.tsx
+++ b/src/spa/BootShell/AppShellSkeleton.tsx
@@ -25,20 +25,7 @@ const CSS_VAR_CLASS = 'lobe-vars';
 
 export const APP_SHELL_FALLBACK_ID = 'app-shell-fallback';
 
-/**
- * A boot that hands over inside a second reads as a transition, not a wait, so
- * the shell stays a bare brand mark. Past that the user is waiting on something
- * and deserves to be told so.
- *
- * Measured from the document, not from this component: the static HTML logo is
- * already on screen before any bundle runs, and the shell itself only mounts
- * `BOOT_SHELL_DELAY` after React's first commit. Timing from mount would restart
- * the clock the user has been watching all along, and on the slow boots that
- * need the hint most it would arrive last.
- */
 const HINT_DELAY = 1000;
-
-const sinceDocument = () => performance.now() - (window.__LOBE_BOOT_T_HTML__ ?? 0);
 
 // The X half of the transform is the centering, not the motion — it has to be
 // restated in both frames or the keyframe overwrites it and the caption jumps
@@ -130,14 +117,12 @@ interface AppShellSkeletonProps {
 
 const AppShellSkeleton = memo<AppShellSkeletonProps>(({ id }) => {
   const { isDark, navPanelBackground, navPanelWidth, showLeftPanel } = readBootShellGeometry();
-  const [waiting, setWaiting] = useState(() => sinceDocument() >= HINT_DELAY);
+  const [waiting, setWaiting] = useState(false);
 
   useEffect(() => {
-    if (waiting) return;
-
-    const timer = setTimeout(() => setWaiting(true), HINT_DELAY - sinceDocument());
+    const timer = setTimeout(() => setWaiting(true), HINT_DELAY);
     return () => clearTimeout(timer);
-  }, [waiting]);
+  }, []);
 
   return (
     <div aria-hidden className={`${CSS_VAR_CLASS} ${styles.root}`} id={id}>

--- a/src/spa/BootShell/AppShellSkeleton.tsx
+++ b/src/spa/BootShell/AppShellSkeleton.tsx
@@ -119,7 +119,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const LoadingHint = memo(() => {
   const { t } = useTranslation('common');
 
-  return <div className={styles.hint}>{t('loading')}</div>;
+  return <div className={styles.hint}>{t('stillLoading')}</div>;
 });
 
 LoadingHint.displayName = 'AppShellLoadingHint';
@@ -173,7 +173,7 @@ const AppShellSkeleton = memo<AppShellSkeletonProps>(({ id }) => {
             <div className={styles.contentBrand}>
               <div className={styles.brand}>
                 <div className={styles.mark}>
-                  <LobeHub size={56} type={'mono'} />
+                  <LobeHub size={40} type={'text'} />
                 </div>
                 {waiting && <LoadingHint />}
               </div>


### PR DESCRIPTION
Replace the brand logo mark in the App Shell skeleton content area with the text wordmark (`type={'text'}`), matching the initial HTML loading screen, and update the delayed `LoadingHint` copy to `stillLoading` ("Still loading...").

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed