### PR TITLE
💄 style(work): show token usage when cost is unavailable

### DIFF
--- a/src/features/Work/WorkSummaryCard.tsx
+++ b/src/features/Work/WorkSummaryCard.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import type { WorkSummaryItem } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
+import { formatUsageValue } from '@lobechat/utils';
+import { Center, Flexbox, Icon as LobeIcon } from '@lobehub/ui';
 import { Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
-import { Trash2Icon } from 'lucide-react';
+import { CircleDollarSignIcon, CoinsIcon, Trash2Icon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
+import { getWorkVersionTotalTokens } from '@/utils/workCumulativeUsage';
 import { formatWorkVersionCost } from '@/utils/workVersionCost';
 
 import { getWorkTypeDescriptor, isSafeExternalUrl } from './descriptors';
@@ -34,6 +36,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   cost: css`
     flex-shrink: 0;
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
     color: ${cssVar.colorTextTertiary};
   `,
   description: css`
@@ -132,6 +136,17 @@ const WorkSummaryCard = memo<WorkSummaryCardProps>(
     const openFilePreview = useChatStore((s) => s.openFilePreview);
     const openTaskDetail = useChatStore((s) => s.openTaskDetail);
     const cost = formatWorkVersionCost(item.totalCost);
+    const totalTokens = getWorkVersionTotalTokens(item.event.cumulativeUsage);
+    const usage = cost
+      ? { icon: CircleDollarSignIcon, value: cost.slice(1) }
+      : totalTokens
+        ? { icon: CoinsIcon, value: formatUsageValue(totalTokens) }
+        : null;
+    const usageTitle = cost
+      ? t('workingPanel.works.totalCost', { cost })
+      : totalTokens
+        ? `${totalTokens.toLocaleString()} ${t('opStatusTray.tokens')}`
+        : undefined;
 
     const descriptor = getWorkTypeDescriptor(item);
     const Icon = descriptor.getIcon(item);
@@ -209,10 +224,11 @@ const WorkSummaryCard = memo<WorkSummaryCardProps>(
               </Text>
             )}
           </Flexbox>
-          {cost && (
-            <span className={styles.inlineCost} title={t('workingPanel.works.totalCost', { cost })}>
-              {cost}
-            </span>
+          {usage && (
+            <Center horizontal className={styles.inlineCost} gap={2} title={usageTitle}>
+              <LobeIcon icon={usage.icon} />
+              {usage.value}
+            </Center>
           )}
         </Flexbox>
       );
@@ -246,15 +262,11 @@ const WorkSummaryCard = memo<WorkSummaryCardProps>(
                 </Tag>
               )}
             </Flexbox>
-            {cost && (
-              <Text
-                code
-                className={styles.cost}
-                fontSize={12}
-                title={t('workingPanel.works.totalCost', { cost })}
-              >
-                {cost}
-              </Text>
+            {usage && (
+              <Center horizontal className={styles.cost} gap={2} title={usageTitle}>
+                <LobeIcon icon={usage.icon} />
+                {usage.value}
+              </Center>
             )}
           </Flexbox>
           {description && (

--- a/src/features/WorkGallery/WorkPreviewCard.tsx
+++ b/src/features/WorkGallery/WorkPreviewCard.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { formatTaskItemDate } from '@/features/AgentTasks/features/formatTaskItemDate';
 import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
 import { getWorkTypeDescriptor } from '@/features/Work/descriptors';
+import { getWorkVersionTotalTokens } from '@/utils/workCumulativeUsage';
 import { formatWorkVersionCost } from '@/utils/workVersionCost';
 
 import WorkPreview from './WorkPreview';
@@ -120,17 +121,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
-
-const getTotalTokens = (item: WorkSummaryItem): number | null => {
-  const usage = item.event.cumulativeUsage?.usage;
-  if (!isRecord(usage) || !isRecord(usage.llm) || !isRecord(usage.llm.tokens)) return null;
-
-  const total = usage.llm.tokens.total;
-  return typeof total === 'number' && Number.isFinite(total) && total > 0 ? total : null;
-};
-
 interface WorkPreviewCardProps {
   item: WorkSummaryItem;
   onOpen: (item: WorkSummaryItem) => void;
@@ -190,7 +180,7 @@ const WorkPreviewCard = memo<WorkPreviewCardProps>(({ item, onOpen }) => {
     date: eventAt,
     ns: 'file',
   });
-  const totalTokens = getTotalTokens(item);
+  const totalTokens = getWorkVersionTotalTokens(item.event.cumulativeUsage);
   const cost = formatWorkVersionCost(item.totalCost);
 
   return (

--- a/src/utils/workCumulativeUsage.test.ts
+++ b/src/utils/workCumulativeUsage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildWorkVersionCumulativeUsage } from './workCumulativeUsage';
+import { buildWorkVersionCumulativeUsage, getWorkVersionTotalTokens } from './workCumulativeUsage';
 
 describe('buildWorkVersionCumulativeUsage', () => {
   it('returns null snapshots when runtime usage and cost are missing', () => {
@@ -51,5 +51,26 @@ describe('buildWorkVersionCumulativeUsage', () => {
         }),
       },
     });
+  });
+});
+
+describe('getWorkVersionTotalTokens', () => {
+  it('reads the total token count from a cumulative usage snapshot', () => {
+    expect(
+      getWorkVersionTotalTokens({
+        capturedAt: '2026-09-03T00:00:00.000Z',
+        usage: { llm: { tokens: { input: 12_000, output: 3456, total: 15_456 } } },
+      }),
+    ).toBe(15_456);
+  });
+
+  it.each([
+    undefined,
+    null,
+    { capturedAt: '2026-09-03T00:00:00.000Z' },
+    { capturedAt: '2026-09-03T00:00:00.000Z', usage: { llm: { tokens: { total: 0 } } } },
+    { capturedAt: '2026-09-03T00:00:00.000Z', usage: { llm: { tokens: { total: NaN } } } },
+  ])('returns null for an unavailable token count', (cumulativeUsage) => {
+    expect(getWorkVersionTotalTokens(cumulativeUsage)).toBeNull();
   });
 });

--- a/src/utils/workCumulativeUsage.ts
+++ b/src/utils/workCumulativeUsage.ts
@@ -4,6 +4,19 @@ import type { WorkVersionCumulativeUsage } from '@lobechat/types';
 const finiteNumberOrNull = (value: unknown): number | null =>
   typeof value === 'number' && Number.isFinite(value) ? value : null;
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const getWorkVersionTotalTokens = (
+  cumulativeUsage?: WorkVersionCumulativeUsage | null,
+): number | null => {
+  const usage = cumulativeUsage?.usage;
+  if (!isRecord(usage) || !isRecord(usage.llm) || !isRecord(usage.llm.tokens)) return null;
+
+  const total = usage.llm.tokens.total;
+  return typeof total === 'number' && Number.isFinite(total) && total > 0 ? total : null;
+};
+
 export const buildWorkVersionCumulativeUsage = ({
   cost,
   now = new Date(),


### PR DESCRIPTION
## Summary

- show cumulative token usage when a Work has no calculated price
- keep price display as the priority when cost is available
- use matching muted icons and numeric styling across Work cards
- share the cumulative token extraction helper with the Work gallery

## Verification

- `bun run check src/features/Work/WorkSummaryCard.tsx src/features/WorkGallery/WorkPreviewCard.tsx src/utils/workCumulativeUsage.ts src/utils/workCumulativeUsage.test.ts`
- 8 related tests passed
- Acceptance: https://app.lobehub.com/acceptance/2f72bf35-e882-4971-bf2c-106a7345125f