### PR TITLE
✨ feat(sub-agent): auto-open the sub-agent thread in the portal on spawn

### DIFF
--- a/packages/builtin-tool-lobe-agent/src/client/Render/CallSubAgent/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Render/CallSubAgent/index.tsx
@@ -56,17 +56,21 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
  */
 export const CallSubAgentRender = memo<
   BuiltinRenderProps<CallSubAgentParams, CallSubAgentState, string>
->(({ args, content, pluginState }) => {
+>(({ args, content, messageId, pluginState }) => {
   const { t } = useTranslation('plugin');
   const { t: tChat } = useTranslation('chat');
   const prompt = args?.instruction?.trim();
   const result = typeof content === 'string' ? content.trim() : '';
   const threadId = pluginState?.threadId;
 
+  // `pluginState.threadId` is only backfilled when the child finishes; while it
+  // is still running the isolation thread is found through its spawn anchor —
+  // it points back at this tool message via `sourceMessageId`. Without the
+  // fallback the "View Detail" button stays hidden for the whole run.
   const subagentThread = useChatStore((s) =>
     threadId
       ? (threadSelectors.currentTopicThreads(s) ?? []).find((thread) => thread.id === threadId)
-      : undefined,
+      : threadSelectors.getIsolationThreadBySourceMsgId(messageId)(s),
   );
   const openThreadInPortal = useChatStore((s) => s.openThreadInPortal);
   const closeThreadPortal = useChatStore((s) => s.closeThreadPortal);

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -1014,9 +1014,10 @@ export class StreamingExecutorActionImpl {
       log('[%s] Created thread %s, userMessage %s', logId, threadId, userMessageId);
 
       // Register the freshly-created isolation thread in the client thread list
-      // so the tool Render can locate it (the "View Detail" button) and it shows
-      // in the sidebar without waiting for a topic switch to re-fetch threads.
-      void this.#get().refreshThreads();
+      // (so the tool Render's "View Detail" button and the sidebar pick it up)
+      // and surface it in the portal right away. The action refreshes threads
+      // internally before resolving the thread by its spawn anchor.
+      void this.#get().internal_autoOpenSubAgentThread(toolMessageId);
 
       // 2. Build the sub-agent ConversationContext (threadId provides isolation)
       const workspaceSlug = parentOperationId

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -11,6 +11,7 @@ import type {
   ToolStartData,
   ToolStateChunkData,
 } from '@lobechat/agent-gateway-client';
+import { LobeAgentApiName, LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
 import type {
   BuiltinToolResult,
   ChatMessageError,
@@ -871,6 +872,27 @@ export const createGatewayEventHandler = (
             // it and dispatch onto a message the store doesn't have yet.
             if ((data as any).toolMessageIds) {
               await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+
+              // A deferred `callSubAgent` in this batch means a sub-agent just
+              // spawned server-side: its placeholder row (mapped in
+              // `toolMessageIds`) and isolation thread both exist by the time
+              // this chunk is published, so the thread can be surfaced in the
+              // portal right away instead of waiting for the run to finish.
+              const toolMessageIds = (data as any).toolMessageIds as Record<string, string>;
+              for (const tool of data.toolsCalling ?? []) {
+                if (
+                  tool?.identifier !== LobeAgentIdentifier ||
+                  tool?.apiName !== LobeAgentApiName.callSubAgent
+                )
+                  continue;
+                const subAgentAnchorId =
+                  typeof tool.id === 'string' ? toolMessageIds[tool.id] : undefined;
+                if (subAgentAnchorId) {
+                  await get()
+                    .internal_autoOpenSubAgentThread(subAgentAnchorId)
+                    .catch(console.error);
+                }
+              }
             }
           }
         });

--- a/src/store/chat/slices/thread/action.test.ts
+++ b/src/store/chat/slices/thread/action.test.ts
@@ -12,6 +12,7 @@ import { type ThreadItem } from '@/types/topic';
 import { ThreadStatus, ThreadType } from '@/types/topic';
 
 import { useChatStore } from '../../store';
+import { PortalViewType } from '../portal/initialState';
 
 // Mock @/libs/swr mutate
 vi.mock('@/libs/swr', async () => {
@@ -324,6 +325,110 @@ describe('thread action', () => {
         threadId: 'thread-id',
         startMessageId: 'source-message-id',
       });
+    });
+  });
+
+  describe('internal_autoOpenSubAgentThread', () => {
+    const isolationThread = (id: string, sourceMessageId: string): ThreadItem => ({
+      createdAt: new Date(),
+      id,
+      lastActiveAt: new Date(),
+      sourceMessageId,
+      status: ThreadStatus.Processing,
+      title: 'Sub-agent run',
+      topicId: 'test-topic-id',
+      type: ThreadType.Isolation,
+      updatedAt: new Date(),
+      userId: 'user-1',
+    });
+
+    it('should refresh threads then open the isolation thread matching the spawn anchor', async () => {
+      const { result } = renderHook(() => useChatStore());
+      act(() => {
+        useChatStore.setState({
+          portalStack: [],
+          showPortal: false,
+          threadMaps: { 'test-topic-id': [isolationThread('sub-thread-1', 'anchor-1')] },
+        });
+      });
+      const refreshThreadsSpy = vi.spyOn(result.current, 'refreshThreads');
+
+      await act(async () => {
+        await result.current.internal_autoOpenSubAgentThread('anchor-1');
+      });
+
+      expect(refreshThreadsSpy).toHaveBeenCalled();
+      expect(result.current.portalThreadId).toBe('sub-thread-1');
+      expect(result.current.showPortal).toBe(true);
+      expect(result.current.portalStack.at(-1)).toEqual({
+        type: PortalViewType.Thread,
+        threadId: 'sub-thread-1',
+        startMessageId: 'anchor-1',
+      });
+    });
+
+    it('should not cover a portal showing a non-Thread view', async () => {
+      const { result } = renderHook(() => useChatStore());
+      act(() => {
+        useChatStore.setState({
+          portalStack: [{ type: PortalViewType.Artifact } as any],
+          showPortal: true,
+          threadMaps: { 'test-topic-id': [isolationThread('sub-thread-2', 'anchor-2')] },
+        });
+      });
+
+      await act(async () => {
+        await result.current.internal_autoOpenSubAgentThread('anchor-2');
+      });
+
+      expect(result.current.portalThreadId).toBeUndefined();
+      expect(result.current.portalStack.at(-1)).toEqual({ type: PortalViewType.Artifact });
+    });
+
+    it('should open at most once per anchor so a closed portal stays closed on replay', async () => {
+      const { result } = renderHook(() => useChatStore());
+      act(() => {
+        useChatStore.setState({
+          portalStack: [],
+          showPortal: false,
+          threadMaps: { 'test-topic-id': [isolationThread('sub-thread-3', 'anchor-3')] },
+        });
+      });
+
+      await act(async () => {
+        await result.current.internal_autoOpenSubAgentThread('anchor-3');
+      });
+      act(() => {
+        result.current.closeThreadPortal();
+      });
+      await act(async () => {
+        await result.current.internal_autoOpenSubAgentThread('anchor-3');
+      });
+
+      expect(result.current.portalThreadId).toBeUndefined();
+      expect(result.current.showPortal).toBe(false);
+    });
+
+    it('should no-op when no isolation thread matches the anchor', async () => {
+      const { result } = renderHook(() => useChatStore());
+      act(() => {
+        useChatStore.setState({
+          portalStack: [],
+          showPortal: false,
+          threadMaps: {
+            'test-topic-id': [
+              { ...isolationThread('sub-thread-4', 'anchor-4'), type: ThreadType.Continuation },
+            ],
+          },
+        });
+      });
+
+      await act(async () => {
+        await result.current.internal_autoOpenSubAgentThread('anchor-4');
+      });
+
+      expect(result.current.portalThreadId).toBeUndefined();
+      expect(result.current.showPortal).toBe(false);
     });
   });
 

--- a/src/store/chat/slices/thread/action.ts
+++ b/src/store/chat/slices/thread/action.ts
@@ -27,6 +27,7 @@ import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user
 import { setNamespace } from '@/utils/storeDebug';
 
 import { PortalViewType } from '../portal/initialState';
+import { chatPortalSelectors } from '../portal/selectors';
 import { type ThreadDispatch } from './reducer';
 import { threadReducer } from './reducer';
 import { genParentMessages } from './selectors';
@@ -105,6 +106,43 @@ export class ChatThreadActionImpl {
       startMessageId: sourceMessageId ?? undefined,
     });
   };
+
+  /**
+   * Surface a freshly spawned `callSubAgent` isolation thread in the portal.
+   *
+   * `toolMessageId` is the pending placeholder tool message anchoring the run —
+   * the thread points back at it via `sourceMessageId`. That anchor is the only
+   * key available at spawn time: the persisted `pluginState.threadId` is only
+   * backfilled by the completion bridge when the child finishes.
+   *
+   * One-shot per anchor: a user who closes the portal mid-run must not have it
+   * forced back open by a replayed spawn event. And when the portal is already
+   * showing a non-Thread view (an Artifact/Document the user is reading), the
+   * open is skipped rather than covering that surface — the same guard
+   * `#syncCreatedThread` applies. The thread-list refresh still runs on the
+   * skip paths so the sidebar and the tool card's "View Detail" button pick the
+   * new thread up without waiting for a topic switch.
+   */
+  internal_autoOpenSubAgentThread = async (toolMessageId: string): Promise<void> => {
+    await this.#get().refreshThreads();
+
+    if (this.#autoOpenedSubAgentAnchors.has(toolMessageId)) return;
+
+    const state = this.#get();
+    const currentViewType = chatPortalSelectors.currentViewType(state);
+    if (state.showPortal && currentViewType && currentViewType !== PortalViewType.Thread) return;
+
+    // `currentTopicThreads` scoping doubles as the topic guard: a sub-agent
+    // spawned in a background topic never hijacks the one being viewed.
+    const thread = threadSelectors.getIsolationThreadBySourceMsgId(toolMessageId)(state);
+    if (!thread) return;
+
+    this.#autoOpenedSubAgentAnchors.add(toolMessageId);
+    this.#get().openThreadInPortal(thread.id, thread.sourceMessageId);
+  };
+
+  /** Spawn anchors (placeholder tool message ids) already auto-opened once. */
+  #autoOpenedSubAgentAnchors = new Set<string>();
 
   /**
    * Sync the portal slice's thread state to a freshly-created thread *without*


### PR DESCRIPTION
When an agent calls `callSubAgent`, the child already runs in an isolation thread that has a perfectly good Thread portal view — but that view was unreachable for the entire run. The card's "View Detail" button resolves the thread from `pluginState.threadId`, and the completion bridge only backfills that field when the child *finishes*. So for a 20-minute sub-agent run the user saw a collapsed row and "task is running on the server, you can safely leave this page", with no way to watch what it was doing.

The thread actually exists from the moment the sub-agent spawns, and it points back at its pending placeholder tool message through `sourceMessageId`. That anchor is available immediately on both runtime paths, so it can drive the portal instead.

| Before | After |
| ------ | ----- |
| Sub-agent spawns → collapsed tool row + "running on the server"; the run is opaque until it completes, and "View Detail" is hidden the whole time. | Sub-agent spawns → its thread opens in the right-hand portal immediately, streaming the child's steps live; "View Detail" also works mid-run. |

#### What changed

- New `internal_autoOpenSubAgentThread(toolMessageId)` on the thread slice: refresh the thread list, resolve the isolation thread by its spawn anchor, open it in the portal.
- Server path — triggered from the `tools_calling` chunk carrying `toolMessageIds`, the earliest point the client can learn the anchor (placeholder row and thread are both persisted by then).
- Client path (`runClientSubAgent`) — triggered right after the thread is created, replacing the bare `refreshThreads()` call.
- The card's "View Detail" button falls back to the same anchor lookup, so it works mid-run and can reopen the portal after the user closes it.

#### Guards, so it doesn't steal the surface

- One-shot per anchor — a user who closes the portal mid-run doesn't get it forced back open by a replayed spawn event.
- Skipped when the portal already shows a non-Thread view (an Artifact or Document the user is reading), mirroring the existing guard in `#syncCreatedThread`.
- Thread lookup is scoped to `currentTopicThreads`, so a sub-agent spawned in a background topic never hijacks the conversation being viewed.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Four regression tests on `internal_autoOpenSubAgentThread` cover the happy path, the non-Thread-view guard, the one-shot-per-anchor behaviour, and the no-matching-thread no-op. Full suite for the touched files: 61 tests passing, lint clean, no new type errors.

#### 🔗 Related Issue

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)