### PR TITLE
🐛 fix(chat): stop stringifying successful CLI skill command output

### DIFF
--- a/src/store/chat/slices/plugin/actions/exector.test.ts
+++ b/src/store/chat/slices/plugin/actions/exector.test.ts
@@ -1,0 +1,82 @@
+import type { ChatToolPayload } from '@lobechat/types';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useToolStore } from '@/store/tool';
+
+import { lobehubSkillExecutor } from './exector';
+
+const basePayload = {
+  apiName: 'runCommand',
+  arguments: JSON.stringify({ command: 'repo view lobehub/lobehub' }),
+  identifier: 'github',
+} as ChatToolPayload;
+
+describe('lobehubSkillExecutor', () => {
+  it('should surface raw output directly for a successful CLI skill command', async () => {
+    vi.spyOn(useToolStore.getState(), 'callLobehubSkillTool').mockResolvedValue({
+      data: {
+        command: 'gh repo view lobehub/lobehub',
+        exitCode: 0,
+        output: 'name:\tlobehub/lobehub\ndescription:\tSelf-hosted AI chat platform',
+      },
+      success: true,
+    });
+
+    const result = await lobehubSkillExecutor(basePayload);
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(
+      'name:\tlobehub/lobehub\ndescription:\tSelf-hosted AI chat platform',
+    );
+    // Must not be JSON-stringified — no escaped envelope, no wrapping quotes/braces
+    expect(result.content).not.toContain('"exitCode"');
+  });
+
+  it('should keep the full envelope for a failed (non-zero exitCode) CLI skill command', async () => {
+    vi.spyOn(useToolStore.getState(), 'callLobehubSkillTool').mockResolvedValue({
+      data: {
+        command: 'gh repo view nonexistent/repo',
+        exitCode: 1,
+        output: 'HTTP 404: Not Found',
+      },
+      success: true,
+    });
+
+    const result = await lobehubSkillExecutor(basePayload);
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(
+      JSON.stringify({
+        command: 'gh repo view nonexistent/repo',
+        exitCode: 1,
+        output: 'HTTP 404: Not Found',
+      }),
+    );
+  });
+
+  it('should keep JSON-stringifying non-CLI-shaped skill results (e.g. Linear)', async () => {
+    vi.spyOn(useToolStore.getState(), 'callLobehubSkillTool').mockResolvedValue({
+      data: { id: 'issue-1', title: 'Example issue' },
+      success: true,
+    });
+
+    const result = await lobehubSkillExecutor({
+      ...basePayload,
+      identifier: 'linear',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(JSON.stringify({ id: 'issue-1', title: 'Example issue' }));
+  });
+
+  it('should pass through a plain string result unchanged', async () => {
+    vi.spyOn(useToolStore.getState(), 'callLobehubSkillTool').mockResolvedValue({
+      data: 'plain text result',
+      success: true,
+    });
+
+    const result = await lobehubSkillExecutor(basePayload);
+
+    expect(result.content).toBe('plain text result');
+  });
+});

--- a/src/store/chat/slices/plugin/actions/exector.ts
+++ b/src/store/chat/slices/plugin/actions/exector.ts
@@ -39,6 +39,24 @@ const createFailedResult = (
   success: false,
 });
 
+/**
+ * Envelope returned by CLI-based LobeHub Skill providers (e.g. GitHub's `gh`
+ * CLI, and any future provider built on the shared cli-base infra) after
+ * running a command.
+ */
+interface CLISkillCommandResult {
+  command: string;
+  exitCode: number;
+  output: string;
+}
+
+const isCLISkillCommandResult = (data: unknown): data is CLISkillCommandResult =>
+  typeof data === 'object' &&
+  data !== null &&
+  typeof (data as CLISkillCommandResult).command === 'string' &&
+  typeof (data as CLISkillCommandResult).exitCode === 'number' &&
+  typeof (data as CLISkillCommandResult).output === 'string';
+
 export const composioExecutor: RemoteToolExecutor = async (p, _context) => {
   const identifier = p.identifier;
   const composioServers = useToolStore.getState().composioServers || [];
@@ -109,8 +127,19 @@ export const lobehubSkillExecutor: RemoteToolExecutor = async (p, context) => {
     });
   }
 
-  // Convert to MCPToolCallResult format
-  const content = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
+  // Convert to MCPToolCallResult format.
+  // CLI-based skill providers (e.g. `gh`) wrap a successful command's stdout in a
+  // { command, exitCode, output } envelope. On success, surface `output` directly
+  // instead of JSON-stringifying the whole envelope — the escaped result is unreadable
+  // in the chat transcript, and command/exitCode add no value once it already succeeded.
+  // A non-zero exitCode still falls through to the full envelope so the model can see
+  // command/exitCode/stderr and self-correct.
+  const content =
+    typeof result.data === 'string'
+      ? result.data
+      : isCLISkillCommandResult(result.data) && result.data.exitCode === 0
+        ? result.data.output
+        : JSON.stringify(result.data);
 
   return {
     content,


### PR DESCRIPTION
<!-- Brief and heads-up -->

`lobehubSkillExecutor` (client-side executor for LobeHub Skill tool calls — GitHub, Linear, etc.) built the tool-call content with `JSON.stringify(result.data)` whenever the result wasn't already a plain string. CLI-based skill providers (currently GitHub's `gh`, built on `packages/builtin-skills`' shared `cli-base.ts`-equivalent infra on the market side) return a `{ command, exitCode, output }` envelope on success, so the chat transcript ended up showing that whole envelope JSON-stringified — escaped `\n`/`\t` and all — instead of the actual, readable command output.

Diagnosed alongside `lobehub-market`: its skill API (`src/api/v1/skill/index.ts`) already returns a properly structured JSON response (`c.json({ data: result.data, ... })`) — the double-encoding only happened on this side, in the client executor that flattens the result into a single `content` string for the tool message.

#### Key Decisions / Non-goals

- Scoped by result *shape* (`{ command, exitCode, output }`), not by provider id — this is the contract shared by any current/future provider built on the CLI-provider base, not GitHub-specific.
- Only applies when `exitCode === 0`. A non-zero exit still returns the full JSON-stringified envelope, so the model keeps `command`/`exitCode`/`stderr` to self-correct — this mirrors how the provider already treats success vs. failure differently upstream.
- Non-CLI-shaped skill results (e.g. Linear issue data) are untouched — still JSON-stringified as before.

#### Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added `src/store/chat/slices/plugin/actions/exector.test.ts` (no prior test file for this executor) covering: successful CLI command → raw output, not JSON; failed CLI command → full envelope preserved; non-CLI skill result → still JSON-stringified; plain string result → passed through unchanged.

#### 🔗 Related Issue

None — reported directly via chat (screenshot showed a `gh repo view` tool result rendered as an escaped JSON blob in the chat transcript).