### PR TITLE
🐛 fix(page-editor): drop document-like analytics so pages open in DocumentModal

### DIFF
--- a/src/features/PageEditor/DocumentLikes/index.tsx
+++ b/src/features/PageEditor/DocumentLikes/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { DocumentLikeSummary } from '@lobechat/types';
-import { useAnalytics } from '@lobehub/analytics/react';
 import { Flexbox } from '@lobehub/ui';
 import { Avatar, Skeleton, Text, toast, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -120,7 +119,6 @@ const DocumentLikes = memo<{ documentId: string }>(({ documentId }) => {
   const { t } = useTranslation('file');
   const workspaceId = useActiveWorkspaceId();
   const user = useUserStore(userProfileSelectors.userProfile);
-  const { analytics } = useAnalytics();
   const { data, error, isLoading, mutate } = useDocumentLikeSummary(workspaceId, documentId);
   // Last user-intended liked state; null when the UI matches the server.
   const targetRef = useRef<boolean | null>(null);
@@ -141,32 +139,11 @@ const DocumentLikes = memo<{ documentId: string }>(({ documentId }) => {
         summary = sent
           ? await documentLikeService.like(documentId)
           : await documentLikeService.unlike(documentId);
-        // Bounded dimensions only — no document id, which would create an
-        // unbounded high-cardinality analytics field.
-        analytics?.track({
-          name: 'document_like_toggle',
-          properties: {
-            action: sent ? 'like' : 'unlike',
-            outcome: 'success',
-            spm: 'page_editor.likes.toggle',
-          },
-        });
       }
       targetRef.current = null;
       if (summary) await mutate(summary, { revalidate: false });
     } catch (toggleError) {
       console.error('Failed to toggle document like', toggleError);
-      // Attribute the failure to the request that actually failed (`sent`),
-      // not the latest queued intent, which may already point the other way.
-      if (sent !== undefined)
-        analytics?.track({
-          name: 'document_like_toggle',
-          properties: {
-            action: sent ? 'like' : 'unlike',
-            outcome: 'failure',
-            spm: 'page_editor.likes.toggle',
-          },
-        });
       targetRef.current = null;
       toast.error(t('pageEditor.likes.failed'));
       // Recover the truth from the server rather than guessing a rollback
@@ -178,7 +155,7 @@ const DocumentLikes = memo<{ documentId: string }>(({ documentId }) => {
     } finally {
       inFlightRef.current = false;
     }
-  }, [analytics, documentId, mutate, t]);
+  }, [documentId, mutate, t]);
 
   const toggle = useCallback(() => {
     if (!data) return;


### PR DESCRIPTION
Opening a page through `DocumentModal` crashed the whole page into the error boundary. `DocumentLikes` called `useAnalytics()`, which throws without an `AnalyticsProvider`, and the modal renders through the global `BaseModalHost`, which sits outside the app's analytics provider. The `/page/<id>` route was unaffected because it renders inside the provider.

The `document_like_toggle` event was not a product requirement (it was added on a review-bot suggestion in #18999), so this removes the event entirely instead of working around the provider tree. `DocumentLikes` no longer depends on any React analytics context, matching `PageEditor`'s "should not depend on context" contract.

Non-goal: the imperative hosts (`ModalHost` / `BaseModalHost`) still sit outside `LobeAnalyticsProviderWrapper`; any future modal content calling `useAnalytics()` would hit the same crash. Left as-is on purpose to keep this fix minimal.

| Before | After |
| ------ | ----- |
| Clicking a page artifact in a task detail → `Oops, something went wrong..` error boundary, console: `useAnalyticsContext must be used within an AnalyticsProvider … in the <DocumentLikes> component` | Modal opens with title, body, likes block and comments; like toggles and persists |

#### Test

- Verified in an isolated dev stack: open a page from a task's Artifacts card (`openDocumentModal`) before/after, plus the `/page/<id>` route as a regression check.
- Pure removal; no non-source-string regression test is expressible.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Fixes LOBE-13774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KpbJjddMbWTobweHA422x