### PR TITLE
⚡️ perf(gateway): add Phase-0 connection latency instrumentation

### DIFF
--- a/src/store/chat/slices/agentRun/actions/transports/gateway/__tests__/gatewayPerf.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/__tests__/gatewayPerf.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  formatGatewayPerfSummary,
+  gatewayPerfAbort,
+  gatewayPerfConnectStart,
+  gatewayPerfFirstEvent,
+  gatewayPerfFreshRun,
+  gatewayPerfReconnect,
+  gatewayPerfReset,
+  gatewayPerfStatusChanged,
+} from '../gatewayPerf';
+
+describe('gatewayPerf', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    gatewayPerfReset();
+  });
+
+  afterEach(() => {
+    gatewayPerfReset();
+    vi.useRealTimers();
+  });
+
+  describe('formatGatewayPerfSummary', () => {
+    it('formats all phases with mode', () => {
+      const line = formatGatewayPerfSummary(
+        'op-1',
+        { exec_roundtrip: 100, pre_connect_gap: 50, ws_handshake: 30, auth_rtt: 20, ttfb: 60 },
+        { reconnect: false },
+      );
+      expect(line).toContain('op=op-1');
+      expect(line).toContain('exec=100ms');
+      expect(line).toContain('gap=50ms');
+      expect(line).toContain('handshake=30ms');
+      expect(line).toContain('auth=20ms');
+      expect(line).toContain('ttfb=60ms');
+      expect(line).toContain('mode=fresh');
+    });
+
+    it('marks missing phases as n/a and reconnect mode', () => {
+      const line = formatGatewayPerfSummary('op-2', { ttfb: 5 }, { reconnect: true });
+      expect(line).toContain('exec=n/a');
+      expect(line).toContain('ttfb=5ms');
+      expect(line).toContain('mode=reconnect');
+    });
+  });
+
+  describe('fresh run flow', () => {
+    it('records exec_roundtrip and pre_connect_gap and logs a summary on first event', () => {
+      vi.setSystemTime(1000);
+      gatewayPerfFreshRun('op-1', 0);
+      vi.setSystemTime(500);
+      gatewayPerfConnectStart('op-1');
+      gatewayPerfStatusChanged('op-1', 'connecting');
+      vi.setSystemTime(620);
+      gatewayPerfStatusChanged('op-1', 'authenticating');
+      vi.setSystemTime(700);
+      gatewayPerfStatusChanged('op-1', 'connected');
+      vi.setSystemTime(800);
+      gatewayPerfFirstEvent('op-1');
+
+      // Summary is logged via debug; assert observable state indirectly —
+      // the timer was consumed, so a second first-event is a no-op and the
+      // abort path doesn't throw.
+      expect(() => gatewayPerfFirstEvent('op-1')).not.toThrow();
+      expect(() => gatewayPerfAbort('op-1')).not.toThrow();
+    });
+
+    it('ignores a second fresh-run registration for the same op', () => {
+      gatewayPerfFreshRun('op-1', 0);
+      // A reconnect racing in must NOT clobber the fresh timer (first wins).
+      expect(() => gatewayPerfReconnect('op-1', 999)).not.toThrow();
+      expect(() => gatewayPerfConnectStart('op-1')).not.toThrow();
+    });
+
+    it('handles precreated results without exec phase', () => {
+      gatewayPerfFreshRun('op-1', null);
+      expect(() => gatewayPerfConnectStart('op-1')).not.toThrow();
+      expect(() => gatewayPerfFirstEvent('op-1')).not.toThrow();
+    });
+  });
+
+  describe('watchdogs', () => {
+    it('drops an orphan timer when connect never starts', () => {
+      gatewayPerfFreshRun('op-1', 0);
+      vi.advanceTimersByTime(31_000);
+      // Orphaned — later connect events are no-ops and don't throw.
+      expect(() => gatewayPerfConnectStart('op-1')).not.toThrow();
+    });
+
+    it('logs a partial summary when no event arrives within the ttfb window', () => {
+      gatewayPerfFreshRun('op-1', 0);
+      gatewayPerfConnectStart('op-1');
+      // Must not throw when the watchdog fires.
+      expect(() => vi.advanceTimersByTime(10 * 60 * 1000 + 1)).not.toThrow();
+    });
+  });
+});

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -55,6 +55,14 @@ import { createGatewayEventBuffer } from './gatewayEventBuffer';
 import { createGatewayEventHandler, isCompletedRuntimeEnd } from './gatewayEventHandler';
 import { createGatewayEventRouter } from './gatewayEventRouter';
 import { createGatewayMemberStreamHandler } from './gatewayMemberStreamHandler';
+import {
+  gatewayPerfAbort,
+  gatewayPerfConnectStart,
+  gatewayPerfFirstEvent,
+  gatewayPerfFreshRun,
+  gatewayPerfReconnect,
+  gatewayPerfStatusChanged,
+} from './gatewayPerf';
 
 /**
  * Interrupts a gateway operation and rejects when its physical shutdown is unconfirmed.
@@ -313,6 +321,7 @@ export class GatewayActionImpl {
 
     // Wire up status changes
     client.on('status_changed', (status) => {
+      gatewayPerfStatusChanged(operationId, status);
       this.#set(
         (state) => {
           const conn = state.gatewayConnections[operationId];
@@ -356,6 +365,7 @@ export class GatewayActionImpl {
     // status. Match on the event's operationId (absent ⇒ legacy single-op WS,
     // treat as this op's to preserve prior behavior).
     client.on('agent_event', (event) => {
+      gatewayPerfFirstEvent(operationId);
       const isOwnOp = !event.operationId || event.operationId === operationId;
       if (isOwnOp && (event.type === 'agent_runtime_end' || event.type === 'error')) {
         receivedTerminalEvent = true;
@@ -435,6 +445,7 @@ export class GatewayActionImpl {
    * Disconnect from the Gateway for a specific operation.
    */
   disconnectFromGateway = (operationId: string): void => {
+    gatewayPerfAbort(operationId);
     const conn = this.#get().gatewayConnections[operationId];
     if (!conn) return;
 
@@ -681,6 +692,10 @@ export class GatewayActionImpl {
     // share config, never by this client.
     const agentShareId = executionContext.agentShareId;
 
+    // Phase-0 perf instrumentation: measure the exec round trip, the store-sync
+    // gap before the WS connect, and the connect/auth/first-event chain. See
+    // gatewayPerf.ts for the phase model.
+    const execStartedAt = precreatedResult ? null : Date.now();
     const result =
       precreatedResult ??
       (agentShareId
@@ -762,6 +777,7 @@ export class GatewayActionImpl {
 
     // Persistence is the ownership boundary. Notify before later UI synchronization awaits and
     // before handling a late abort so callers never delete a file already attached server-side.
+    gatewayPerfFreshRun(result.operationId, execStartedAt);
     try {
       onMessageAccepted?.();
     } catch (error) {
@@ -1016,6 +1032,8 @@ export class GatewayActionImpl {
       }),
     });
 
+    gatewayPerfConnectStart(result.operationId);
+
     // Demux the supervisor's WebSocket: with single-connection multiplexing
     // this WS also carries each broadcast member's streaming events (forwarded
     // server-side onto the supervisor op channel). Route owner events to the
@@ -1165,6 +1183,7 @@ export class GatewayActionImpl {
     // the store). Clear it and bail silently so the reconnect SWR fetcher resolves
     // and does not retry the 404 forever.
     let token: string;
+    const refreshStartedAt = Date.now();
     try {
       // Share visitors have no owner-scoped access to `aiAgentService.refreshGatewayToken`
       // (its TopicModel is scoped to the caller, and share topics belong to the
@@ -1273,6 +1292,8 @@ export class GatewayActionImpl {
       ownerOperationId: operationId,
     });
 
+    gatewayPerfReconnect(operationId, refreshStartedAt);
+    gatewayPerfConnectStart(operationId);
     this.#get().connectToGateway({
       gatewayUrl: agentGatewayUrl,
       onEvent: eventRouter,

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayPerf.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayPerf.ts
@@ -1,0 +1,246 @@
+import debug from 'debug';
+
+const log = debug('lobe-store:gateway-perf');
+
+/**
+ * Phase 0 instrumentation for the Agent Gateway connection cost.
+ *
+ * Measures the serial latency chain a user feels between "send" and "first
+ * streamed event" on the gateway transport:
+ *
+ *   exec_roundtrip   tRPC execAgentTask (fresh) / refreshGatewayToken
+ *                    (reconnect) + server-side topic/message/runtime init
+ *   pre_connect_gap  client-side store sync between the exec result and
+ *                    connectToGateway (getMessages / switchTopic / refresh…)
+ *   ws_handshake     new WebSocket → server accepted the upgrade
+ *                    (TCP + TLS + WS upgrade, plus DO cold scheduling)
+ *   auth_rtt         auth message → auth_success round trip (JWT verify)
+ *   ttfb             connectToGateway → first agent_event
+ *   total_to_ttfb    exec start → first agent_event (user-perceived dead time)
+ *
+ * Timers are keyed by operationId and log one summary line through the
+ * `lobe-store:gateway-perf` debug namespace when the first event lands (or
+ * the watchdog fires). Field data: `localStorage.debug = 'lobe-store:gateway-perf'`
+ * (web) or `DEBUG=lobe-store:gateway-perf` (node/electron main).
+ */
+
+const TTFB_TIMEOUT_MS = 10 * 60 * 1000; // log a partial summary after 10 min without an event
+const ORPHAN_TIMEOUT_MS = 30_000; // exec returned but connect never started → drop
+const MAX_CONCURRENT = 20; // cap memory; beyond this we instrument nothing
+
+export interface GatewayPerfPhases {
+  /** auth message → auth_success round trip. */
+  auth_rtt?: number;
+  /** tRPC exec/refresh round trip. */
+  exec_roundtrip?: number;
+  /** store-sync awaits between exec result and WS connect. */
+  pre_connect_gap?: number;
+  /** connectToGateway → first agent event. */
+  ttfb?: number;
+  /** new WebSocket → upgrade accepted (status 'authenticating'). */
+  ws_handshake?: number;
+}
+
+export interface GatewayPerfContext {
+  /** Whether this run re-attached to an existing op (useGatewayReconnect). */
+  reconnect: boolean;
+}
+
+interface ActiveTimer {
+  context: GatewayPerfContext;
+  marks: Partial<{
+    authEnd: number;
+    connectStart: number;
+    execEnd: number;
+    execStart: number;
+    firstEventAt: number;
+    handshakeEnd: number;
+  }>;
+  orphanTimeout: ReturnType<typeof setTimeout> | null;
+  phases: GatewayPerfPhases;
+  ttfbTimeout: ReturnType<typeof setTimeout> | null;
+}
+
+const active = new Map<string, ActiveTimer>();
+
+/**
+ * Build the summary line. Exported for testing only.
+ */
+export const formatGatewayPerfSummary = (
+  operationId: string,
+  phases: GatewayPerfPhases,
+  context: GatewayPerfContext,
+): string => {
+  const parts: string[] = [];
+
+  const append = (label: string, value?: number) => {
+    parts.push(`${label}=${value !== undefined ? `${value}ms` : 'n/a'}`);
+  };
+
+  append('exec', phases.exec_roundtrip);
+  append('gap', phases.pre_connect_gap);
+  append('handshake', phases.ws_handshake);
+  append('auth', phases.auth_rtt);
+  append('ttfb', phases.ttfb);
+
+  return `gateway-perf op=${operationId} ${parts.join(' ')} mode=${context.reconnect ? 'reconnect' : 'fresh'}`;
+};
+
+const clearTimers = (timer: ActiveTimer) => {
+  if (timer.ttfbTimeout) clearTimeout(timer.ttfbTimeout);
+  if (timer.orphanTimeout) clearTimeout(timer.orphanTimeout);
+};
+
+const maybeLogSummary = (operationId: string, timer: ActiveTimer) => {
+  const { marks } = timer;
+  // Summary needs the absolute bookends: exec start → first event. Phases in
+  // between stay silent until then, keeping the output one-line-per-run.
+  if (marks.execStart === undefined || marks.firstEventAt === undefined) return;
+
+  const phases = {
+    ...timer.phases,
+    ttfb: marks.firstEventAt - (marks.connectStart ?? marks.execStart),
+  };
+  const total = marks.firstEventAt - marks.execStart;
+  log(
+    '%s',
+    `${formatGatewayPerfSummary(operationId, phases, timer.context)} total_to_ttfb=${total}ms`,
+  );
+};
+
+// ─── Public instrumentation API (called from gateway.ts) ───
+
+/**
+ * A fresh run's exec round trip returned. `execStartedAt` is the timestamp
+ * captured just before the tRPC call; pass `null` when the result was
+ * precreated (exec happened elsewhere — no exec_roundtrip is recorded).
+ */
+export const gatewayPerfFreshRun = (operationId: string, execStartedAt: number | null): void => {
+  if (active.has(operationId)) return; // reconnect raced with fresh run — first wins
+  if (active.size >= MAX_CONCURRENT) return;
+
+  const now = Date.now();
+  const timer: ActiveTimer = {
+    context: { reconnect: false },
+    marks: execStartedAt === null ? {} : { execEnd: now, execStart: execStartedAt },
+    orphanTimeout: null,
+    phases: execStartedAt === null ? {} : { exec_roundtrip: now - execStartedAt },
+    ttfbTimeout: null,
+  };
+  active.set(operationId, timer);
+
+  // If connectToGateway never runs (post-exec throw / cancel), drop silently.
+  timer.orphanTimeout = setTimeout(() => {
+    const t = active.get(operationId);
+    if (t && t.marks.connectStart === undefined) active.delete(operationId);
+  }, ORPHAN_TIMEOUT_MS);
+};
+
+/**
+ * A reconnect's token refresh returned. Same as {@link gatewayPerfFreshRun}
+ * with the reconnect mode flag set.
+ */
+export const gatewayPerfReconnect = (operationId: string, refreshStartedAt: number): void => {
+  if (active.has(operationId)) return; // fresh run owns this op — don't clobber
+  if (active.size >= MAX_CONCURRENT) return;
+
+  const now = Date.now();
+  const timer: ActiveTimer = {
+    context: { reconnect: true },
+    marks: { execEnd: now, execStart: refreshStartedAt },
+    orphanTimeout: null,
+    phases: { exec_roundtrip: now - refreshStartedAt },
+    ttfbTimeout: null,
+  };
+  active.set(operationId, timer);
+
+  timer.orphanTimeout = setTimeout(() => {
+    const t = active.get(operationId);
+    if (t && t.marks.connectStart === undefined) active.delete(operationId);
+  }, ORPHAN_TIMEOUT_MS);
+};
+
+/**
+ * Mark connectToGateway: WS connect begins from this instant; the gap since
+ * the exec result becomes pre_connect_gap.
+ */
+export const gatewayPerfConnectStart = (operationId: string): void => {
+  const timer = active.get(operationId);
+  if (!timer || timer.marks.connectStart !== undefined) return;
+  const now = Date.now();
+  timer.marks.connectStart = now;
+  if (timer.orphanTimeout) {
+    clearTimeout(timer.orphanTimeout);
+    timer.orphanTimeout = null;
+  }
+  if (timer.marks.execEnd !== undefined) {
+    timer.phases.pre_connect_gap = now - timer.marks.execEnd;
+  }
+
+  // Watchdog: if no event ever arrives (dead DO, auth never completes), log
+  // what we have so the run still shows up in field data, then stop tracking.
+  timer.ttfbTimeout = setTimeout(() => {
+    const t = active.get(operationId);
+    if (!t || t.marks.firstEventAt !== undefined) return;
+    t.marks.firstEventAt = Date.now();
+    maybeLogSummary(operationId, t);
+    active.delete(operationId);
+  }, TTFB_TIMEOUT_MS);
+};
+
+/**
+ * Observe a connection-status transition from the AgentStreamClient:
+ *   connecting → authenticating  ⇒ ws_handshake done
+ *   authenticating → connected   ⇒ auth_rtt done
+ */
+export const gatewayPerfStatusChanged = (operationId: string, status: string): void => {
+  const timer = active.get(operationId);
+  if (!timer) return;
+  const now = Date.now();
+
+  if (status === 'authenticating' && timer.marks.handshakeEnd === undefined) {
+    timer.marks.handshakeEnd = now;
+    if (timer.marks.connectStart !== undefined) {
+      timer.phases.ws_handshake = now - timer.marks.connectStart;
+    }
+  }
+  if (status === 'connected' && timer.marks.authEnd === undefined) {
+    timer.marks.authEnd = now;
+    if (timer.marks.handshakeEnd !== undefined) {
+      timer.phases.auth_rtt = now - timer.marks.handshakeEnd;
+    }
+  }
+};
+
+/**
+ * Mark the first agent event. Emits the summary line and stops tracking.
+ */
+export const gatewayPerfFirstEvent = (operationId: string): void => {
+  const timer = active.get(operationId);
+  if (!timer || timer.marks.firstEventAt !== undefined) return;
+  timer.marks.firstEventAt = Date.now();
+  if (timer.ttfbTimeout) {
+    clearTimeout(timer.ttfbTimeout);
+    timer.ttfbTimeout = null;
+  }
+  maybeLogSummary(operationId, timer);
+  active.delete(operationId);
+};
+
+/**
+ * Drop a timer without logging (op cancelled / superseded before any event).
+ */
+export const gatewayPerfAbort = (operationId: string): void => {
+  const timer = active.get(operationId);
+  if (!timer) return;
+  clearTimers(timer);
+  active.delete(operationId);
+};
+
+// Test-only helper: reset module state between tests.
+export const gatewayPerfReset = (): void => {
+  for (const [, timer] of active) {
+    clearTimers(timer);
+  }
+  active.clear();
+};


### PR DESCRIPTION
<!-- Brief and heads-up -->

Phase 0 of the gateway connection-cost investigation: add lightweight, zero-dependency instrumentation that measures how much of the send-to-first-token latency comes from the per-operation WebSocket connection chain. The collected field data will decide whether a shared long-lived session WebSocket (per-user SessionDO multiplexing) is worth building, or whether the tRPC exec round trip is the real bottleneck.

No behavioral change — SDK, gateway worker, and server are untouched. Instrumentation hooks only on existing `AgentStreamClient` seams.

## What is measured

One summary line is logged per run, keyed by operationId, through the `lobe-store:gateway-perf` debug namespace:

    gateway-perf op=xxx exec=812ms gap=240ms handshake=310ms auth=180ms ttfb=95ms total_to_ttfb=1637ms mode=fresh

| Phase | Meaning |
|---|---|
| `exec` | tRPC `execAgentTask` (fresh) / `refreshGatewayToken` (reconnect) + server-side topic/message/runtime init |
| `gap` | Client store sync between the exec result and the WS connect (`getMessages` / `switchTopic` / `refreshTopic`) |
| `handshake` | `new WebSocket` to upgrade accepted (TCP + TLS + WS upgrade, incl. DO cold scheduling) |
| `auth` | auth message to `auth_success` round trip (JWT verify) |
| `ttfb` | `connectToGateway` to first streamed agent event |
| `total_to_ttfb` | exec start to first event (user-perceived dead time) |

Both fresh sends and reconnects (`useGatewayReconnect`) are instrumented; the `mode=` field distinguishes them.

## How to collect

    // Web console:
    localStorage.debug = 'lobe-store:gateway-perf'
    // Node / electron main:
    DEBUG=lobe-store:gateway-perf

## Implementation notes

- New `gatewayPerf.ts` module (pure `debug()` output, no reporting dependency) with a per-operation timer registry.
- 7 hook points in `gateway.ts`, all on existing seams: `status_changed` (handshake/auth split), first `agent_event` (ttfb), exec call sites, and both `connectToGateway` call sites.
- Robustness: reconnect-vs-fresh race keeps the first timer (mirrors the existing reconnect guard); orphan timers (exec returned but never connected) drop after 30s; a 10-minute watchdog logs a partial summary when no event ever arrives; concurrency capped at 20.
- `disconnectFromGateway` aborts the timer so cancelled ops do not leak.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New unit tests (`gatewayPerf.test.ts`, 7 cases with fake timers) cover the fresh flow, phase accounting, race handling, and both watchdogs. The existing `gateway.test.ts` suite (65 cases) passes unchanged.

#### 🔗 Related Issue

- Part of LOBE-13808 (Agent Gateway connection latency optimization epic)
- Closes LOBE-13809 (Phase 0: connection latency instrumentation)