### PR TITLE
🐛 fix(chat): collapsed tool rows lead with the model-written step description

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.test.tsx
@@ -1,0 +1,57 @@
+import { LocalSystemApiName, LocalSystemIdentifier } from '@lobechat/builtin-tool-local-system';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ToolTitle from './ToolTitle';
+
+// ToolTitle reads the plugin namespace through react-i18next; resolve the
+// runCommand label to a fixed echo so assertions can match on it verbatim.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key.startsWith('builtins.') ? (key.split('.').at(-1) ?? key) : key),
+  }),
+}));
+
+describe('ToolTitle', () => {
+  describe('model-written description rendering', () => {
+    it('renders a CJK description standalone — no action label, no code font', () => {
+      render(
+        <ToolTitle
+          apiName={LocalSystemApiName.runCommand}
+          args={{ command: 'docker ps', description: '查看当前运行中的 Docker 容器' }}
+          identifier={LocalSystemIdentifier}
+        />,
+      );
+
+      expect(screen.getByText('查看当前运行中的 Docker 容器')).toBeInTheDocument();
+      // The action label must be dropped next to a standalone description.
+      expect(screen.queryByText('runCommand')).toBeNull();
+    });
+
+    it('keeps the "<label> <keyword>" shape for a latin command keyword', () => {
+      render(
+        <ToolTitle
+          apiName={LocalSystemApiName.runCommand}
+          args={{ command: 'docker ps' }}
+          identifier={LocalSystemIdentifier}
+        />,
+      );
+
+      expect(screen.getByText('runCommand')).toBeInTheDocument();
+      expect(screen.getByText('docker')).toBeInTheDocument();
+    });
+
+    it('keeps the label for a latin model description (reads as a spec, not a step)', () => {
+      render(
+        <ToolTitle
+          apiName={LocalSystemApiName.runCommand}
+          args={{ command: 'ls -la', description: 'docker-compose.yaml' }}
+          identifier={LocalSystemIdentifier}
+        />,
+      );
+
+      expect(screen.getByText('runCommand')).toBeInTheDocument();
+      expect(screen.getByText('docker-compose.yaml')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
@@ -36,6 +36,11 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextDescription};
     white-space: nowrap;
   `,
+  standalone: css`
+    overflow: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+  `,
 }));
 
 interface ToolTitleProps {
@@ -47,10 +52,14 @@ interface ToolTitleProps {
   partialArgs?: Record<string, unknown>;
 }
 
+const isCJK = (value: string) => /[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF]/.test(value);
+
 /**
- * Collapsed tool row title: a localized action phrase ("Run command",
- * "Edit file") plus at most one keyword of context (file basename, program,
- * query…). Full arguments stay in the expanded Detail view.
+ * Collapsed tool row title. When the model wrote a step description it stands
+ * alone — the action label ("执行代码") adds nothing next to "恢复登录态", and
+ * showing both at different sizes reads as a glitch, so the description takes
+ * the label's typography. Command-like keywords (program name, file basename)
+ * keep the "<label> <keyword>" shape in the smaller code font.
  */
 const ToolTitle = memo<ToolTitleProps>(
   ({ identifier, apiName, args, partialArgs, isLoading, isAborted }) => {
@@ -67,22 +76,36 @@ const ToolTitle = memo<ToolTitleProps>(
 
     const keyword = useMemo(() => extractToolKeyword(args ?? partialArgs), [args, partialArgs]);
 
+    // A model-written description states the whole step on its own; pairing it
+    // with the action label duplicates meaning ("执行代码 查看当前运行中的
+    // Docker 容器") at mismatched font sizes. Let it replace the label and
+    // inherit the label's typography instead of the small code font.
+    const isStandaloneDescription = !!keyword && isCJK(keyword);
+
     return (
       <div className={cx(styles.root, isAborted && styles.aborted)}>
-        <span className={cx(isLoading && shinyTextStyles.shinyText)}>
-          {actionLabel || (
-            <>
-              {pluginTitle && (
+        {isStandaloneDescription ? (
+          <span className={cx(styles.standalone, isLoading && shinyTextStyles.shinyText)}>
+            {keyword}
+          </span>
+        ) : (
+          <>
+            <span className={cx(isLoading && shinyTextStyles.shinyText)}>
+              {actionLabel || (
                 <>
-                  <span>{pluginTitle}</span>
-                  <Icon icon={ChevronRight} />
+                  {pluginTitle && (
+                    <>
+                      <span>{pluginTitle}</span>
+                      <Icon icon={ChevronRight} />
+                    </>
+                  )}
+                  <span>{getToolDisplayName(apiName)}</span>
                 </>
               )}
-              <span>{getToolDisplayName(apiName)}</span>
-            </>
-          )}
-        </span>
-        {keyword && <span className={styles.keyword}>{keyword}</span>}
+            </span>
+            {keyword && <span className={styles.keyword}>{keyword}</span>}
+          </>
+        )}
       </div>
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/extractToolKeyword.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/extractToolKeyword.test.ts
@@ -28,10 +28,14 @@ describe('extractToolKeyword', () => {
       );
     });
 
-    it('prefers command over the model-written description', () => {
+    it('prefers the model-written description over command fragments', () => {
       expect(
         extractToolKeyword({ command: 'ls -la', description: 'List files in current directory' }),
-      ).toBe('ls');
+      ).toBe('List files in current directory');
+    });
+
+    it('falls back to the command program when no description exists', () => {
+      expect(extractToolKeyword({ command: 'ls -la' })).toBe('ls');
     });
   });
 

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/extractToolKeyword.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/extractToolKeyword.ts
@@ -1,13 +1,14 @@
 const MAX_KEYWORD_LENGTH = 32;
 
-// Arg keys checked in priority order. Query/pattern outranks path because
-// Grep/Glob-style calls carry both, and the pattern is the informative half;
-// pure file tools (Read/Edit/Write) only carry a path.
+// Arg keys checked in priority order. NAME_KEYS (model-written description /
+// title) lead because they state what the step does; then query/pattern
+// outranks path (Grep/Glob-style calls carry both, and the pattern is the
+// informative half); pure file tools (Read/Edit/Write) only carry a path.
+const NAME_KEYS = ['name', 'title', 'skill', 'description', 'prompt'];
 const COMMAND_KEYS = ['command', 'cmd', 'script'];
 const QUERY_KEYS = ['query', 'q', 'pattern', 'keywords'];
 const PATH_KEYS = ['file_path', 'filePath', 'path', 'filename', 'file'];
 const URL_KEYS = ['url', 'urls'];
-const NAME_KEYS = ['name', 'title', 'skill', 'description', 'prompt'];
 
 // Shell tokens that never identify the program being run. The ones that take
 // an argument (`source .env`, `cd dir`) consume the following token too.
@@ -99,6 +100,13 @@ const extractUrlKeyword = (url: string): string => {
 export const extractToolKeyword = (args?: Record<string, unknown>): string | undefined => {
   if (!args) return undefined;
 
+  // The model-written description ("恢复登录态", "List files in current
+  // directory") is the clearest statement of what this step does — every
+  // command-running tool schema asks for one, so prefer it over distilling
+  // fragments (flags, session names) out of the raw command.
+  const description = pickString(args, NAME_KEYS);
+  if (description) return truncate(description);
+
   const command = pickString(args, COMMAND_KEYS);
   if (command) {
     const keyword = extractCommandKeyword(command);
@@ -113,9 +121,6 @@ export const extractToolKeyword = (args?: Record<string, unknown>): string | und
 
   const url = pickString(args, URL_KEYS);
   if (url) return truncate(extractUrlKeyword(url));
-
-  const name = pickString(args, NAME_KEYS);
-  if (name) return truncate(name);
 
   return undefined;
 };


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Collapsed command rows distill the keyword from the raw command first, so flags and session names leak into the title (`执行代码 1h`, `执行代码 lobehub-dev"`); a model-written description renders as a small monospace fragment next to the action label (`执行代码 查看当前运行中的 Docker 容器`) at two mismatched font sizes | The model-written step description takes over the collapsed row: `运行 docker ps 查看容器列表` at the action label's font size; command fragments only appear when no description exists (`执行代码 docker`) |

#### Change Type

- [x] `🐛 fix`
- [ ] `✨ feat`
- [ ] `💄 style`
- [ ] `⚡️ perf`

#### Description of Change

Every command-running tool schema (local-system `runCommand`, skills `runCommand`/`execScript`, Claude Code `Bash` …) asks the model for a one-line `description` of the step — e.g. `恢复登录态`. Two problems in the collapsed `"<action> <keyword>"` row:

1. `extractToolKeyword` distilled its keyword from the raw `command` first, so flag values and session names leaked into the title (`执行代码 1h`, `执行代码 lobehub-dev"`) while the useful description sat unused.
2. Once the description did render, it was styled as a 12px monospace fragment next to the action label — the two texts at mismatched sizes read as a glitch, and the label adds nothing next to a description that already states the step ("执行代码 查看当前运行中的 Docker 容器").

Fixes, in `ToolTitle` + `extractToolKeyword`:

- Priority order becomes description → command → query/pattern → path → url, keeping the command-program distillation as the no-description fallback.
- A CJK description (the human-language step the schemas ask for) replaces the action label entirely and inherits the label's typography; command-like keywords (program name, file basename) keep the `"<label> <keyword>"` shape in the small code font.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `extractToolKeyword.test.ts` — priority tests inverted/extended (description over command fragments, no-description fallback).
- `ToolTitle.test.tsx` (new) — CJK description renders standalone with no action label; latin command keywords keep label + keyword; latin descriptions do not trigger the standalone path.
- Verified end-to-end on a local build with real agent runs: collapsed rows show `运行 docker ps 查看容器列表` / `运行 uname -a 查看系统信息` with uniform font size, no bare `docker` fragment (acceptance rounds: https://app.lobehub.com/acceptance/698d2649-9541-49b7-a83d-7d18160059ff).
- `bun run check` on touched files: lint clean, 42/42 tests in the Tool directory pass.

#### 🔗 Related Issue

Related to #19050 (which introduced the collapsed keyword distillation).
