### PR TITLE
💄 style(acceptance): promote evidence alt text to the fold row title

### DIFF
--- a/src/features/Acceptance/Report/MarkdownEvidence.tsx
+++ b/src/features/Acceptance/Report/MarkdownEvidence.tsx
@@ -81,6 +81,7 @@ const styles = createStaticStyles(({ css }) => ({
     overflow: auto;
     flex: 1;
 
+    height: 100%;
     min-height: 0;
     padding-block: 12px;
     padding-inline: 16px;
@@ -167,63 +168,86 @@ export const evidenceTitleFromMarkdown = (content: string): string => {
 };
 
 /**
+ * The fold decision, shared by the component and its tests: an authored title
+ * (the evidence's alt/description) both wins the label and forces the fold —
+ * the caller is saying this row has a real label worth reading at list level.
+ * Without one, a couple of plain lines carry no structure worth hiding and
+ * folding them would trade one click for nothing.
+ */
+export const resolveMarkdownEvidenceFold = (content: string, authoredTitle?: string) => {
+  const derivedTitle = evidenceTitleFromMarkdown(content);
+  const foldTitle = authoredTitle?.trim() || derivedTitle;
+  const trimmed = content.trim();
+  const inlineEligible = !trimmed.includes('\n') && trimmed.length <= INLINE_RENDER_MAX_CHARS;
+  const fold = Boolean(foldTitle) && (Boolean(authoredTitle?.trim()) || !inlineEligible);
+  return { fold, foldTitle };
+};
+
+/**
  * Inline prose evidence, folded to ONE titled row by default — the first line
  * of the document is the label, the click is the disclosure. Expanding renders
  * the full text in place, typographically subordinated (small header scale) so
  * the evidence's own headings never compete with the page's hierarchy.
+ *
+ * `title` lets a caller hand the row a better label — the evidence's authored
+ * alt/description. It outranks the document's first line and its presence
+ * forces the fold: the label IS the point, and the caller stops rendering the
+ * description as a supplement below the row (it now reads as the row itself).
  *
  * Replaces the earlier first-180px preview fold: agent-authored evidence opens
  * with headings and environment metadata, so a height-cropped preview spent a
  * card of space showing the least informative part of the document — and read
  * as noise. Need it → expand; don't → one quiet line.
  */
-export const CollapsibleMarkdownEvidence = memo<{ children: string }>(({ children }) => {
-  const { t } = useTranslation('verify');
-  const [expanded, setExpanded] = useState(false);
-  const title = useMemo(() => evidenceTitleFromMarkdown(children), [children]);
-
-  // A couple of plain lines carry no structure worth hiding — folding them
-  // would trade one click for nothing.
-  const trimmed = children.trim();
-  if (!title || (!trimmed.includes('\n') && trimmed.length <= INLINE_RENDER_MAX_CHARS)) {
-    return (
-      <Markdown fontSize={13} variant={'chat'}>
-        {children}
-      </Markdown>
+export const CollapsibleMarkdownEvidence = memo<{ children: string; title?: string }>(
+  ({ children, title }) => {
+    const { t } = useTranslation('verify');
+    const [expanded, setExpanded] = useState(false);
+    const { fold, foldTitle } = useMemo(
+      () => resolveMarkdownEvidenceFold(children, title),
+      [children, title],
     );
-  }
 
-  return (
-    <Flexbox className={styles.foldCard}>
-      <button
-        aria-expanded={expanded}
-        className={styles.foldHeader}
-        title={t(expanded ? 'report.evidence.collapse' : 'report.evidence.expand')}
-        type={'button'}
-        onClick={() => setExpanded(!expanded)}
-      >
-        <Icon
-          className={cx(styles.foldChevron, expanded && styles.foldChevronOpen)}
-          icon={ChevronRight}
-          size={14}
-        />
-        <span className={styles.fileCardIcon}>
-          <Icon icon={FileText} size={13} />
-        </span>
-        <span data-fold-title className={styles.foldTitle}>
-          {title}
-        </span>
-      </button>
-      {expanded && (
-        <div className={styles.foldBody}>
-          <Markdown fontSize={13} headerMultiple={0.1} variant={'chat'}>
-            {children}
-          </Markdown>
-        </div>
-      )}
-    </Flexbox>
-  );
-});
+    if (!fold) {
+      return (
+        <Markdown fontSize={13} variant={'chat'}>
+          {children}
+        </Markdown>
+      );
+    }
+
+    return (
+      <Flexbox className={styles.foldCard}>
+        <button
+          aria-expanded={expanded}
+          className={styles.foldHeader}
+          title={t(expanded ? 'report.evidence.collapse' : 'report.evidence.expand')}
+          type={'button'}
+          onClick={() => setExpanded(!expanded)}
+        >
+          <Icon
+            className={cx(styles.foldChevron, expanded && styles.foldChevronOpen)}
+            icon={ChevronRight}
+            size={14}
+          />
+          <span className={styles.fileCardIcon}>
+            <Icon icon={FileText} size={13} />
+          </span>
+          <span data-fold-title className={styles.foldTitle}>
+            {foldTitle}
+          </span>
+        </button>
+        {expanded && (
+          <div className={styles.foldBody}>
+            <Markdown fontSize={13} headerMultiple={0.1} variant={'chat'}>
+              {children}
+            </Markdown>
+          </div>
+        )}
+      </Flexbox>
+    );
+  },
+);
 
 CollapsibleMarkdownEvidence.displayName = 'CollapsibleMarkdownEvidence';
 

--- a/src/features/Acceptance/Report/ReportViewer.tsx
+++ b/src/features/Acceptance/Report/ReportViewer.tsx
@@ -825,7 +825,9 @@ const EvidenceItem = memo<{
           {label}
         </Text>
       )}
-      {description && !flat && (
+      {description && !flat && !isInlineProse && (
+        // Inline prose is excluded: its authored description becomes the fold
+        // row's title below, so a standalone line here would say it twice.
         <Text fontSize={13} type={'secondary'}>
           {description}
         </Text>
@@ -863,7 +865,13 @@ const EvidenceItem = memo<{
           />
         </div>
       ) : e.content && markdownTextEvidenceTypes.has(e.type) ? (
-        <CollapsibleMarkdownEvidence>{e.content}</CollapsibleMarkdownEvidence>
+        // Same dialect as the acceptance viewer: an authored alt/description
+        // becomes the fold row's title, not a supplement line below it. The
+        // raw description, not the caption filter — with no fileName the label
+        // IS the description, and the filter would null it out.
+        <CollapsibleMarkdownEvidence title={e.description ?? undefined}>
+          {e.content}
+        </CollapsibleMarkdownEvidence>
       ) : e.content ? (
         <div className={styles.evidenceText}>{e.content}</div>
       ) : (

--- a/src/features/Acceptance/Report/markdownEvidenceTitle.test.ts
+++ b/src/features/Acceptance/Report/markdownEvidenceTitle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { evidenceTitleFromMarkdown } from './MarkdownEvidence';
+import { evidenceTitleFromMarkdown, resolveMarkdownEvidenceFold } from './MarkdownEvidence';
 
 describe('evidenceTitleFromMarkdown — the collapsed row label', () => {
   it('strips heading syntax so the first line reads as a sentence', () => {
@@ -33,5 +33,39 @@ describe('evidenceTitleFromMarkdown — the collapsed row label', () => {
 
   it('returns empty for whitespace-only content (caller renders inline)', () => {
     expect(evidenceTitleFromMarkdown('   \n\n')).toBe('');
+  });
+});
+
+describe('resolveMarkdownEvidenceFold — authored alt as the fold title', () => {
+  const DOC = '## 环境说明\n\n正文第一段。';
+
+  it('uses the authored alt/description as the fold title and folds the row', () => {
+    const { fold, foldTitle } = resolveMarkdownEvidenceFold(DOC, 'T-338 审计补充说明');
+    expect(fold).toBe(true);
+    expect(foldTitle).toBe('T-338 审计补充说明');
+  });
+
+  it('keeps the document-first-line label when no title is given', () => {
+    const { fold, foldTitle } = resolveMarkdownEvidenceFold(DOC);
+    expect(fold).toBe(true);
+    expect(foldTitle).toBe('环境说明');
+  });
+
+  it('folds a short single-line doc when an explicit title is present', () => {
+    // Without a title this renders inline (too short to be worth folding);
+    // an authored title means the row label IS the point, so it folds anyway.
+    const { fold, foldTitle } = resolveMarkdownEvidenceFold('只有一行正文。', '一句简短说明');
+    expect(fold).toBe(true);
+    expect(foldTitle).toBe('一句简短说明');
+  });
+
+  it('renders a short single-line doc inline when no title is given', () => {
+    expect(resolveMarkdownEvidenceFold('只有一行正文。').fold).toBe(false);
+  });
+
+  it('ignores a blank authored title (falls back to the derived one)', () => {
+    const { fold, foldTitle } = resolveMarkdownEvidenceFold(DOC, '   ');
+    expect(fold).toBe(true);
+    expect(foldTitle).toBe('环境说明');
   });
 });

--- a/src/features/Acceptance/Viewer/CheckList.tsx
+++ b/src/features/Acceptance/Viewer/CheckList.tsx
@@ -610,10 +610,11 @@ const EvidenceList = memo<{
         }
         if (item.content && markdownTextEvidenceTypes.has(item.type))
           return (
-            <Flexbox gap={4} key={item.id}>
-              <CollapsibleMarkdownEvidence>{item.content}</CollapsibleMarkdownEvidence>
-              {caption}
-            </Flexbox>
+            // An authored alt/description becomes the fold row's title itself —
+            // the supplement below the row duplicated it one line later.
+            <CollapsibleMarkdownEvidence key={item.id} title={description ?? undefined}>
+              {item.content}
+            </CollapsibleMarkdownEvidence>
           );
         if (item.content)
           return (


### PR DESCRIPTION
<!-- Brief and heads-up -->

Acceptance / verify-report evidence with an authored alt/description used to render it as a gray supplement line **below** the folded document row, while the row label came from the document's own first line. This PR promotes the alt text to be the fold row's title itself and removes the supplement — one line instead of two, and the label the author wrote is what the reviewer reads.

| Before | After |
| ------ | ----- |
| Fold row labeled by the document's first line, with the authored alt repeated as a gray supplement line below it | Fold row titled by the authored alt (falls back to the document's first line when there is none), no supplement line |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

How it behaves now:

- `CollapsibleMarkdownEvidence` accepts an optional `title` (the evidence alt). When present it wins over the document-derived first line and **forces the fold** even for short single-line docs — an authored label is worth a row. Without a title, behavior is unchanged (first line as label; short docs render inline).
- **Acceptance viewer** (`CheckList → EvidenceList`): passes the evidence description as the title and no longer renders the caption below the fold.
- **Verify report** (`ReportViewer → EvidenceItem`): same dialect, plus skips the standalone description line for inline prose (it would repeat the title). The title uses the raw `e.description` rather than the caption-filtered value — when the evidence has no `fileName`, the display label falls back to the description itself and the filter would null it out.

Verification: unit tests for the fold decision (alt wins / fallback / short-doc forced fold / blank alt / inline kept) plus an end-to-end acceptance round driving the real product on both surfaces — https://app.lobehub.com/acceptance/2e01d8e3-08ca-4dd5-94ba-2388da06440f (4/4 passed).

#### 🔗 Related Issue

None.
