### PR TITLE
🐛 fix(goal): recenter graph after panel resize

### DIFF
--- a/src/features/AgentGoals/ProcessControl/Graph/index.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@xyflow/react';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { Maximize2, X } from 'lucide-react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { PortalContent } from '@/features/Portal/router';
@@ -31,6 +31,7 @@ import type { GoalGraphView, GoalNodeView } from '../goalGraphViewModel';
 import { KindDot } from '../shared';
 import GraphNodeView, { GhostNodeView, type GraphNodeData } from './GraphNode';
 import { hideKinds, layoutGraph, NODE_WIDTH } from './layout';
+import { useFitViewOnResize } from './useFitViewOnResize';
 
 /**
  * The exploration map. Two views: 当前阶段 (what got the goal here plus what the
@@ -250,6 +251,8 @@ const useEdgeLabel = () => {
 
 const nodeTypes = { goalGhost: GhostNodeView, goalNode: GraphNodeView };
 
+const FIT_VIEW_OPTIONS = { duration: 200, maxZoom: 1, minZoom: 0.6, padding: 0.12 } as const;
+
 /** Ghost placeholders rendered beneath the problem while planning runs. */
 const GHOST_COUNT = 3;
 const GHOST_GAP = 32;
@@ -278,6 +281,7 @@ const Canvas = memo<
     view,
   }) => {
     const { fitView } = useReactFlow();
+    const containerRef = useRef<HTMLDivElement>(null);
     const subtitleOf = useSubtitle();
     const edgeLabel = useEdgeLabel();
 
@@ -440,11 +444,12 @@ const Canvas = memo<
     const allNodes = useMemo(() => [...flowNodes, ...ghostFlowNodes], [flowNodes, ghostFlowNodes]);
     const allEdges = useMemo(() => [...flowEdges, ...ghostFlowEdges], [flowEdges, ghostFlowEdges]);
 
+    // The inline map is a framed overview, so keep it fitted to the space left by
+    // the detail panel. Fullscreen keeps its existing user-navigation behavior.
+    useFitViewOnResize(containerRef, fitView, FIT_VIEW_OPTIONS, !interactive);
+
     useEffect(() => {
-      const timer = setTimeout(
-        () => fitView({ duration: 200, maxZoom: 1, minZoom: 0.6, padding: 0.12 }),
-        30,
-      );
+      const timer = setTimeout(() => fitView(FIT_VIEW_OPTIONS), 30);
       return () => clearTimeout(timer);
     }, [view, allNodes.length, hiddenKinds, fitView]);
 
@@ -452,15 +457,16 @@ const Canvas = memo<
     // animation before refitting, or the fit is computed mid-transition.
     useEffect(() => {
       if (refitKey === undefined) return;
-      const timer = setTimeout(
-        () => fitView({ duration: 200, maxZoom: 1, minZoom: 0.6, padding: 0.12 }),
-        280,
-      );
+      const timer = setTimeout(() => fitView(FIT_VIEW_OPTIONS), 280);
       return () => clearTimeout(timer);
     }, [refitKey, fitView]);
 
     return (
-      <div className={className} style={interactive ? undefined : { height: inlineHeight }}>
+      <div
+        className={className}
+        ref={containerRef}
+        style={interactive ? undefined : { height: inlineHeight }}
+      >
         {/* Inline, the map is a picture: it settles on `fitView` and stays
             there. Panning or zooming it inside a scrolling page moves the graph
             under the cursor while the page moves too, and leaves no way back to

--- a/src/features/AgentGoals/ProcessControl/Graph/useFitViewOnResize.test.ts
+++ b/src/features/AgentGoals/ProcessControl/Graph/useFitViewOnResize.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { observeWidth } from './useFitViewOnResize';
+
+let resizeCallback: ResizeObserverCallback;
+const disconnect = vi.fn();
+const observe = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      disconnect = disconnect;
+      observe = observe;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('observeWidth', () => {
+  it('reframes once after an animated panel width change settles', () => {
+    const element = document.createElement('div');
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      bottom: 0,
+      height: 560,
+      left: 0,
+      right: 1000,
+      toJSON: vi.fn(),
+      top: 0,
+      width: 1000,
+      x: 0,
+      y: 0,
+    });
+    const reframe = vi.fn();
+    const cleanup = observeWidth(element, reframe);
+
+    for (const width of [900, 800, 700]) {
+      resizeCallback([{ contentRect: { width } } as ResizeObserverEntry], {} as ResizeObserver);
+      vi.advanceTimersByTime(50);
+    }
+
+    expect(reframe).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(reframe).toHaveBeenCalledOnce();
+
+    cleanup();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('ignores height-only resize notifications', () => {
+    const element = document.createElement('div');
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      bottom: 0,
+      height: 560,
+      left: 0,
+      right: 1000,
+      toJSON: vi.fn(),
+      top: 0,
+      width: 1000,
+      x: 0,
+      y: 0,
+    });
+    const reframe = vi.fn();
+    const cleanup = observeWidth(element, reframe);
+
+    resizeCallback(
+      [{ contentRect: { height: 400, width: 1000 } } as ResizeObserverEntry],
+      {} as ResizeObserver,
+    );
+    vi.runAllTimers();
+
+    expect(reframe).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/src/features/AgentGoals/ProcessControl/Graph/useFitViewOnResize.ts
+++ b/src/features/AgentGoals/ProcessControl/Graph/useFitViewOnResize.ts
@@ -1,0 +1,42 @@
+import type { FitViewOptions } from '@xyflow/react';
+import { type RefObject, useEffect } from 'react';
+
+const RESIZE_SETTLE_DELAY = 100;
+
+export const observeWidth = (element: HTMLElement, onSettledResize: () => void) => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let width = element.getBoundingClientRect().width;
+
+  const observer = new ResizeObserver(([entry]) => {
+    const nextWidth = entry?.contentRect.width;
+    if (nextWidth === undefined || nextWidth === width) return;
+
+    width = nextWidth;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(onSettledResize, RESIZE_SETTLE_DELAY);
+  });
+
+  observer.observe(element);
+
+  return () => {
+    if (timer) clearTimeout(timer);
+    observer.disconnect();
+  };
+};
+
+/** Reframe the graph after a surrounding panel changes the canvas width. */
+export const useFitViewOnResize = (
+  containerRef: RefObject<HTMLDivElement | null>,
+  fitView: (options?: FitViewOptions) => Promise<boolean>,
+  options: FitViewOptions,
+  enabled = true,
+) => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+
+    return observeWidth(container, () => void fitView(options));
+  }, [containerRef, enabled, fitView, options]);
+};


### PR DESCRIPTION
## Summary

- observe inline goal graph width changes caused by opening, closing, or resizing the right panel
- debounce React Flow refitting until the panel transition settles
- preserve the existing fullscreen navigation behavior
- add regression coverage for animated width changes and height-only resize notifications

## Testing

- `bun run check src/features/AgentGoals/ProcessControl/Graph/index.tsx src/features/AgentGoals/ProcessControl/Graph/useFitViewOnResize.ts src/features/AgentGoals/ProcessControl/Graph/useFitViewOnResize.test.ts`
- 2 related tests passed
- visual acceptance: https://app.lobehub.com/acceptance/87c23925-3328-4e8e-9f6f-53dcc46ab887
