### PR TITLE
➕ chore: add npmmirror registry for faster installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,6 +5,15 @@ dedupe-peer-dependents=true
 ignore-workspace-root-check=true
 enable-pre-post-scripts=true
 
+# 国内镜像（淘宝 npmmirror）
+registry=https://registry.npmmirror.com/
+# pnpm 二进制下载镜像
+disturl=https://npmmirror.com/dist
+electron_mirror=https://npmmirror.com/mirrors/electron/
+electron-builder-binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
+sharp_binary_host=https://npmmirror.com/mirrors/sharp
+sharp_libvips_binary_host=https://npmmirror.com/mirrors/sharp-libvips
+
 
 public-hoist-pattern[]=*@umijs/lint*
 public-hoist-pattern[]=*changelog*


### PR DESCRIPTION
Add npmmirror registry and binary mirrors to .npmrc for faster installs in China.