### PR TITLE
🐛 fix(workspace): show working directory picker for a member's local device override

### DIFF
--- a/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
+++ b/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
@@ -1,19 +1,14 @@
 'use client';
 
-import { isDesktop } from '@lobechat/const';
 import { Tooltip } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatInputResourceAccess } from '@/features/ChatInput/hooks/useChatInputResourceAccess';
-import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
-import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
-import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 
 import CloudRepoSwitcher from './CloudRepoSwitcher';
 import HeteroDeviceSwitcher from './HeteroDeviceSwitcher';
+import { useWorkspaceSurface } from './useWorkspaceSurface';
 import WorkingDirectorySection from './WorkingDirectorySection';
 
 interface WorkspaceControlsProps {
@@ -40,41 +35,22 @@ const WorkspaceControls = memo<WorkspaceControlsProps>(
   ({ agentId, alwaysShowWorkspace = false }) => {
     const { t } = useTranslation('setting');
     const { canConfigureResource, canUseResource } = useChatInputResourceAccess();
-    const runtimeMode = useAgentStore(chatConfigByIdSelectors.getRuntimeModeById(agentId));
-    const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
-    // Effective config = shared row + this member's device override,
-    // so `isDeviceMode` routes the working-directory section by the device THIS
-    // member's run actually targets.
-    const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);
-    const deviceRoutingAvailable = useIsGatewayModeEnabled(agentId);
-    const effectiveTarget = resolveExecutionTarget(agencyConfig, {
-      clientExecutionAvailable: isDesktop,
-      deviceRoutingAvailable,
-      isHetero: isHeterogeneous,
-      workspaceScoped,
-    });
-    const isDeviceMode = effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId;
+    // Resolved from the effective (override-merged) execution target so the
+    // surface follows the device THIS member's run actually targets.
+    const surface = useWorkspaceSurface(agentId, alwaysShowWorkspace);
 
     const renderWorkspace = () => {
-      // Remote device runs get the device-scoped picker, regardless of runtimeMode
-      // (HeteroDeviceSwitcher sets runtimeMode to 'none' when a device is selected).
-      if (isDeviceMode) return <WorkingDirectorySection agentId={agentId} />;
-
-      // Web has no local filesystem — cloud / heterogeneous agents browse the repo
-      // through the cloud repo switcher instead.
-      if (!isDesktop) {
-        return isHeterogeneous || alwaysShowWorkspace ? (
-          <CloudRepoSwitcher agentId={agentId} />
-        ) : null;
+      switch (surface) {
+        case 'workingDirectory': {
+          return <WorkingDirectorySection agentId={agentId} />;
+        }
+        case 'cloudRepo': {
+          return <CloudRepoSwitcher agentId={agentId} />;
+        }
+        default: {
+          return null;
+        }
       }
-
-      // Desktop: local working directory + git branch / diff / PR. Shown when the
-      // run is local, or always for heterogeneous agents (they always have a cwd).
-      if (alwaysShowWorkspace || runtimeMode === 'local') {
-        return <WorkingDirectorySection agentId={agentId} />;
-      }
-
-      return null;
     };
 
     // The directory picker and git controls write shared agent config / run

--- a/src/features/ChatInput/ControlBar/__tests__/useWorkspaceSurface.test.ts
+++ b/src/features/ChatInput/ControlBar/__tests__/useWorkspaceSurface.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type * as LobechatConstModule from '@lobechat/const';
+import type { LobeAgentAgencyConfig } from '@lobechat/types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentStore } from '@/store/agent';
+
+import { resolveWorkspaceSurface, useWorkspaceSurface } from '../useWorkspaceSurface';
+
+// The EFFECTIVE config (shared row + this member's per-user device override),
+// as `useEffectiveAgencyConfig` would resolve it. The raw shared row lives in
+// the real agent store so store-derived selectors see what they see in prod.
+const effective = vi.hoisted(() => ({
+  agencyConfig: undefined as LobeAgentAgencyConfig | undefined,
+  workspaceScoped: false,
+}));
+
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal<typeof LobechatConstModule>()),
+  isDesktop: true,
+}));
+
+vi.mock('@/helpers/gatewayMode', () => ({
+  resolveGatewayModeEnabled: () => true,
+  useIsGatewayModeEnabled: () => true,
+}));
+
+vi.mock('@/hooks/useEffectiveAgencyConfig', () => ({
+  useEffectiveAgencyConfig: () => ({
+    agencyConfig: effective.agencyConfig,
+    workspaceScoped: effective.workspaceScoped,
+  }),
+}));
+
+const AGENT_ID = 'agent-1';
+
+const setSharedAgent = (agent: { agencyConfig?: LobeAgentAgencyConfig; workspaceId?: string }) => {
+  useAgentStore.setState({
+    agentMap: { [AGENT_ID]: { id: AGENT_ID, visibility: 'public', ...agent } },
+  });
+};
+
+beforeEach(() => {
+  effective.agencyConfig = undefined;
+  effective.workspaceScoped = false;
+  useAgentStore.setState({ agentMap: {} });
+});
+
+describe('useWorkspaceSurface (desktop)', () => {
+  // Regression for LOBE-13771: a workspace member's "Local device" pick lives in
+  // their per-user override, never in the shared row. The surface must follow
+  // the effective target — a shared-row-only runtime mode can never be `local`
+  // for a workspace agent, which hid the directory picker.
+  it.each([
+    ['no target yet', undefined],
+    ['cloud sandbox', { executionTarget: 'sandbox' } as LobeAgentAgencyConfig],
+  ])(
+    'shows the working directory picker when a workspace member overrides a shared row (%s) with local',
+    (_, sharedAgencyConfig) => {
+      setSharedAgent({ agencyConfig: sharedAgencyConfig, workspaceId: 'ws-1' });
+      effective.agencyConfig = {
+        ...sharedAgencyConfig,
+        boundDeviceId: 'personal-device',
+        executionTarget: 'local',
+      };
+      effective.workspaceScoped = false;
+
+      const { result } = renderHook(() => useWorkspaceSurface(AGENT_ID));
+
+      expect(result.current).toBe('workingDirectory');
+    },
+  );
+
+  it('keeps the device-scoped picker for a workspace-scoped shared local target bound to a workspace device', () => {
+    const shared: LobeAgentAgencyConfig = {
+      boundDeviceId: 'workspace-device',
+      executionTarget: 'local',
+    };
+    setSharedAgent({ agencyConfig: shared, workspaceId: 'ws-1' });
+    effective.agencyConfig = shared;
+    effective.workspaceScoped = true;
+
+    const { result } = renderHook(() => useWorkspaceSurface(AGENT_ID));
+
+    expect(result.current).toBe('workingDirectory');
+  });
+
+  it('hides the picker when the member override targets the cloud sandbox', () => {
+    setSharedAgent({
+      agencyConfig: { boundDeviceId: 'workspace-device', executionTarget: 'local' },
+      workspaceId: 'ws-1',
+    });
+    effective.agencyConfig = { executionTarget: 'sandbox' };
+    effective.workspaceScoped = false;
+
+    const { result } = renderHook(() => useWorkspaceSurface(AGENT_ID));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('shows the picker for a personal agent running locally', () => {
+    const shared: LobeAgentAgencyConfig = { executionTarget: 'local' };
+    setSharedAgent({ agencyConfig: shared });
+    effective.agencyConfig = shared;
+
+    const { result } = renderHook(() => useWorkspaceSurface(AGENT_ID));
+
+    expect(result.current).toBe('workingDirectory');
+  });
+
+  it('always shows the picker for a heterogeneous agent, even on a sandbox target', () => {
+    const shared: LobeAgentAgencyConfig = {
+      executionTarget: 'sandbox',
+      heterogeneousProvider: { command: 'claude', type: 'claude-code' },
+    };
+    setSharedAgent({ agencyConfig: shared });
+    effective.agencyConfig = shared;
+
+    const { result } = renderHook(() => useWorkspaceSurface(AGENT_ID, true));
+
+    expect(result.current).toBe('workingDirectory');
+  });
+});
+
+describe('resolveWorkspaceSurface (web)', () => {
+  const web = {
+    alwaysShowWorkspace: false,
+    clientExecutionAvailable: false,
+    deviceRoutingAvailable: true,
+    isHetero: false,
+    workspaceScoped: false,
+  };
+
+  it('routes a bound local target to the device-scoped picker', () => {
+    expect(
+      resolveWorkspaceSurface({
+        ...web,
+        agencyConfig: { boundDeviceId: 'desktop-device', executionTarget: 'local' },
+      }),
+    ).toBe('workingDirectory');
+  });
+
+  it('offers the cloud repo switcher to heterogeneous agents', () => {
+    expect(
+      resolveWorkspaceSurface({
+        ...web,
+        agencyConfig: { executionTarget: 'sandbox' },
+        isHetero: true,
+      }),
+    ).toBe('cloudRepo');
+  });
+
+  it('offers the cloud repo switcher when the workspace is forced on', () => {
+    expect(
+      resolveWorkspaceSurface({
+        ...web,
+        agencyConfig: { executionTarget: 'sandbox' },
+        alwaysShowWorkspace: true,
+      }),
+    ).toBe('cloudRepo');
+  });
+
+  it('shows nothing for a plain agent without a bound device', () => {
+    expect(resolveWorkspaceSurface({ ...web, agencyConfig: { executionTarget: 'local' } })).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/features/ChatInput/ControlBar/useWorkspaceSurface.ts
+++ b/src/features/ChatInput/ControlBar/useWorkspaceSurface.ts
@@ -1,0 +1,90 @@
+import { isDesktop } from '@lobechat/const';
+import type { LobeAgentAgencyConfig } from '@lobechat/types';
+
+import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+
+/**
+ * Which workspace control sits next to the device switcher:
+ *
+ * - `workingDirectory` — directory picker + git status, for a run on this
+ *   machine or on a bound device
+ * - `cloudRepo`        — cloud repo switcher (web has no local filesystem)
+ * - `undefined`        — nothing; the run has no browsable workspace here
+ */
+export type WorkspaceSurface = 'cloudRepo' | 'workingDirectory' | undefined;
+
+export interface ResolveWorkspaceSurfaceParams {
+  /** The EFFECTIVE config — shared row merged with this member's device override. */
+  agencyConfig: LobeAgentAgencyConfig | undefined;
+  /** Heterogeneous agents always run inside a working directory. */
+  alwaysShowWorkspace: boolean;
+  /** See `ResolveExecutionTargetOptions.clientExecutionAvailable` (`isDesktop` in the UI). */
+  clientExecutionAvailable: boolean;
+  deviceRoutingAvailable: boolean;
+  isHetero: boolean;
+  /** See `UseEffectiveAgencyConfigResult.workspaceScoped`. */
+  workspaceScoped: boolean;
+}
+
+export const resolveWorkspaceSurface = ({
+  agencyConfig,
+  alwaysShowWorkspace,
+  clientExecutionAvailable,
+  deviceRoutingAvailable,
+  isHetero,
+  workspaceScoped,
+}: ResolveWorkspaceSurfaceParams): WorkspaceSurface => {
+  const effectiveTarget = resolveExecutionTarget(agencyConfig, {
+    clientExecutionAvailable,
+    deviceRoutingAvailable,
+    isHetero,
+    workspaceScoped,
+  });
+
+  // Remote device runs get the device-scoped picker, whatever else is set.
+  if (effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId) return 'workingDirectory';
+
+  // Web has no local filesystem — cloud / heterogeneous agents browse the repo
+  // through the cloud repo switcher instead.
+  if (!clientExecutionAvailable) {
+    return isHetero || alwaysShowWorkspace ? 'cloudRepo' : undefined;
+  }
+
+  // Desktop: local working directory + git branch / diff / PR. Shown when the
+  // run is local, or always for heterogeneous agents (they always have a cwd).
+  if (alwaysShowWorkspace || effectiveTarget === 'local') return 'workingDirectory';
+
+  return undefined;
+};
+
+/**
+ * The workspace surface for an agent, resolved from the EFFECTIVE execution
+ * target (shared row + this member's per-user device override).
+ *
+ * Deliberately not `chatConfigByIdSelectors.getRuntimeModeById`: that store
+ * selector only sees the workspace-shared row and treats every workspace agent
+ * as workspace-scoped, so a member's "Local device" pick — which lives solely
+ * in `agentDeviceOverrides` — never resolves to `local` there. The device chip
+ * would say "Local device" while the directory picker stayed hidden.
+ */
+export const useWorkspaceSurface = (
+  agentId: string,
+  alwaysShowWorkspace = false,
+): WorkspaceSurface => {
+  const isHetero = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
+  const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);
+  const deviceRoutingAvailable = useIsGatewayModeEnabled(agentId);
+
+  return resolveWorkspaceSurface({
+    agencyConfig,
+    alwaysShowWorkspace,
+    clientExecutionAvailable: isDesktop,
+    deviceRoutingAvailable,
+    isHetero,
+    workspaceScoped,
+  });
+};


### PR DESCRIPTION
On the desktop app, a workspace agent whose member picked **Local device** rendered only `Agent | Local device` in the chat control bar — the **Working Directory** picker never appeared, so no directory could be selected.

`WorkspaceControls` decided the desktop branch with `chatConfigByIdSelectors.getRuntimeModeById`, which only reads the workspace-shared `agents.agencyConfig` row and treats every workspace agent as workspace-scoped. A member's "Local device" pick lives solely in their per-user `agentDeviceOverrides`, so that selector can never resolve to `local` for a workspace agent, while the device chip (effective config) already said "Local device".

**Change**

- New `useWorkspaceSurface` hook (+ pure `resolveWorkspaceSurface`) resolves which workspace control to show from the **effective** execution target (shared row merged with the caller's override, via `useEffectiveAgencyConfig`): `workingDirectory` / `cloudRepo` / nothing.
- `WorkspaceControls` consumes the hook; device mode, the web `CloudRepoSwitcher` branch and heterogeneous `alwaysShowWorkspace` behave as before.
- Regression test `useWorkspaceSurface.test.ts` (real agent store + mocked effective config): a workspace member's local override on a shared row with no target / sandbox now shows the picker, plus guards for workspace-scoped device mode, sandbox override, personal local, hetero, and the web branches.

| Before | After |
| ------ | ----- |
| Control bar: `Agent \| Local device` — no Working Directory | Control bar: `Agent \| Local device \| Working Directory`, popover offers "Choose a folder..." |

Verified on the real Electron cloud desktop against an isolated backend with a same-session HMR A/B: https://app.lobehub.com/acceptance/2cd8c8b2-eb20-499e-aaa5-d91125b6855d

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes LOBE-13771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5hYkUf1jSg2fDiQh72FWV