### PR TITLE
👷 ci(e2e): keep canary baseline runs from being cancelled

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,13 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Canary push runs publish the bundle-size / entry-graph baselines every PR
+  # gate compares against (find-size-baseline.cjs only accepts a *successful*
+  # canary run). Cancelling them under a burst of canary merges leaves the
+  # baseline pinned to the last completed run — after a chunking change every
+  # rebased PR then fails the "new chunk entered the static import graph" gate
+  # until a canary run manages to finish. Keep canary runs; cancel the rest.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/canary' }}
 
 env:
   # Same-repo PRs get their pull_request run skipped as a duplicate of the push run,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,14 +8,17 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   # Canary push runs publish the bundle-size / entry-graph baselines every PR
-  # gate compares against (find-size-baseline.cjs only accepts a *successful*
-  # canary run). Cancelling them under a burst of canary merges leaves the
-  # baseline pinned to the last completed run — after a chunking change every
-  # rebased PR then fails the "new chunk entered the static import graph" gate
-  # until a canary run manages to finish. Keep canary runs; cancel the rest.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/canary' }}
+  # gate compares against, and find-size-baseline.cjs only accepts a
+  # *successful* canary run whose commit is an ancestor of the PR. A shared
+  # ref-level group drops canary runs under a burst of merges — cancelled when
+  # in progress, or replaced while pending (GitHub keeps one pending run per
+  # group) — so after a chunking change every PR rebased past it stays pinned
+  # to the pre-change baseline and fails the "new chunk entered the static
+  # import graph" gate. Give each canary commit its own group so every canary
+  # lineage publishes its artifact; other refs keep cancelling superseded runs.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/canary' && github.sha || github.ref }}
+  cancel-in-progress: true
 
 env:
   # Same-repo PRs get their pull_request run skipped as a duplicate of the push run,


### PR DESCRIPTION
Every PR's bundle-size / entry-graph gate compares against the baseline artifact of the **latest successful `canary` push run** of `e2e.yml` whose commit is an ancestor of the PR (`find-size-baseline.cjs`). Canary push runs shared the `${{ github.workflow }}-${{ github.ref }}` concurrency group with `cancel-in-progress: true`, so under a burst of canary merges each new push cancelled the in-progress canary run — and GitHub keeps only one *pending* run per group, so intermediate pushes were replaced before running at all.

Today that pinned the baseline before #19062 (`vendor-ui-core` / `vendor-antd` chunk regrouping): the canary runs for `8d6d9615e0`, `0877876478`, `5390ba8f1a` and `2b55c8e7ef` were all cancelled (33732930045, 33733321813, 33734833400, 33737625402), so every PR rebased on the new canary fails `Check entry static-import graph against baseline` with `vendor/vendor-ui-core.js`, `vendor/vendor-antd.js` "added to sync graph" — e.g. #19091 (run 33734064391) and `feat/auth-micro-app` (run 33737785647) — although their diffs add no imports. Canary itself never runs the check (`SIZE_GATE_ENABLED` is false on canary), so the only thing standing between PRs and a fresh baseline is a canary run that finishes.

**Change**

Give each canary push its own concurrency group (`${{ github.ref == 'refs/heads/canary' && github.sha || github.ref }}`) so every canary commit publishes its baseline artifact regardless of how fast canary moves; feature branches and PR refs keep the ref-level group and keep cancelling superseded runs. Overlapping canary runs are harmless — the baseline finder already picks the newest successful ancestor.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Unblocks #19091 and other PRs rebased on canary after #19062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5hYkUf1jSg2fDiQh72FWV