### PR TITLE
♻️ refactor(acceptance): inject common-mistakes as a checklist with holds-while

### DIFF
--- a/.agents/acceptance/PROCESS.md
+++ b/.agents/acceptance/PROCESS.md
@@ -31,13 +31,29 @@ invocation:
    labeled as a guess. Never execute against an unconfirmed guess.
 3. Only when nothing is inferable, ask one direct open question.
 
-**Once the target is known**, read both layers of both living logs in full:
+**Once the target is known**, load both layers of both living logs — silently,
+each by its own retrieval shape (the shape is defined in the generic file's
+"How this file is injected"):
 
-- Generic (ships with the skill, read-only here):
-  `.agents/skills/acceptance/references/common-mistakes.md` and
-  `probe-mock-patterns.md`.
-- Project (writable, ours): [`common-mistakes.md`](./common-mistakes.md) and
-  [`probe-mock-patterns.md`](./probe-mock-patterns.md).
+- **`common-mistakes.md` — the Checklist in full**, both layers: generic
+  `.agents/skills/acceptance/references/common-mistakes.md` (read-only here) and
+  project [`common-mistakes.md`](./common-mistakes.md). Re-read both checklists
+  before marking any case `pass`; pull an entry by id only when its line applies.
+- **`probe-mock-patterns.md` — index first, entries on demand**, both layers:
+  generic `.agents/skills/acceptance/references/probe-mock-patterns.md` and
+  project [`probe-mock-patterns.md`](./probe-mock-patterns.md). The headings are
+  the index; a round needs a handful of the \~100 recipes, not all of them.
+
+```bash
+P=.agents/acceptance/probe-mock-patterns.md
+rg -n '^#{2,4} ' "$P"           # the index, with line numbers
+sed -n '<start>,<next-1>p' "$P" # one entry, in full — bounds from the index
+```
+
+Pick from the index by meaning, not by keyword — `rg` over the body is a
+fallback for when no heading obviously matches. Reading an entry you turned out
+not to need is cheap; skipping one because you searched for `dropdown` and the
+heading says `slash menu` is not.
 
 Two that keep biting: never declare a case `passed` from grep or skeleton counts
 — open the screenshot with Read and confirm it rendered; and when the goal is an
@@ -57,11 +73,22 @@ passing all five is recorded automatically — no separate user request needed:
    underlying failure is the same.
 5. **Actionable** — can a future verifier choose a different action or reject
    invalid evidence with it? Product taste and incident narrative cannot.
+6. **Mechanism-bound** — can you write its `holds-while:` line, naming the script
+   default, validator gap, or platform behavior it depends on (`always` only for
+   pure judgment)? An entry that cannot name its mechanism is a symptom, not a
+   rule — it goes to the field notes as "cause not established".
+
+Every admitted entry is one checklist line plus a Trap / Rule entry carrying
+`since` and `holds-while`. **Exit rule:** the day a mechanism moves into a script
+default or an ingest check, delete the entry in the same change — do not keep it
+"for reference"; the field notes hold history. A rule an agent skips under
+pressure (not a judgment call) goes into the table under Step 4, not the log.
 
 A candidate that fails only for being too implementation-specific gets routed:
 product behavior to the spec, UI values to the component, regressions to a test,
-long incident context to `references/probe-field-notes.md`. Do not skip the
-recording merely because it requires abstracting the feedback first.
+long incident context to `references/common-mistakes-field-notes.md` or
+`references/probe-field-notes.md`. Do not skip the recording merely because it
+requires abstracting the feedback first.
 
 ### Step 1 — Prepare the plan
 
@@ -187,6 +214,16 @@ Leave the trace in the report directory — `acceptance run ingest` prices it wi
 the platform's timing model. There is no analyze step, and no cost is published
 when no trace exists. Contract:
 `.agents/skills/acceptance/references/interaction-cost.md`.
+
+**Rules that hold under pressure.** Not judgment calls — each excuse below was
+made in a real LobeHub round. The generic set is in the skill's SKILL.md.
+
+| Excuse                                                                    | Reality                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "The agent operation finished, I'll stop the dev server"                  | Verification and repair can start minutes later and still own pending operations. Keep every dependency alive until the bound Task reaches a stable terminal state or non-progress is proven. (was L-S4)                                                                                                                       |
+| "No popup in the DOM 500ms after the click — the trigger is broken"       | A Chrome MCP tab is hidden: `visibilityState === 'hidden'`, rAF delivers 0 frames. Assert on state (`data-open`, the store), confirm the tab's health first, and get timing-dependent behavior confirmed in a foreground tab. A negative from a hidden tab is not evidence. (was L-S10)                                        |
+| "My change has no effect — must be the Vite cache" / "the app won't open" | Another session may have stashed the whole tree (`pre-rebase2-<pr>-<sha>`) or left conflict markers. Confirm your file is in `git status` with a unique marker before and after capture; recover only your file with `git checkout stash@{n} -- <file>`; never pop or drop their stash or resolve their conflicts. (was L-S13) |
+| "The fix is in and the tests are green"                                   | Reproduce the failure's precondition first (here: the empty→non-empty task-list transition swaps the composer instance). A run that cannot fail proves nothing; when the mocked seam is the suspect, drop the mock and drive the real kernel. (was L-S18, now generic M31)                                                     |
 
 ### Step 5 — Report and publish
 

--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -1,1094 +1,537 @@
 # LobeHub Acceptance Mistakes
 
-Project-specific mistakes only. Read this with the agent-testing skill's generic
-`references/common-mistakes.md`. Stable ids use the `L-` prefix so they cannot be
-confused with the generic `M` catalogue.
+Project-specific mistakes only. Read this with the acceptance skill's generic
+`references/common-mistakes.md`; stable ids use the `L-` prefix so they cannot be
+confused with the generic `M` catalogue. The generic file's "How this file is
+injected" applies here unchanged: **read the Checklist in full** once the target
+is known and again before marking any case `pass`; pull an **entry by id** only
+when its line applies (`rg -n '^### L-' <file>`, then `sed -n`).
 
-Keep this file at the level of durable LobeHub product and environment invariants.
-Exact copy, pixel values, component slot order, and one-off review directions belong
-in feature specifications or in
-[the field notes](./references/common-mistakes-field-notes.md), not in this living
-checklist — the field notes keep the detailed incident narratives available without
-making them mandatory reading for every Acceptance run.
+Only judgment rules live here. Every entry carries `since` and `holds-while` —
+the mechanism it depends on. When that mechanism moves into a script default or
+an ingest check, the entry is deleted the same day (admission and exit rules:
+[PROCESS.md](./PROCESS.md) Step 0). Rules an agent skips under pressure are in
+PROCESS.md, not here. Incident narratives, feature-spec facts, and retired
+entries live in [the field notes](./references/common-mistakes-field-notes.md).
 
-Every entry lives under one of the three categories below, and its id prefix names
-that category: `L-E*` evidence and publication, `L-D*` product and interaction
-contracts, `L-S*` environment safety. Append a new entry inside the category it
-belongs to, with the next free number of that prefix — never after the last entry of
-the file.
+Categories and id prefixes: `L-E*` evidence and publication, `L-D*` product and
+interaction contracts, `L-S*` environment safety. Append inside the category with
+the next free number of that prefix.
 
-## Evidence and publication
+## Checklist
+
+**Evidence and publication**
+
+- **L-E1** A replacing check declares `supersedes`; a visible-UI check passes only on opened visual evidence asserting the full spatial outcome, overlap included.
+- **L-E2** A passing layout screenshot shows the settled real transition — never a DOM under a synthetic transform.
+- **L-E3** An authoring flow is proven end to end: entry, completed input and preview, the created item in its pre-verification state.
+- **L-E4** Verify in the requested product container at representative scale, on both sides of every behavior-changing threshold; a harness is supporting evidence only.
+- **L-E5** Every criterion maps to its verifier, its own inspectable evidence, and a verdict — never an aggregate "all passed".
+- **L-E6** When the Task requires a durable document, create and pin the real artifact; evidence explains a verdict, it is not the deliverable.
+- **L-E9** Check the acceptance's status before ingest; new scoped work on an accepted acceptance goes to a new subject.
+- **L-E10** After any Agent assignment or Task edit, verify the persisted provider/model and the first completed message's metadata before judging quality.
+- **L-E11** Reconcile the evidence count in `result.json` against the ingest JSON; any `[WARN] evidence upload failed` is a failed publish — republish a fresh round.
+- **L-E13** Uncommitted work on a branch that owns a PR: decide provenance explicitly (open the real PR, or say in `report.md` there is none) and re-read `branch`/`commit` at publish time.
+- **L-E14** After an insertion affordance, continue the user's action in the same case and assert node order in persisted `editor_data`; send the payload through the same entry point.
+- **L-E15** A conversation-branch regression is verified by sending the next message through the real composer: DB row, parent on the active spine, render before and after cold reload.
+- **L-E16** Streaming is proven by timestamped intermediate samples and a GIF whose frames progress — a terminal reply after exit proves persistence only.
+- **L-E17** Direct-mention routing is verified with a real tool call and the full persisted tree; no owner assistant, `callAgent`, or synthetic target-user row.
+- **L-E19** Markdown evidence: one paragraph per physical line; newline only where it is content.
+- **L-E20** Build fixtures through the same composition the product uses; compare an entity page against a canary-created sibling before publishing it as evidence.
+- **L-E21** Publish against production even when the subject exists only locally; a local ingest may supplement, never replace.
+
+**Product and interaction contracts**
+
+- **L-D6** Master-detail scroll ownership is asserted with DOM measurements (bounded frame, independent regions), not only visually.
+- **L-D7** Verify the deepest route of every section; a route-driven Segmented's active segment is inert, so deep routes need their own ancestor affordance.
+- **L-D11** A data-height popover is measured with its trigger at the bottom of the list: `rect.bottom` vs `innerHeight`, non-negative overflow is a defect.
+- **L-D12** Every menu entry you add is clicked and its effect asserted; "menu closed, nothing happened" is the failure signature.
+
+**Environment safety**
+
+- **L-S1** Prove the ingest target from effective CLI settings or an environment-distinguishing probe, never from `lh whoami` alone.
+- **L-S2** Green Vite/Vitest/lint/tsc is not boot insurance: boot the real surface and read `agent-browser console` on an ErrorBoundary.
+- **L-S3** Fetch `origin canary`, record the SHA, and confirm it is an ancestor of the branch before starting the evidence environment.
+- **L-S5** Before driving CDP 9222 or a pool port, prove who owns it: Electron `Browser` string on `/json/version`, a LobeHub renderer marker, and _your_ worktree's absolute source path.
+- **L-S7** Before capturing evidence for a dependency or module-graph change, prove the served bundle carries it, or restart Vite; compare the running port with `test-env.sh`'s resolved `PORT`.
+- **L-S8** A first-boot renderer `Cannot access 'X' before initialization` is reloaded once and re-probed before it is attributed to the change.
+- **L-S9** After `migrate`, assert the tables exist; on the shared Postgres, never reset — create a per-run database and export `DATABASE_URL`.
+- **L-S14** An image property (alpha, aspect, no text) is asserted from the decoded bytes, never from the prompt that asked for it.
+- **L-S16** Every long-run health probe has connect and total timeouts; a listening socket is not health.
+- **L-S17** Empty reads plus failing writes: check `select id from users` in the DB the running server uses before debugging the feature.
+- **L-S19** `plan[]` holds only what the user accepts or rejects, each id fulfilled by a case; a clean ingest prints `plan: N item(s)` with nothing after it.
+- **L-S20** Read the managed containers' host ports from `docker ps` and pass `DB_PORT`/`REDIS_PORT` to every `init-dev-env.sh` subcommand; `auth_failed` on migrate is a port mismatch.
+- **L-S21** In a worktree, invoke scripts by absolute path and prove the SPA's identity (Vite pid cwd, changed module from the Vite origin) before trusting any gate or evidence.
+
+## Entries
 
 ### L-E1 — Publishing a replacement as a second Acceptance row
 
-**Wrong approach:** assign a replacement check a new id without `supersedes`, or
-pass a visible UI check from test output or computed styles alone.
+`since 2026-07-24` · `holds-while: Acceptance does not fuzzy-match check titles`
 
-**Why it fails:** Acceptance intentionally does not fuzzy-match titles, and program
-output does not establish the rendered result.
+**Trap:** a replacement check gets a new id without `supersedes`, or a visible UI
+check passes from test output or computed styles alone.
 
-**Correct approach:** declare the previous stable id in `supersedes`; give every
-user-visible case opened visual evidence and assert the complete spatial outcome,
-including overlap.
+**Rule:** declare the previous stable id in `supersedes`; give every user-visible
+case opened visual evidence and assert the complete spatial outcome, overlap
+included.
 
 ### L-E2 — Publishing synthetic displacement as passing layout evidence
 
-**Wrong approach:** apply a temporary transform to isolate position syncing, then
-publish a screenshot while the product panel is visibly displaced.
+`since 2026-07-24` · `holds-while: always`
 
-**Why it fails:** the numeric assertion may pass while the visual evidence depicts a
-broken product state.
+**Trap:** a temporary transform isolates position syncing and the screenshot
+ships with the panel visibly displaced; the numeric assertion passes while the
+image depicts a broken product.
 
-**Correct approach:** capture the settled result of a real layout transition. Keep
-synthetic probes as supporting text evidence and restore the DOM before capturing a
-passing screenshot.
+**Rule:** capture the settled result of a real layout transition. Synthetic
+probes stay as supporting text; restore the DOM before any passing screenshot.
 
 ### L-E3 — Claiming an authoring flow from its entry point
 
-**Wrong approach:** publish an entry button and source-level evidence as proof that
-manual check creation is complete.
+`since 2026-07-24` · `holds-while: always`
 
-**Why it fails:** an entry point does not demonstrate form entry, the resulting
-check, or where it enters the Acceptance lifecycle.
+**Trap:** an entry button plus source-level evidence is published as proof that
+manual check creation works.
 
-**Correct approach:** verify entry, completed input and preview, and the created item
-in its editable pre-verification state. Keep this path independent from unrelated
-rubric loading.
+**Rule:** verify entry, completed input and preview, and the created item in its
+editable pre-verification state, independent of unrelated rubric loading.
 
-### L-E4 — Verifying the wrong product container or scale boundary
+### L-E4 — Verifying the wrong container or scale boundary
 
-**Wrong approach:** prove behavior in a standalone or harness surface when the
-requested surface is a Task drawer, or use a small fixture for behavior that changes
-at a list-size threshold.
+`since 2026-07-24` · `holds-while: always`
 
-**Why it fails:** the same content composes differently across containers, and small
-fixtures cannot expose grouping, density, overflow, or master-detail pressure.
+**Trap:** behavior is proven in a standalone harness when the requested surface
+is a Task drawer, or with a small fixture for behavior that changes at a
+list-size threshold.
 
-**Correct approach:** capture the requested product container with representative
-titles, state mix, item count, and both sides of every behavior-changing threshold.
-Use harnesses only as supporting evidence.
+**Rule:** capture the requested container with representative titles, state mix
+and item count, on both sides of every threshold. Harnesses are supporting
+evidence only.
 
 ### L-E5 — Replacing per-check evidence with a verification summary
 
-**Wrong approach:** publish only an aggregate checklist or transcript saying that all
-checks passed.
+`since 2026-07-30` · `holds-while: ingest accepts a pass/fail case with no evidence`
 
-**Why it fails:** reviewers cannot inspect what each verifier saw or why each
-delivery criterion passed.
+**Trap:** an aggregate checklist or transcript saying everything passed.
 
-**Correct approach:** capture a readable overview and inspectable detail evidence for
-each underlying criterion. Map every stable criterion id to its verifier, evidence,
-and verdict.
+**Rule:** a readable overview plus inspectable detail evidence per criterion; map
+every stable id to its verifier, evidence, and verdict.
 
 ### L-E6 — Treating Acceptance evidence as the requested product artifact
 
-**Wrong approach:** upload a generated document only as Acceptance evidence when the
-Task requires a durable document deliverable.
+`since 2026-07-30` · `holds-while: always`
 
-**Why it fails:** audit evidence explains a verdict; it does not create a reusable
-artifact in the Task workspace.
+**Trap:** a generated document is uploaded only as evidence when the Task
+requires a durable document deliverable.
 
-**Correct approach:** create and pin the real product artifact to the Task, then
-attach separate evidence proving its content and association.
-
-### L-E7 — Hiding multimodal requirements in split verifier metadata
-
-**Wrong approach:** label a screenshot check only as `LLM` or `Agent`, with media
-requirements and model capability shown elsewhere.
-
-**Why it fails:** reviewers cannot tell whether the visual evidence was actually
-inspected by a multimodal model.
-
-**Correct approach:** present verifier type, multimodal capability, and required
-evidence media together; explicitly identify screenshot checks as multimodal.
-
-### L-E8 — Proving Task continuity with different Tasks
-
-**Wrong approach:** compare criteria from one Task with results from another and
-interpret the different item counts as a lifecycle defect.
-
-**Why it fails:** Tasks may legitimately have different goals, while Acceptance
-retains later-round checks as delivery history.
-
-**Correct approach:** capture definition and result states from the same Task, keep
-the complete cross-round check union visible, and synchronize the Task verification
-requirement with the aggregate goal.
+**Rule:** create and pin the real artifact to the Task; attach separate evidence
+proving its content and association.
 
 ### L-E9 — Appending a new delivery to a terminally accepted Acceptance
 
-**Wrong approach:** publish separately scoped implementation work as a new round on
-an Acceptance whose delivery has already been accepted.
+`since 2026-07-30` · `holds-while: ingest does not refuse a round on an accepted acceptance`
 
-**Why it fails:** the closed audit record no longer matches the delivery that was
-decided, and reviewers cannot independently accept or reject the new work.
+**Trap:** separately scoped work is published as a new round on an acceptance
+whose delivery was already accepted, so the closed audit record no longer matches
+what was decided.
 
-**Correct approach:** inspect Acceptance status before ingest. Create a new Task or
-subject for a materially new delivery; reopen the existing delivery only when the
-user explicitly requests it and the lifecycle supports it.
+**Rule:** inspect the acceptance status before ingest. New Task or subject for a
+materially new delivery; reopen only on explicit user request.
 
 ### L-E10 — Judging agent quality without proving the runtime model
 
-**Wrong approach:** trust the model shown before Agent assignment, then judge the run
-without checking the persisted Task configuration and completed message metadata.
+`since 2026-07-30` · `holds-while: always`
 
-**Why it fails:** Agent assignment can replace the Task provider or model, so the
-observed behavior may belong to a fallback model.
+**Trap:** trusting the model shown before Agent assignment; assignment can
+replace the Task provider or model, so the observed behavior belongs to a
+fallback.
 
-**Correct approach:** after every assignment or Task edit, verify both persisted
-provider/model configuration and the first completed assistant message metadata.
-Attach the runtime identity to the Acceptance round before judging quality.
+**Rule:** after every assignment or Task edit, verify the persisted
+provider/model and the first completed assistant message metadata; attach the
+runtime identity to the round.
 
 ### L-E11 — Declaring an ingest done without reconciling its evidence count
 
-**Wrong approach:** read `acceptance run ingest`'s success JSON, see an
-`acceptanceId` and a round index, and stop — treating a `[WARN] evidence upload
-failed, skipping <file>` line above it as noise because the command still exited 0.
+`since 2026-07-31` · `holds-while: ingest exits 0 after "[WARN] evidence upload failed, skipping <file>"`
 
-**Why it fails:** a transient storage error skips exactly one artifact and the run
-publishes anyway. When the casualty is one half of a `comparison` pair, the
-surviving half renders alone under its role band — a lone `before` screenshot reads
-as "the fix never landed", inverting the round's verdict.
+**Trap:** the success JSON shows an `acceptanceId` and a round index, the WARN
+above it is read as noise. One skipped half of a `comparison` pair renders alone
+— a lone `before` reads as "the fix never landed".
 
-**Correct approach:** count the evidence items in `result.json` before publishing
-and compare against the ingest JSON's `evidence` field; treat any WARN line as a
-failure of the publish step. Do not retro-attach the missing file with
-`acceptance run evidence upload` — that path carries no `comparison` metadata, so
-the image lands unpaired and unlabeled. Publish a fresh round carrying the complete
-evidence set instead, and say in `report.md` that it re-publishes the same
-observations rather than re-running the cases.
-
-### L-E11b — Publishing a new round onto a check the reviewer already accepted
-
-**Wrong approach:** when new feedback arrives about a check the user has already
-accepted, reuse that check's id for the new work — because reusing ids is the rule for
-rejected checks.
-
-**Why it fails:** an accepted verdict is deliberately sticky (`acceptanceService`
-computes `stale` only for rejects, and a test pins that behaviour by name). A later
-result on a settled id therefore inherits the tick: the round publishes green and the
-reviewer is never told there is anything new to look at. Since 2026-08, `attachRun`
-refuses such a round outright — the error names the offending ids and nothing is
-written, so a partially attached round cannot happen.
-
-**Correct approach:** read `userReview.action` before writing the plan. `accept` means
-settled: the new work needs a NEW check id, which appears unreviewed and can actually
-be judged. Reuse the id only while the check is rejected or never reviewed. Decide by
-_is the criterion new, and has the old one been accepted_ — not by how big the change
-is: a presentation fix on a still-open check reuses its id (\[\[L-E1]]), while a newly
-raised criterion on an accepted check must not.
-
-### L-E12 — Expressing multimodal disclosure through the `verifier` enum
-
-**Wrong approach:** write a value such as `"verifier": "multimodal LLM"` in a plan
-item to satisfy the requirement that screenshot checks disclose multimodal review.
-
-**Why it fails:** `verifier` is a closed set (`program` / `agent` / `llm`) that the
-ingest validator rejects outside those values, so the whole payload fails. The
-disclosure is not expressible in that field.
-
-**Correct approach:** set `"verifier": "llm"` and carry the multimodal disclosure in
-the plan item's `method` prose alongside `"requiredEvidence": ["screenshot"]`.
+**Rule:** count evidence items in `result.json` against the ingest JSON's
+`evidence` field; any WARN is a failed publish. Do not retro-attach with
+`acceptance run evidence upload` (no `comparison` metadata → unpaired). Publish
+a fresh round with the complete set and say in `report.md` that it republishes
+the same observations.
 
 ### L-E13 — Publishing uncommitted work onto the branch's unrelated PR
 
-**Wrong approach:** verify working-tree changes that have no PR of their own, then
-ingest without stating that, assuming the round carries no PR because `result.json`
-omits `pullRequest` (or sets it to `null`).
+`since 2026-08-10` · `holds-while: ingest resolves the PR from branch when pullRequest is absent OR null`
 
-**Why it fails:** the ingest resolves the PR from `branch` whenever the field is
-absent OR null, so a long-lived branch that already owns a PR stamps every round
-with it. The page then presents an unrelated PR as the provenance of this
-verification, and deleting the run and re-ingesting reproduces the same stamp.
-Two rounds later nobody can tell which delivery the evidence belongs to.
+**Trap:** working-tree changes with no PR are ingested on a long-lived branch
+that owns one; every round is stamped with that PR and re-ingesting reproduces
+it.
 
-**Correct approach:** before publishing a round for uncommitted work, decide the
-provenance explicitly — commit and open the real PR first, or state in `report.md`
-that this round has no PR and that any PR shown belongs to other work on the same
-branch. Also re-read `branch` / `commit` at publish time rather than trusting the
-scaffold: a session that spans a branch switch fills them from whatever is checked
-out when `report-init.sh` ran.
+**Rule:** decide provenance before publishing — commit and open the real PR, or
+state in `report.md` that this round has no PR and any PR shown belongs to other
+work. Re-read `branch` / `commit` at publish time; `report-init.sh` fills them
+from whatever was checked out when it ran.
 
-### L-E14 — Verifying an insertion affordance without continuing the user's next action
+### L-E14 — Verifying an insertion affordance without the user's next action
 
-**Wrong approach:** check that a composer affordance (an action-tag chip, a mention,
-a file token) inserted the right node, screenshot it, and move on — then verify the
-sent payload through a _different_ entry point that happens to be easier to drive.
+`since 2026-08-10` · `holds-while: always`
 
-**Why it fails:** insertion is half the affordance; the caret it leaves behind is
-the other half. A caret parked in front of the inserted node sends the user's very
-next keystroke to the wrong side of it. For any chip that serializes into the prompt
-with position semantics — the `/goal` marker must lead the message for `isGoalPrompt`
-to match — that silently rewrites the payload into something the runtime no longer
-recognizes, while every screenshot of the insertion itself still looks correct.
-Verifying the payload through a different entry point hides it completely: the path
-with the defect is never the path that gets sent.
+**Trap:** a composer chip/mention/token is checked for presence, screenshotted,
+and the sent payload is verified through a different, easier entry point. The
+caret parked on the wrong side of the node sends the next keystroke to the wrong
+place, and the entry point with the defect is never the one that sends.
 
-**Correct approach:** for every insertion affordance, continue the user's action in
-the same case — type after inserting — and assert the resulting node order, not just
-the node's presence. Drive the payload check through the _same_ entry point the case
-under test uses; if an affordance has several entries (slash menu, `+` menu), the one
-you send from must be the one you are claiming works. Assert order in the persisted
-`editor_data`, since that is what both the prompt serializer and the bubble read.
+**Rule:** continue the user's action in the same case — type after inserting —
+and assert node order in the persisted `editor_data`. Send the payload through
+the same entry point the case claims to verify.
 
-### L-E15 — Treating historical branch rendering as proof that conversation can continue
+### L-E15 — Treating historical branch rendering as proof that conversation continues
 
-**Wrong approach:** render a recovered historical `taskCallback` card beside the
-active tool continuation, then call the message-loss regression verified without
-sending another user message.
+`since 2026-08-10` · `holds-while: always`
 
-**Why it fails:** read-path recovery proves only that existing rows are visible.
-The next user turn exercises a separate write/parent-selection path and can still
-attach to the wrong branch, disappear after reconciliation, or vanish after reload.
+**Trap:** a recovered `taskCallback` card beside the active continuation is
+called a verified message-loss fix without sending another user message.
 
-**Correct approach:** for every conversation-branch regression, continue from the
-fixture through the real composer. Assert the new user row in the database, its
-parent on the active spine, its rendered presence before and after a cold reload,
-and the resulting assistant continuation when the environment supports it.
+**Rule:** continue from the fixture through the real composer; assert the new
+user row in the DB, its parent on the active spine, its rendering before and
+after a cold reload, and the assistant continuation when the environment allows.
 
 ### L-E16 — Treating a terminal reply as evidence of live streaming
 
-**Wrong approach:** ask a device-executed Claude Code agent for a one-token fixed
-marker, record until the process exits, and treat the eventual assistant text or
-a refreshed screenshot as proof that the reply streamed into the open Topic.
+`since 2026-08-10` · `holds-while: lh hetero exec runs Claude Code without --include-partial-messages`
 
-**Why it fails:** `lh hetero exec` can run Claude Code without
-`--include-partial-messages`. In that mode the adapter receives only the final
-assistant snapshot, so the UI may show an empty target-Agent shell for the whole
-run and acquire the text only during terminal reconciliation. A short fixed
-marker also has no observable intermediate state even when partial framing works.
+**Trap:** a one-token marker recorded until process exit; the UI shows an empty
+target-Agent shell for the whole run and acquires text only at reconciliation,
+and the GIF of that shell is mistaken for streaming.
 
-The acceptance proves persistence and refresh recovery but
-does not prove the user sees the answer arrive live; a GIF of an empty shell is
-mistaken for streaming evidence.
-
-**Correct approach:** enable Claude Code partial messages on the device/sandbox
-CLI spawn path. Verify with a multi-part response and timestamped DOM/store
-samples before any reload, then attach a GIF whose frames visibly progress and
-whose final frame contains the complete answer. Check persistence separately by
-refreshing only after the live-stream assertion has passed.
+**Rule:** enable partial messages on the device/sandbox spawn path. Verify with a
+multi-part response and timestamped DOM/store samples before any reload, then a
+GIF whose frames visibly progress to the complete answer. Check persistence
+separately, after the live assertion passed.
 
 ### L-E17 — Proving direct-mention routing with a text-only response
 
-**Wrong approach:** verify a leading single-Agent mention only with a plain-text
-response, then conclude that the direct-routing message tree is correct for all
-target-Agent runs.
+`since 2026-08-10` · `holds-while: always`
 
-**Why it fails:** tool-capable runs add assistant tool-call chunks and
-tool-result messages. Those nodes can accidentally inherit the owner Agent,
-create a synthetic target-user envelope, or resume the owner after the tool
-result even when the initial text response looked correct.
+**Trap:** a leading single-Agent mention verified with plain text; tool-capable
+runs add tool-call chunks and tool results that can inherit the owner Agent,
+create a synthetic target-user envelope, or resume the owner afterwards.
 
-The simple happy path passes while real coding Agents either
-lose their tool output, render it under the wrong Agent, or invoke Lobe AI for
-the final answer.
-
-**Correct approach:** exercise a deterministic real tool call through the same
-gateway/device route, then assert the complete persisted tree: original owner
-user, target assistant/tool call, tool result, and target final response. Also
-assert there is no owner assistant, `callAgent`, or synthetic target-user row.
-
-### L-E18 — Concluding a composer surface is dead code because nothing imports it
-
-**Wrong approach:** after changing a component the ActionBar reuses (a skill row, for
-instance), grep for a default import of `ActionBar/Tools`, find no hit, conclude the
-surface is not mounted, and verify only the `+` menu path.
-
-**Why it fails:** ActionBar surfaces are not mounted by a direct import. They are
-enabled by an action-key registry plus each route's own `leftActions` array.
-`ActionBar/config` registers `tools: Tools` at all times; what actually decides
-whether it renders is `leftActions` in `src/routes/(main)/**/MainChatInput` — the
-group-chat composer enables `'tools'` and reaches the component through
-`PopoverContent → ToolsList`, a different composition path from the `+` menu. Missing
-it makes a green verification cover only half of what users can see.
-
-**Correct approach:** after changing any component the ActionBar reuses, enumerate
-where the action key is actually enabled (grep each route's `leftActions` array, not
-the component's imports) and capture evidence for every surface that enables it. Mark
-any surface you deliberately skip as untested.
+**Rule:** exercise a deterministic real tool call through the same route and
+assert the complete persisted tree — owner user, target assistant/tool call,
+tool result, target final response — with no owner assistant, `callAgent`, or
+synthetic target-user row.
 
 ### L-E19 — Hard-wrapping the prose inside a markdown evidence document
 
-**Wrong approach:** author a `markdown` / `text` evidence artifact the way you write
-a source file, folding every paragraph at \~80 columns, and assume the page reflows
-it like any other markdown.
+`since 2026-08-29` · `holds-while: the evidence renderer parses markdown in chat mode with remark-breaks`
 
-**Why it fails:** the Acceptance evidence renderer parses evidence documents in chat
-mode, where `remark-breaks` turns every single newline inside a paragraph into a
-`<br>`. The author's fold is frozen into the page: paragraphs break mid-sentence at a
-column count unrelated to the reader's viewport, next to a report body that reflows
-normally, so the same round shows two different text behaviours. Reviewers read the
-ragged block as a rendering defect and spend the round on the wrapping instead of the
-finding.
+**Trap:** a `markdown`/`text` artifact folded at \~80 columns; every newline
+becomes `<br>` and paragraphs break mid-sentence next to a report body that
+reflows.
 
-**Correct approach:** keep each paragraph of evidence prose on ONE physical line and
-separate blocks with a blank line. Spend a newline only where it carries meaning —
-list items, table rows, fenced code, and literal transcript output, which are exactly
-the places the break is the content. Never run a proseWrap formatter over files under
-`assets/`.
+**Rule:** one paragraph per physical line, blank line between blocks; spend a
+newline only on list items, table rows, fenced code, and literal transcripts.
+Never run a proseWrap formatter over `assets/`.
 
 ### L-E20 — Seeding an entity below its composing layer, then publishing its page as evidence
 
-**Wrong approach:** build a goal/task fixture by calling the service or TRPC endpoint
-directly with minimal fields, skipping the client-side composer the real creation flows
-run (e.g. `buildGoalRequirement` folding acceptance criteria into the requirement
-prose), then screenshot the entity page as feature evidence.
+`since 2026-09-03` · `holds-while: goal/task services accept decomposed inputs without a server-side guard re-deriving the composed field`
 
-**Why it fails:** the page renders the under-composed data faithfully — a requirement
-reduced to one bare sentence — and the reviewer reads that as a code regression in an
-untouched block ("这块怎么被改了？canary 才是对的"). A whole feedback round gets spent
-disproving a defect that only exists in the fixture. The diff shows nothing because
-nothing changed.
+**Trap:** a goal/task fixture created by calling the service or TRPC endpoint with
+minimal fields skips the client-side composer (`buildGoalRequirement` folding
+acceptance criteria into the requirement prose); the page renders the
+under-composed data faithfully and the reviewer reads it as a regression in an
+untouched block.
 
-**Correct approach:** drive fixtures through the same composition the product uses —
-either the real creation surface, or the same shaping helpers the callers invoke — and
-before publishing an entity page as evidence, compare its populated fields against a
-canary-created sibling. When a service accepts decomposed inputs, prefer adding a
-server-side guard that re-derives the composed field, so no API caller (fixtures
-included) can create the under-composed shape at all.
+**Rule:** drive fixtures through the real creation surface or the same shaping
+helpers the callers invoke; before publishing an entity page, compare its
+populated fields against a canary-created sibling. Prefer a server-side guard so
+no API caller can create the under-composed shape.
 
-## Product and interaction contracts
+### L-E21 — Publishing locally because the subject exists only locally
 
-### L-D1 — Rebuilding a canonical surface from visual impression
+`since 2026-09-03` · `holds-while: always`
 
-**Wrong approach:** copy a sibling surface's appearance without enumerating its
-semantics, states, affordances, wiring, and authored-data conventions.
+**Trap:** the primary report is ingested into a local instance because its Task
+or Topic is absent from production; the link dies with the environment.
 
-**Why it fails:** visual similarity can hide a second interaction dialect for the
-same product object and causes later improvements to drift.
-
-**Correct approach:** inspect the canonical implementation feature by feature, reuse
-its semantic components where possible, and compare both surfaces side by side.
-
-### L-D2 — Applying role and scope rules to only one bulk action
-
-**Wrong approach:** add own/workspace scope variants to one maintenance action while
-leaving sibling actions with different authority semantics.
-
-**Why it fails:** authority was reviewed per menu item instead of as a role × action
-× scope matrix.
-
-**Correct approach:** enumerate every matrix cell; keep members own-only and give
-owners explicit workspace variants with stronger confirmation for destructive work.
-
-### L-D3 — Exposing a disabled host capability
-
-**Wrong approach:** configure a host to keep a shared composer permanently open while
-continuing to render the component's Collapse action.
-
-**Why it fails:** the host contract and the advertised state transition contradict
-each other.
-
-**Correct approach:** model collapse capability as an explicit host option. Verify
-pinned and collapsible hosts independently.
-
-### L-D4 — Stretching a list row into a detail surface
-
-**Wrong approach:** reuse dense list-row chrome and controls unchanged inside an
-already-open detail panel.
-
-**Why it fails:** list affordances such as expansion controls and compact metadata
-duplicate context and compete with the detail surface's reading and decision tasks.
-
-**Correct approach:** preserve canonical object semantics and evidence order, but
-give detail mode its own permanently expanded interaction contract and clear decision
-hierarchy. Keep exact layout values in the feature specification.
-
-### L-D5 — Reserving floating-composer space in only one content path
-
-**Wrong approach:** reserve the measured composer overlay height in the virtualized
-message list but not in the empty or welcome path.
-
-**Why it fails:** alerts and trays can overlap welcome content even though overlay
-items do not overlap each other.
-
-**Correct approach:** apply the same measured reservation to every content path and
-capture the real combined overlay state.
+**Rule:** create a production Task or Topic as the anchor and publish in a clean
+environment against `app.lobehub.com`. A local ingest may supplement, never
+replace.
 
 ### L-D6 — Giving a master-detail page ambiguous scroll ownership
 
-**Wrong approach:** let long outline and detail content expand the document, or rely
-on one shared outer scroll container.
+`since 2026-07-30` · `holds-while: always`
 
-**Why it fails:** navigation and reading context drift together, headers disappear,
-and intermediate flex sizing can hide the intended inner scrollbars.
+**Trap:** long outline and detail content expand the document or share one outer
+scroll container; headers disappear and intermediate flex sizing hides the
+intended inner scrollbars.
 
-**Correct approach:** bound the workspace, keep the frame overflow hidden, assign
-independent scroll regions to navigation and detail, and verify scroll ownership with
-DOM measurements as well as visual evidence.
+**Rule:** bound the workspace, keep the frame overflow hidden, give navigation and
+detail independent scroll regions, and verify ownership with DOM measurements as
+well as screenshots.
 
-### L-D7 — Treating a route-driven Segmented's selected segment as a clickable affordance
+### L-D7 — Passing a section on its index route only
 
-**Wrong approach:** put a `Segmented` in a page header, have `onChange` write the URL, and
-then rely on clicking the already-selected segment to reach that section's own index route —
-typically to get back to a list from a `:param` detail route nested under it. Removing the
-breadcrumb's section link on the strength of that assumption is the usual companion move.
+`since 2026-08-07` · `holds-while: always`
 
-**Why it fails:** `Segmented` fires only on a _change_, so the active segment dispatches
-nothing. On the detail route the segment is still highlighted, so it reads as the obvious way
-back while being completely inert — the click is silent, the URL does not move, and nothing
-errors. A grouped route family makes this easy to miss, because the switcher works perfectly
-on every sibling index route and fails only one level deeper.
+**Trap:** a route-driven `Segmented` switches sibling sections perfectly, so the
+index-route pass is taken as coverage; on a nested `:param` route the active
+segment is still highlighted and dispatches nothing (`onChange` fires only on
+change), so the way back is silently inert.
 
-**Correct approach:** treat a route-driven Segmented as a switcher between sibling sections,
-never as navigation _within_ the selected section. Whenever a section owns deeper routes,
-keep a separate ancestor affordance for them — the breadcrumb's section link is the natural
-one. Where that link would otherwise duplicate the segment's own label, render it only on the
-deeper routes and let the segment name the section on the index route. Verify the deepest
-route of every section, not just the index: an index-only pass cannot see this failure.
-
-### L-D8 — Rendering a cross-agent dispatch envelope as a visible user turn
-
-**Wrong approach:** treat every persisted `role: user` row as a user-authored
-message when building the visible conversation list.
-
-**Why it fails:** `callAgent` persists a synthetic user envelope beneath the
-caller assistant so the target Agent has an isolated execution context. When
-that envelope is rendered, the original prompt appears twice even though the
-target Agent produced only one reply.
-
-Users see a duplicate prompt bubble and cannot tell whether
-the delegation ran once or twice; acceptance screenshots become misleading.
-
-**Correct approach:** stamp synthetic envelopes with explicit dispatch metadata
-when they are persisted, keep them in the context tree, and let the presentation
-layer hide only rows declared `visibility: internal`. Continue traversal through
-the envelope so the target assistant reply remains independently visible.
-Never infer authorship from agent-id differences or a parent tool call: a real
-cross-Agent user follow-up can have the same tree shape.
-
-### L-D9 — A Project conversation must preserve Project identity across routing and history
-
-**Wrong approach:** implement Project chat by navigating users to the Project coordinator's
-ordinary `/agent/:agentId/:topicId` surface and present that Agent's topic list as the Project
-history.
-
-**Why it fails:** the coordinator is an implementation detail. Leaving the Project route changes
-the visible owner and navigation contract, so users reasonably read the conversation as belonging
-to an Agent rather than to the Project that provides its tasks, goals, resources, and history.
-
-**Correct approach:** keep creation, topic selection, and resumed conversations under the Project
-route and Project sidebar. The coordinator may still execute the conversation internally, but the
-visible URL, active list, empty state, and navigation must consistently identify the Project.
-
-### L-D10 — Long `confirmModal` bodies overlay the footer
-
-**Wrong approach:** put a long list into `confirmModal({ content })` and assume the
-library pins Cancel / OK below a scroll area.
-
-**Why it fails:** `confirmModal` renders `ConfirmBody` (content + footer) inside
-`ModalContent`, which is itself `overflow: auto`. A tall list makes the dialog
-scroll as one column, or the footer paints over the last rows. Callers cannot pass
-content styles to change that.
-
-**Correct approach:** for any confirm body that can exceed a few lines, use
-`createModal` with a height-capped `ScrollArea` as `content` and put the actions in
-the modal `footer` slot. Assert `footer.top === scroller.bottom` at both ends of the
-list, not just that the dialog opened.
+**Rule:** verify the deepest route of every section. Whenever a section owns
+deeper routes, require a separate ancestor affordance (the breadcrumb's section
+link) and drive it.
 
 ### L-D11 — Trusting a popover to flip itself away from the viewport edge
 
-**Wrong approach:** anchor a hover card to a full-width list row, screenshot it once from a
-row near the top of the list, and assume the popover library will flip or shift the card
-when a lower row leaves no room below.
+`since 2026-08-21` · `holds-while: popovers rendered into the app portal container do not side-flip; collisionPadding has no effect`
 
-**Why it fails:** popovers here render into the app's portal container, and side flipping
-does not kick in from it — the popup keeps `data-side="bottom"` and simply extends past the
-viewport, even when the space above the trigger would have fitted it. Adding
-`collisionPadding` does not change that. The screenshot still looks like a working card,
-because the part that fell off the bottom is the part you cannot see; only the tail of the
-content (the last evidence row, a footer hint, an action) becomes unreachable.
+**Trap:** a hover card anchored to a full-width row is screenshotted from a top
+row; from a bottom row it keeps `data-side="bottom"` and extends past the
+viewport, and the part that fell off is the part you cannot see.
 
-**Correct approach:** for any hover/click popup whose content height is data-dependent,
-assert its rect against the viewport (`getBoundingClientRect().bottom` vs
-`window.innerHeight`) with the trigger at the **bottom** of its list, not the top — a
-non-negative overflow is a defect regardless of how the screenshot reads. Bound the content
-by the space the positioner publishes (`--available-height`, less the popup's own chrome)
-rather than relying on collision flipping.
+**Rule:** with the trigger at the **bottom** of its list, assert
+`getBoundingClientRect().bottom` against `window.innerHeight`; non-negative
+overflow is a defect however the screenshot reads. Bound content by the
+positioner's `--available-height` rather than relying on flipping.
 
-### L-D12 — Assuming a menu dispatches an item just because it rendered
+### L-D12 — Assuming a menu dispatches an item because it rendered
 
-**Wrong approach:** add an entry to a message/context menu — especially a nested one under a
-submenu — confirm from a screenshot that the label and icon appear where intended, and call
-the entry verified.
+`since 2026-08-31` · `holds-while: the dropdown group wrapper attaches onClick to top-level items only`
 
-**Why it fails:** menu rendering and menu dispatch are separate contracts here. The dropdown
-only invokes an item that carries its own `onClick`, and the group wrapper attaches one to
-top-level items only, so a nested child renders perfectly and does nothing when clicked — the
-menu just closes, with no error, no toast, and no console output. Any routing the consumer
-writes on the parent's side (by `keyPath` or otherwise) never runs, because the click was
-dropped before it. A screenshot of an open submenu therefore proves placement and nothing
-else.
+**Trap:** a nested menu entry renders in the right place and does nothing on
+click — the menu closes, no error, no toast, and any `keyPath` routing on the
+parent never runs.
 
-**Correct approach:** for every menu entry you add, click it and assert the effect it is
-supposed to have — a dialog opens, a request fires, a store field changes. Treat "the menu
-closed and nothing happened" as the expected failure signature, not as a missed click. When
-the entry is nested, verify the child's own dispatch wiring, not the parent's.
-
-### L-D13 — Picking `cssVar` color-scale steps by antd-palette intuition
-
-**Wrong approach:** choose antd-style palette steps (`cssVar.blue1` for a tint,
-`cssVar.blue6` for the primary line) from the standard antd 10-step palette in
-your head, and judge the result from the code alone.
-
-**Why it fails:** LobeHub's theme overrides the color scales with an 11-step
-palette whose primary-strength band sits at x9–x10 — light-mode `blue-6`
-resolves to `#acd4ff` and `blue-7` to `#93c8ff`, both near-pastel, nothing like
-antd's `blue-6` `#1677ff`. The UI then renders washed out while every token
-name in the code reads correct, and a one-step "fix" (x1→x2, x6→x7) changes
-almost nothing.
-
-**Correct approach:** never pick a scale step without reading the resolved
-value in the running app (`getComputedStyle` on the element, or resolve
-`--ant-<color>-<n>` from the element's scope — the variables are scoped, not on
-`:root`). For a tinted-tile + line pairing, the working band is around x3 for
-the tint and x9–x10 for the line, verified in both themes: the scale flips in
-dark mode, so a step that is a tint in light is a deep fill in dark.
+**Rule:** click every entry you add and assert its effect (dialog, request, store
+field). Treat "closed and nothing happened" as the expected failure signature;
+for a nested entry verify the child's own dispatch wiring.
 
 ### L-D14 — Linking to an agent document with the Work's binding id
 
-**Wrong approach:** build an in-app document link out of the identifier a
-document Work carries in `work_versions.metadata.agentDocumentId`, on the
-reading that it names the agent's document.
+`since 2026-09-05` · `holds-while: document Works carry no url and agentDocumentId names the binding row`
 
-**Why it fails:** `agentDocumentId` is the `agent_documents` binding ROW id — it
-establishes that a binding exists and is not addressable. The document route
-resolves the DOCUMENT id (`src/routes/(main)/agent/docs/[docId]` runs
-`getIdFromIdentifier(docId, 'docs')`), which lives on `works.resource_id`
-(`docs_xxx`). Document Works also carry no `url`, so there is nothing to fall
-back to: the mis-addressed link degrades silently to the documents index
-instead of erroring, and both the click and the navigation look successful.
-Unit tests that assert the field was carried through cannot see it, because the
-failure is in what the id means, not whether it arrived.
+**Trap:** `work_versions.metadata.agentDocumentId` is the `agent_documents`
+binding ROW id, not the document id the route resolves (`works.resource_id`,
+`docs_xxx`); the mis-addressed link degrades silently to the documents index
+instead of erroring, so click and navigation both look successful.
 
-**Correct approach:** address an agent document by `works.resourceId`; use
-`metadata.agentDocumentId` only as the gate proving the document is bound to an
-agent. When verifying any Work-to-resource link, open it in the running app and
-read `location.pathname` plus `document.title` — a link that lands on a list
-page is the tell, and the id shape (`docs_xxx` vs a bare uuid) says which id was
-used.
-
-## Environment safety
-
-### L-S0 — Concluding a dependency moved from the root manifest alone
-
-**Wrong approach:** refresh a shared dependency by running `pnpm install --filter .`
-at the repo root — or by bumping only the root range and running a full install —
-then read the new version out of `package.json` and treat a type-check failure in
-untouched files as pre-existing.
-
-**Why it fails:** the filter installs only the root workspace, and even an unfiltered
-install leaves `packages/*` on their old resolution when they declare a loose range
-(`"@lobehub/ui": "^5"` is satisfied by both the old and the new version, so nothing
-forces them to move). Two identities of the same package then coexist in the graph,
-and the errors surface far from the change — a duplicated `next` shows up as
-`NextRequest is not assignable to NextRequest` in backend route shells, and a
-duplicated UI package kills routes at the ErrorBoundary with a missing React context,
-or gives a component library two copies of a shared z-index/portal manager. Neither
-names the real cause.
-
-**Correct approach:** run a full `pnpm install` (no filter) after any dependency
-range change, then `pnpm dedupe` when the root and the workspace packages resolve
-different versions of a shared peer. State the version only from resolved copies —
-count the versions under `node_modules/<pkg>` and every `packages/*/node_modules/<pkg>`
-and require one distinct value — never from the root manifest. Remember `apps/desktop`
-and `apps/cli` are standalone installs that a root install never covers.
+**Rule:** address an agent document by `works.resourceId`, using
+`metadata.agentDocumentId` only as the binding gate. Verify any Work-to-resource
+link in the running app by reading `location.pathname` and `document.title` — a
+landing on a list page is the tell.
 
 ### L-S1 — Publishing to an assumed server target
 
-**Wrong approach:** strip a server environment variable and treat `lh whoami` as
-proof that Acceptance ingest targets production.
+`since 2026-07-24` · `holds-while: lh whoami does not print the effective serverUrl`
 
-**Why it fails:** `lh login` persists `serverUrl` in the CLI settings, and a local
-database may contain the user's synchronized profile.
+**Trap:** stripping a server env var and taking `lh whoami` as proof the ingest
+targets production; `lh login` persists `serverUrl` in CLI settings and a local
+DB may hold the synchronized profile.
 
-**Correct approach:** inspect the effective CLI settings or use a data probe that
-distinguishes environments. For production publishing without changing a local
-login, use an isolated `LOBEHUB_CLI_HOME` for login and ingest.
+**Rule:** inspect the effective CLI settings or run a data probe that
+distinguishes environments. For production publishing without touching a local
+login, use an isolated `LOBEHUB_CLI_HOME`.
 
 ### L-S2 — Trusting green gates as proof the app boots
 
-**Wrong approach:** use green Vite, Vitest, lint, and type-check results as
-blank-screen insurance for a routing or module-graph change, on Electron or Web.
+`since 2026-07-29` · `holds-while: always`
 
-**Why it fails:** browser ESM initialization cycles and nested-router invariants can
-fail only when the real renderer starts. Vitest resolves a module graph in its own
-order, so a cycle that is harmless under test can still put a module-level binding in
-the temporal dead zone in the bundler's order — the app then dies at the
-`ErrorBoundary` with `Cannot access '<X>' before initialization` while every gate
-stays green. Adding a shared constant next to the logic that uses it is the common
-way to close such a cycle in a folder where a node/component pair already import each
-other.
+**Trap:** Vite, Vitest, lint and tsc are green after a routing or module-graph
+change, and the real renderer dies at the `ErrorBoundary` with
+`Cannot access '<X>' before initialization` — Vitest resolves the graph in a
+different order than the bundler.
 
-**Correct approach:** boot the real surface, require the project readiness probe to
-report a non-error UI, and inspect a screenshot before claiming a UI change is
-delivered. On a boot failure read `agent-browser console` (the ErrorBoundary page
-itself shows no stack) and attribute before diagnosing. Keep cross-module constants
-in the folder's leaf module — the one that imports nothing from its siblings — rather
-than beside their primary consumer. Router-host component tests must also cover the
-real outer-router composition.
+**Rule:** boot the real surface, require the readiness probe to report a
+non-error UI, inspect a screenshot. On a boot failure read `agent-browser
+console` (the ErrorBoundary page shows no stack) before diagnosing. Keep
+cross-module constants in the folder's leaf module; router-host component tests
+cover the real outer-router composition.
 
-### L-S3 — Verifying Acceptance UI against an unfetched canary ref
+### L-S3 — Verifying against an unfetched canary ref
 
-**Wrong approach:** rebase against a stale local `canary` pointer and treat its UI as
-the latest canary behavior.
+`since 2026-07-30` · `holds-while: PROCESS.md Step 2 does not fetch canary itself`
 
-**Why it fails:** already-merged presentation changes may make every screenshot prove
-the retired product version.
+**Trap:** rebasing onto a stale local `canary` and screenshotting the retired
+product version.
 
-**Correct approach:** fetch `origin canary`, record the resolved SHA, and verify it is
-an ancestor of the test branch before starting the evidence environment.
+**Rule:** fetch `origin canary`, record the resolved SHA, and verify it is an
+ancestor of the test branch before starting the evidence environment.
 
-### L-S4 — Tearing down before asynchronous verification settles
+### L-S5 — Driving a CDP port without proving its owner
 
-**Wrong approach:** stop the dev server or workflow dependencies when the main agent
-operation finishes or the first verification snapshot appears stuck.
+`since 2026-07-30` · `holds-while: electron-dev.sh start treats any reachable CDP port as "already running", and app-probe checks a product-level marker only`
 
-**Why it fails:** verification and repair can start minutes later and may still own
-pending operations.
+**Trap**, three shapes: 9222 belongs to another Electron project; it is LobeHub
+but a sibling worktree's instance (the first `electron-dev.sh` started owns
+9222/5173, and a product marker passes for every worktree); or the pool port is
+owned by a different debugger — `wrangler`/`workerd` defaults to 9229, which is
+pool id 7, and `electron-dev.sh start <id>` skips the launch with
+`CDP already reachable`.
 
-**Correct approach:** monitor verification results, repair-operation links, and the
-bound Task until a stable terminal state. Keep every required dependency alive until
-the final round settles or a concrete non-progress failure is proven.
-
-### L-S5 — Trusting CDP port 9222 without verifying its owner
-
-**Wrong approach:** attach to port 9222 and assume it belongs to the LobeHub dev
-Electron instance.
-
-**Why it fails:** another Electron project can own the universal default port, while
-the user's LobeHub instance may expose no debugging port at all.
-
-**Correct approach:** verify the owning process path and probe a LobeHub-specific
-renderer marker before collecting evidence. If needed, start an isolated pool
-instance on a distinct port rather than guessing.
-
-**Same failure, second shape — the instance is LobeHub, but a different worktree.**
-A product-level marker passes for every worktree, so it cannot answer the question
-that matters: does this renderer serve _my_ working tree? Sibling worktrees each run
-their own `electron-dev.sh` legacy instance, and the first one started owns the
-default CDP 9222 and Vite 5173. Ask the renderer for the absolute source path of a
-module the change touches — the dev transform embeds it — and require both the
-worktree path and a marker unique to the change:
+**Rule:** before collecting evidence, require all three: an Electron `Browser`
+string on `/json/version` (a `wrangler/*` or `node` answer → pick another id),
+a LobeHub renderer marker, and _your_ worktree's absolute source path plus a
+marker unique to the change:
 
 ```bash
 agent-browser --cdp 9222 eval "(async()=>{const t=await (await fetch('app://renderer/<repo-relative>.tsx')).text();return t.match(/_jsxFileName = \"[^\"]*\"/)[0]+' '+t.includes('<CHANGE_MARKER>')})()"
 ```
 
-A wrong-worktree hit means the instance is someone else's session: do not restart or
-reuse it, start a pool instance (`electron-dev.sh start <id>`) or switch surface.
+A wrong-worktree hit is someone else's session: never restart or reuse it —
+start a pool instance (`electron-dev.sh start <id>`) or switch surface.
 
-**Same failure, third shape — the pool port is not owned by Electron at all.**
-`electron-dev.sh start <id>` treats a reachable `CDP_BASE + id` as "already running"
-and skips the launch with `CDP already reachable on <port>. Skipping start`, so the
-run then drives whatever owns it. Any other debugger on that port claims the slot —
-`workerd`/`wrangler` defaults to 9229, which is pool id 7. The give-away is that
-`electron-dev.sh list` does not list the instance as up while the port answers.
-Before picking a pool id, read `/json/version` on its port and require an Electron
-`Browser` string (a `wrangler/*` or `node` answer means pick another id), or check
-the port is free at all.
+### L-S7 — Capturing evidence through a Vite that predates the code
 
-### L-S6 — Reading or writing the url from a portal'd sidebar on desktop
+`since 2026-08-06` · `holds-while: test-env.sh does not compare its resolved PORT with the running server, and nothing restarts Vite on a stale .vite/deps`
 
-**Wrong approach:** use `useSearchParams`, `useQueryState`, `useParams`,
-`useLocation`, `useNavigate`, or a bare `<Link>` inside a component that a route
-layout registers through `NavPanelPortal`, and verify it only on web.
+**Trap**, four shapes: the fixed version is in `node_modules` but a Vite started
+before the install serves the old bundle for its lifetime; a leftover server
+listens on a port that no longer matches `test-env.sh`, and the SPA dies with
+`Failed to fetch dynamically imported module` while every module still returns
+200 to `curl`; after a `git stash` the server keeps serving deleted files with
+200; the dep optimizer wedges — `.vite/deps/*` answers 504 with a clean console
+and `vite connected`.
 
-**Why it fails:** the desktop shell renders every registered sidebar outside the
-per-tab routers, so React context binds those hooks to the root router, whose
-location never moves. A write lands on a router no page reads and a read resolves
-the boot url. Both are silent: the sidebar renders normally and web is unaffected,
-so the defect looks like unrelated page logic. Verified twice in this catalogue's
-lifetime — as a topic-switch failure that made the generation page ignore its own
-send button, and as a library tree that never expanded to the open folder.
+**Rule:** prove the served bundle carries the change — fetch the relevant
+`/node_modules/.vite/deps/*` chunk and grep a marker that cannot collide
+(`SkillRow` also matches `addSkillRow`) — or restart the Vite **process**
+(touching the config wedges the optimizer). Compare the running port with
+`test-env.sh`'s resolved `PORT`; on a mismatch `stop-dev` and restart, and the
+restarted server is yours to stop at teardown. On 504s from `.vite/deps`,
+`rm -rf node_modules/.vite/deps` and restart Vite alone (`bun run dev:spa` is
+its own process; reuse the same env file, leave the Next tree untouched).
 
-**Correct approach:** in any shell-rendered tree, read through the active-tab
-facades (`useActiveLocation`, `useActiveRouteParams`) and navigate through
-`useWorkspaceAwareNavigate` / `appNavigate`, keeping `<Link>` only for its href
-with the click handled by the facade. Note that no active-tab twin exists for
-search params: express a param write as a facade navigation rather than
-`setSearchParams`. When the state is a url ⇄ store sync owned by the page, mount
-it in the route layout instead, and cover it with a test that asserts which router
-received the write — a test that only asserts a write happened passes on the
-broken topology too.
+### L-S8 — Reading a first-boot renderer crash as a defect of the change
 
-### L-S7 — Verifying a dependency-level fix through a dev server that predates the install
+`since 2026-08-10` · `holds-while: electron-dev.sh start reports Ready before the renderer is interactive`
 
-**Wrong approach:** confirm the fixed version exists in `node_modules`, then capture
-behavioral evidence through an already-running Vite dev server.
+**Trap:** the desktop Vite renderer serves a partially initialized module graph
+on the first boot after a cold start; the app sits on the HTML shell with
+`rootChildren: 0` and a TDZ `ReferenceError` from the router config.
 
-**Why it fails:** Vite pins its optimized dependency bundle at server boot. A server
-started before (or during) the `pnpm install` that brought the fix serves the old
-dependency code for its entire lifetime — the browser provably executes code that no
-longer exists on disk, and the evidence contradicts the source. An in-process restart
-via touching the Vite config can wedge the optimizer (new dep URLs 504); only a real
-process restart is trustworthy.
-
-**Correct approach:** before capturing evidence for a dependency-level change, prove
-the served bundle carries it — fetch the relevant `/node_modules/.vite/deps/*` chunk
-from the dev server and grep for a marker of the fix — or restart the dev server
-process outright and re-verify.
-
-**Same failure, second shape — a dev server that was already running when the run
-started.** A leftover server can be listening on a port that no longer matches what
-`test-env.sh` resolves, serving a dep graph optimized against a different config. The
-SPA then dies at the ErrorBoundary with `TypeError: Failed to fetch dynamically
-imported module: …/_layout/index.tsx`, which reads exactly like a broken route tree in
-the branch under test — while every module in that graph still returns 200 to `curl`,
-because the served copy and the requested copy disagree, not the source. Before
-attributing any module-load failure to the change under test, compare the running
-server's port with `test-env.sh`'s resolved `PORT`; on a mismatch, `stop-dev` and
-restart before diagnosing anything. The restarted server is then yours to stop at
-teardown even though you did not start the original.
-
-**Same failure, third shape — files removed from the working tree still being served.**
-After a `git stash` used to capture a "before" frame, the dev server can keep serving the
-pre-stash transform: a file deleted from disk still answers **200** and the module body still
-contains the new code. Reloading the page does not help. Restart the process (and clear
-`node_modules/.vite`) before capturing, and gate the capture on a marker that cannot collide
-with unrelated identifiers — a component name like `SkillRow` also matches a CSS class such as
-`addSkillRow`, so a substring count "confirms" the wrong state.
-
----
-
-**Same failure, fourth shape — the dep optimizer is wedged, and only Vite needs
-restarting.** The SPA sits on the HTML loading shell (`rootChildren: 0`, `innerText`
-empty) with a clean console and `vite connected` — no error anywhere. Crawling the
-module graph from the entry is what names it: every direct import returns 200 while
-`node_modules/.vite/deps/*` answers **504**, so `import()` of the entry fails with the
-generic `Failed to fetch dynamically imported module`, which reads like a broken route
-tree in the branch under test. Recovery is `rm -rf node_modules/.vite/deps` plus a real
-Vite process restart — and Vite is its OWN process here (`bash -c source /tmp/dev-env.sh
-&& bun run dev:spa`), independent of the `next dev` tree, so a shared worktree's Next
-server does not have to be touched. Reuse the same env file the running pair was
-started from rather than re-deriving it.
-
-### L-S17 — Diagnosing the feature when the dev DB lost its seeded user row
-
-**Wrong approach:** see the product's own list endpoint return `{ items: [] }` and its
-write endpoints fail, and start debugging the query, the scope filter, or the change
-under test.
-
-**Why it fails:** the dev server resolves `ctx.userId` for the seeded account without
-needing a `sessions` row, so a database that lost its `users` row still reads as
-authenticated: `setup-auth.sh status --surface web` reports green, every read returns
-an empty result, and every write dies inside Postgres on the `user_id` foreign key.
-The tRPC error surfaces as a giant `Failed query: insert into "acceptances" …` whose
-FK cause is only visible in the params tail, so it reads as a schema or payload
-problem rather than a missing row. The managed acceptance Postgres is shared and
-long-lived, so a `clean-db` from any worktree leaves every later run in this state.
-
-**Correct approach:** when reads are empty AND writes fail, check the row before the
-code — `select id from users` in the DB the server actually uses. Resolve that DB from
-the env file the running server was launched with, never from `test-env.sh` defaults;
-a dev server started by another session can point somewhere else entirely. Re-seed with
-`init-dev-env.sh seed-user`, then prove the fix with a real product write (an `ensure`
-round-trip), and re-run `setup-auth.sh web-seed` because the SPA's client-side auth
-gate still redirects to `/signin` after the row is recreated.
-
-### L-S20 — Bootstrapping the isolated stack with the script's default DB port hits another project's Postgres
-
-**Wrong approach:** run `init-dev-env.sh setup-db` / `seed-user` / `dev` from a fresh
-worktree and trust "database migration pass" plus a started server.
-
-**Why it fails:** the script defaults to `DB_PORT=5433` / `REDIS_PORT=6380`, but on a
-machine where those ports were already taken the managed containers were created on
-5434 / 6381 (`docker ps` shows `lobehub-agent-testing-postgres` → `0.0.0.0:5434`). The
-default then dials whatever owns 5433 — another project's Postgres — and fails with
-`password authentication failed` (`routine: 'auth_failed'`), or worse, succeeds against
-a database that is not ours. The dev server started in that state serves a healthy page
-whose every tRPC write fails far from the cause.
-
-**Correct approach:** read the managed containers' host ports from `docker ps` first and
-pass them explicitly to every subcommand and to the backgrounded `dev`
-(`DB_PORT=5434 REDIS_PORT=6381 init-dev-env.sh …`). Treat a `migrate` that fails with
-`auth_failed` as a port mismatch, never as a credentials problem.
-
-### L-S8 — Reading a first-boot renderer crash as a defect of the change under test
-
-**Wrong approach:** treat the Electron dev instance's first renderer boot as
-representative, and diagnose a `ReferenceError: Cannot access '<X>' before
-initialization` thrown from the desktop router config as a bug in the branch.
-
-**Why it fails:** the desktop Vite renderer can serve a partially initialized
-module graph on the very first boot after a cold start (dependency optimization
-runs concurrently with the first evaluation). The app stays on the HTML loading
-shell with `rootChildren: 0` while the stores are already exposed, which reads
-exactly like a broken route tree. A single `location.reload()` boots it cleanly
-with no code change.
-
-**Correct approach:** on a first-boot renderer error, reload once and re-probe
-before drawing any conclusion. Only if the error survives a reload does it belong
-to the code. Never attribute it to the change under test without that A/B — and
-note that `electron-dev.sh start` reports "Ready" even when the renderer never
-became interactive, so its own readiness line is not the gate.
+**Rule:** reload once and re-probe before any conclusion. Only an error that
+survives the reload belongs to the code.
 
 ### L-S9 — Trusting "migration pass" on the shared acceptance Postgres
 
-**Wrong approach:** run `init-dev-env.sh migrate` in a worktree whose branch adds a
-migration, read `✅ database migration pass`, and start seeding fixtures against the
-new tables.
+`since 2026-08-16` · `holds-while: init-dev-env.sh migrate trusts drizzle's pass line, and every worktree shares lobehub-agent-testing-postgres`
 
-**Why it fails:** the managed `lobehub-agent-testing-postgres` container is shared by
-every worktree, and drizzle decides what to apply by comparing each journal entry's
-`when` timestamp against the newest `created_at` in `drizzle.__drizzle_migrations` —
-not by hash or by index. A sibling worktree that applied its own same-numbered
-migration a few minutes later leaves a newer row, after which your migration is
-skipped in silence and the command still reports success in \~40ms. Every later probe
-then fails as `relation ... does not exist`, which reads like a broken schema import
-rather than a migration that never ran.
+**Trap**, two shapes: drizzle applies journal entries by `when` vs the newest
+`created_at`, so a sibling worktree's same-numbered migration applied minutes
+later makes yours skip silently with `✅ database migration pass` in \~40ms and
+`relation ... does not exist` later; and a sibling suite truncates `postgres`
+repeatedly, so a seeded user is gone seconds after `seed-user` reports success
+(web auth 401 on `/api/auth/sign-in/email`).
 
-**Correct approach:** after any migrate, assert the tables/columns your fixtures need
-actually exist (`select tablename from pg_tables where tablename like '<prefix>%'`)
-rather than trusting the pass line. When it was skipped, apply the branch's SQL
-directly — strip `--> statement-breakpoint` and run it with `psql -v ON_ERROR_STOP=1`
-— and treat the collision as a local multi-worktree artifact, never as a defect of
-the branch or of canary (the numbers get rebased on merge).
-
-**Same container, second shape — a sibling session truncates the data out from under
-you.** The tables can be perfectly migrated and still hold none of your fixtures: a
-worktree running the repo's DB test suites seeds and truncates `postgres` repeatedly,
-so a seeded user is gone seconds after `seed-user` reports success. It surfaces as
-web auth failing with `401` on `/api/auth/sign-in/email` while the seed command keeps
-printing the same credentials — nothing points at the database. Confirm by listing
-the table (`select id, email from users`) right after seeding and looking for rows
-that are not yours (`test-user-id` and friends are another suite's fixtures).
-
-Do NOT wait it out and do NOT reset the shared database — that destroys the other
-session's run. Create your own database inside the same container and point the whole
-run at it:
+**Rule:** after any migrate, assert the tables your fixtures need
+(`select tablename from pg_tables where tablename like '<prefix>%'`); if
+skipped, run the branch's SQL with `psql -v ON_ERROR_STOP=1` after stripping
+`--> statement-breakpoint`, and treat the collision as a local artifact. Never
+wait out or reset the shared database — create your own inside the container:
 
 ```bash
 docker exec lobehub-agent-testing-postgres psql -U postgres -c "CREATE DATABASE <run>"
 docker exec lobehub-agent-testing-postgres psql -U postgres -d "CREATE EXTENSION IF NOT EXISTS vector" < run > -c
 export DATABASE_URL="postgresql://postgres:postgres@localhost:5433/<run>"
-# migrate / seed-user / dev all inherit it; drop the database at teardown
 ```
 
-`init-dev-env.sh` honours an inherited `DATABASE_URL` (PROJECT.md §2), so nothing else
-about the run changes. Drop the database when finished and verify the shared one still
-holds the other session's rows.
-
-### L-S10 — Judging popover/menu behaviour from a Chrome MCP tab (it is hidden)
-
-**Wrong approach:** drive the debug-proxy page through the Chrome MCP tools, click a
-popover trigger, read the DOM \~500ms later, see no popup, and conclude the trigger is
-broken — then bisect, revert a refactor, and write up a root cause from those readings.
-
-**Why it fails:** the MCP tab is not the foreground tab. Measured inside it:
-`document.visibilityState === 'hidden'`, `requestAnimationFrame` delivers **0 frames**,
-and `setInterval(16ms)` fires **once per second** (Chrome's background throttling). A
-base-ui popup still opens in its store and mounts in the DOM, but its entry transition
-never advances, so it sits at `data-starting-style` with `visibility: hidden` and zero
-size — indistinguishable from "the click did nothing". Anything else timed from that
-tab (perceived latency, "it landed 7 seconds later") is an artifact of the same
-throttling, not of the code under test.
-
-**Correct approach:** in an MCP tab, assert on **state**, not on visibility — the
-component's own store/props (`handle.store.state.open`, a probed React state), or DOM
-presence with `data-open`, never `visibility`/painted pixels or a rAF-timed measurement.
-Confirm the tab's own health first (`visibilityState`, a rAF frame count) before
-trusting any negative UI observation, and get behaviour that depends on animation or
-input timing confirmed in a foreground tab — the user's window, or a screenshot-based
-check that tolerates a frozen transition. A negative result from a hidden tab is not
-evidence of a defect.
-
-### L-S11 — Bundled SPA HTML is not the whole site
-
-**Wrong approach:** collect only tags and CSS `url()` from `index.html`, then treat
-a Vite/webpack `dist` as publishable.
-
-**Why it fails:** hashed images and public sprites live in the JS bundle
-(`new URL('hero-….png', import.meta.url)`, `href: '/icons.svg#…'`). HTML-only
-collection ships CSS/JS and drops the files the app actually paints. Those JS
-references also cannot be inlined as data URIs: `import.meta.url` and SVG
-`<use href="/icons.svg#id">` need real sibling/root files.
-
-**Correct approach:** walk collected JS the same way as CSS. Keep
-`import.meta.url` targets and root-absolute sprites as sidecars even when they
-are under the inline size limit. Judge a Vite publish by the running page
-(images, icons, counter), not by whether `index.html` listed three tags.
-
-### L-S12 — macOS `/tmp` and `/private/tmp` are the same workspace
-
-**Wrong approach:** treat a Files-tree path and the topic working directory as
-outside each other when one string starts with `/tmp` and the other with
-`/private/tmp`.
-
-**Why it fails:** Darwin's `/tmp` is a symlink to `/private/tmp`. Electron's
-project index reports the real path; topic cwd is often the public alias. A
-prefix check then marks `./app.css` as an escape, HTML-only publish keeps the
-relative hrefs, and the live host 404s those files.
-
-**Correct approach:** canonicalize those Darwin private aliases before workspace
-containment. Prove a publish by fetching the public HTML (data URIs or 200
-sidecars) and opening the live page — in-app preview of the local file does not
-prove the hosted assets.
-
-### L-S13 — Treating a workspace another session has rewritten as your own code
-
-**Wrong approach:** edit and verify in place in this repo, and when the screenshots
-stop matching the source, suspect the Vite cache or your own CSS — restarting the
-dev server, adding more changes, and capturing again.
-
-**Why it fails:** a second session can be working on the same worktree. Its rebase
-helper stashes the **entire working tree** (stash message shaped like
-`pre-rebase2-<pr>-<sha>`), rebases the branch, and pops later; a conflicted pop
-leaves `<<<<<<<` markers inside the other session's files and breaks the whole SPA
-build. Both phases point away from the real cause: first "my change is written but
-has no effect" (the file was actually reverted to its HEAD version), then "the app
-will not open" (a conflict marker in someone else's file). Either one sends you
-debugging code you never broke.
-
-**Correct approach:** confirm your change is still on the tree both before and after
-capturing evidence — the file appears in `git status` and a marker unique to your
-change greps. On a mismatch, read `git stash list` timestamps and `git reflog`
-before suspecting the build cache. When your work has been stashed, recover only
-your own file with `git checkout stash@{n} -- <your file>`; **never pop or drop the
-whole stash** — it belongs to the other session, and popping it is that session's
-own action. When you find conflict markers in someone else's file, wait for them to
-resolve it rather than resolving it for them.
+`init-dev-env.sh` honours the inherited `DATABASE_URL` (PROJECT.md §2). Drop
+the database at teardown and verify the shared one still holds the other
+session's rows.
 
 ### L-S14 — Claiming an image property from the prompt that asked for it
 
-**Wrong approach:** satisfy a requirement about a generated image (transparent
-background, exact aspect ratio, no text) by adding that wording to the prompt, then
-publish the prompt diff, a unit test asserting the wording, and a screenshot of the
-result as proof.
+`since 2026-08-20` · `holds-while: always`
 
-**Why it fails:** the property lives in the returned bytes, not in the request. LobeHub's
-preferred artwork model returns JPEG, so an alpha channel is impossible regardless of
-wording — and asked for "a transparent background" the model _paints_ the grey-white
-checkerboard that UIs use to depict transparency. Both failures look correct in a
-screenshot and pass any prompt-level assertion.
+**Trap:** "transparent background" is added to the prompt and proven by the
+prompt diff and a screenshot; the artwork model returns JPEG (no alpha possible)
+and paints a checkerboard.
 
-**Correct approach:** verify the produced artifact — decode it and assert the property
-numerically (alpha at the corners vs the subject, encoded format signature, dimensions),
-and where the property is compositional, show the artifact over a contrasting surface.
-When the model cannot deliver the property, produce it in code after generation rather
-than re-wording the prompt.
-
-### L-S15 — Trusting a lockfile-false workspace's node\_modules to track current specs
-
-**Wrong approach:** debug a "missing export" build failure in a workspace with
-`lockfile: false` by bumping package.json specs or running `pnpm up`, assuming the
-next install re-resolves.
-
-**Why it fails:** pnpm keeps a hidden `node_modules/.pnpm/lock.yaml` that freezes
-prior resolutions even with `lockfile: false`; `pnpm install` and `pnpm up` can
-report success while every symlink stays on the stale version. CI never hits this
-because it installs from scratch.
-
-**Correct approach:** when installed versions contradict fresh-resolution
-expectations, delete the hidden `node_modules/.pnpm/lock.yaml` (or the whole
-node\_modules) in the affected workspace root and reinstall, then re-verify the
-actual resolved version via the importing package's symlink.
+**Rule:** decode the produced bytes and assert the property numerically (alpha at
+corners vs subject, format signature, dimensions); show compositional properties
+over a contrasting surface. When the model cannot deliver it, produce it in code
+after generation.
 
 ### L-S16 — Treating a listening dev-server process as a healthy long-run probe
 
-**Wrong approach:** use process existence, an open TCP connection, or an unbounded
-`curl` as the health signal for an unattended LobeHub soak.
+`since 2026-08-26` · `holds-while: project probe scripts carry no connect/total timeouts`
 
-**Why it fails:** Next dev can remain alive and accept a TCP connection while never
-returning an HTTP response. An unbounded probe then blocks the monitor itself, so the
-log stops exactly when the failure begins and makes the run look shorter rather than
-recording an unhealthy interval.
+**Trap:** Next dev stays alive and accepts TCP while never answering HTTP; an
+unbounded `curl` blocks the monitor exactly when the failure begins.
 
-**Correct approach:** give every HTTP and CLI probe explicit connect and total
-timeouts, record timeout/`000` as an observation, and keep the monitor advancing.
-Prove recovery with a successful application request after restarting the owned
-server; neither a PID nor a listening socket is sufficient.
+**Rule:** explicit connect and total timeouts on every probe, record `000` as an
+observation, keep the monitor advancing, and prove recovery with a successful
+application request.
 
-### L-S17 — Starting the dev server by a relative path, and getting the main checkout's SPA
+### L-S17 — Diagnosing the feature when the dev DB lost its seeded user row
 
-**Wrong approach:** in a worktree under `.claude/worktrees/<name>/`, invoke
-`.agents/acceptance/scripts/init-dev-env.sh dev` by its relative path and assume the
-resulting dev server serves the worktree. Then, when the feature never fires, look for
-the bug in the feature: check the lab flag, the store hydration, the click handler.
+`since 2026-09-01` · `holds-while: setup-auth.sh status reports green without a users row`
 
-**Why it fails:** `REPO_ROOT` is derived from the invocation path
-(`dirname "$0"/../../..`), and `cmd_dev` does `cd "$REPO_ROOT"` before `bun run dev`,
-which spawns Vite with that inherited cwd. A worktree-isolated session's shell cwd can
-silently reset to the main checkout between tool calls, so the very same relative
-command starts the **main checkout's** stack instead. Nothing looks wrong: the port
-answers, auth succeeds, `task.create` returns 200, the page renders the current
-product. Only the code under test is absent, because the SPA is a different tree.
-Fetching the module through the Next origin does not reveal it either — unknown `/src/*`
-paths fall through to the SPA HTML shell, so a `grep` for your symbol "fails" against
-`<!DOCTYPE html>` and reads as a stale bundle.
+**Trap:** the list endpoint returns `{ items: [] }` and writes die on the
+`user_id` foreign key inside a giant `Failed query: insert …`; auth still reads
+green because `ctx.userId` needs no `sessions` row.
 
-**Same failure, quality-gate shape.** The silent cwd reset also sends `bun run check`
-and `bunx vitest run` to the MAIN checkout, where the same relative test paths exist in
-their pre-change form — the run prints `lint clean · tests N passed` against files your
-edits never touched, and a regression test you just added "passes" without ever
-executing. The tell is the count: fewer tests reported than the file now declares —
-though the number alone cannot be trusted either way, since `it.each` expands one
-declaration into many executed cases. Before trusting any gate result in a worktree
-session, `pwd` (or prefix the command with an explicit `cd <worktree> &&`) and
-confirm the NAME of the test you just added appears in the runner's output.
-
-**Correct approach:** invoke the script by absolute path from the worktree, and before
-capturing any evidence prove the SPA's identity rather than the server's liveness:
-resolve the Vite pid from its port and read its cwd
-(`lsof -a -p <pid> -d cwd -Fn`), then fetch the changed module **from the Vite origin
-directly** (the port in the `Debug Proxy` line, not the Next port) and require a marker
-unique to the change. A behavioural probe is equally decisive and cheaper: drive the
-feature once and assert its server call appears in the log — an absent call with a
-successful sibling call is this failure, not a client bug. Related but distinct:
-\[\[L-S7]] is a stale bundle from the _right_ tree; this is a healthy bundle from the
-_wrong_ tree.
-
-### L-S18 — Calling a fix verified without reproducing the failure's precondition
-
-**What happened.** A "draft stays in the composer after the task is created"
-bug was declared fixed across four separate rounds (r5 / r7 / r8 / r9) and was
-still fully present. Each verification ran against a task list that _already had
-tasks in it_, and the bug only exists on the empty→non-empty transition — that
-transition is what swaps the composer for a different component instance. Every
-"fix" ran green on a page where the failure could not occur.
-
-Two false root causes were shipped on the way: a stale editor handle (the handle
-is `useMemo(..., [])`, it was never stale) and a Lexical update landing outside
-the React event batch. Both were reasoned by analogy to other call sites rather
-than measured.
-
-**Rule.** Before verifying a fix, first reproduce the failure and write down the
-precondition that makes it appear. Then verify with that precondition held. A
-verification run that cannot fail proves nothing, and a green result on it is
-worse than no result — it retires the bug from the todo list.
-
-**Tell.** The bug reproduces "sometimes" or "only on the first try". That is not
-flakiness; it is an unnamed precondition. Find it before touching the code.
-
-**Tell.** The unit tests pass and the real app still breaks. Check what the test
-mocks: here `cleanDocument` was `vi.fn()`, so the tests asserted the call was
-made and could never observe that it landed on a dead instance. When the mocked
-seam _is_ the suspect, drop the mock and drive the real thing — a 20-line probe
-with the real editor kernel settled in one run what four rounds of analogy had
-not.
+**Rule:** when reads are empty AND writes fail, `select id from users` in the DB
+the running server actually uses (from the env file it was launched with, never
+`test-env.sh` defaults). Re-seed with `init-dev-env.sh seed-user`, prove with a
+real write, and re-run `setup-auth.sh web-seed` — the SPA auth gate still
+redirects to `/signin` after the row is recreated.
 
 ### L-S19 — Putting your own work plan into `result.json` `plan[]`
 
-**What happened.** A round's `plan[]` was filled with the agent's task list —
-"find the root cause", "fix it and add a regression test", "record the flows" —
-instead of acceptance criteria. `plan[]` is the _frozen check plan_: every item
-is a check that must be executed by a case with the same `id`, and a planned
-item with no case renders as **未执行** rather than vanishing. The three items
-had no `id`, so the server numbered them `case-1..3` and three permanent
-`not executed` gate checks appeared on the user's acceptance board — gates that
-can never pass, on work that was in fact complete.
+`since 2026-09-02` · `holds-while: ingest prints "N planned but not executed" as a summary line and still publishes`
 
-**Rule.** `plan[]` holds only what the _user_ would accept or reject, each with
-a stable `id` that a case in the same round fulfills. Your own steps —
-investigate, fix, test, record — are not checks. If a round has one criterion,
-`plan[]` has exactly one item.
+**Trap:** `plan[]` filled with the agent's task list ("find the root cause",
+"fix and add a test"); items without `id` are numbered `case-N` and render as
+permanent **未执行** rows on the user's board.
 
-**Rule.** Read the ingest summary line. `plan: N item(s) — N planned but not
-executed — M unplanned case(s)` is not cosmetic: it says the plan and the
-results do not line up, and the board is about to render rows nobody can clear.
-A clean round prints `plan: N item(s)` with nothing after it.
+**Rule:** `plan[]` holds only what the user would accept or reject, each with a
+stable `id` a case in the same round fulfills; one criterion → one item. Read
+the ingest summary line: clean is `plan: N item(s)` with nothing after. Repair by
+folding bogus ids into the real check with `supersedes: ['case-1', …]` in the
+next round — never `run delete`, which destroys the round's real evidence too.
 
-**Repair.** Fold the bogus ids into the real check with
-`supersedes: ['case-1', ...]` in the next round. Prefer this over
-`lh acceptance run delete`: deleting the round to hide a bookkeeping error also
-destroys the real results and evidence it carried, and rounds are immutable
-snapshots.
+### L-S20 — Bootstrapping the isolated stack on the script's default DB port
+
+`since 2026-09-03` · `holds-while: init-dev-env.sh defaults DB_PORT=5433 / REDIS_PORT=6380 instead of reading the managed containers' ports`
+
+**Trap:** on a machine where the managed containers were created on 5434/6381
+(`docker ps` → `lobehub-agent-testing-postgres` on `0.0.0.0:5434`), the default
+dials another project's Postgres — `password authentication failed`
+(`routine: 'auth_failed'`), or worse, a successful migrate against a database
+that is not ours, followed by a healthy page whose every tRPC write fails.
+
+**Rule:** read the host ports from `docker ps` first and pass them to every
+subcommand and to the backgrounded `dev`
+(`DB_PORT=5434 REDIS_PORT=6381 init-dev-env.sh …`). `auth_failed` on migrate is
+a port mismatch, never a credentials problem.
+
+### L-S21 — Starting the dev server by a relative path from a worktree
+
+`since 2026-09-01` · `holds-while: init-dev-env.sh derives REPO_ROOT from its invocation path, and a worktree session's shell cwd can reset to the main checkout between tool calls`
+
+**Trap:** `.agents/acceptance/scripts/init-dev-env.sh dev` by relative path
+starts the **main checkout's** stack: the port answers, auth succeeds, the page
+renders — only the code under test is absent. The same reset sends
+`bun run check` / `bunx vitest run` to main, where the pre-change test files
+"pass". Fetching `/src/*` through the Next origin falls through to the SPA shell,
+so a marker grep "fails" against `<!DOCTYPE html>` and reads as a stale bundle.
+
+**Rule:** absolute paths from the worktree. Before evidence, prove the SPA's
+identity: resolve the Vite pid from its port and read its cwd
+(`lsof -a -p <pid> -d cwd -Fn`), fetch the changed module from the **Vite**
+origin (the Debug Proxy port) and require a unique marker — or drive the feature
+once and require its server call in the log. Before trusting any gate,
+`pwd`/`cd <worktree> &&` and confirm the NAME of the test you added appears in
+the runner output. Distinct from L-S7: that is a stale bundle from the right
+tree; this is a healthy bundle from the wrong tree.

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -5,6 +5,103 @@ together with the agent-testing skill's generic `references/probe-mock-patterns.
 Product-independent rules belong upstream; LobeHub routes, stores, services, env
 variables, and fixtures belong here.
 
+## Index
+
+Read this block in full, pick entries by meaning, then pull each one by id — the next
+heading bounds it. Do not read the whole file.
+
+```bash
+P=.agents/acceptance/probe-mock-patterns.md
+rg -n '^#{3,4} P07 ' "$P" # start line of one entry
+rg -n '^#{2,4} ' "$P"     # every heading, to find the next bound
+```
+
+`applies-to` filters a round: **surface** = web / electron / cli / any; **runtime** = client /
+gateway / hetero / any (the agent runtime the recipe depends on); **phase** = env / auth / fixture /
+drive / probe / capture / publish. Skip a row only when its surface AND runtime both miss yours.
+
+| id  | surface       | runtime         | phase          | situation                                                                                                                     |
+| --- | ------------- | --------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| P01 | any           | any             | probe          | `window.__LOBE_STORES.<name>()` returns state only; add a dev action instead of HMR `setState` patches                        |
+| P02 | web, electron | any             | probe          | `goto` / `location.assign` full-reload wipes fetch wrappers; change route via `history.pushState` + `popstate`                |
+| P03 | any           | client, gateway | probe          | Prove which runtime ran with a server-only artifact (operation row, queue step, server log)                                   |
+| P04 | web, electron | any             | probe          | A top-level `const` in a second `agent-browser eval` collides; wrap payloads in an IIFE                                       |
+| P05 | web           | any             | drive          | `lobehub-dev` is shared across runs; use a run-specific session and check `location.origin` / script src first                |
+| P06 | electron      | any             | probe          | After adding or moving a module the renderer may keep the old graph; `goto`, then confirm a structural signal                 |
+| P07 | web           | any             | env            | `_dangerous_local_dev_proxy` in a signed-out automation context sits on the loading shell; use the isolated local stack       |
+| P08 | web           | any             | env            | Workspace `packages/*` dynamic imports fail cross-origin through the proxy; A/B at HEAD, use Electron for settled state       |
+| P09 | any           | client, gateway | fixture        | The stub must answer `stream:false` chat/completions with a plain JSON completion, never SSE                                  |
+| P10 | web           | gateway         | fixture        | `review_predict` is pinned to Gemini; pin the constants, allow private IPs, return schema JSON from the stub                  |
+| P11 | any           | gateway         | fixture        | `generateObject` via the deepseek stub crashes; route through the openai `/v1/responses` stub                                 |
+| P12 | web           | gateway         | fixture        | Backdate node and op rows past the client's 15-minute lease, not the server's 5                                               |
+| P13 | web, cli      | any             | fixture        | `lh topic create` rows have NULL trigger/status and drop out of the paged view; set both, then `goto`                         |
+| P14 | web, electron | hetero          | fixture        | Seed `agency_config.heterogeneousProvider` with SQL, then cold-load; the store write drops it                                 |
+| P15 | web           | any             | fixture        | Derive day boundaries from the browser's `resolvedOptions().timeZone`, never an assumed zone                                  |
+| P16 | web, electron | any             | fixture        | Clear cache tiers in the NEW document via `addScriptToEvaluateOnNewDocument`; the outgoing page re-flushes on reload          |
+| P17 | web           | any             | drive          | Goals live at `/agent/:aid/goals` behind the Labs toggle `enableTopicAcceptance`                                              |
+| P18 | electron      | hetero          | fixture        | Local-execution CC agent plus a four-table ledger fixture keyed to the live CLI identity                                      |
+| P19 | web           | any             | auth           | Seed a second user and sign in from inside a run-specific session; a signed-out context hits `/signin`                        |
+| P20 | cli           | any             | fixture        | Strip ambient topic/agent/operation ids for a LOCAL ingest; keep them for the production publish                              |
+| P21 | web           | any             | drive          | Upload through the Add-menu input, poll `dockUploadFileList`, A/B the hashing worker with `window.Worker = undefined`         |
+| P22 | web, electron | any             | drive          | `keyboard type` emits no keydown; fire `/` (and any menu trigger) with `press`                                                |
+| P23 | web, electron | any             | drive          | Tag `svg.lucide-<rendered-name>` and click through agent-browser; `el.click()` on the wrapper does nothing                    |
+| P24 | web, electron | any             | drive          | Re-query elements after every re-render; one assertion per eval                                                               |
+| P25 | web, electron | any             | capture        | Anchor on `#nav-panel-drawer`'s aside sibling; tell skeleton states apart by testid, not row count                            |
+| P26 | web           | any             | capture        | Park the route's own tRPC call with `park-request.cjs`; a broad `*trpc*` pattern stalls the shell                             |
+| P27 | web           | any             | drive          | `SWRConfig` only affects hooks below it; move the hooks into a child component                                                |
+| P28 | electron      | any             | capture        | Raw CDP `Fetch.enable` on the layout chunk holds the sidebar fallback; name the layout module only                            |
+| P29 | web, electron | any             | fixture, drive | Seed via `mkdirDocumentByPath` / `writeDocumentByPath`; rows live in pierre's shadow DOM; hetero agents have no Documents tab |
+| P30 | web, electron | any             | drive          | pierre's focus-visible and truncation-mask contracts when restyling the tree                                                  |
+| P31 | web           | any             | drive          | Row-shape bugs need the real account: foreground the MCP tab, zero-write clicks, in-page event ring buffer                    |
+| P32 | web, electron | hetero          | fixture        | Dispatch a temp assistant message and attach an `AgentRuntimeError` guide code                                                |
+| P33 | web, electron | any             | fixture        | Backfill `pluginState` from each tool message's result after Agent Mock playback                                              |
+| P34 | web, electron | any             | fixture        | Dispatch an assistant+tool pair into an empty conversation; truncate args to reach the Streaming render                       |
+| P35 | web           | gateway         | probe          | Step-boundary `uiMessages` snapshots overwrite the bucket; record `replaceMessages` stacks, A/B with `disableGatewayMode`     |
+| P36 | web           | gateway         | env            | Run the JWT handshake probe after every gateway restart; `/health` 200 proves nothing                                         |
+| P37 | any           | gateway         | env            | QStash / s3rver on fixed ports may belong to a sibling session; read the start log before stopping anything                   |
+| P38 | web           | any             | fixture        | Call the real load-more store action when the fixture is too short for the observer                                           |
+| P39 | web, electron | any             | fixture        | Replace the react-query `mutationFn` with a rejection via HMR so no network call ever fires                                   |
+| P40 | web, electron | any             | drive          | Remount the DevDock panel after a reload; pre-seed `LOBE_DEV_DOCK_UI` to land on it                                           |
+| P41 | web           | client          | fixture, drive | openai speaks `/v1/responses`; the model must be in `enabledAiModels`; set approval `auto-run`                                |
+| P42 | web           | hetero          | fixture, drive | In-page IPC mock feeding stream-json through the real `ClaudeCodeAdapter`, no Electron needed                                 |
+| P43 | web, electron | any             | capture        | Focus and read in one eval, wait past the transition, assert an untransitioned property too                                   |
+| P44 | web, electron | any             | capture        | Inject `html > canvas { display: none }` at capture time and disclose it                                                      |
+| P45 | web           | any             | capture        | Gate on `checkVisibility`, match own text nodes, assert both columns in one pass                                              |
+| P46 | web, electron | any             | capture        | Sample in-page (`addScriptToEvaluateOnNewDocument` or an entry injection), record the max tick gap, mirror the timer          |
+| P47 | web, electron | any             | capture        | Sample opacity in-page at 8 ms and use `Page.startScreencast`; `data-ending-style` is never set                               |
+| P48 | web           | any             | capture        | `localStorage.theme` + reload; assert `dataset.theme`; restore before stopping the server                                     |
+| P49 | electron      | any             | capture        | Prove the hosted URL (curl + open it), not the in-app preview                                                                 |
+| P50 | any           | any             | publish        | Re-running `ingest` mints a duplicate round; re-read with `run list` / `run get` / `view`                                     |
+| P51 | electron      | any             | probe          | Read the loaded entry script per run; never assume `entry.desktop.tsx`                                                        |
+| P52 | electron      | any             | capture        | `DESKTOP_RENDERER_STATIC=1` pool instance; prove the build via modulepreload hashes                                           |
+| P53 | electron      | any             | drive          | Open via `openTopicInNewWindow` and attach raw CDP to the popup target                                                        |
+| P54 | electron      | any             | drive          | `activateTab` alone is a no-op on the single-router shell; click the TabItem element and assert the pathname                  |
+| P55 | electron      | any             | drive          | `addTab` activates; enter the route with `goto` and assert tab / pathname / activeTopicId agree                               |
+| P56 | electron      | any             | capture        | Classify hidden slots on both sides of the switch and use the intersection                                                    |
+| P57 | electron      | any             | capture        | The renderer tracks OS appearance; `themeMode` never applies; mark the dark case untested                                     |
+| P58 | electron      | any             | probe          | i18next stays English until `switchLocale`; decide language from the DOM, not `status.language`                               |
+| P59 | electron      | any             | drive          | `addTab('/')` first; `goto /` alone keeps the restored tab                                                                    |
+| P60 | electron      | any             | auth, env      | Read `dataSyncConfig` first; `storageMode: cloud` means the run must stay read-only                                           |
+| P61 | web, electron | any             | capture        | Stall `indexedDB.open` only on web; it kills the Electron renderer                                                            |
+| P62 | electron      | any             | env            | Keep locale tests out of `packages/locales/src/default/` or the renderer imports vitest                                       |
+| P63 | cli           | gateway         | auth           | `lh task run --follow` needs OIDC; poll with `task view`; use internal ids for `--subject task:`                              |
+| P64 | web           | any             | auth           | No seeded session for the debug proxy; drive the user's Chrome and add DOM measurements                                       |
+| P65 | electron      | any             | auth, env      | Start the server on the snapshot's port with `SERVER_PORT=`; inject a better-auth cookie over CDP                             |
+| P66 | electron      | any             | auth           | `safeStorage` cannot decrypt the copied token; fall back to the legacy single instance                                        |
+| P67 | electron      | any             | auth, env      | Read the port from `/tmp/electron-dev.log`, mint a session, `Network.setCookie`                                               |
+| P68 | electron      | any             | auth, env      | Pool logs are `instance-<id>.log`; fix the port and start the server before Electron                                          |
+| P69 | electron      | any             | fixture        | Snapshot `dist/renderer` before building so the manifest differs from the local tree                                          |
+| P70 | any           | any             | env            | `.records/runtime/` holds the owned server's PID and ports; poll that port                                                    |
+| P71 | web           | any             | env            | `lsof` the listener, kill only the run-owned tree, restart, reseed auth                                                       |
+| P72 | web, electron | any             | env            | Two copies of a dep produce context errors; `pnpm dedupe`; local-only, never a branch defect                                  |
+| P73 | web           | any             | env            | Install without `--ignore-scripts` and `rm -rf .next`; turbo-tasks panics are disposable cache                                |
+| P74 | electron      | any             | env            | The desktop install duplicates `@types/react`; intersect errors with changed files, A/B after evidence                        |
+| P75 | electron      | any             | env            | Run the Model B desktop command in a long-lived PTY                                                                           |
+| P76 | any           | any             | env            | Prefix git and check commands with `cd <worktree>`; read the diffstat before pushing                                          |
+| P77 | web, cli      | gateway         | probe          | Read `llm_generation_tracing.prompt_version` after one call; restart the server if stale                                      |
+| P78 | web, cli      | gateway         | env            | `SSRF_ALLOW_PRIVATE_IP_ADDRESS=1` so the server can read local s3rver URLs                                                    |
+| P79 | web, cli      | client, gateway | env            | Local SearXNG with `SEARCH_PROVIDERS=searxng`; the on-disk search1api keys are dead                                           |
+
 ## Choose the least invasive mechanism
 
 1. **Use a supported command** in `scripts/app-probe.sh` for read-only app state.
@@ -69,7 +166,9 @@ belongs to, above `Detailed references`.
 
 ### Probing app state
 
-#### Store exposure
+#### P01 · Store exposure
+
+**applies-to:** surface=any · runtime=any · phase=probe
 
 `window.__LOBE_STORES.<name>` is a function returning the current state. Call it:
 
@@ -81,7 +180,9 @@ It intentionally does not expose Zustand's `getState` or `setState`. If a test
 repeatedly needs mutation, add a dev-only supported action or fixture command
 instead of normalizing temporary `setState` HMR patches.
 
-#### In-SPA navigation that preserves instrumentation
+#### P02 · In-SPA navigation that preserves instrumentation
+
+**applies-to:** surface=web, electron · runtime=any · phase=probe
 
 `app-probe.sh goto` and `location.assign("app://renderer/…")` perform a FULL
 reload — any `window.fetch` wrapper or debug global installed via `eval` is
@@ -97,13 +198,17 @@ This remounts the route component (SWR revalidates, list fetch observable by the
 wrapper) without recreating the JS context. Leave-and-return with this pattern is
 the way to capture a page's first-load request after installing a fetch wrapper.
 
-#### Runtime proof
+#### P03 · Runtime proof
+
+**applies-to:** surface=any · runtime=client, gateway · phase=probe
 
 Client and server agent runtimes can produce the same visible result. Prove the
 runtime with a server-only artifact: operation row, queue step, or enabled
 main/server log namespace. Renderer state alone is not sufficient.
 
-#### `eval` declarations persist in the page global scope
+#### P04 · `eval` declarations persist in the page global scope
+
+**applies-to:** surface=web, electron · runtime=any · phase=probe
 
 **Situation:** running several `agent-browser eval` payloads against one renderer.
 
@@ -114,7 +219,9 @@ shares the page's global scope.
 **Works:** wrap every payload in an IIFE (`(() => { … })()`), or attach state to a
 single namespaced `window.__X` object.
 
-#### Shared agent-browser session names can cross-wire concurrent acceptance runs
+#### P05 · Shared agent-browser session names can cross-wire concurrent acceptance runs
+
+**applies-to:** surface=web · runtime=any · phase=drive
 
 **Situation:** a Web acceptance run uses the adapter's default `lobehub-dev`
 session while another local run is active against a different port.
@@ -144,7 +251,9 @@ assertion about working-tree code, read `location.origin` AND the page's script
 `.records/runtime` resolved. A dead script origin that still renders = disk
 cache, not your build.
 
-#### A new module needs a renderer reload, not HMR, before probing the fix
+#### P06 · A new module needs a renderer reload, not HMR, before probing the fix
+
+**applies-to:** surface=electron · runtime=any · phase=probe
 
 **Situation:** verifying a source fix in the running Electron dev instance
 (`electron-dev.sh`) right after editing.
@@ -160,7 +269,9 @@ adding or moving a module, then re-probe. Confirm the new code is live by a
 structural signal (a renamed component in the fiber chain, a new class in the
 computed cascade) before concluding anything about behavior.
 
-#### Production debug proxy stays on the development loading shell in an isolated browser
+#### P07 · Production debug proxy stays on the development loading shell in an isolated browser
+
+**applies-to:** surface=web · runtime=any · phase=env
 
 **Situation:** verifying a public SPA route with local frontend code against the
 production backend through `/_dangerous_local_dev_proxy`.
@@ -176,7 +287,9 @@ Acceptance fixture through the local CLI, and capture the same route in separate
 authenticated and storage-empty browser contexts. This proves both owner and
 shared-viewer rendering without depending on production browser cookies.
 
-#### The debug proxy cannot reach a settled app — workspace `packages/*` dynamic imports fail cross-origin
+#### P08 · The debug proxy cannot reach a settled app — workspace `packages/*` dynamic imports fail cross-origin
+
+**applies-to:** surface=web · runtime=any · phase=env
 
 **Situation:** verifying frontend work through `/_dangerous_local_dev_proxy` (production
 page + production login + local Vite modules), needing a screenshot of the app after it
@@ -202,7 +315,9 @@ agent-browser session).
 
 ### Seeding fixtures
 
-#### Structured generation through the local OpenAI-compatible stub
+#### P09 · Structured generation through the local OpenAI-compatible stub
+
+**applies-to:** surface=any · runtime=client, gateway · phase=fixture
 
 **Situation:** a real product path uses non-streaming `chat/completions` for
 `generateObject`, while ordinary agent turns use streaming completions against the
@@ -217,7 +332,9 @@ before schema parsing.
 return a standard JSON chat completion for `stream: false`; set `STUB_TEXT` to the
 schema-valid JSON required by the check.
 
-#### Driving the Acceptance AI-review predictor locally: pinned Gemini, image fetch-back, and stub JSON
+#### P10 · Driving the Acceptance AI-review predictor locally: pinned Gemini, image fetch-back, and stub JSON
+
+**applies-to:** surface=web · runtime=gateway · phase=fixture
 
 **Situation:** verifying the ✨ "ask AI to review" round on `/acceptance/<id>` (the
 `review_predict` generation, its toast, the proposal cards) without a real vision key.
@@ -252,7 +369,9 @@ completion whose `content` is parsed as the object. A text-only evidence check i
 Assert the round from three places together: the toast copy (a MutationObserver on
 `document.body`), the rows' `status`/`action`/`created_at`, and the card count.
 
-#### Structured generation crashes on the deepseek provider path — stub via openai instead
+#### P11 · Structured generation crashes on the deepseek provider path — stub via openai instead
+
+**applies-to:** surface=any · runtime=gateway · phase=fixture
 
 **Situation:** driving a server-side `generateObject` scenario (e.g. `verify_plan_gen`)
 through `llm-stub.mjs` when the resolved model config is `deepseek` (the OSS default).
@@ -269,7 +388,9 @@ where slug='verify-agent'`) at the stubbed openai provider. The server-side open
 provider calls `/v1/responses`, which the stub answers correctly for `stream:false`
 structured generation (`llm_generation_tracing.success=t` is the confirmation probe).
 
-#### Forcing the goal frontier 失联 state needs >15 min, not the server's 5
+#### P12・Forcing the goal frontier 失联 state needs >15 min, not the server's 5
+
+**applies-to:** surface=web · runtime=gateway · phase=fixture
 
 **Situation:** A/B-forcing the goal page's 失联 (lost-heartbeat) banner by backdating
 `goal_nodes.updated_at` / `agent_operations.updated_at` with SQL.
@@ -286,7 +407,9 @@ node row and `runHeartbeats` (the running operation's `updated_at` served by
 Restore the forced rows (node/task/task\_topics/operation status + timestamps) after
 capturing.
 
-#### A CLI-created topic has no trigger/status and is filtered out of the Agent paged view
+#### P13 · A CLI-created topic has no trigger/status and is filtered out of the Agent paged view
+
+**applies-to:** surface=web, cli · runtime=any · phase=fixture
 
 **Situation:** building a topic fixture with `lh topic create`, writing fields such as
 `workingDirectoryConfig` into `metadata` with SQL, then opening the UI to verify.
@@ -307,7 +430,9 @@ UI" split is especially misleading.
 more. Keep the assertion order from generic M6: confirm `app-probe.sh topic` returns the
 metadata before asserting anything in the UI.
 
-#### `agent.updateAgentConfig` silently drops `agencyConfig.heterogeneousProvider`
+#### P14 · `agent.updateAgentConfig` silently drops `agencyConfig.heterogeneousProvider`
+
+**applies-to:** surface=web, electron · runtime=hetero · phase=fixture
 
 **Situation:** turning a test agent into a CLI-agent shape (Claude Code / Codex) so
 the heterogeneous chat input and its quota badges render.
@@ -333,7 +458,9 @@ cache, so the renderer still shows the pre-write value (generic M6). Clear
 `Page.addScriptToEvaluateOnNewDocument` and reload (see "Cold SWR cache" above),
 then assert `agentMap[id].agencyConfig` before drawing any conclusion.
 
-#### Day-scoped fixtures must use the browser's measured timezone, not an assumed one
+#### P15 · Day-scoped fixtures must use the browser's measured timezone, not an assumed one
+
+**applies-to:** surface=web · runtime=any · phase=fixture
 
 **Situation:** seeding backdated rows (briefs, activity, digests) whose UI grouping is
 by the viewer's _local calendar day_ (`dayjs().startOf('day')` on the client).
@@ -351,7 +478,9 @@ every `[startAt, endAt)` from that. When a day view comes back empty, diff the
 client's real request window (fetch wrapper on the batch URL) against the seeded
 timestamps before suspecting the query.
 
-#### Cold SWR cache: clearing then reloading is undone by the outgoing page
+#### P16 · Cold SWR cache: clearing then reloading is undone by the outgoing page
+
+**applies-to:** surface=web, electron · runtime=any · phase=fixture
 
 **Situation:** forcing a first-load / skeleton state for anything backed by the
 tiered SWR cache (`recent:*`, `topic:*`, `message:*`, …).
@@ -395,7 +524,9 @@ stale frame separately if you observed it. Pair it with a warm control run: if
 the warm run renders data while the request is held paused and the cold run shows
 the skeleton, the cache tier is proven to be what the render reads.
 
-#### Reaching the Goals page: nested route plus a Labs toggle
+#### P17 · Reaching the Goals page: nested route plus a Labs toggle
+
+**applies-to:** surface=web · runtime=any · phase=drive
 
 **Situation:** accepting goal-related functionality requires opening the Goals page.
 
@@ -419,7 +550,9 @@ skips AI generation of the acceptance criteria (required when there is no local 
 key); the criteria editor and budget field are ordinary inputs, while the goal
 description is contenteditable (use `fill`; `type` does not support contenteditable).
 
-#### Reaching the Claude Code usage calendar: a local-execution agent, a live-CLI identity, and a four-table ledger fixture
+#### P18 · Reaching the Claude Code usage calendar: a local-execution agent, a live-CLI identity, and a four-table ledger fixture
+
+**applies-to:** surface=electron · runtime=hetero · phase=fixture
 
 **Situation:** verifying the quota usage calendar (`AgentQuotaCalendar`), which needs
 both a way to open it and quota history to render.
@@ -467,7 +600,9 @@ renders. Seed the history and the ledger, but never assert on the live window's 
 percentage — read it back from `agent_quota_snapshots` and report what the run
 actually rendered.
 
-#### Shared-viewer (non-owner) evidence needs a second signed-in user — signed-out hits /signin
+#### P19 · Shared-viewer (non-owner) evidence needs a second signed-in user — signed-out hits /signin
+
+**applies-to:** surface=web · runtime=any · phase=auth
 
 **Situation:** capturing how a page renders for someone who is NOT the owner of the
 object (a shared acceptance link, a workspace-member view), on the local full stack.
@@ -494,7 +629,9 @@ await fetch('/api/auth/sign-in/email', {
 Reload and assert identity with `app-probe.sh auth` before capturing. Use a
 run-specific session name, never `lobehub-dev` (that one is the owner).
 
-#### Ambient `LOBEHUB_TOPIC_ID` hijacks a local CLI ingest — strip it for fixture creation
+#### P20 · Ambient `LOBEHUB_TOPIC_ID` hijacks a local CLI ingest — strip it for fixture creation
+
+**applies-to:** surface=cli · runtime=any · phase=fixture
 
 **Situation:** creating a fixture acceptance on the LOCAL dev server with
 `bun src/index.ts acceptance run ingest` while running inside a LobeHub conversation
@@ -513,7 +650,9 @@ there the auto-attach to the current conversation is exactly what you want.
 
 ### Driving the UI
 
-#### Driving a 资源库 upload with agent-browser: use the Add-menu input, and a same-build A/B for the hashing thread
+#### P21・Driving a 资源库 upload with agent-browser: use the Add-menu input, and a same-build A/B for the hashing thread
+
+**applies-to:** surface=web · runtime=any · phase=drive
 
 **Situation:** uploading a multi-GB fixture through the resource library (`/resource`)
 to verify the upload/hash pipeline without a real drag-and-drop.
@@ -541,7 +680,9 @@ marks the end of hashing. A re-upload of the same file still hashes and then ded
 (only `checkFileHash` + `createFile`), so it is a cheap way to re-capture the progress
 UI without another transfer.
 
-#### The composer's slash menu needs real key events — `keyboard type` never opens it
+#### P22 · The composer's slash menu needs real key events — `keyboard type` never opens it
+
+**applies-to:** surface=web, electron · runtime=any · phase=drive
 
 **Situation:** driving the chat composer's `/` slash menu (or anything else gated on
 a Lexical `KEY_DOWN_COMMAND`) through agent-browser.
@@ -571,7 +712,9 @@ Confirm the mechanism rather than assuming a menu is missing:
 agent-browser --session "$RS" eval '(() => { window.__KD=[]; document.addEventListener("keydown", e => window.__KD.push(e.key), true); return "installed"; })()'
 ```
 
-#### An `ActionIcon` is not a `<button>` — select it by its lucide class, click through agent-browser
+#### P23 · An `ActionIcon` is not a `<button>` — select it by its lucide class, click through agent-browser
+
+**applies-to:** surface=web, electron · runtime=any · phase=drive
 
 **Situation:** driving an icon-only affordance inside a popover or panel (`ActionIcon`
 from `@lobehub/ui`: refresh, calendar, more, …).
@@ -614,7 +757,9 @@ and re-tag rather than assuming the control vanished), and a `Tooltip`-wrapped c
 needs a real pointer move (`Input.dispatchMouseEvent` over several coordinates, or a
 dispatched `pointerover`+`mouseover` pair) before its content mounts.
 
-#### A node reference captured before a re-render is silently dead — re-query per assertion
+#### P24 · A node reference captured before a re-render is silently dead — re-query per assertion
+
+**applies-to:** surface=web, electron · runtime=any · phase=drive
 
 **Situation:** asserting several tab-strip interactions (close, pin, switch) in one
 `agent-browser eval` payload, reusing the element list collected at the top.
@@ -631,7 +776,9 @@ stale reference, and it survived review because the number looked plausible.
 share a payload, re-query between actions and assert `el.isConnected` before dispatch.
 The same applies to any probe whose own action re-renders the tree it is measuring.
 
-#### Anchor nav-panel assertions on `#nav-panel-drawer`, not a `data-insp-path` match
+#### P25 · Anchor nav-panel assertions on `#nav-panel-drawer`, not a `data-insp-path` match
+
+**applies-to:** surface=web, electron · runtime=any · phase=capture
 
 **Situation:** asserting what the left nav panel renders on a given route.
 
@@ -656,7 +803,9 @@ identify the fallback by a row count — it is shaped per navKey now
 (`NAV_SKELETON_SHAPES`), so memory/discover render header plus a nav list and no body
 at all, while settings renders a search box plus four accordion groups.
 
-#### Hold a route's Suspense fallback by parking its data request
+#### P26 · Hold a route's Suspense fallback by parking its data request
+
+**applies-to:** surface=web · runtime=any · phase=capture
 
 **Situation:** the route skeleton is now held by data (`SWRConfig{ suspense: true }`
 at the layout), not only by the lazy module, so parking the chunk no longer keeps it
@@ -676,7 +825,9 @@ Name the route's **own** query in the pattern (`aiProvider*` for the provider pa
 A broad `*trpc*` parks the shell's queries too and the route never mounts, which reads
 as a product hang. For the error state, prefer `agent-browser network route <pattern> --abort` — an aborted request settles, so the boundary renders instead of hanging.
 
-#### `SWRConfig` reaches hooks below it, never the component that renders it
+#### P27 · `SWRConfig` reaches hooks below it, never the component that renders it
+
+**applies-to:** surface=web · runtime=any · phase=drive
 
 **Situation:** opting one page out of a subtree's suspense (a page whose sections are
 gated independently and must keep their own Retry).
@@ -689,7 +840,9 @@ whole route thrown to the error boundary the first time one section's fetch fail
 **Works:** move the hooks into a child component and wrap that child. Verify by failing
 one section's request and confirming the rest of the page still renders.
 
-#### Park a route's lazy chunk to hold its pending sidebar on screen
+#### P28 · Park a route's lazy chunk to hold its pending sidebar on screen
+
+**applies-to:** surface=electron · runtime=any · phase=capture
 
 **Situation:** verifying what a route's `NavPanel` fallback (or any `dynamicElement`
 Suspense fallback) actually renders. The pending state lasts a few hundred ms, so no
@@ -721,7 +874,9 @@ pattern missed, it is not a product finding.
 Drive the navigation with `app-probe.sh goto <route>` (a full reload, so the module
 is re-requested and re-parked).
 
-#### Document-tree evidence: seed fixtures by path, drive through the shadow DOM, and note that heterogeneous Agents have no Documents tab
+#### P29 · Document-tree evidence: seed fixtures by path, drive through the shadow DOM, and note that heterogeneous Agents have no Documents tab
+
+**applies-to:** surface=web, electron · runtime=any · phase=fixture, drive
 
 **Situation:** verifying how `DocumentExplorerTree` renders (the left column of
 `/agent/:id/docs`, and the Documents tab of the conversation's right-hand working
@@ -781,7 +936,9 @@ if (el.getAttribute('aria-expanded') === 'false') el.click();
    screenshot. For indentation, read the content-box `x` and diff it level by level —
    that difference is the real step.
 
-#### Restyling ExplorerTree: pierre's focus state and truncation mask have two counter-intuitive contracts
+#### P30 · Restyling ExplorerTree: pierre's focus state and truncation mask have two counter-intuitive contracts
+
+**applies-to:** surface=web, electron · runtime=any · phase=drive
 
 **Situation:** tuning `ExplorerTree` (pierre/trees) appearance through `unsafeCSS` /
 `--trees-*` variables — removing the focus highlight, changing truncation behaviour,
@@ -836,7 +993,9 @@ recolouring row states.
   `opacity` to 0 is not enough — pierre has two more rules ("reveal on tree hover" and
   "highlight the focused row's ancestors") that push the opacity back to 1.
 
-#### Skill-menu interaction bugs depend on the shape of the user's data — foreground the MCP window and reproduce with zero-write clicks
+#### P31 · Skill-menu interaction bugs depend on the shape of the user's data — foreground the MCP window and reproduce with zero-write clicks
+
+**applies-to:** surface=web · runtime=any · phase=drive
 
 **Situation:** reproducing a row-level interaction defect in the `+` menu / skills
 submenu (hover detail card, the `...` policy menu, the uninstall confirmation). The
@@ -867,7 +1026,9 @@ alone cannot separate outside-press from focus-out from hover-out.
 
 ### Rendering messages and tool calls
 
-#### Message-attached heterogeneous-agent errors
+#### P32 · Message-attached heterogeneous-agent errors
+
+**applies-to:** surface=web, electron · runtime=hetero · phase=fixture
 
 Inject a temporary assistant message through
 `chat().internal_dispatchMessage`, then attach an `AgentRuntimeError`. Supported
@@ -875,7 +1036,9 @@ guide codes are `auth_required`, `cli_not_found`, `overloaded`, and `rate_limit`
 other values follow the generic error path. Use a unique content marker, verify the
 real rendered card, and delete the temporary message afterward.
 
-#### Agent Mock playback leaves `pluginState` empty — backfill it before capturing pluginState-driven renders
+#### P33 · Agent Mock playback leaves `pluginState` empty — backfill it before capturing pluginState-driven renders
+
+**applies-to:** surface=web, electron · runtime=any · phase=fixture
 
 **Situation:** verifying a builtin-tool Render/Inspector (lobe-agent todos, plans —
 anything reading `message.pluginState`) with DevDock → Agent Mock case playback as
@@ -917,7 +1080,9 @@ is what selects the Render component) and the tool message (`updateMessagePlugin
   (NOT `lobe-claude-code`) and PascalCase `apiName` (`TodoWrite`). All of this is
   in-memory only — a reload clears it; delete the temp topic at teardown.
 
-#### Verifying a builtin-tool Render with no provider key — dispatch a fresh assistant+tool pair
+#### P34 · Verifying a builtin-tool Render with no provider key — dispatch a fresh assistant+tool pair
+
+**applies-to:** surface=web, electron · runtime=any · phase=fixture
 
 **Situation:** verifying a builtin tool's Render / Streaming component when the local
 env has no LLM provider key, so no real model can be made to emit that tool call
@@ -1002,7 +1167,9 @@ code A/B, re-dispatch after each edit rather than expecting react-refresh to kee
 the messages — and re-run the identical dispatch + expand + scroll sequence on both
 sides so the two frames differ only by the change.
 
-#### A client bucket that keeps reverting mid-run is the gateway `uiMessages` snapshot, not your write
+#### P35 · A client bucket that keeps reverting mid-run is the gateway `uiMessages` snapshot, not your write
+
+**applies-to:** surface=web · runtime=gateway · phase=probe
 
 **Situation:** a store bucket (`dbMessagesMap[<key>]`) holds the right messages right
 after a gateway send, then silently loses them a second or two later and stays wrong
@@ -1032,7 +1199,9 @@ applies a pushed snapshot. If the behavior is correct there and wrong in gateway
 mode, the defect is in the gateway transport or in the server snapshot, and you have
 halved the search space before reading any code.
 
-#### `curl /health` does not prove the local agent-gateway trusts your key — run the JWT probe
+#### P36 · `curl /health` does not prove the local agent-gateway trusts your key — run the JWT probe
+
+**applies-to:** surface=web · runtime=gateway · phase=env
 
 **Situation:** restarting the local agent-gateway between acceptance rounds and
 gating on `curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>/health`.
@@ -1062,7 +1231,9 @@ worktree regenerating it) silently invalidates it for the next run — compare t
 `kid` in `agent-gateway/.dev.vars` against `.records/env/agent-testing-jwks.json`
 when in doubt.
 
-#### A required local service can be someone else's, and `preflight` will not tell you
+#### P37 · A required local service can be someone else's, and `preflight` will not tell you
+
+**applies-to:** surface=any · runtime=gateway · phase=env
 
 **Situation:** starting QStash / s3rver for a run through `init-dev-env.sh` in a
 worktree while another agent-testing session is already active on the machine.
@@ -1080,14 +1251,18 @@ does not own.
 kills the other session's run. Only the dev server (`stop-dev`, which verifies PID
 ownership) and anything you launched on a port you chose yourself are yours to stop.
 
-#### Infinite-scroll failure states
+#### P38 · Infinite-scroll failure states
+
+**applies-to:** surface=web · runtime=any · phase=fixture
 
 When the fixture is too short for the observer to fire, call the real load-more
 store action rather than pretending to scroll. This covers the request, catch
 path, and rendered retry row; it does not prove the observer gate itself. Use a
 scrollable fixture when the observer behavior is the claim.
 
-#### Safe mutation-error injection against a real (cloud) account
+#### P39 · Safe mutation-error injection against a real (cloud) account
+
+**applies-to:** surface=web, electron · runtime=any · phase=fixture
 
 To exercise a mutation error branch when the app points at the user's real cloud
 backend, replace the react-query `mutationFn` body with an immediate
@@ -1098,7 +1273,9 @@ error shapes through a window flag (e.g. plain `Error` vs
 marker before clicking. Snapshot the dirty file first and restore byte-identically
 (cmp), never `git checkout --`.
 
-#### Render Gallery shows "No builtin tool renders registered." after a reload
+#### P40 · Render Gallery shows "No builtin tool renders registered." after a reload
+
+**applies-to:** surface=web, electron · runtime=any · phase=drive
 
 **Situation:** driving DevDock → Render Gallery to capture builtin-tool
 Inspector/Render evidence, after a renderer reload or an HMR update.
@@ -1126,9 +1303,83 @@ localStorage.setItem(
 );
 ```
 
+#### P41 · Driving a real queued-message (steer) run in client runtime: Responses-API stub, an enabled function-call model, and auto-run approval
+
+**applies-to:** surface=web · runtime=client · phase=fixture, drive
+
+**Situation:** verifying anything downstream of the input queue (steer/follow-up drain,
+the merged assistant chain) needs a turn that stays open long enough to enqueue a
+second message AND ends on a tool round, so the first turn renders as an
+`assistantGroup` rather than a bare `assistant`.
+
+**Doesn't work:** three things, each of which reads as a product defect.
+
+- Pointing the openai provider at the chat-completions `llm-stub.mjs`. The openai
+  provider calls `/v1/responses` (the stub 404s and the turn dies with
+  `ProviderBizError … retrying 4/6`). Side requests (topic title) hit the same endpoint
+  with `stream: false` and a `text.format` json\_schema — answer them with a JSON
+  `{"title":…}` string, never with SSE.
+- Setting `model: 'gpt-4o'` on the agent. Only models present in
+  `aiInfra().enabledAiModels` for the provider carry `abilities.functionCall`; an
+  unlisted id gets NO `tools` in the request, the runtime then flattens tool rounds
+  into plain user/assistant text, and a stub that keeps emitting a function call loops
+  until `Stopped after the same tool call was requested 20 consecutive times`. Note the
+  app still EXECUTES a function call the stub emits unprompted, so "the tool ran" is not
+  proof that tools were offered.
+- Leaving `tool.humanIntervention.approvalMode` on its default. The calculator call parks
+  on the approval bar, which also covers the composer at its click point
+  (`agent-browser click` refuses; use `eval` `el.focus()` + `keyboard type` instead).
+
+**Works:** `updateAgentConfig({ model: 'gpt-5.6-luna', provider: 'openai' })` (any
+`enabledAiModels` entry with `functionCall: true`), `setPluginMode('lobe-calculator',
+'pinned')`, `user().updateHumanIntervention({ approvalMode: 'auto-run' })`, and a stub
+that speaks Responses SSE: `response.output_item.added` (`type: 'function_call'`,
+`call_id`, `name: 'lobe-calculator____calculate'`) → `response.function_call_arguments.delta`
+→ `response.output_item.done` → `response.completed`; on the next request the tool
+result arrives as a `function_call_output` input item, so stream the final text then.
+Detect the conversation turn by `payload.stream === true`, not by `payload.tools`.
+Restore the agent's original `plugins` array afterwards — `updateAgentConfig({ plugins })`
+replaces the whole list (the read-back is stale for \~1s, so verify after a delay).
+
+#### P42 · Driving the heterogeneous (Claude Code) runtime on web without Electron — an in-page IPC mock over the real adapter
+
+**applies-to:** surface=web · runtime=hetero · phase=fixture, drive
+
+**Situation:** verifying anything the `hetero` executor owns (its own queue drain, `--resume`
+turn chaining, streamed tool/text rendering) when Electron is unavailable, or the dev
+Electron login snapshot is `storageMode: cloud` (writes would land in the real account).
+
+**Doesn't work:** a fake `claude` binary. It needs the desktop main process, a local backend
+for the `agencyConfig.heterogeneousProvider` SQL seed, and the Electron auth/port traps.
+
+**Works:** three `[AGENT-TEST]` injections, all gated on `localStorage.__HETERO_MOCK === '1'`
+(snapshot dirty files first, restore with `cp` + `cmp`):
+
+- `src/services/electron/heterogeneousAgent.ts` — the `ipc` getter returns an in-page object
+  whose `sendPrompt` feeds scripted stream-json lines through
+  `new ClaudeCodeAdapter().adapt(line)` (importable from `@lobechat/heterogeneous-agents` in
+  the renderer) and emits each event on `window.__HETERO_BUS` as `heteroAgentEvent
+{ event, sessionId }`, then `heteroAgentSessionComplete`. `startSession` reuses
+  `resumeSessionId` so turn 2 chains; stub every other method the executor calls
+  (`getClaudeCodeIdentity`, `cancelSession`, `stopSession`, quotas) or the getter throws
+  inside a `.then`.
+- executor `subscribeBroadcasts` — `const ipc = window.__HETERO_BUS ?? window.electron!.ipcRenderer`.
+- `conversationLifecycle` — under the flag inject `heterogeneousProvider = { type: 'claude-code',
+command: 'claude' }` and call `selectRuntimeType(ctx, { isDesktop: true })`.
+
+Line order that streams live: `system/init` → `stream_event message_start` → `assistant`
+(tool\_use Bash) → `user` (tool\_result) → `stream_event message_start` → `content_block_delta`
+text\_delta ×N → `assistant` (full text) → `result`. The op shows as `execHeterogeneousAgent`,
+the bubble shows "Claude Code is running…", and the topic persists user → assistant(Bash) →
+tool → assistant(text) rows. Capture mid-turn by polling the top-level `[data-index]` rows,
+not `body.innerText`, and key turn-2 captures on the store/DOM state you assert rather than a
+fixed sleep.
+
 ### Capturing and publishing evidence
 
-#### Reading a transitioned CSS property immediately after focus/hover
+#### P43 · Reading a transitioned CSS property immediately after focus/hover
+
+**applies-to:** surface=web, electron · runtime=any · phase=capture
 
 **Situation:** asserting that a `:focus-within` / `:hover` rule reveals a
 control.
@@ -1143,7 +1394,9 @@ and assert the untransitioned property too (`width`) plus
 `el.matches('<selector>:focus-within')` so a mid-transition value cannot be
 mistaken for a non-matching rule.
 
-#### Leftover React Scan instrumentation poisons every screenshot
+#### P44 · Leftover React Scan instrumentation poisons every screenshot
+
+**applies-to:** surface=web, electron · runtime=any · phase=capture
 
 **Situation:** capturing UI evidence in a dev instance the user (or an earlier
 round) had DevTools / the DevDock open on.
@@ -1162,7 +1415,9 @@ survives re-creation, touches no product code or styles, and disappears on
 reload. Remove it at teardown. Disclose it in the report: it suppresses a dev
 overlay, which is a capture-time adjustment a reviewer should know about.
 
-#### Counting section instances across the Home rail collapse needs real visibility, not a rect
+#### P45 · Counting section instances across the Home rail collapse needs real visibility, not a rect
+
+**applies-to:** surface=web · runtime=any · phase=capture
 
 **Situation:** asserting that a Home section moved between the rail and the main
 column rather than being duplicated or lost.
@@ -1193,7 +1448,9 @@ if (!el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true })) conti
 Assert both columns in the same pass — a claim about _moving_ is only settled by
 observing the source column go empty and the destination fill in one snapshot.
 
-#### Boot-phase UI cannot be observed by CDP polling — sample in-page, and mirror the timer
+#### P46 · Boot-phase UI cannot be observed by CDP polling — sample in-page, and mirror the timer
+
+**applies-to:** surface=web, electron · runtime=any · phase=capture
 
 **Situation:** asserting whether a transient boot-phase surface (a splash, a skeleton,
 a first-paint gate) appears between React's first commit and the app painting.
@@ -1229,7 +1486,9 @@ them turns a clean boot into a false "the logo flashed"); and record the max gap
 consecutive ticks — LobeHub's boot routinely shows a single 0.6–1.1s blocking task, so a
 phase with no sample inside it is a blocked window, not a missing state.
 
-#### Asserting a modal's exit window: `data-ending-style` is never set, and `record-gif.sh` is far too slow
+#### P47 · Asserting a modal's exit window: `data-ending-style` is never set, and `record-gif.sh` is far too slow
+
+**applies-to:** surface=web, electron · runtime=any · phase=capture
 
 **Situation:** proving what a base-ui modal does during its \~120ms exit — typically that the body
 stays mounted while the panel fades, rather than blanking at the start of the animation.
@@ -1268,7 +1527,9 @@ compositor paints, so they cluster inside the animation — \~9 frames in the 12
 those unmodified frames slowly with ffmpeg. Do not slow the product's own transition: the exit is a
 JS animation, so a CSS `transition-duration` override does nothing anyway.
 
-#### Switching web-session theme for dark-mode evidence needs no UI — next-themes reads `localStorage.theme`
+#### P48 · Switching web-session theme for dark-mode evidence needs no UI — next-themes reads `localStorage.theme`
+
+**applies-to:** surface=web · runtime=any · phase=capture
 
 **Situation:** capturing light- and dark-mode evidence in the seeded `agent-browser`
 web session (settings UI navigation is slow and the theme control moved between
@@ -1293,7 +1554,9 @@ document becomes sourceless and `localStorage` access throws SecurityError, so t
 override stays behind for the next run. Assert the applied theme via
 `document.documentElement.dataset.theme`, not the storage value.
 
-#### Workspace HTML publish: prove the hosted page, not the local preview
+#### P49 · Workspace HTML publish: prove the hosted page, not the local preview
+
+**applies-to:** surface=electron · runtime=any · phase=capture
 
 **Situation:** after publishing workspace HTML, checking whether CSS/SVG/images
 actually load on the public Artifact URL.
@@ -1311,7 +1574,9 @@ open that URL and assert computed CSS plus `img.naturalWidth > 0`. If the hosted
 `<img>` is a data URI with `text/plain`, the image is broken even though it is
 not a 404.
 
-#### `acceptance run ingest` is creative — re-running it to re-read its output mints a duplicate round
+#### P50 · `acceptance run ingest` is creative — re-running it to re-read its output mints a duplicate round
+
+**applies-to:** surface=any · runtime=any · phase=publish
 
 **Situation:** after a successful ingest, wanting to re-check a field from its JSON
 output (evidence count, acceptanceId).
@@ -1328,7 +1593,9 @@ error, distinct from the forbidden overwrite-a-real-round.
 
 ### Electron and the desktop shell
 
-#### Which entry the dev Electron main window loads is NOT stable — measure it, never assume
+#### P51 · Which entry the dev Electron main window loads is NOT stable — measure it, never assume
+
+**applies-to:** surface=electron · runtime=any · phase=probe
 
 **Situation:** verifying anything that lives in `src/spa/entry.desktop.tsx` (bootstrap
 identity, adapter registration, boot marks) on an `electron-dev.sh` instance.
@@ -1360,7 +1627,9 @@ a source-order regression test, and say in the report that the runtime path need
 packaged build (`DESKTOP_RENDERER_STATIC` / `resolveRendererFilePath` maps
 `apps/desktop/index.html`, `popup.html`, `overlay.html`).
 
-#### Measuring production-bundle startup behavior without packaging the app
+#### P52 · Measuring production-bundle startup behavior without packaging the app
+
+**applies-to:** surface=electron · runtime=any · phase=capture
 
 **Situation:** a claim depends on the built renderer (chunk splitting, lazy-route
 boundaries, startup paint timing), which dev-mode Vite cannot reproduce.
@@ -1396,7 +1665,9 @@ A/B builds, swap `dist/renderer` directories between restarts — remote-image L
 entries are network-noisy, so compare text-paint candidates and DCL across ≥5
 cold samples per variant before attributing a delta.
 
-#### Driving and probing a real Electron popup window
+#### P53 · Driving and probing a real Electron popup window
+
+**applies-to:** surface=electron · runtime=any · phase=drive
 
 **Situation:** verifying `entry.popup.tsx` behavior (its own HTML shell, no `BootShell`).
 
@@ -1417,7 +1688,9 @@ claims, measure rather than eyeball: `getComputedStyle` for `pointer-events` / b
 alpha plus `document.elementFromPoint(x, y)` — a 50%-alpha scrim looks like a cosmetic
 tint in a screenshot while actually swallowing every click.
 
-#### Desktop tab switching is not `activateTab` alone — drive the real tab element
+#### P54 · Desktop tab switching is not `activateTab` alone — drive the real tab element
+
+**applies-to:** surface=electron · runtime=any · phase=drive
 
 **Situation:** benchmarking or driving a desktop tab switch from an `eval`
 payload, using `window.__LOBE_STORES.electron().activateTab(id)`.
@@ -1452,7 +1725,9 @@ the generic D11 trusted-input caveat does not apply). Always record
 `location.pathname` before and after and keep a `navigated` flag on every sample —
 that flag is what catches a payload that silently stopped switching.
 
-#### Clicking an already-active tab is a no-op — a desynced tab can never be re-entered by clicking
+#### P55 · Clicking an already-active tab is a no-op — a desynced tab can never be re-entered by clicking
+
+**applies-to:** surface=electron · runtime=any · phase=drive
 
 **Situation:** a probe adds a tab with `addTab(url)` and then clicks it to enter that route.
 
@@ -1473,7 +1748,9 @@ const tab = (st.tabs || []).find((t) => t.id === st.activeTabId);
 // tab.url, location.pathname and chat.activeTopicId must all point at the same topic
 ```
 
-#### Attributing switch work to hidden keep-alive trees — classify on BOTH sides of the action
+#### P56 · Attributing switch work to hidden keep-alive trees — classify on BOTH sides of the action
+
+**applies-to:** surface=electron · runtime=any · phase=capture
 
 **Situation:** measuring what a per-tab keep-alive shell costs while a tab is hidden.
 
@@ -1501,7 +1778,9 @@ Measured this way, still-hidden slots produced **0** mutations in 6/6 switches: 
 changes (visible/hidden, active/inactive, mounted/unmounted), capture the classification on both sides
 and use the intersection. Otherwise the action's own effect lands in the wrong bucket.
 
-#### Desktop theme follows the system appearance, not `settings.general.themeMode`
+#### P57 · Desktop theme follows the system appearance, not `settings.general.themeMode`
+
+**applies-to:** surface=electron · runtime=any · phase=capture
 
 **Situation:** capturing dark-mode evidence for a desktop UI change.
 
@@ -1518,7 +1797,9 @@ outside the harness's remit: mark the dark case untested and say why, rather tha
 flipping a device-level preference. Note the setting write is not free — it syncs to
 the account and affects other surfaces; restore it (`auto`) at teardown if you set it.
 
-#### A cold desktop boot renders English copy while `status.language` already says zh-CN
+#### P58 · A cold desktop boot renders English copy while `status.language` already says zh-CN
+
+**applies-to:** surface=electron · runtime=any · phase=probe
 
 **Situation:** asserting anything about localized UI copy on a freshly started
 `electron-dev.sh` instance — a label's text, or that a settings section rendered at all.
@@ -1535,7 +1816,9 @@ by calling `window.__LOBE_STORES.global().switchLocale('<locale>')` — the same
 select calls — and only then assert. When the check under test IS the language, drive the real
 select, and re-read `status.language` plus the DOM copy after every switch: the two can disagree.
 
-#### `app-probe.sh goto /` cannot reach the desktop Home route — seed the tab first
+#### P59 · `app-probe.sh goto /` cannot reach the desktop Home route — seed the tab first
+
+**applies-to:** surface=electron · runtime=any · phase=drive
 
 **Situation:** driving the Electron shell to the Home route (`/`) to check the nav
 panel there.
@@ -1558,7 +1841,9 @@ window.__LOBE_STORES.electron().addTab('/'); // addTab also activates it
 
 Assert `location.pathname` after the reload rather than trusting `goto`'s echo.
 
-#### The dev Electron instance may be a thin client on PRODUCTION — read `dataSyncConfig` before any write
+#### P60 · The dev Electron instance may be a thin client on PRODUCTION — read `dataSyncConfig` before any write
+
+**applies-to:** surface=electron · runtime=any · phase=auth, env
 
 **Situation:** starting `electron-dev.sh` to verify a frontend change, then driving flows that
 create or mutate product objects (labels, groups, agents, forwarded topics, saved edits).
@@ -1592,7 +1877,9 @@ confirm the request body carries the key, and confirm an ALREADY-shipped sibling
 server schema version rather than failing the change; only a local full stack running the branch's
 schema can close that loop.
 
-#### A global `indexedDB.open` stall holds the boot on web but kills the Electron renderer
+#### P61 · A global `indexedDB.open` stall holds the boot on web but kills the Electron renderer
+
+**applies-to:** surface=web, electron · runtime=any · phase=capture
 
 **Situation:** needing to freeze the boot at a pre-app phase long enough to capture it,
 by keeping the SWR cache hydration from ever completing.
@@ -1611,7 +1898,9 @@ in-page sampler above. Either way, disarm with
 `Page.removeScriptToEvaluateOnNewDocument` and reload before capturing the settled
 state, or the comparison shot is taken against a still-crippled runtime.
 
-#### Locale regression tests and desktop resource scanning
+#### P62 · Locale regression tests and desktop resource scanning
+
+**applies-to:** surface=electron · runtime=any · phase=env
 
 **Situation:** a locale-copy change needs a focused regression assertion while
 the Electron dev renderer imports locale resources from the default resource tree.
@@ -1626,7 +1915,9 @@ bad scan because the optimized dependency graph can remain poisoned.
 
 ### Auth and session state
 
-#### Task CLI polling with seeded API-key auth
+#### P63 · Task CLI polling with seeded API-key auth
+
+**applies-to:** surface=cli · runtime=gateway · phase=auth
 
 **Situation:** A local acceptance run is driven through `lh task run` with the
 seeded `LOBEHUB_CLI_API_KEY`, and the test needs to observe the asynchronous
@@ -1649,7 +1940,9 @@ acceptance by the task's INTERNAL id — the page then renders an empty state ev
 though ingest succeeded. Use the internal id in `--subject` (or fix the
 `subject_id` row afterwards) when the evidence must render in the local app UI.
 
-#### Production-backend web runs have no seeded agent-browser session
+#### P64 · Production-backend web runs have no seeded agent-browser session
+
+**applies-to:** surface=web · runtime=any · phase=auth
 
 **Situation:** verifying frontend-only work against real production data through
 `bun run dev:spa`'s `_dangerous_local_dev_proxy` URL.
@@ -1668,7 +1961,9 @@ Prove the working-tree bundle is actually live first — read back a string that
 exists only in the working tree (e.g. a changed placeholder), never assume HMR
 applied.
 
-#### The desktop instance pins a previous run's server port, and its saved OAuth login expires
+#### P65 · The desktop instance pins a previous run's server port, and its saved OAuth login expires
+
+**applies-to:** surface=electron · runtime=any · phase=auth, env
 
 **Situation:** starting an Electron dev instance for a surface that needs the local
 backend (any tRPC-backed panel), in a fresh worktree.
@@ -1713,7 +2008,9 @@ curl -c cookie.jar -H 'Content-Type: application/json' -X POST \
 Gate on `app-probe.sh server-auth` returning `{"authenticated":true,"status":200}` —
 renderer `isSignedIn` alone never proves the server accepted anything.
 
-#### A pool instance seeded from the login snapshot can boot signed out — `safeStorage` cannot decrypt the copied token
+#### P66 · A pool instance seeded from the login snapshot can boot signed out — `safeStorage` cannot decrypt the copied token
+
+**applies-to:** surface=electron · runtime=any · phase=auth
 
 **Situation:** `electron-dev.sh start <id>` in a worktree; the helper reports the
 renderer ready and the seeded login is present on disk.
@@ -1731,7 +2028,9 @@ which runs on the golden profile in place and decrypts normally. It boots on the
 loading shell once, so reload once before probing (see L-S8). Gate on
 `app-probe.sh auth` AND `server-auth`, never on the helper's "Ready" line.
 
-#### Electron dev's BackendProxy targets the server port persisted in the login snapshot — mint a session and inject the cookie over CDP
+#### P67 · Electron dev's BackendProxy targets the server port persisted in the login snapshot — mint a session and inject the cookie over CDP
+
+**applies-to:** surface=electron · runtime=any · phase=auth, env
 
 **Situation:** starting the Electron surface inside a worktree to verify a pure
 frontend change; the renderer looks fine, but `app-probe.sh server-auth` returns 502
@@ -1755,7 +2054,9 @@ Electron's cookie store through raw CDP `Network.setCookie` (with `url` set to
 `http://localhost:<port>/`); after `location.reload()`, `server-auth` returns 200 and
 `isUserStateInit` is true.
 
-#### A pool instance's BackendProxy port also comes from the login snapshot, and its log is `instance-<id>.log`
+#### P68 · A pool instance's BackendProxy port also comes from the login snapshot, and its log is `instance-<id>.log`
+
+**applies-to:** surface=electron · runtime=any · phase=auth, env
 
 **Situation:** starting a pool instance with `electron-dev.sh start <id>` to verify a
 pure frontend change; `auth` and `server-auth` both pass, but the content area shows
@@ -1777,7 +2078,9 @@ pool instance along the way (the log shows
 `GPU process exited unexpectedly: exit_code=15`), so the order is: fix the port and
 start the server first, then start Electron.
 
-### Renderer OTA: creating a real download delta in dev
+### P69 · Renderer OTA: creating a real download delta in dev
+
+**applies-to:** surface=electron · runtime=any · phase=fixture
 
 **Situation:** verifying renderer OTA incremental download in dev, where the
 "builtin" renderer (`apps/desktop/dist/renderer`) is the same directory the build
@@ -1795,7 +2098,9 @@ delta. Also: read the feed server's 404 line after boot to learn the exact
 
 ### Dev server, install, and ports
 
-#### A backgrounded `init-dev-env.sh dev` looks dead while the server is alive on a dynamic port
+#### P70 · A backgrounded `init-dev-env.sh dev` looks dead while the server is alive on a dynamic port
+
+**applies-to:** surface=any · runtime=any · phase=env
 
 **Situation:** starting the dev server from a harness-managed background command in a
 worktree, then waiting for readiness.
@@ -1810,7 +2115,9 @@ already up elsewhere; a retry then fails with "an owned dev server is already ru
 that. For a long-lived start prefer a detached `screen -dmS <name> … >> .records/logs/x.log`
 so the log lands in a stable file; `stop-dev` still stops the recorded PID tree either way.
 
-#### Agent-browser navigation hangs after an orphaned Next child keeps the port
+#### P71 · Agent-browser navigation hangs after an orphaned Next child keeps the port
+
+**applies-to:** surface=web · runtime=any · phase=env
 
 **Situation:** an isolated full-stack dev launcher exits, but its Next child
 continues listening without returning HTTP responses. `agent-browser open`,
@@ -1826,7 +2133,9 @@ working tree, terminate only that run-owned process tree, then restart through
 `init-dev-env.sh dev` and reseed the isolated browser auth. A successful HTTP
 probe must precede browser assertions.
 
-#### An unconverged lockfile puts two copies of a dep in the graph — every route using it dies at the ErrorBoundary
+#### P72 · An unconverged lockfile puts two copies of a dep in the graph — every route using it dies at the ErrorBoundary
+
+**applies-to:** surface=web, electron · runtime=any · phase=env
 
 **Situation:** after rebasing onto a canary that bumped a shared UI dependency and
 running `pnpm install`, every route rendering the rich-text editor (agent profile,
@@ -1868,7 +2177,9 @@ checkout and appears right after a rebase that bumps the root range. Do not repo
 as a defect of the branch or of the base ref; note it as an environment finding and
 move on. Back up the lockfile before `dedupe` anyway — it is the only copy.
 
-#### A fresh worktree installed with `--ignore-scripts` returns 500 on every `/trpc/lambda/*`
+#### P73 · A fresh worktree installed with `--ignore-scripts` returns 500 on every `/trpc/lambda/*`
+
+**applies-to:** surface=web · runtime=any · phase=env
 
 **Situation:** bootstrapping a new git worktree for a run — `pnpm install` at the root,
 then `init-dev-env.sh dev`.
@@ -1907,7 +2218,9 @@ Gate on a real authenticated TRPC call rather than on the page rendering: a 200 
 `apps/desktop` are standalone installs (PROJECT.md §1), so each also needs its own
 `pnpm install` in a fresh worktree.
 
-#### A worktree Electron run leaves a second `@types/react` that fails the worktree type-check
+#### P74 · A worktree Electron run leaves a second `@types/react` that fails the worktree type-check
+
+**applies-to:** surface=electron · runtime=any · phase=env
 
 **Situation:** running the Electron surface from a git worktree, which requires
 the `apps/desktop` standalone install (adapter §1), then running `bun run check --type`.
@@ -1926,7 +2239,9 @@ drawing any conclusion, and confirm causality by A/B — moving
 Electron binary runs out of that directory, so parking it kills the instance;
 capture all UI evidence first.
 
-#### Managed command runners can reap `electron-dev.sh start` children after the helper returns
+#### P75 · Managed command runners can reap `electron-dev.sh start` children after the helper returns
+
+**applies-to:** surface=electron · runtime=any · phase=env
 
 **Situation:** `electron-dev.sh start` (legacy and pool forms) reports that CDP
 and the renderer are ready, but the CDP port closes immediately after the helper
@@ -1952,7 +2267,9 @@ Keep that command session open for the run. Confirm the CDP endpoint, project
 process path, `app-probe.sh ready`, renderer auth, server auth, and a raw-CDP
 screenshot before collecting evidence.
 
-#### A reset shell cwd silently retargets git commits at the main repo's checked-out branch
+#### P76 · A reset shell cwd silently retargets git commits at the main repo's checked-out branch
+
+**applies-to:** surface=any · runtime=any · phase=env
 
 **Situation:** a long worktree-based session where the harness occasionally resets the
 shell cwd back to the main repo root (e.g. after a `cd /tmp` in a compound command).
@@ -1975,7 +2292,9 @@ restores the user's branch and leaves their working tree as it was (verify again
 the session-start `gitStatus` snapshot); nothing needs force-pushing because the
 wrong-branch push was a no-op.
 
-#### Proving which prompt version the running server holds
+#### P77 · Proving which prompt version the running server holds
+
+**applies-to:** surface=web, cli · runtime=gateway · phase=probe
 
 **Situation:** verifying a change to a prompt under `packages/prompts` — the assertion is
 about the model's behaviour, so the run is only meaningful if the server is executing the
@@ -2000,7 +2319,9 @@ A stale version means the server needs a real process restart (PROJECT.md §6), 
 reload. Gate the first evidence-bearing call on this row, not on the edit's timestamp —
 otherwise the round publishes new-prompt claims backed by old-prompt output.
 
-#### The user's Vite serves a `node_modules` that a reinstall already replaced — every `.vite/deps` 504s, the page is black
+#### P80 · The user's Vite serves a `node_modules` that a reinstall already replaced — every `.vite/deps` 504s, the page is black
+
+**applies-to:** surface=web · runtime=client · phase=env
 
 **Situation:** the user's own `bun run dev` is up (Next answers, auth is green), but
 the SPA never mounts: `#root` has 0 children, no console error, and every
@@ -2018,7 +2339,9 @@ already signed in there. Prove identity before capturing (fetch the changed modu
 the new Vite origin and grep the change's marker), stop only that pid at teardown, and
 tell the user to restart their `dev:spa`.
 
-#### Every agent/topic read returns 500 `Failed query: select … from "agents"` — the `.env` database is behind the repo's migrations
+#### P81 · Every agent/topic read returns 500 `Failed query: select … from "agents"` — the `.env` database is behind the repo's migrations
+
+**applies-to:** surface=web · runtime=gateway · phase=env
 
 **Situation:** with the user's `.env` backend, opening a conversation shows
 "Failed to load agent settings"; `agent.getBuiltinAgent` and `topic.queryTopics`
@@ -2040,7 +2363,9 @@ user's database: surface it at the plan gate and run `bun run db:migrate` (it lo
 `.env` itself) only with their authorization; the isolated alternative is a worktree
 with a second Next against the managed `:5434` test DB.
 
-#### Server-side reads of local S3 evidence are blocked by SSRF protection — private IPs must be allowed explicitly
+#### P78 · Server-side reads of local S3 evidence are blocked by SSRF protection — private IPs must be allowed explicitly
+
+**applies-to:** surface=web, cli · runtime=gateway · phase=env
 
 **Situation:** verifying any capability where the **server** reads back an uploaded
 file (multimodal image judging, thumbnail processing, feeding a screenshot to a
@@ -2062,7 +2387,9 @@ domain and is unaffected, so this is purely a local verification-environment gat
 not a product defect — do not report it as a bug, and do not work around it by
 switching to inline base64, which would verify a path the product never takes.
 
-#### Real web-search evidence needs local SearXNG — the on-disk search1api keys are dead
+#### P79 · Real web-search evidence needs local SearXNG — the on-disk search1api keys are dead
+
+**applies-to:** surface=web, cli · runtime=client, gateway · phase=env
 
 **Situation:** a check needs the product's real web-search pipeline (builtin
 `lobe-web-browsing____search` executing an actual HTTP search and rendering result
@@ -2109,3 +2436,5 @@ stub's answer-mode off the NAME of the last `function_call` instead.
   duplicating them here.
 - Put a new recipe inside the `Project-specific recipes` group it belongs to, above
   `Detailed references` — never after the closing sections, or the taxonomy drifts.
+- Give it the next `P<nn>` id in its heading, an `**applies-to:**` line right under the
+  heading, and one row in the `## Index` table. Ids are stable — never renumber.

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -274,7 +274,7 @@ structured generation (`llm_generation_tracing.success=t` is the confirmation pr
 **Situation:** A/B-forcing the goal page's 失联 (lost-heartbeat) banner by backdating
 `goal_nodes.updated_at` / `agent_operations.updated_at` with SQL.
 
-**Doesn't work:** backdating by ~10 minutes because the server reclaim default
+**Doesn't work:** backdating by \~10 minutes because the server reclaim default
 (`resolveOperationLeaseTimeout`) is 5 minutes. The frontier still shows 运行中: the
 client view model has its own `DEFAULT_LEASE_TIMEOUT_MS = 15 min` and only honors
 `goal.config.recovery.operationLeaseTimeoutMs` when the goal sets one.
@@ -282,8 +282,8 @@ client view model has its own `DEFAULT_LEASE_TIMEOUT_MS = 15 min` and only honor
 **Works:** backdate past the client's window (25 min is comfortable), or create the
 goal with an explicit `--operation-lease-timeout-ms`. Liveness = the newer of the
 node row and `runHeartbeats` (the running operation's `updated_at` served by
-`goal.graph`), so the A/B is: node stale + op fresh → 运行中; both stale → 失联.
-Restore the forced rows (node/task/task_topics/operation status + timestamps) after
+`goal.graph`), so the A/B is: node stale + op fresh → 运行中；both stale → 失联.
+Restore the forced rows (node/task/task\_topics/operation status + timestamps) after
 capturing.
 
 #### A CLI-created topic has no trigger/status and is filtered out of the Agent paged view
@@ -304,7 +304,7 @@ UI" split is especially misleading.
 
 **Works:** right after writing the metadata, also run
 `update topics set status='active', trigger='chat'`, then `app-probe.sh goto` once
-more. Keep the assertion order from M19: confirm `app-probe.sh topic` returns the
+more. Keep the assertion order from generic M6: confirm `app-probe.sh topic` returns the
 metadata before asserting anything in the UI.
 
 #### `agent.updateAgentConfig` silently drops `agencyConfig.heterogeneousProvider`
@@ -328,7 +328,7 @@ docker exec lobehub-agent-testing-postgres psql -U postgres -d postgres -tAc \
 ```
 
 Then cold-load: a plain reload keeps serving the agent config from the tiered SWR
-cache, so the renderer still shows the pre-write value (generic M18). Clear
+cache, so the renderer still shows the pre-write value (generic M6). Clear
 `lobechat-swr-cache*` + `lobehub-local-data` through
 `Page.addScriptToEvaluateOnNewDocument` and reload (see "Cold SWR cache" above),
 then assert `agentMap[id].agencyConfig` before drawing any conclusion.
@@ -1966,7 +1966,7 @@ only tell is an unexpected diffstat / parent commit; `push <branch>` then report
 
 The same reset has a second, harder-to-spot consequence: it also retargets
 `init-dev-env.sh dev`, so the dev server and its Vite serve the MAIN checkout while
-every health signal stays green — see `common-mistakes.md` L-S17.
+every health signal stays green — see `common-mistakes.md` L-S21.
 
 **Works:** in any worktree session, prefix every git/check command with an explicit
 `cd <worktree> &&`, and read the commit output's diffstat + `git log -1` parent
@@ -2082,7 +2082,7 @@ rate-limit (429) or ship JSON-disabled (HTML back).
 `SEARCH_PROVIDERS=searxng SEARXNG_URL=http://localhost:8888`. It aggregates real
 engines, so the whole product path (server search impl → result cards → tool
 message persistence) is genuine. English queries return results more reliably
-than Chinese ones. One trap when the model is a tool_call-emitting stub AND a
+than Chinese ones. One trap when the model is a tool\_call-emitting stub AND a
 synthetic context injector is active (e.g. `getGoalContext`): "last message is a
 tool result → answer" fires on the injected pair and skips the search — key the
 stub's answer-mode off the NAME of the last `function_call` instead.

--- a/.agents/acceptance/references/common-mistakes-field-notes.md
+++ b/.agents/acceptance/references/common-mistakes-field-notes.md
@@ -154,3 +154,425 @@ activity into their real browsing context, and erodes trust in automated runs.
 report auth as ❌ Blocked and request ONE manual sign-in. The corrected policy
 lives in `references/auth.md` ("When the instance comes up signed out") and
 PROJECT.md §4 Electron.
+
+---
+
+## Retired from the checklist — 2026-09-03
+
+Removed from `../common-mistakes.md` when the catalogue moved to the checklist + `holds-while` shape. Kept verbatim; a future run that hits one of these again promotes it back with a `holds-while` it can name.
+
+### Enforced by code since — the tool now reports it
+
+#### L-E11b — Publishing a new round onto a check the reviewer already accepted
+
+**Wrong approach:** when new feedback arrives about a check the user has already
+accepted, reuse that check's id for the new work — because reusing ids is the rule for
+rejected checks.
+
+**Why it fails:** an accepted verdict is deliberately sticky (`acceptanceService`
+computes `stale` only for rejects, and a test pins that behaviour by name). A later
+result on a settled id therefore inherits the tick: the round publishes green and the
+reviewer is never told there is anything new to look at. Since 2026-08, `attachRun`
+refuses such a round outright — the error names the offending ids and nothing is
+written, so a partially attached round cannot happen.
+
+**Correct approach:** read `userReview.action` before writing the plan. `accept` means
+settled: the new work needs a NEW check id, which appears unreviewed and can actually
+be judged. Reuse the id only while the check is rejected or never reviewed. Decide by
+_is the criterion new, and has the old one been accepted_ — not by how big the change
+is: a presentation fix on a still-open check reuses its id (\[\[L-E1]]), while a newly
+raised criterion on an accepted check must not.
+
+#### L-E12 — Expressing multimodal disclosure through the `verifier` enum
+
+**Wrong approach:** write a value such as `"verifier": "multimodal LLM"` in a plan
+item to satisfy the requirement that screenshot checks disclose multimodal review.
+
+**Why it fails:** `verifier` is a closed set (`program` / `agent` / `llm`) that the
+ingest validator rejects outside those values, so the whole payload fails. The
+disclosure is not expressible in that field.
+
+**Correct approach:** set `"verifier": "llm"` and carry the multimodal disclosure in
+the plan item's `method` prose alongside `"requiredEvidence": ["screenshot"]`.
+
+### Feature-spec facts — belong in the feature spec or a regression test
+
+#### L-E7 — Hiding multimodal requirements in split verifier metadata
+
+**Wrong approach:** label a screenshot check only as `LLM` or `Agent`, with media
+requirements and model capability shown elsewhere.
+
+**Why it fails:** reviewers cannot tell whether the visual evidence was actually
+inspected by a multimodal model.
+
+**Correct approach:** present verifier type, multimodal capability, and required
+evidence media together; explicitly identify screenshot checks as multimodal.
+
+#### L-E8 — Proving Task continuity with different Tasks
+
+**Wrong approach:** compare criteria from one Task with results from another and
+interpret the different item counts as a lifecycle defect.
+
+**Why it fails:** Tasks may legitimately have different goals, while Acceptance
+retains later-round checks as delivery history.
+
+**Correct approach:** capture definition and result states from the same Task, keep
+the complete cross-round check union visible, and synchronize the Task verification
+requirement with the aggregate goal.
+
+#### L-E14 — Verifying an insertion affordance without continuing the user's next action
+
+**Wrong approach:** check that a composer affordance (an action-tag chip, a mention,
+a file token) inserted the right node, screenshot it, and move on — then verify the
+sent payload through a _different_ entry point that happens to be easier to drive.
+
+**Why it fails:** insertion is half the affordance; the caret it leaves behind is
+the other half. A caret parked in front of the inserted node sends the user's very
+next keystroke to the wrong side of it. For any chip that serializes into the prompt
+with position semantics — the `/goal` marker must lead the message for `isGoalPrompt`
+to match — that silently rewrites the payload into something the runtime no longer
+recognizes, while every screenshot of the insertion itself still looks correct.
+Verifying the payload through a different entry point hides it completely: the path
+with the defect is never the path that gets sent.
+
+**Correct approach:** for every insertion affordance, continue the user's action in
+the same case — type after inserting — and assert the resulting node order, not just
+the node's presence. Drive the payload check through the _same_ entry point the case
+under test uses; if an affordance has several entries (slash menu, `+` menu), the one
+you send from must be the one you are claiming works. Assert order in the persisted
+`editor_data`, since that is what both the prompt serializer and the bubble read.
+
+#### L-E18 — Concluding a composer surface is dead code because nothing imports it
+
+**Wrong approach:** after changing a component the ActionBar reuses (a skill row, for
+instance), grep for a default import of `ActionBar/Tools`, find no hit, conclude the
+surface is not mounted, and verify only the `+` menu path.
+
+**Why it fails:** ActionBar surfaces are not mounted by a direct import. They are
+enabled by an action-key registry plus each route's own `leftActions` array.
+`ActionBar/config` registers `tools: Tools` at all times; what actually decides
+whether it renders is `leftActions` in `src/routes/(main)/**/MainChatInput` — the
+group-chat composer enables `'tools'` and reaches the component through
+`PopoverContent → ToolsList`, a different composition path from the `+` menu. Missing
+it makes a green verification cover only half of what users can see.
+
+**Correct approach:** after changing any component the ActionBar reuses, enumerate
+where the action key is actually enabled (grep each route's `leftActions` array, not
+the component's imports) and capture evidence for every surface that enables it. Mark
+any surface you deliberately skip as untested.
+
+#### L-D2 — Applying role and scope rules to only one bulk action
+
+**Wrong approach:** add own/workspace scope variants to one maintenance action while
+leaving sibling actions with different authority semantics.
+
+**Why it fails:** authority was reviewed per menu item instead of as a role × action
+× scope matrix.
+
+**Correct approach:** enumerate every matrix cell; keep members own-only and give
+owners explicit workspace variants with stronger confirmation for destructive work.
+
+#### L-D3 — Exposing a disabled host capability
+
+**Wrong approach:** configure a host to keep a shared composer permanently open while
+continuing to render the component's Collapse action.
+
+**Why it fails:** the host contract and the advertised state transition contradict
+each other.
+
+**Correct approach:** model collapse capability as an explicit host option. Verify
+pinned and collapsible hosts independently.
+
+#### L-D4 — Stretching a list row into a detail surface
+
+**Wrong approach:** reuse dense list-row chrome and controls unchanged inside an
+already-open detail panel.
+
+**Why it fails:** list affordances such as expansion controls and compact metadata
+duplicate context and compete with the detail surface's reading and decision tasks.
+
+**Correct approach:** preserve canonical object semantics and evidence order, but
+give detail mode its own permanently expanded interaction contract and clear decision
+hierarchy. Keep exact layout values in the feature specification.
+
+#### L-D5 — Reserving floating-composer space in only one content path
+
+**Wrong approach:** reserve the measured composer overlay height in the virtualized
+message list but not in the empty or welcome path.
+
+**Why it fails:** alerts and trays can overlap welcome content even though overlay
+items do not overlap each other.
+
+**Correct approach:** apply the same measured reservation to every content path and
+capture the real combined overlay state.
+
+#### L-D8 — Rendering a cross-agent dispatch envelope as a visible user turn
+
+**Wrong approach:** treat every persisted `role: user` row as a user-authored
+message when building the visible conversation list.
+
+**Why it fails:** `callAgent` persists a synthetic user envelope beneath the
+caller assistant so the target Agent has an isolated execution context. When
+that envelope is rendered, the original prompt appears twice even though the
+target Agent produced only one reply.
+
+Users see a duplicate prompt bubble and cannot tell whether
+the delegation ran once or twice; acceptance screenshots become misleading.
+
+**Correct approach:** stamp synthetic envelopes with explicit dispatch metadata
+when they are persisted, keep them in the context tree, and let the presentation
+layer hide only rows declared `visibility: internal`. Continue traversal through
+the envelope so the target assistant reply remains independently visible.
+Never infer authorship from agent-id differences or a parent tool call: a real
+cross-Agent user follow-up can have the same tree shape.
+
+#### L-D9 — A Project conversation must preserve Project identity across routing and history
+
+**Wrong approach:** implement Project chat by navigating users to the Project coordinator's
+ordinary `/agent/:agentId/:topicId` surface and present that Agent's topic list as the Project
+history.
+
+**Why it fails:** the coordinator is an implementation detail. Leaving the Project route changes
+the visible owner and navigation contract, so users reasonably read the conversation as belonging
+to an Agent rather than to the Project that provides its tasks, goals, resources, and history.
+
+**Correct approach:** keep creation, topic selection, and resumed conversations under the Project
+route and Project sidebar. The coordinator may still execute the conversation internally, but the
+visible URL, active list, empty state, and navigation must consistently identify the Project.
+
+#### L-S11 — Bundled SPA HTML is not the whole site
+
+**Wrong approach:** collect only tags and CSS `url()` from `index.html`, then treat
+a Vite/webpack `dist` as publishable.
+
+**Why it fails:** hashed images and public sprites live in the JS bundle
+(`new URL('hero-….png', import.meta.url)`, `href: '/icons.svg#…'`). HTML-only
+collection ships CSS/JS and drops the files the app actually paints. Those JS
+references also cannot be inlined as data URIs: `import.meta.url` and SVG
+`<use href="/icons.svg#id">` need real sibling/root files.
+
+**Correct approach:** walk collected JS the same way as CSS. Keep
+`import.meta.url` targets and root-absolute sprites as sidecars even when they
+are under the inline size limit. Judge a Vite publish by the running page
+(images, icons, counter), not by whether `index.html` listed three tags.
+
+#### L-S12 — macOS `/tmp` and `/private/tmp` are the same workspace
+
+**Wrong approach:** treat a Files-tree path and the topic working directory as
+outside each other when one string starts with `/tmp` and the other with
+`/private/tmp`.
+
+**Why it fails:** Darwin's `/tmp` is a symlink to `/private/tmp`. Electron's
+project index reports the real path; topic cwd is often the public alias. A
+prefix check then marks `./app.css` as an escape, HTML-only publish keeps the
+relative hrefs, and the live host 404s those files.
+
+**Correct approach:** canonicalize those Darwin private aliases before workspace
+containment. Prove a publish by fetching the public HTML (data URIs or 200
+sidecars) and opening the live page — in-app preview of the local file does not
+prove the hosted assets.
+
+### Design or tooling knowledge — belongs to another skill (modal / react / ux / spa-routes) or the dependency docs
+
+#### L-D1 — Rebuilding a canonical surface from visual impression
+
+**Wrong approach:** copy a sibling surface's appearance without enumerating its
+semantics, states, affordances, wiring, and authored-data conventions.
+
+**Why it fails:** visual similarity can hide a second interaction dialect for the
+same product object and causes later improvements to drift.
+
+**Correct approach:** inspect the canonical implementation feature by feature, reuse
+its semantic components where possible, and compare both surfaces side by side.
+
+#### L-D10 — Long `confirmModal` bodies overlay the footer
+
+**Wrong approach:** put a long list into `confirmModal({ content })` and assume the
+library pins Cancel / OK below a scroll area.
+
+**Why it fails:** `confirmModal` renders `ConfirmBody` (content + footer) inside
+`ModalContent`, which is itself `overflow: auto`. A tall list makes the dialog
+scroll as one column, or the footer paints over the last rows. Callers cannot pass
+content styles to change that.
+
+**Correct approach:** for any confirm body that can exceed a few lines, use
+`createModal` with a height-capped `ScrollArea` as `content` and put the actions in
+the modal `footer` slot. Assert `footer.top === scroller.bottom` at both ends of the
+list, not just that the dialog opened.
+
+#### L-D13 — Picking `cssVar` color-scale steps by antd-palette intuition
+
+**Wrong approach:** choose antd-style palette steps (`cssVar.blue1` for a tint,
+`cssVar.blue6` for the primary line) from the standard antd 10-step palette in
+your head, and judge the result from the code alone.
+
+**Why it fails:** LobeHub's theme overrides the color scales with an 11-step
+palette whose primary-strength band sits at x9–x10 — light-mode `blue-6`
+resolves to `#acd4ff` and `blue-7` to `#93c8ff`, both near-pastel, nothing like
+antd's `blue-6` `#1677ff`. The UI then renders washed out while every token
+name in the code reads correct, and a one-step "fix" (x1→x2, x6→x7) changes
+almost nothing.
+
+**Correct approach:** never pick a scale step without reading the resolved
+value in the running app (`getComputedStyle` on the element, or resolve
+`--ant-<color>-<n>` from the element's scope — the variables are scoped, not on
+`:root`). For a tinted-tile + line pairing, the working band is around x3 for
+the tint and x9–x10 for the line, verified in both themes: the scale flips in
+dark mode, so a step that is a tint in light is a deep fill in dark.
+
+## Environment safety
+
+#### L-S6 — Reading or writing the url from a portal'd sidebar on desktop
+
+**Wrong approach:** use `useSearchParams`, `useQueryState`, `useParams`,
+`useLocation`, `useNavigate`, or a bare `<Link>` inside a component that a route
+layout registers through `NavPanelPortal`, and verify it only on web.
+
+**Why it fails:** the desktop shell renders every registered sidebar outside the
+per-tab routers, so React context binds those hooks to the root router, whose
+location never moves. A write lands on a router no page reads and a read resolves
+the boot url. Both are silent: the sidebar renders normally and web is unaffected,
+so the defect looks like unrelated page logic. Verified twice in this catalogue's
+lifetime — as a topic-switch failure that made the generation page ignore its own
+send button, and as a library tree that never expanded to the open folder.
+
+**Correct approach:** in any shell-rendered tree, read through the active-tab
+facades (`useActiveLocation`, `useActiveRouteParams`) and navigate through
+`useWorkspaceAwareNavigate` / `appNavigate`, keeping `<Link>` only for its href
+with the click handled by the facade. Note that no active-tab twin exists for
+search params: express a param write as a facade navigation rather than
+`setSearchParams`. When the state is a url ⇄ store sync owned by the page, mount
+it in the route layout instead, and cover it with a test that asserts which router
+received the write — a test that only asserts a write happened passes on the
+broken topology too.
+
+#### L-S0 — Concluding a dependency moved from the root manifest alone
+
+**Wrong approach:** refresh a shared dependency by running `pnpm install --filter .`
+at the repo root — or by bumping only the root range and running a full install —
+then read the new version out of `package.json` and treat a type-check failure in
+untouched files as pre-existing.
+
+**Why it fails:** the filter installs only the root workspace, and even an unfiltered
+install leaves `packages/*` on their old resolution when they declare a loose range
+(`"@lobehub/ui": "^5"` is satisfied by both the old and the new version, so nothing
+forces them to move). Two identities of the same package then coexist in the graph,
+and the errors surface far from the change — a duplicated `next` shows up as
+`NextRequest is not assignable to NextRequest` in backend route shells, and a
+duplicated UI package kills routes at the ErrorBoundary with a missing React context,
+or gives a component library two copies of a shared z-index/portal manager. Neither
+names the real cause.
+
+**Correct approach:** run a full `pnpm install` (no filter) after any dependency
+range change, then `pnpm dedupe` when the root and the workspace packages resolve
+different versions of a shared peer. State the version only from resolved copies —
+count the versions under `node_modules/<pkg>` and every `packages/*/node_modules/<pkg>`
+and require one distinct value — never from the root manifest. Remember `apps/desktop`
+and `apps/cli` are standalone installs that a root install never covers.
+
+#### L-S15 — Trusting a lockfile-false workspace's node\_modules to track current specs
+
+**Wrong approach:** debug a "missing export" build failure in a workspace with
+`lockfile: false` by bumping package.json specs or running `pnpm up`, assuming the
+next install re-resolves.
+
+**Why it fails:** pnpm keeps a hidden `node_modules/.pnpm/lock.yaml` that freezes
+prior resolutions even with `lockfile: false`; `pnpm install` and `pnpm up` can
+report success while every symlink stays on the stale version. CI never hits this
+because it installs from scratch.
+
+**Correct approach:** when installed versions contradict fresh-resolution
+expectations, delete the hidden `node_modules/.pnpm/lock.yaml` (or the whole
+node\_modules) in the affected workspace root and reinstall, then re-verify the
+actual resolved version via the importing package's symlink.
+
+### Moved to PROCESS.md as rules that hold under pressure (narrative kept here)
+
+#### L-S4 — Tearing down before asynchronous verification settles
+
+**Wrong approach:** stop the dev server or workflow dependencies when the main agent
+operation finishes or the first verification snapshot appears stuck.
+
+**Why it fails:** verification and repair can start minutes later and may still own
+pending operations.
+
+**Correct approach:** monitor verification results, repair-operation links, and the
+bound Task until a stable terminal state. Keep every required dependency alive until
+the final round settles or a concrete non-progress failure is proven.
+
+#### L-S10 — Judging popover/menu behaviour from a Chrome MCP tab (it is hidden)
+
+**Wrong approach:** drive the debug-proxy page through the Chrome MCP tools, click a
+popover trigger, read the DOM \~500ms later, see no popup, and conclude the trigger is
+broken — then bisect, revert a refactor, and write up a root cause from those readings.
+
+**Why it fails:** the MCP tab is not the foreground tab. Measured inside it:
+`document.visibilityState === 'hidden'`, `requestAnimationFrame` delivers **0 frames**,
+and `setInterval(16ms)` fires **once per second** (Chrome's background throttling). A
+base-ui popup still opens in its store and mounts in the DOM, but its entry transition
+never advances, so it sits at `data-starting-style` with `visibility: hidden` and zero
+size — indistinguishable from "the click did nothing". Anything else timed from that
+tab (perceived latency, "it landed 7 seconds later") is an artifact of the same
+throttling, not of the code under test.
+
+**Correct approach:** in an MCP tab, assert on **state**, not on visibility — the
+component's own store/props (`handle.store.state.open`, a probed React state), or DOM
+presence with `data-open`, never `visibility`/painted pixels or a rAF-timed measurement.
+Confirm the tab's own health first (`visibilityState`, a rAF frame count) before
+trusting any negative UI observation, and get behaviour that depends on animation or
+input timing confirmed in a foreground tab — the user's window, or a screenshot-based
+check that tolerates a frozen transition. A negative result from a hidden tab is not
+evidence of a defect.
+
+#### L-S13 — Treating a workspace another session has rewritten as your own code
+
+**Wrong approach:** edit and verify in place in this repo, and when the screenshots
+stop matching the source, suspect the Vite cache or your own CSS — restarting the
+dev server, adding more changes, and capturing again.
+
+**Why it fails:** a second session can be working on the same worktree. Its rebase
+helper stashes the **entire working tree** (stash message shaped like
+`pre-rebase2-<pr>-<sha>`), rebases the branch, and pops later; a conflicted pop
+leaves `<<<<<<<` markers inside the other session's files and breaks the whole SPA
+build. Both phases point away from the real cause: first "my change is written but
+has no effect" (the file was actually reverted to its HEAD version), then "the app
+will not open" (a conflict marker in someone else's file). Either one sends you
+debugging code you never broke.
+
+**Correct approach:** confirm your change is still on the tree both before and after
+capturing evidence — the file appears in `git status` and a marker unique to your
+change greps. On a mismatch, read `git stash list` timestamps and `git reflog`
+before suspecting the build cache. When your work has been stashed, recover only
+your own file with `git checkout stash@{n} -- <your file>`; **never pop or drop the
+whole stash** — it belongs to the other session, and popping it is that session's
+own action. When you find conflict markers in someone else's file, wait for them to
+resolve it rather than resolving it for them.
+
+#### L-S18 — Calling a fix verified without reproducing the failure's precondition
+
+**What happened.** A "draft stays in the composer after the task is created"
+bug was declared fixed across four separate rounds (r5 / r7 / r8 / r9) and was
+still fully present. Each verification ran against a task list that _already had
+tasks in it_, and the bug only exists on the empty→non-empty transition — that
+transition is what swaps the composer for a different component instance. Every
+"fix" ran green on a page where the failure could not occur.
+
+Two false root causes were shipped on the way: a stale editor handle (the handle
+is `useMemo(..., [])`, it was never stale) and a Lexical update landing outside
+the React event batch. Both were reasoned by analogy to other call sites rather
+than measured.
+
+**Rule.** Before verifying a fix, first reproduce the failure and write down the
+precondition that makes it appear. Then verify with that precondition held. A
+verification run that cannot fail proves nothing, and a green result on it is
+worse than no result — it retires the bug from the todo list.
+
+**Tell.** The bug reproduces "sometimes" or "only on the first try". That is not
+flakiness; it is an unnamed precondition. Find it before touching the code.
+
+**Tell.** The unit tests pass and the real app still breaks. Check what the test
+mocks: here `cleanDocument` was `vi.fn()`, so the tests asserted the call was
+made and could never observe that it landed on a dead instance. When the mocked
+seam _is_ the suspect, drop the mock and drive the real thing — a 20-line probe
+with the real editor kernel settled in one run what four rounds of analogy had
+not.

--- a/.agents/acceptance/scripts/llm-stub.mjs
+++ b/.agents/acceptance/scripts/llm-stub.mjs
@@ -5,7 +5,7 @@
  * Lets a check drive a turn to COMPLETION (or to a deterministic provider
  * failure) without any real LLM key: a real HTTP + SSE round trip through the
  * app's whole provider pipeline, same principle as s3rver standing in for S3.
- * Probe the shell for real keys first (M19) — only stub what is provably absent.
+ * Probe the shell for real keys first (generic M17) — only stub what is provably absent.
  *
  * Implements BOTH protocols the app speaks:
  *   - /v1/chat/completions  (chat-completions SSE chunks)

--- a/.agents/skills/skills-audit/SKILL.md
+++ b/.agents/skills/skills-audit/SKILL.md
@@ -80,6 +80,22 @@ git log --since="3 months ago" -- .agents/skills/ < skill > /SKILL.md # is it be
 
 If the underlying surface is gone and the skill hasn't been edited in 3+ months → flag for archival.
 
+### 5b — Living-log freshness (`common-mistakes.md`, `probe-mock-patterns.md`)
+
+Both layers (`.agents/skills/acceptance/references/` generic, `.agents/acceptance/`
+project) are injected into every acceptance round, so a stale entry is a stale
+instruction. For each entry:
+
+```bash
+rg -n '^`since|holds-while' .agents/acceptance/common-mistakes.md        # every entry must carry both
+rg -n 'holds-while: (?!always)' -P .agents/acceptance/common-mistakes.md # the mechanism-bound ones
+```
+
+- Missing `since` / `holds-while` → the entry predates the admission rule; either add them or move it to field-notes.
+- For every non-`always` `holds-while`, check whether the named mechanism still exists (the script default, the ingest gap, the platform behavior). Gone → delete the entry (PROCESS.md Step 0 exit rule); the field notes keep history.
+- An entry that names a project script from the generic layer, or a product noun, is in the wrong layer.
+- Duplicate ids (`rg -o '^### [ML]-?[A-Z]?\d+' | sort | uniq -d`).
+
 ### 6 — Cross-reference integrity
 
 Any skill body mentioning another skill by name:

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acceptance
-version: 0.1.0
+version: 0.3.0
 description: >
   End-to-end verification and self-evidence for a delivery in any repository,
   with or without a preconfigured verify plan. Discover an existing plan when
@@ -14,20 +14,20 @@ description: >
   ambient ids, and never depends on running inside a LobeHub conversation.
 ---
 
-# Verify (Builder Self-Evidence)
+# Acceptance (Builder Self-Evidence)
 
 You are the **builder** for a delivery. A separate review step judges it against
-either an existing **verify plan** or checks you author before testing. Some
-criteria demand **evidence** (a screenshot, a DOM snapshot, CLI output…). A
-criterion that declares `requiredEvidence` **cannot pass on your text alone**:
-if the artifact is missing, the structural gate marks it `uncertain` and the
-delivery is held.
+a **plan** — checks you author, or a verify plan handed to this run. A check that
+declares `requiredEvidence` **cannot pass on your text alone**: a missing artifact
+marks it `uncertain` and holds the delivery.
 
-## Read the project layer first (when the repository has one)
+```
+author (or discover) the plan  →  pick the surface  →  capture evidence  →  publish the round  →  self-check coverage
+```
 
-Before touching an environment, check for `.agents/acceptance/`. A repository
-that verifies itself keeps its own layer there, and it outranks any guess you
-would otherwise make:
+## Read the project layer first
+
+Before touching an environment, check for `.agents/acceptance/`:
 
 | File                     | What it owns                                                 |
 | ------------------------ | ------------------------------------------------------------ |
@@ -36,278 +36,146 @@ would otherwise make:
 | `common-mistakes.md`     | Project living log — what earlier rounds got wrong here      |
 | `probe-mock-patterns.md` | Project living log — how to force state on this product      |
 
-**The division of labor:** the project layer owns _how this repository is run_;
-this skill owns _what a valid acceptance round is_ (plan, evidence, report,
-immutable round, the hard rule below). Where they disagree on running, the
-project layer wins. Where they disagree on what may be published, this skill
-wins. Never invent a start command, a port, or an auth flow that `PROJECT.md`
-already answers, and never work around a divergence silently — fix the adapter
-in place during the run.
-
-No `.agents/acceptance/` means the repository has no project layer yet. Continue
-with the portable path below; if the run needs an adapter, bootstrap one first —
+The project layer owns _how this repository is run_; this skill owns _what a
+valid round is_ (plan, evidence, report, immutable round, the hard rule). On
+running, the project layer wins; on what may be published, this skill wins. Never
+invent a start command, port, or auth flow `PROJECT.md` answers; fix a divergence
+in the adapter during the run instead of working around it. No
+`.agents/acceptance/` → bootstrap one first:
 [project-adapter.md](references/project-adapter.md).
 
-Read both living-log layers before executing a round that drives a product
-surface: this skill's generic
-[common-mistakes.md](references/common-mistakes.md) and
-[probe-mock-patterns.md](references/probe-mock-patterns.md), plus the project's
-own copies. Record new project-specific learnings in the project layer only.
+## Living logs — inject each by its own shape
 
-## Applicability invariant
+Both layers (this skill's generic copies and the project's own) are loaded once
+the target is known, silently:
 
-This skill applies whenever the delivery needs real verification. **It requires
-no ids at all** — nothing about it is conditional on where it runs:
+- **[common-mistakes.md](references/common-mistakes.md)** — read its
+  **Checklist** in full, now and again before marking any case `pass`. Pull an
+  entry by id only when a checklist line applies to a case.
+- **[probe-mock-patterns.md](references/probe-mock-patterns.md)** — read the
+  heading index, then pull only the entries this round needs. Pick by meaning,
+  not keyword; `rg` over the body is the fallback.
 
-- **Were you handed an operation id** (a verify plan already exists for this
-  run)? Discover that plan and satisfy it.
-- **Otherwise** — the normal case — author the checks yourself and publish a
-  structured report round.
-- **Attaching to something specific?** Pass `--subject` (`task:<id>`,
-  `topic:<id>`, or `document:<id>`) when the caller named one. Otherwise omit it:
-  `lh acceptance run ingest` attaches the round itself when it can, and creates a
-  standalone acceptance when it cannot.
-
-Never report this skill inapplicable, and never go hunting through the
-environment for an id to make it applicable. Missing ids are the default state,
-not a degraded one.
-
-So while you do the work, capture the proof and submit it. The loop:
-
-```
-discover or author plan  →  pick the surface  →  capture evidence  →  publish the round  →  self-check coverage
+```bash
+rg -n '^#{2,4} ' <file>          # the index, with line numbers
+sed -n '<start>,<end>p' <file>   # one entry, in full
 ```
 
-The skill package is portable, but execution capabilities are surface-specific:
-`agent-browser` serves Web/Electron, while native macOS and iOS Simulator require
-a local macOS display and their platform tools. No repository-specific scripts are
-required; rounds land under `.acceptances/`, which the CLI keeps out of git for
-you (see [report.md](./references/report.md#directory-layout)).
+Record new project-specific learnings in the project layer only.
 
-## Two entry points — an operation id is NOT required
+## Two paths — no id is required
 
-Every evidence command targets a **verification session** (a round). How you name
-that session is a choice, not a prerequisite:
+Every evidence command targets a round. **The authored path is the default**; you
+have an operation id only when the invocation names one. Never hunt the
+environment for one, and never report this skill inapplicable — a round without
+an operation is simply recorded as `standalone`.
 
-| You have                        | Target the round with                                                                                                     | Path                                                   |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| An operation id you were given  | `--operation "$OPERATION_ID"`                                                                                             | This document: discover the plan, satisfy its criteria |
-| No plan — you author the checks | Publish a whole directory with `lh acceptance run ingest`; it creates the round and, when needed, a standalone acceptance | [references/report.md](references/report.md)           |
+| You have                        | Path                                                                                                                 |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| No plan — you author the checks | Write `result.json` + `assets/`, publish with `lh acceptance run ingest` — [report.md](references/report.md)         |
+| An operation id you were given  | `lh verify plan state`, then `result submit --operation` per criterion — [plan-format.md](references/plan-format.md) |
 
-**The authored path is the default.** You have an operation id only when the
-invocation names one — a task, a caller, or the user hands it to you. Do not read
-the environment looking for one, and do not treat its absence as a problem to
-solve: a round created without an operation is simply recorded as `standalone`.
+Pass `--subject` (`task:<id>` / `topic:<id>` / `document:<id>`) only when the
+caller named one; otherwise ingest attaches the round itself when it can and
+creates a standalone acceptance when it cannot. On the first ingest, always supply
+`--requirement "<one-sentence business goal>"` — the durable goal of the whole
+acceptance, not this round's scope; it is immutable once recorded.
 
-`--operation` and `--run` are interchangeable on `result submit` and
-`result list`. (`evidence list` takes neither — it keys off a positional
-`<checkResultId>` you read from `result list`.) On a later repair round, pass the
-previously printed `--acceptance <acceptanceId>` so the new snapshot joins the
-same history.
-
-On the first ingest, always supply `--requirement "<one-sentence business goal>"`.
-The requirement describes what the whole acceptance judges, not the narrower
-scope of one round. It is immutable once recorded.
+Prerequisites: `lh` is authed (`lh acceptance run list --json` returns `[]` or
+data; an auth error means stop and surface it), and only the UI driver the
+selected surface needs is installed — probe before adding dependencies, and never
+substitute a private agent plugin.
 
 ## HARD RULE — programmatic gates are NEVER acceptance checks
 
-This is a binding constraint on every check you author, enforced at ingest —
-not a style preference.
+Every check MUST be an outcome a **person decides about the delivery**: what the
+user sees, hears, reads, or receives. These MUST NOT appear as a check, under any
+phrasing: unit / integration / regression / snapshot tests, coverage,
+`type-check` / `tsc`, lint / `eslint`, format, "compiles", "build passes",
+"CI is green". Run them, then report them as **one line of narrative**.
 
-Every check MUST be an outcome a **person decides about the delivery**: what
-the user sees, hears, reads, or receives. The repo's own automated gates are
-not that. The following MUST NOT appear as a check, in any round, under any
-phrasing:
-
-- unit / integration / regression / snapshot tests; test suites or test cases
-- coverage, `type-check` / `tsc`, lint / `eslint`, format, "compiles cleanly",
-  "build passes", "CI is green"
-
-They are preconditions of shipping, and a page full of them buries the two or
-three checks that actually needed a human eye. Run them — then report them as
-**one line of narrative**, never as a check.
-
-Enforcement, so plan around it rather than against it:
-
-- `lh acceptance run ingest` **drops** every matching plan item and case and
-  warns — the round publishes without them, so a gate-check wastes the effort
-  spent producing it.
-- A round consisting **only** of such checks **fails to publish entirely**:
-  there is nothing in it for a person to accept.
-
-The line is the _subject_ of the check, not who judged it: a CLI behavior check
-asserted by a command is a good acceptance item (`verifier: "program"`);
-"`bun run test` is green" is not. Before writing any plan, re-read each draft
-check and ask: _would the user click accept/reject on this?_ If the honest
-answer is "it's a gate", it does not go in.
+Enforced at ingest: every matching item (matched on title, category, AND
+`method` — "run `bun run test`" under a product-sounding title still matches) is
+**dropped** with a warning and `summary` recounted; a round of only such checks
+**fails to publish**. The line is the _subject_ of the check, not who judged it:
+a CLI behavior asserted by a command is a fine check (`verifier: "program"`);
+"the suite is green" is not. Before writing any plan, ask of each draft check:
+_would the user click accept/reject on this?_
 
 ## Rounds are immutable — repair means a NEW round
 
-A published round is a permanent record of what was true at that moment. **Never
-re-submit into a round to "fix" it after changing the code** — publish the
-re-verification as the next round, and let the acceptance page show the
-progression. Correcting a typo in the same session's report is fine; passing off
-post-fix evidence as the original round is not.
+A published round is a permanent record. **Never re-submit into a round after
+changing the code** — publish the re-verification as the next round and let the
+acceptance page show the progression.
 
-Before a repair round, read the current acceptance with
+Before a repair round, read the aggregate with
 `lh acceptance view <acceptanceId | type:id> --json`. Omit checks whose latest
-`userReview.action` is `accept`; address non-stale rejects and reuse their exact
-stable check ids. When one check semantically replaces another, declare
-`supersedes: ['old-id']` and repeat the complete lineage in every later round
-that reuses the successor id.
+`userReview.action` is `accept`; address non-stale rejects under their exact
+stable ids; when a check semantically replaces another, declare
+`supersedes: ['old-id']` and repeat the full lineage in every later round that
+reuses the successor id. Pass `--acceptance <acceptanceId>` so the round joins
+the same history.
 
-The **acceptance** (`/acceptance/<acceptanceId>`) is the stable cross-round
-decision surface that aggregates every immutable round for a subject. In the
-final reply, expose only the acceptance page. A fixed snapshot of the current
-round uses that same path with `?r=<roundIndex>`; implementation-level run pages
-stay internal.
+## Rules you will be tempted to skip
 
-## Prerequisites
+Not judgment calls — the moves an agent under pressure makes and must not. Each
+excuse below was made in a real round.
 
-- **`lh` is authed.** Confirm with `lh acceptance run list --json` (an empty `[]`
-  means authed; an auth error means stop and surface it).
-- **A round path.** Use the operation id when this run was given one. Otherwise
-  author a structured report; ingest creates both its round and its acceptance.
-- **Install only the UI driver required by the selected surface.** Web/Electron
-  use `agent-browser`; native iOS uses Xcode/`simctl` plus a Simulator HID/AX CLI
-  such as AXe, or the repository's existing UI-test driver. Probe installed tools
-  before adding dependencies, and do not substitute a private agent plugin.
+| Excuse                                                                                                 | Reality                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Injection is hard; happy-path plus unit tests covers it"                                              | The error state _was_ the goal. Walk the probe ladder ([probe-mock-patterns.md](references/probe-mock-patterns.md) A) before calling it blocked. (M2)                                                                           |
+| "The branch name says what to verify" / "Loading the living logs first…"                               | The task lives in the user's words. Recover it, or confirm a labeled guess with one structured question — silently; never narrate setup. (M3, M21)                                                                              |
+| "The black frame is probably display sleep / a permission"                                             | Measure first: pixel brightness, the permission bit, an A/B with one variable toggled. Publish "confirmed by X" or "suspected", never a guess. (M4)                                                                             |
+| "Let me ask how they want it run" / "I'll click Sign in and you authorize" / "too small to screenshot" | Environment mechanics are yours: full isolated run, auth by direct injection (never an interactive login — it hijacks the user's browser), a screenshot for every user-facing change. Ask only about the product decision. (M8) |
+| "One more config edit and the env will boot" / "I'll mock it" / "I'll drive the rest myself"           | Timebox. Inventory running instances, probe for the real capability before mocking (a mock that records nothing is not in the path), re-delegate a dead subagent's remaining steps, revert experiments and ask. (M17)           |
+| "The fix is in and tests pass — verified"                                                              | Reproduce the failure's precondition first, then verify with it held. A run that cannot fail proves nothing; "reproduces sometimes" means an unnamed precondition. When the mocked seam is the suspect, drop the mock. (M31)    |
 
-## Step 1 — Discover the plan (what to prove)
+## Pick the surface by what you changed
 
-> Plan-driven path only. Authoring your own checks instead? Apply the
-> [hard rule](#hard-rule--programmatic-gates-are-never-acceptance-checks) to
-> every check you write, then jump to
-> [references/report.md](references/report.md) and use the relevant surface
-> recipes below to capture its evidence. Publish that authored plan and its
-> cases together with `lh acceptance run ingest`.
+Match the change to the cheapest surface that can prove it; escalate only if
+needed.
 
-One read tells you what to prove (`$OPERATION_ID` is the id this run was given):
+| What your task changed                                      | Surface                                               | Guide                                                  |
+| ----------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| Backend / CLI / library / data logic                        | **CLI** — stdout as `text`, zero UI flakiness         | [surfaces/cli.md](surfaces/cli.md)                     |
+| Web app frontend / styles / interactions                    | **Web** (agent-browser → running web app)             | [surfaces/web.md](surfaces/web.md)                     |
+| New/changed API **plus** the UI consuming it                | **Web**, full-stack (agent-browser + network capture) | [surfaces/web.md](surfaces/web.md#web-full-stack)      |
+| Desktop-only behavior (native windows, IPC, packaged shell) | **Electron** (agent-browser `--cdp`)                  | [surfaces/electron.md](surfaces/electron.md)           |
+| Native macOS app / OS chrome agent-browser can't reach      | **Native** (osascript + screencapture, local macOS)   | [surfaces/native.md](surfaces/native.md)               |
+| Native iOS behavior, gestures, device-size layout           | **iOS Simulator** (AXe/native CLI + `simctl`)         | [surfaces/ios-simulator.md](surfaces/ios-simulator.md) |
 
-```bash
-lh verify plan state "$OPERATION_ID" --json
-```
+- **Don't open a browser for a backend change**; command output as `text` is the
+  strongest, cheapest proof. Use **Electron** only when the criterion depends on
+  desktop-only code; iOS is driven by a Simulator HID/AX CLI, never host mouse —
+  mark the case `blocked` if the CLI cannot express the gesture.
+- **Structured data uses native visualizations** (`cases[].datasets` +
+  `cases[].visualizations`; raw CSV/JSON stays as `evidence`), not a PNG —
+  [report.md](references/report.md#structured-visualizations). **A deliverable
+  the user hears needs `audio`** —
+  [evidence.md](references/evidence.md#audio-deliverables).
+- **Auth is a gate scoped to the surface**: authenticate that surface first or
+  every capture lands on the sign-in page. Web:
+  [auth-web.md](references/auth-web.md).
+- **A UI round may price its interaction cost** by recording KLM operator counts
+  into `interaction-trace.jsonl`; optional, never hand-written —
+  [interaction-cost.md](references/interaction-cost.md).
 
-Each `verifyPlan[]` item carries `id` (the **checkItemId**), `title`, `required`,
-and `verifierConfig.requiredEvidence` (`[{ type, hint }]` — the artifacts you MUST
-capture). The `checkItemId` is the only handle you need: `lh acceptance run result submit` (Step 3)
-keys off it plus your operation id and creates the result row for you, so you do
-**not** need a `checkResultId` up front. (Result rows generally don't exist yet at
-this point — that's expected.) Exact shapes:
-[references/plan-format.md](references/plan-format.md).
+Shared rules for every artifact — media types, provenance, file vs inline,
+safety — are in [evidence.md](references/evidence.md).
 
-> Only items with a non-empty `requiredEvidence` need an artifact. Items without
-> it are judged on the deliverable text alone — don't fabricate evidence.
+## Final handoff (mandatory)
 
-## Step 2 — Pick the surface by what you changed
+Before declaring the task done, prove coverage: for each check with
+`requiredEvidence`, every declared `type` is present at least once. Report it
+explicitly; a missing type holds the delivery at `uncertain` no matter how good
+the work is.
 
-The criterion's `hint` usually implies the surface. Match the change you made to
-the cheapest surface that can actually prove it, and escalate only if needed:
-
-| What your task changed                                         | Surface                                               | Why                                                                                            | Guide                                                  |
-| -------------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| Backend / CLI / library / data logic                           | **CLI**                                               | Fastest, text-assertable, zero UI flakiness — upload stdout as `text`                          | [surfaces/cli.md](surfaces/cli.md)                     |
-| Web app frontend / styles / interactions                       | **Web** (agent-browser → running web app)             | The product shape users see; screenshot/DOM the rendered result                                | [surfaces/web.md](surfaces/web.md)                     |
-| New/changed API **plus** the UI consuming it                   | **Web**, full-stack (agent-browser + network capture) | One surface where request/response and rendered result are both observable                     | [surfaces/web.md](surfaces/web.md#web-full-stack)      |
-| Desktop (Electron) app behavior                                | **Electron** (agent-browser `--cdp`)                  | Only the real desktop shell exercises desktop-only code paths                                  | [surfaces/electron.md](surfaces/electron.md)           |
-| Native macOS app / OS-level behavior agent-browser can't reach | **Native** (Computer Use: osascript + screencapture)  | The only way to drive non-Chromium apps and OS chrome (local macOS only)                       | [surfaces/native.md](surfaces/native.md)               |
-| Native iOS app behavior, gestures, or device-size layout       | **iOS Simulator** (AXe/native CLI + `simctl`)         | Proves the installed iOS binary, native HID input, Accessibility state, and device framebuffer | [surfaces/ios-simulator.md](surfaces/ios-simulator.md) |
-
-Rules of thumb:
-
-- **Don't open a browser for a backend change.** If a criterion is satisfied by a
-  command's output, capture that as `text` — it's the strongest, cheapest proof.
-- **Structured data uses native Acceptance visualizations by default.** Metrics,
-  time series, model or benchmark comparisons, distributions, matrices, and
-  tables belong in `cases[].datasets` plus `cases[].visualizations`; keep the raw
-  CSV/JSON, benchmark output, trace, profile, or vectors as `evidence`. Do not
-  generate a PNG/GIF when a supported renderer can faithfully express the data.
-  Static charts are only a fallback when no native renderer fits, and that
-  limitation must be stated in the case observation. See
-  [references/report.md](references/report.md#structured-visualizations).
-- **A deliverable the user hears needs `audio`.** TTS output, a voice reply, an
-  alert tone: upload the clip itself so the page renders a player. Prose about a
-  sound, or a screenshot of a waveform, proves nothing.
-  See [references/evidence.md](references/evidence.md#audio-deliverables).
-- **Web vs Electron:** use **web** when the behavior is identical in a normal
-  browser against the app's dev server or deployed URL. Use **Electron** only when
-  the criterion depends on desktop-only behavior (native windows, IPC, the
-  packaged shell, OS integration) — that code path doesn't exist in a plain web
-  page. Switching conditions per surface: [surfaces/web.md](surfaces/web.md) and
-  [surfaces/electron.md](surfaces/electron.md).
-- **iOS is not a browser or host-mouse surface.** Use AXe or another installed
-  Simulator HID/Accessibility CLI for taps, long press, swipe, pan, and UI-tree
-  inspection; use `simctl` for lifecycle/framebuffer capture. If the available
-  CLI cannot express the planned touch sequence, mark the case `blocked`.
-- **A UI round may also price its interaction cost.** While driving the product,
-  record each action's raw KLM operator counts into `interaction-trace.jsonl` in
-  the report directory; ingest prices them with the platform's pinned timing
-  model. It is an optional overlay — a CLI round, or a machine with no UI driver
-  installed, records no trace and publishes normally. Never hand-write the
-  numbers. See [interaction-cost.md](references/interaction-cost.md).
-- **Auth is a gate, scoped to the surface.** If the state under test is behind a
-  login, authenticate that surface first or every capture lands on the sign-in
-  page. Follow the selected surface's Auth section; load
-  [references/auth-web.md](references/auth-web.md) only for a Web session.
-
-## Step 3 — Capture, then submit each artifact
-
-Capture each required `type` with the selected surface guide, then apply the
-shared artifact rules in [references/evidence.md](references/evidence.md) and
-submit one artifact per call with the criterion's `checkItemId`.
-`lh acceptance run result submit` resolves your session from the operation id,
-lazily creates/updates the result row, and attaches the evidence — one call, no
-`checkResultId` needed:
-
-```bash
-# CHECK_ITEM_ID is the plan item id for this criterion (from Step 1).
-# file artifact already captured by the selected surface
-lh acceptance run result submit --operation "$OPERATION_ID" --item "$CHECK_ITEM_ID" \
-  --type "$EVIDENCE_TYPE" --file "$ARTIFACT_PATH" --by "$PROVENANCE" \
-  --desc "Observed state after the planned action"
-
-# inline text artifact (stdout / computed value) — no file
-lh acceptance run result submit --operation "$OPERATION_ID" --item "$CHECK_ITEM_ID" \
-  --type text --content "$(your-cli command --json)" --by cli \
-  --desc "command reports success after the change"
-```
-
-`--by` records provenance: `agent-browser` | `cdp` | `cli` | `program`. Use
-`--file` for binaries, `--content` for text — exactly one. Submit one artifact per
-call; call again for each additional one (same `--item` reuses the row). Leave the
-pass/fail **verdict** to the review step — only add `--verdict` if your task
-explicitly asks you to self-assert the outcome. Every successful submit prints the
-an internal run URL. Keep the returned run id only for coverage checks; never
-expose that URL in the final handoff.
-
-## Step 4 — Self-check coverage (do not skip)
-
-Before you declare the task done, prove every required artifact landed. For each
-criterion with `requiredEvidence`, list what you submitted and confirm each `type`
-is present. After submitting, the result rows exist, so map each `checkItemId` to
-its `checkResultId` and list that row's evidence:
-
-```bash
-lh acceptance run result list --operation "$OPERATION_ID" --json # checkItemId → checkResultId
-lh acceptance run evidence list "$CHECK_RESULT_ID" --json
-```
-
-Coverage rule: for each required criterion, **every** `requiredEvidence[].type`
-must appear at least once in its evidence list. Report it explicitly, e.g.
-`coverage: 2/2 criteria, all required evidence uploaded`. If a type is missing, go
-back to Step 3 — a missing artifact holds the delivery at `uncertain` no matter
-how good the work is.
-
-### Final handoff (mandatory)
-
-The final response MUST include the published acceptance URL when the round is
-attached to an acceptance, together with the explicit coverage result. Do not
-finish with only a check-result id or prose claim.
-
-Expose only the **acceptance** link — it is the stable cross-round decision
-surface. For this round's fixed snapshot, append `?r=<roundIndex>` to that same
-URL. Put no images, local paths, local file links, or internal run-page paths in
-the chat reply.
+The final response MUST include the published acceptance URL together with the
+coverage result — never only a check-result id or a prose claim. Expose only the
+**acceptance** (`/acceptance/<acceptanceId>`), the stable cross-round decision
+surface; append `?r=<roundIndex>` for this round's fixed snapshot.
+Put no images, local paths, local file links, or internal run-page paths in the
+chat reply.
 
 ```text
 Acceptance:   https://app.lobehub.com/acceptance/<acceptanceId>
@@ -316,31 +184,26 @@ Coverage: 2/2 criteria, all required evidence uploaded
 
 ## Portability rules
 
-- **Prefer engine-level capture over OS capture.** `agent-browser screenshot` /
-  `dom` / `eval` render from the browser engine and run headless; `screencapture`
-  / osascript are macOS-only and break in the cloud. For iOS Simulator, prefer
-  its own framebuffer via `xcrun simctl io` over host-window capture.
-- **Upload as you go, not at the end.** Evidence uploaded mid-run is keyed to the
-  criterion immediately; a crash near the end doesn't lose your proof.
-- **Don't invent evidence.** Only capture the types a criterion declares.
-  Over-uploading noise makes the review harder, not easier.
+- **Engine-level capture over OS capture.** `agent-browser screenshot` / `dom` /
+  `eval` run headless; `screencapture` / osascript are macOS-only. iOS: `xcrun
+simctl io` over host-window capture. Rounds land under `.acceptances/`, which
+  the CLI keeps out of git.
+- **Upload as you go.** Evidence keyed to its check mid-run survives a crash near
+  the end.
+- **Don't invent evidence.** Capture only the types a check declares.
 
 ## Reference map
 
-Load detailed references only after selecting the applicable path:
-
-| Need                                                   | Reference                                                           |
-| ------------------------------------------------------ | ------------------------------------------------------------------- |
-| The project layer, and bootstrapping an adapter        | [project-adapter.md](references/project-adapter.md)                 |
-| Verification mistakes to self-check against            | [common-mistakes.md](references/common-mistakes.md)                 |
-| Forcing state, error injection, runtime probes         | [probe-mock-patterns.md](references/probe-mock-patterns.md)         |
-| Existing verify-plan schema and join keys              | [plan-format.md](references/plan-format.md)                         |
-| Shared media, provenance, submission, and safety rules | [evidence.md](references/evidence.md)                               |
-| Interaction cost for a UI round (optional overlay)     | [interaction-cost.md](references/interaction-cost.md)               |
-| Authored structured rounds and `result.json`           | [report.md](references/report.md)                                   |
-| Web/Electron Chromium CLI commands                     | [agent-browser.md](references/agent-browser.md)                     |
-| Authenticated Web session                              | [auth-web.md](references/auth-web.md)                               |
-| Native macOS or OS-owned step                          | [computer-use.md](references/computer-use.md)                       |
-| Web/Electron temporal evidence                         | [recording-cdp.md](references/recording-cdp.md)                     |
-| iOS Simulator temporal/frame evidence                  | [recording-ios-simulator.md](references/recording-ios-simulator.md) |
-| Native macOS temporal evidence                         | [recording-native-macos.md](references/recording-native-macos.md)   |
+| Need                                           | Reference                                                                                                                                                                               |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The project layer, bootstrapping an adapter    | [project-adapter.md](references/project-adapter.md)                                                                                                                                     |
+| Mistakes checklist (read every round)          | [common-mistakes.md](references/common-mistakes.md)                                                                                                                                     |
+| Forcing state, error injection, runtime probes | [probe-mock-patterns.md](references/probe-mock-patterns.md)                                                                                                                             |
+| Authored rounds, `result.json`, ingest         | [report.md](references/report.md)                                                                                                                                                       |
+| Plan-driven rounds: schema, submit, coverage   | [plan-format.md](references/plan-format.md)                                                                                                                                             |
+| Evidence media, provenance, submission, safety | [evidence.md](references/evidence.md)                                                                                                                                                   |
+| Interaction cost overlay                       | [interaction-cost.md](references/interaction-cost.md)                                                                                                                                   |
+| Web/Electron Chromium CLI commands             | [agent-browser.md](references/agent-browser.md)                                                                                                                                         |
+| Authenticated Web session                      | [auth-web.md](references/auth-web.md)                                                                                                                                                   |
+| Native macOS / OS-owned step                   | [computer-use.md](references/computer-use.md)                                                                                                                                           |
+| Temporal evidence: Web/Electron, iOS, native   | [recording-cdp.md](references/recording-cdp.md), [recording-ios-simulator.md](references/recording-ios-simulator.md), [recording-native-macos.md](references/recording-native-macos.md) |

--- a/packages/builtin-skills/src/acceptance/references/common-mistakes.md
+++ b/packages/builtin-skills/src/acceptance/references/common-mistakes.md
@@ -2,650 +2,174 @@
 
 > **This is the GENERIC layer of the living log.** It ships with the skill, so a
 > consumer repo's copy is materialized and read-only — change it by PR to the
-> skill source. Every entry here must be **product-independent**: no project's
+> skill source. Every entry must be **product-independent**: no project's
 > packages, routes, schemas, env vars, service names, or business logic. Those go
 > to `.agents/acceptance/common-mistakes.md`, the writable project layer.
->
-> **Read this file in full before executing a round that drives a product
-> surface**, and self-check against each case before calling a check passed. When
-> the user gives negative feedback that is product-independent, genericize it and
-> PR it here; otherwise record it in the project layer. Each case: Wrong approach
-> / Why it's wrong / What it breaks / Correct approach.
 
----
+## How this file is injected
 
-## M1 — Judging `passed` from heuristics instead of looking at the screenshot
+A mistake catalogue works by having been read — you cannot search for a failure
+mode you do not yet know you are about to hit. But the rule is what must be in
+context, not the narrative. So the file has two tiers, read at two moments:
 
-**Wrong approach**: after navigating to a surface, deciding "renders fine / passed"
-from only `innerText` keyword greps + a skeleton/element count, without ever opening
-the screenshot.
+| Tier          | Read                                                                                      | When                                                                                 |
+| ------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Checklist** | in full — one line per mistake                                                            | once the target is known, and again before marking any case `pass` or the round done |
+| **Entries**   | by id — `rg -n '^### M' <file>` for line numbers, `sed -n '<start>,<end>p'` for one entry | when a checklist line applies to a case, or a reviewer's feedback matches one        |
 
-**Why it's wrong**: the persistent nav / layout-shell text is always in the DOM, so
-an `innerText` grep almost always false-positives. A blank/white page also has 0
-skeletons, so `skeletons === 0` cannot tell "rendered successfully" from "rendered
-blank".
+Only **judgment** rules live here — the ones no tool can check. Rules an agent
+skips under pressure are in SKILL.md ("Rules you will be tempted to skip");
+rules a validator or a script default can enforce are removed the day that
+code lands. Every entry therefore carries `since` (first observed) and
+`holds-while` (the mechanism it depends on; `always` means pure judgment). An
+entry whose `holds-while` no longer holds is deleted, not kept as reference.
 
-**What it breaks**: publishes a **false `passed`** — a blank or watermark-only page
-reported as working, hiding a real regression.
+Apply the same shape to the project layer's file. Never narrate the reading.
 
-**Correct approach**: every screenshot destined for a report `evidence` **must first
-be opened with the Read tool and visually confirmed to render the expected content**
-before pass/fail. Greps/counts are supporting signals only, never the verdict. A
-blank page / watermark / layout-shell-only = fail or uncertain — go find the root
-cause.
+## Checklist
 
-**The mirror case — asserting a feature is ABSENT by grep.** Searching the page
-text for a feature's name to prove it is _not_ rendered is worse than the positive
-case, because your own report prose is on that page: an acceptance whose goal
-sentence names the feature will match its own words and report the feature as
-present. When the claim is about presence or absence of a UI section, assert it
-against structured state (the API/metadata that drives it, or a located DOM node),
-not against a substring of the rendered text.
+- **M1** Open every screenshot with Read before `pass`; greps and element counts never decide. Presence/absence of a UI section is asserted on structured state, never on page text.
+- **M5** Before/after is a `comparison` pair with exactly one `before` and one `after`; never a stale shot loose in `evidence`, never a hand-composed image, never sequential flow steps.
+- **M6** Prove the running instance loads your working-tree code by measuring a changed value. After a direct fixture write, cold-load and assert at the layer the behavior reads, not where you wrote.
+- **M12** A UI chip/badge is supporting evidence; the payload, request body, DB row, or side effect is the proof.
+- **M13** A GIF's last frame is its headline — end on the asserted state or say in `observation` why it ends elsewhere.
+- **M14** GIF at source resolution, per-frame palette, no dithering on neutral UI; inspect first/middle/last frames.
+- **M15** A changed shared component is verified on every surface that renders it; skipped surfaces are marked untested.
+- **M16** A change inside a bar/row with overflow is verified in default and collapsed/overflow state.
+- **M22** An error-state case needs the failed status AND the user-facing message in the same screenshot.
+- **M28** Non-visual behavioral claims carry two text artifacts in the same round: reasoning, then execution record.
+- **M30** Electron evidence is the visible viewport, never `screenshot --full`.
 
----
+## Entries
 
-## M2 — Goal is verifying error states, but stopping at happy-path because injection is hard
+### M1 — Judging `pass` from heuristics instead of the screenshot
 
-**Wrong approach**: after the first batch of fault-injection methods fails to force
-an error, giving up on the error-state screenshots and shipping only happy-path +
-unit tests, marking the core goal uncertain/blocked.
+`since 2026-07-17` · `holds-while: always`
 
-**Why it's wrong**: the **entire point** of the task was verifying the error states.
-Abandoning that = task not done — especially when other viable methods exist
-unattempted.
+**Trap:** deciding "renders fine" from `innerText` greps plus an element/skeleton
+count. Layout-shell text is always in the DOM and a blank page also has zero
+skeletons, so both false-positive. The mirror is worse: grepping page text to
+prove a feature is _absent_ matches your own report prose naming it.
 
-**What it breaks**: the deliverable doesn't cover what the user asked for — a wasted
-round that needs redoing.
+**Rule:** every screenshot cited as evidence is opened with the Read tool and
+visually confirmed first. Blank / watermark / shell-only = fail or uncertain; go
+find the cause. Presence or absence of a UI section is asserted against the state
+that drives it or a located DOM node, never a substring.
 
-**Correct approach**: **do not stop until the core goal is met.** When the first
-batch of methods fails, immediately switch to the next known-working one — see
-[probe-mock-patterns.md](./probe-mock-patterns.md) for the escalation ladder (code
-injection via HMR, CDP `Network.setBlockedURLs`, server-side fault injection). Get
-the **real failure-state evidence** before writing the report.
+### M5 — Before/after that is not a comparison pair
 
----
+`since 2026-07-17` · `holds-while: ingest does not reject a comparison id with a missing or duplicated half`
 
-## M3 — Deriving the task from commit messages / branch name instead of the actual ask
+**Trap:** a stale "before" shot loose in a passed case's `evidence` (the page
+headings each image by filename, so it reads as the current result); two shots
+hand-composed into one image; or two sequential steps of a flow tagged as
+`before`/`after`.
 
-**Wrong approach**: on a resumed session with lost prior context, reading the branch
-name and top commits and concluding _that_ is the thing to verify — then building a
-whole test run around it — when the user's real task was a different feature.
+**Rule:** one view in two states = a `comparison` pair with a shared `id`,
+exactly one `before` and one `after`, one pair per case; the page owns the
+labeling. Flow steps are ordered evidence with captions. Shape in
+[report.md](./report.md#beforeafter-comparison-pairs).
 
-**Why it's wrong**: a branch's committed work is not necessarily the current ask.
-When context was summarized/lost, the commit history is a _hypothesis_, not the task.
-The task lives in the user's words.
+### M6 — Verifying against a build or cache that is not your code
 
-**What it breaks**: burns a full test run and clarifying rounds on the wrong feature
-before course-correcting.
+`since 2026-07-17` · `holds-while: always`
 
-**Correct approach**: when the user references a task you don't have in context, say
-so plainly and RECOVER it before acting — check `.acceptances/` for prior
-sessions on this branch, read the live conversation's own messages (the first user
-turn is usually the task), or ask for a pointer. Only translate the ask into
-code/commits after it's grounded.
+**Trap:** driving a resident or packaged instance and eyeballing the first
+screenshot as "changed" — it serves a built snapshot, not your working tree.
+Same shape one layer down: writing a fixture to the DB, reloading, and filing the
+stale value the persisted client cache still serves as a product bug.
 
----
-
-## M4 — Asserting a capture/tooling root cause from plausibility instead of measuring it
-
-**Wrong approach**: when a screenshot came out black or a capture failed, declaring a
-root cause from what "sounds right" (missing permission, display sleep, tool bug) and
-publishing it — before running the experiment.
-
-**Why it's wrong**: each of these is falsifiable in seconds and often wrong. A black
-frame can be display sleep OR a wedged capture daemon OR a real blank page; guessing
-sends the next reader to fix the wrong thing.
-
-**What it breaks**: a published report with a wrong root cause, plus wasted
-round-trips retracting each claim.
-
-**Correct approach**: for any capture / permission / timing / "environment" failure,
-**reproduce and measure before asserting or publishing** — pixel brightness for
-blackness, the permission bit for TCC, an A/B with the variable toggled to isolate
-the cause. State "confirmed by X" vs "suspected", and never ship a root cause a
-one-line probe could have checked.
-
----
-
-## M5 — Attaching a stale "before" screenshot as a passed case's evidence (unlabeled)
-
-**Wrong approach**: putting BOTH the "after" and a stale "before" screenshot into the
-same `cases[].evidence` array, unlabeled. The acceptance page renders every evidence
-image with its filename as a heading, so the user opens the stale shots and concludes
-the fix didn't land.
-
-**Why it's wrong**: a passed case's evidence must show the PASSING (after) state. An
-unlabeled before-shot next to it reads as "the current result", making a correct fix
-look broken. Filenames are not captions.
-
-**What it breaks**: the user reads a green report as a failure, loses trust, and it
-takes another round to re-explain.
-
-**Correct approach**: never ship a raw stale/before screenshot as standalone
-evidence. When a contrast helps, use the report format's **native comparison
-pairing** — attach both raw screenshots tagged with a shared `comparison` id and the
-page renders them under Before / After bands (see
-[report.md](./report.md)). **Do NOT hand-compose the two shots into one image** — the
-page owns the labeling. Two more traps: one evidence item per case (don't reuse the
-same pair across cases), and a group needs **exactly one `before` and one `after`**
-or it silently degrades to unlabeled evidence.
-
----
-
-## M6 — Verifying against a stale build, not your working-tree code
-
-**Wrong approach**: driving an already-running app instance to verify a working-tree
-change, and eyeballing the first screenshot as "looks changed".
-
-**Why it's wrong**: a resident or packaged app serves a BUILT snapshot — it does not
-reflect uncommitted / HMR src changes. The change under test may not be running at
-all, so the screenshot proves nothing about your code.
-
-**What it breaks**: verifying against code that isn't your change → a false pass (or
-false fail) on the wrong bundle entirely.
-
-**Correct approach**: verify working-tree code in an instance that actually loads it
-(a dev instance with HMR/live reload), and **prove it's live by MEASURING a
-known-changed value** (a computed style, a new string) before trusting any
-screenshot. Don't disturb the user's resident instance — use a separate
-instance/port. Remember main-process / server / adapter code often does not
-hot-reload; restart the process and prove which code it runs before concluding a
-logic bug.
-
----
-
-## M7 — Exposing working-artifact paths in the chat reply
-
-**Wrong approach**: ending the final reply with an inline image embed or link
-pointing at the local report dir, believing it will render as a picture in chat.
-
-**Why it's wrong**: the chat UI cannot load a local filesystem path. An image embed
-of a local path renders as an empty broken-image box, and a markdown link to a local
-path is an un-openable dead link. Local report paths only resolve on the machine,
-never inside the message.
-
-**What it breaks**: the reply looks like it has evidence but shows nothing — the user
-gets a broken box and has to go find the acceptance link anyway.
-
-**Correct approach**: put NO images and NO local paths or local-file links in the
-chat reply. The
-published `/acceptance/<id>` page already renders every screenshot inline (append
-`?r=<roundIndex>` for this round's fixed snapshot) — that URL is the only visual
-deliverable. Describe key visual outcomes in prose without exposing the working
-artifact location or any internal run-page path.
-
----
-
-## M8 — Asking the user "how should I run this?" instead of defaulting to a full isolated run
-
-**Wrong approach**: when a visual/screenshot request needs a non-trivial environment
-(the app must run a specific branch, a fixture must be built, an isolated instance is
-needed), stopping to ask the user which approach to take — full isolated run vs a
-lighter shot vs a static prototype.
-
-**Why it's wrong**: environment mechanics are the skill's job to own. Presenting env
-difficulty as a menu of shortcuts pushes setup decisions back onto the user and
-signals the agent will cut corners on fidelity when the env is inconvenient.
-
-**What it breaks**: wastes a round on a question the user doesn't want.
-
-**Correct approach**: for any "run it and show me" request, default to the **full
-isolated run** that ends in a published acceptance report — spin up whatever dedicated
-instance and fixture data the surface needs (a throwaway repo, an isolated dev
-instance, seeded data), capture the real rendered evidence, verify it by opening the
-image, and publish. Only surface a plan-approval question when the _product decision_
-is ambiguous (what to test), never for _environment mechanics_ (how to render it).
-
----
-
-## M9 — Handing the user the sign-in click when the app under test is signed out
-
-**Wrong approach**: an isolated instance came up signed out, so the run stopped and
-offered the user a choice: "I click Sign in and you authorize" vs "skip the
-screenshot".
-
-**Why it's wrong**: auth is environment mechanics, and the skill owns those end to
-end. "Log in once in the app" is addressed to the **agent**, not the user.
-
-**What it breaks**: burns a round on a question the user doesn't want, and stalls a
-UI-touching change one click short of its screenshot.
-
-**Correct approach**: obtain the login state by **direct injection** — restore the
-project's persisted login snapshot, or mint a session via CLI/API seeding — and
-never by driving an interactive login/OAuth flow: clicking "Sign in" makes the app
-open an authorize page in the **user's own default browser** (visibly hijacking
-their session, and in dev pointing at a per-instance localhost origin that often
-cannot complete). If no injectable state exists, report auth as blocked and ask for
-one manual sign-in, naming the exact blocking step instead of offering to drop the
-evidence. Corollary: never assume a profile is signed in because it exists — probe
-for a real signed-in state (a cheap authed call) before building a fixture on top of
-it; a rendered shell is not proof (a signed-out onboarding screen has text too).
-
----
-
-## M10 — Self-judging a screenshot as "too costly" and asking the user to picture the result
-
-**Wrong approach**: after a small user-facing UI change, skipping the rendered
-screenshot with "it's a trivial style change; restarting to screenshot costs more
-than it's worth — tell me if you want one." Deciding the cost/benefit for the user and
-shipping a diff they had to picture.
-
-**Why it's wrong**: whether a verification artifact is "worth it" is not the agent's
-to decide. The measuring stick is _whether the user can conveniently inspect the
-product_, not how much effort the agent spends rendering it. Making the user guess the
-visual effect from a diff is the actually-expensive outcome.
-
-**What it breaks**: the user can't check the deliverable, loses trust, and has to push
-back — burning a round to get the screenshot that should have been produced up front.
-
-**Correct approach**: for ANY user-facing change (even one line of padding/color),
-default to rendering it and attaching the screenshot as a record point — open the
-image to confirm, publish. Never offer the screenshot as an opt-in.
-
----
-
-## M11 — Reporting a UI-touching change with only CLI transcripts and no screenshot
-
-**Wrong approach**: when a change includes visible UI (copy, badges, alerts, a
-rejection state), treating the run as purely backend/service validation and
-publishing only command-output evidence.
-
-**Why it's wrong**: CLI transcripts prove code paths and tests passed, but they do not
-let the reviewer inspect the rendered UI. "The diff touches no UI file" does not mean
-"no UI surface" — a permission tightening, for instance, IS a UI-visible state (the
-blocked user still sees the affordance and now gets a rejection).
-
-**What it breaks**: the user opens the report expecting visual proof and finds none.
-
-**Correct approach**: if any UI surface changed, include a visual case in the same
-run. Drive the real UI and attach a screenshot of the changed/blocked state (and the
-success state where relevant), or explicitly mark the UI screenshot case blocked with
-the measured environment blocker. Do not present a UI-touching report as complete with
-only CLI evidence.
-
----
-
-## M12 — Verifying the UI state but not the final effect / payload
-
-**Wrong approach**: marking a "inject context / apply setting / send data" feature
-verified because the UI showed the expected chip/badge/state — without checking the
-actual payload or side effect the feature is supposed to produce.
-
-**Why it's wrong**: UI metadata can be saved and displayed while a later
-runtime/transport gate drops it before the real effect. The UI looks successful while
-the underlying behavior never happened.
-
-**What it breaks**: ships a feature that looks right in the UI but has no effect;
-the user must inspect the network/DB to discover it.
-
-**Correct approach**: for any feature that claims to change what the system _does_,
-verify the last mile — assert against the transformed request/payload or the observed
-side effect (a network body, a DB row, a downstream call), and treat the UI state as
-supporting evidence only.
-
----
-
-## M13 — GIF evidence ending on an expected-failure frame reads as "the page failed"
-
-**Wrong approach**: for a loading/streaming case, attaching a GIF that records the
-full timeline through to a terminal error state that the test data inevitably
-produces. The GIF loops and rests on its final frames, so the viewer opens the report
-and sees the error, not the asserted state.
-
-**Why it's wrong**: the LAST frame of a GIF is its de-facto headline. An
-expected-failure terminal state without explanation reads as the case failing, even
-when the asserted behavior passed.
-
-**What it breaks**: the user reads a passed case as a failure and a round is burned
-re-explaining.
-
-**Correct approach**: trim evidence to the asserted state — end the GIF on the phase
-you're asserting (cut frames after the terminal state), or attach a static shot of the
-asserted state as primary evidence. If the terminal state is worth showing, say so in
-the case's `observation` so the viewer is told before they see it.
-
----
-
-## M14 — Downscaling a neutral UI into one global GIF palette destroys the evidence
-
-**Wrong approach**: downscale high-resolution screenshots by default and encode the
-whole recording with one shared 256-color palette and ordinary dithering.
-
-**Why it's wrong**: pale skeletons and thin borders need many nearby neutral tones.
-A shared palette converts them into colored speckles, while downscaling blurs text and
-one-pixel geometry. The GIF then documents encoder artifacts instead of the product.
-
-**What it breaks**: reviewers cannot reliably judge alignment, visual weight, or
-loading continuity, even though the source PNG frames are clear.
-
-**Correct approach**: keep source resolution by default, generate palettes per frame,
-disable dithering for neutral application UI, and inspect the first, middle, and final
-frames at readable size before publishing. Downscale only when file size requires it.
-
----
-
-## M15 — Verifying only the entry surface when a shared component also renders deeper
-
-**Wrong approach**: after changing a shared UI component, publishing a passing report
-from one surface only, even though the same component also renders on other pages.
-
-**Why it's wrong**: shared components are composed with different wrappers, slots, and
-responsive containers across surfaces. A fix that looks correct in one place can still
-be misplaced elsewhere.
-
-**What it breaks**: the report goes green while a deeper product path still shows the
-old or awkward behavior, and the user has to point out the surface that was never
-checked.
-
-**Correct approach**: enumerate every product surface where the changed shared UI
-renders before publishing, attach separate screenshot evidence for each, and mark any
-skipped surface explicitly blocked or untested.
-
----
-
-## M16 — Verifying a UI change only in its default state, not its collapsed/overflow state
-
-**Wrong approach**: after changing something inside an action bar / toolbar / list
-row, checking only the normal expanded state and publishing, without forcing the
-collapsed / auto-collapsed / overflow state.
-
-**Why it's wrong**: bars and rows often have their own overflow behavior and saved
-user preference. A change can shrink the available width enough to trigger a collapse,
-or a previously saved collapsed preference can hide the exact affordance the change
-sits beside.
-
-**What it breaks**: the screenshot looks fine for a fresh profile while real users
-with a collapsed toolbar or narrower container see something different.
-
-**Correct approach**: for any UI change inside a bar/row with overflow behavior,
-verify both the default and the collapsed/overflow state, with evidence for each.
-
----
-
-## M17 — Publishing a component harness when the user asked for full product verification
-
-**Wrong approach**: when the product surface hit friction once, declaring it blocked
-and publishing a narrow component harness as the main answer — even though another
-live path (a running dev instance, a sibling worktree) was available.
-
-**Why it's wrong**: a component harness proves a narrow render contract; it does not
-prove the full product composition, layout, theming, or that the evidence is
-inspectable in the real surface. Environment friction is the skill's job to solve, not
-a reason to downgrade before exhausting known-working paths.
-
-**What it breaks**: the user opens a report expecting full product evidence and gets a
-partial proof.
-
-**Correct approach**: before marking a product surface blocked, inventory existing dev
-instances and running surfaces, measure the target to confirm it renders current code,
-and use that path if it does. Keep a harness only as supporting evidence; the primary
-UI evidence must come from the product surface, or the report must clearly fail/block
-after every known path is measured.
-
----
-
-## M18 — Turning a feature verification into an unbounded environment repair
-
-**Wrong approach**: after the normal surface fails to boot, repeatedly modifying
-shared dev configuration, reinstalling the whole workspace, and chasing unrelated
-dependency problems before running any assertion for the feature under test.
-
-**Why it's wrong**: environment readiness is a gate, not the test goal. A workaround
-that changes shared configuration can also make the verification less representative,
-while an open-ended repair loop produces no feature evidence.
-
-**What it breaks**: the user waits through a long sequence of setup experiments, the
-tree gains unrelated edits, and the run still has no reportable result.
-
-**Correct approach**: follow only recovery paths documented by this skill or the
-project adapter. If the failure mode is not covered, stop, revert any experimental
-changes, summarize the exact checks and evidence collected, and ask the user before
-continuing. Do not repair the environment, switch surfaces, or invent a fallback
-without direction.
-
----
-
-## M19 — Probing the wrong layer: asserting a fixture landed because the write succeeded
-
-**Wrong approach**: writing a fixture directly to the database, reloading the page, and
-reading what the UI shows — then treating a stale value as a product bug.
-
-**Why it's wrong**: a persisted client cache (SWR / IndexedDB / localStorage) can keep
-serving the old value. A successful DB write proves the row changed; it proves nothing
-about what the app is _running on_. A fixture bug wearing a product-bug costume is the
-most expensive kind.
-
-**What it breaks**: you nearly file your own fixture as a regression.
-
-**Correct approach**: after any direct-DB fixture write, cold-load (clear client
-storage/caches, re-seed auth, reopen) and then **assert the fixture in the store
-before asserting anything downstream of it**. The DB is where you _wrote_ it; the store
-is where the behavior _reads_ it — verify at the layer the behavior reads. See
+**Rule:** verify in an instance that loads your code, and prove it by measuring a
+known-changed value before trusting any screenshot; restart non-hot-reloading
+layers (server, main process, adapters) and prove which code they run. After a
+direct fixture write, cold-load (clear client storage, re-seed auth) and assert
+the fixture in the store before anything downstream —
 [probe-mock-patterns.md](./probe-mock-patterns.md) B.
 
----
+### M12 — Verifying the UI state but not the effect
 
-## M20 — Building an elaborate mock before checking whether the env already has the real thing
+`since 2026-07-17` · `holds-while: always`
 
-**Wrong approach**: needing a capability (a working provider key, a service) and,
-finding none in the shell env, building a mock server and seeding it — then watching
-the mock receive **zero** requests while the run produces real output.
+**Trap:** an "inject context / apply setting / send data" feature is marked verified
+because the chip or badge showed, while a later transport gate dropped it.
 
-**Why it's wrong**: the capability may already exist somewhere the runtime actually
-reads (a different config store than the one you checked). Two unmeasured assumptions
-stack: that no capability existed, and that you knew where it comes from.
+**Rule:** assert the last mile — the transformed request body, the DB row, the
+downstream call. UI state is supporting evidence.
 
-**What it breaks**: a chunk of the run spent building an apparatus the test didn't
-need, plus a fixture to tear down. Worse, had the mock _partially_ worked, the run
-would have silently verified a fake path.
+### M13 — A GIF that ends on an expected-failure frame
 
-**Correct approach**: before constructing any mock, **probe the env for the real
-capability** — query the config the runtime reads, or fire one cheap real call and see
-whether it completes. Only mock what is provably absent. And when a mock records
-nothing while the feature clearly works, that is the signal the mock is _not in the
-path_ — everything "verified" through it is unverified.
+`since 2026-07-17` · `holds-while: always`
 
----
+**Trap:** a loading/streaming GIF records through to the terminal error the test
+data inevitably produces; it loops on that frame and reads as the case failing.
 
-## M21 — Bare invocation: narrating skill setup, then asking an open "what should I test?"
+**Rule:** end the GIF on the asserted phase, or make a static shot the primary
+evidence. If the terminal state is worth showing, say so in `observation` before
+the viewer sees it.
 
-**Wrong approach**: invoked with no test target, the agent announces "I'm loading the
-mandatory living logs first", reads both logs in full, then asks an open "what should I
-verify?" that ignores the visible candidate (the current branch and its commits).
+### M14 — One global palette destroys neutral UI
 
-**Why it's wrong**: the living logs inform execution, not target selection — reading
-them before a target exists burns context that may be compacted away before the run.
-Narrating internal setup is compliance-reporting the user never asked for. And an open
-question pushes work onto the user that observable context could have pre-filled.
+`since 2026-07-17` · `holds-while: the GIF encoder in use does not default to per-frame palettes without dithering`
 
-**What it breaks**: two user-visible turns whose combined value is one clarifying
-question, asked twice.
+**Trap:** downscaling by default and encoding with one shared 256-color palette
+plus dithering turns pale skeletons and thin borders into speckle.
 
-**Correct approach**: ground the target first (SKILL.md Step 0): the user's words > an
-inferred candidate from branch/commits/working tree, confirmed via one structured
-question and labeled as a guess (never executed on unconfirmed) > an open question only
-as last resort. Read the living logs once the target is known, and never narrate
-skill-internal setup.
+**Rule:** keep source resolution, generate palettes per frame, disable dithering
+for neutral UI, inspect first/middle/final frames at readable size. Downscale only
+when file size forces it.
 
----
+### M15 — Verifying only the entry surface of a shared component
 
-## M22 — A status badge is not proof the error message rendered
+`since 2026-07-17` · `holds-while: always`
 
-**Wrong approach**: marking an error-state UI case passed because the page showed a
-`Failed` badge, while the screenshot did not actually contain the error alert or its
-translated message.
+**Trap:** a shared component changed; one surface is screenshotted; the same
+component composed with different wrappers elsewhere still shows the old
+behavior.
 
-**Why it's wrong**: the badge proves only that a failed state reached the page. It does
-not prove the error was translated and presented to the user, which is the core
-assertion of an error-message verification.
+**Rule:** enumerate every surface that renders it, attach separate evidence for
+each, mark skipped surfaces blocked or untested.
 
-**What it breaks**: a report claims users receive an actionable explanation while its
-evidence shows none.
+### M16 — Default state only, never collapsed / overflow
 
-**Correct approach**: for an error-presentation case, visually require all the signals
-in the same screenshot: the failed status AND the error alert containing the expected
-user-facing message. An unrelated warning or setup reminder does not satisfy the
-assertion.
+`since 2026-07-17` · `holds-while: always`
 
----
+**Trap:** a change inside a toolbar/action bar/list row is checked expanded only; a
+narrower container or a saved collapsed preference hides the affordance.
 
-## M23 — Coordinator hand-driving a broken flow instead of re-delegating
+**Rule:** force and capture both states.
 
-**Wrong approach**: after a delegated verification subagent dies mid-case, the
-coordinator takes over and drives the remaining flow inline — dozens of small steps
-plus a deep root-cause dig into a flapping shared dependency, all in the main loop.
+### M22 — A status badge is not the error message
 
-**Why it's wrong**: the coordinator's per-step latency and context cost are far higher
-than a subagent's, and inline grinding turns one recoverable failure into a long
-visible stall. Root-causing an env flake is also not the test's goal.
+`since 2026-07-17` · `holds-while: always`
 
-**What it breaks**: the user watches minutes of micro-steps with no case progress;
-total wall-clock and token spend balloon for zero extra evidence value.
+**Trap:** a `Failed` badge is on screen, the error alert with the translated
+message is not, and the case passes.
 
-**Correct approach**: when a delegated case dies, repackage the _remaining_ steps into
-a fresh, tightly-scoped subagent prompt (include everything already learned: working
-recipes, seeded fixtures, exact remaining assertions). Timebox any environment rabbit
-hole to a couple of probes, then switch to a disposable local substitute instead of
-diagnosing shared infrastructure.
+**Rule:** an error-presentation case requires the failed status AND the alert
+containing the expected user-facing text in the same screenshot. An unrelated
+warning does not count.
 
----
+### M28 — Explanation and raw output as interchangeable text evidence
 
-## M24 — Stopping after a fix without publishing the next verification round
+`since 2026-08-03` · `holds-while: ingest does not warn on a non-visual case with fewer than two text artifacts`
 
-**Wrong approach**: implementing and locally validating a requested iteration, then
-ending the task without committing, pushing, or publishing a fresh immutable acceptance run
-to the existing acceptance.
+**Trap:** only a polished explanation with no observations; only a green
+transcript the reviewer must infer a claim from; or the explanation in one round
+and the logs in a later one.
 
-**Why it's wrong**: an acceptance is the cross-round audit trail. A local-only fix
-leaves the PR stale and makes the acceptance claim the previous round is still the
-latest result. Local tests are preparation, not delivery.
+**Rule:** two ordered text artifacts per non-visual behavioral case — a reasoning
+document (claim, setup/threat model, attempt, pass criteria, interpretation,
+limitations) and an execution document (exact command/request, raw observations,
+mapping to the criteria). Republish both in every follow-up round.
 
-**What it breaks**: reviewers can't inspect the updated code, the acceptance timeline
-misses the iteration, and the user has to ask whether anything shipped.
+### M30 — Full-page screenshot of an Electron window
 
-**Correct approach**: after every requested iteration, complete the whole delivery loop
-unless told not to: validate the new state, commit and push the branch, create a fresh
-report directory, ingest exactly once as the next immutable run on the same subject
-acceptance, verify the new round appears, then return both the commit and the
-production link.
+`since 2026-08-16` · `holds-while: ingest does not flag a desktop screenshot whose aspect ratio or black margin is implausible`
 
----
+**Trap:** `agent-browser screenshot --full` follows the renderer's document
+extent, not the `BrowserWindow`, producing a giant mostly-black image in which
+the UI is a tiny corner.
 
-## M25 — Labeling sequential flow steps as a before/after comparison
-
-**Wrong approach**: attaching two sequential steps of one flow as a `comparison`
-pair with `before` and `after` roles.
-
-**Why it is wrong**: comparison rendering means the same surface before and after
-a change. Sequential steps are neither a defect nor its remediation.
-
-**Correct approach**: reserve `comparison` for one view in two states. Attach
-flow steps as ordinary ordered evidence with a caption naming each step.
-
----
-
-## M26 — Publishing locally because the acceptance subject exists only locally
-
-**Wrong approach**: ingesting the primary report into a local instance because
-its task or topic is absent from production.
-
-**Why it is wrong**: localhost links disappear with the environment and cannot
-serve as shared deliverables. Subject convenience does not change the production
-publication requirement.
-
-**Correct approach**: create a production task or topic as the acceptance anchor,
-then publish in a clean environment against `app.lobehub.com`. A local ingest may
-supplement the run, but never replace the production deliverable.
-
----
-
-## M27 — Creating an acceptance without its requirement
-
-**Wrong approach**: using a bare subject string on the first ingest and assuming
-the acceptance goal is inferred automatically.
-
-**Why it is wrong**: the requirement is author-supplied. Omitting it leaves the
-decision page without the business goal against which all rounds are judged.
-
-**Correct approach**: supply `--requirement` or the object subject form on the
-first ingest. State the cross-round business goal, not the current round's scope.
-
----
-
-## M28 — Treating explanation and raw output as interchangeable text evidence
-
-**Wrong approach**: attaching only a polished explanation with no concrete
-observations, attaching only a green test transcript and expecting the reviewer
-to infer the security or product claim, or putting the explanation in one round
-and the logs in a later round.
-
-**Why it's wrong**: non-visual behavioral evidence has two different jobs. The
-reasoning must make the test design and inference understandable; the execution
-record must make the observations auditable. Combining them into an undifferentiated
-wall of text makes both harder to read, while splitting them across immutable
-rounds makes the latest decision snapshot incomplete.
-
-**What it breaks**: reviewers cannot tell whether the probe actually tests the
-claimed boundary, auditors cannot find the exact values that support the verdict,
-and follow-up rounds require manual cross-round reconstruction.
-
-**Correct approach**: attach two ordered text artifacts to every non-visual
-behavioral case. The first is a reasoning document: claim, setup/threat model,
-attempt, pass criteria, interpretation, and limitations. The second is an
-execution document: exact command/request, relevant raw output and observed state,
-plus a short mapping from those values to the criteria. Republish both halves in
-every follow-up round so the round remains self-contained.
-
----
-
-## M29 — Writing a report field from the router's summary instead of opening the linked schema
-
-**Wrong approach**: reading SKILL.md's Step 5, seeing that it describes `result.json`
-and links the format reference, and then writing the file from that summary plus
-inference — without opening the reference. The summary describes what the fields
-_mean_; it does not spell out the nested shapes.
-
-**Why it's wrong**: the fields that get written wrong are exactly the ones a summary
-cannot convey — a before/after `comparison`, a structured visualization, plan-item
-verifier metadata. The plausible-looking guess (a flat `comparison` + `role` pair of
-keys instead of one nested object per half) parses as valid JSON, so nothing on the
-authoring side objects. Ingest then drops the unrecognized shape, exits zero, and the
-published round looks complete.
-
-**What it breaks**: a passing round whose evidence is silently degraded — two
-screenshots that were meant to read as Before / After render as unlabeled siblings,
-so the contrast the case depends on is invisible to the reviewer. It surfaces only
-when a human asks why the page looks wrong, costing a whole extra round.
-
-**Correct approach**: when a step links a schema or format reference, open it before
-writing the artifact, and **copy the example rather than reconstructing it**. After
-ingest, read the command's warnings as failures, not noise: a dropped-field warning
-means the round published incomplete and needs a corrected re-ingest, the same as a
-skipped evidence upload. And when a reviewer reports that something rendered wrong,
-suspect your own metadata shape before the renderer.
-
----
-
-## M30 — Using a full-page browser screenshot for an Electron window
-
-**Wrong approach**: capturing Electron evidence with `agent-browser screenshot --full` and publishing it because the target UI is technically visible in the
-top-left corner.
-
-**Why it's wrong**: Electron renderers can expose a document or layout canvas much
-larger than the visible `BrowserWindow`. Full-page capture follows that document
-extent instead of the application viewport, producing a giant image dominated by
-empty or black space. Acceptance preserves the source aspect ratio, so the actual
-UI becomes tiny and the evidence is practically unreadable even though the capture
-command succeeded.
-
-**What it breaks**: reviewers cannot judge spacing, hierarchy, icon placement, or
-interaction state without zooming into a small corner; otherwise valid visual
-evidence looks like a product rendering defect.
-
-**Correct approach**: for Electron, capture the visible renderer viewport without
-`--full`, or use the project Electron/CDP window-capture helper (and OS window
-capture when browser capture cannot represent the native surface). Open the saved
-image before publishing and reject it if the application occupies only a small
-fraction of the frame or if unexplained black margins dominate the canvas. Crop by
-capturing the correct window or viewport, not by post-processing evidence to hide
-unverified state.
+**Rule:** capture the visible viewport without `--full` (or the project's CDP
+window-capture helper). Open the image; reject it if the app occupies a small
+fraction or black margins dominate. Never crop evidence in post-processing.

--- a/packages/builtin-skills/src/acceptance/references/plan-format.md
+++ b/packages/builtin-skills/src/acceptance/references/plan-format.md
@@ -1,10 +1,12 @@
-# Verify plan — machine-readable format
+# Plan-driven rounds — discover, submit, self-check
 
-The plan is the contract between the task config and you, the builder. It is
-exposed through `lh verify plan state` keyed off your operation id. This file
-documents its shape and how to turn it into a per-criterion worklist. You submit
-each criterion's evidence by its `checkItemId` — no separate upload handle to
-resolve.
+Use this path only when the invocation handed you an operation id: a verify plan
+already exists and you satisfy it criterion by criterion. Authoring your own
+checks (the default) is [report.md](./report.md). Never mix both for one round.
+
+`--operation` and `--run` are interchangeable on `result submit` and
+`result list`; `evidence list` keys off a positional `<checkResultId>` from
+`result list`.
 
 ## (a) `lh verify plan state $OPERATION_ID --json`
 
@@ -41,10 +43,15 @@ confirmed):
 - `hint` is guidance for what the artifact should show — it is not validated, but
   follow it so the reviewer can recognize the proof.
 
+Only items with a non-empty `requiredEvidence` need an artifact; the rest are
+judged on the deliverable text — don't fabricate evidence for them. The `hint`
+usually implies the surface (SKILL.md, Pick the surface).
+
 ## Your worklist → submit by checkItemId
 
-The plan (a) is all you need. For each `verifyPlan[]` item with non-empty
-`requiredEvidence`, capture each `type` and submit it by `checkItemId`:
+For each `verifyPlan[]` item with non-empty `requiredEvidence`, capture each
+`type` with the selected surface guide and submit **one artifact per call** by
+`checkItemId` (the same `--item` reuses the row):
 
 | checkItemId  | title                            | requiredEvidence |
 | ------------ | -------------------------------- | ---------------- |
@@ -58,12 +65,16 @@ lh acceptance run result submit --operation "$OP" --item vci_a1b2c3 --type scree
 
 `lh acceptance run result submit` resolves the session from the operation id and **creates the
 check-result row for you** (idempotent on `checkItemId`), then attaches the
-evidence — there is no `checkResultId` to look up first.
+evidence — there is no `checkResultId` to look up first. `--by` records
+provenance (`agent-browser` | `cdp` | `cli` | `program`); `--file` for binaries,
+`--content` for text, exactly one. Leave the verdict to the review step — add
+`--verdict` only when the task explicitly asks you to self-assert. Keep the
+printed run URL internal.
 
-## Self-check after submitting (optional)
+## Self-check coverage (do not skip)
 
-Once you've submitted, the result rows exist. To confirm coverage, read them back
-and list each row's evidence:
+Once you've submitted, the result rows exist. Map each `checkItemId` to its
+`checkResultId` and list that row's evidence:
 
 ```jsonc
 // lh acceptance run result list --operation "$OP" --json
@@ -79,3 +90,7 @@ and list each row's evidence:
 ```bash
 lh acceptance run evidence list "$CHECK_RESULT_ID" --json # confirm each required type is present
 ```
+
+Coverage rule: for each required criterion, **every** `requiredEvidence[].type`
+appears at least once in its evidence list. A missing type → capture and submit
+again; then hand off per SKILL.md (acceptance URL + `coverage: n/n`).

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -14,7 +14,6 @@ never gets that rendering; the structured round does.
 ## Contents
 
 - [No operation ID needed](#no-operation-id-needed)
-- [Immutable rounds](#rounds-are-immutable)
 - [Directory layout](#directory-layout)
 - [Workflow](#workflow)
 - [result.json schema](#resultjson-schema)
@@ -64,28 +63,6 @@ lh acceptance run result submit --run "$RUN" --item "$CHECK_ITEM_ID" …
 Prefer **A**: per-criterion submits without a plan produce checks with no
 declared intent, so the page has nothing to pair the outcome against.
 
-## Rounds are immutable
-
-Each ingest creates a **new** round. After fixing something, never edit or
-re-submit into the previous round to make it look green — publish the
-re-verification as the next round. The acceptance
-(`/acceptance/<acceptanceId>`) aggregates the rounds in order, so the repair
-history is the point, not something to hide. Reuse the same `--subject` across
-rounds for a LobeHub object, or pass `--acceptance <acceptanceId>` after an
-external project's first standalone round.
-
-Before composing a repair round, read the aggregate:
-
-```bash
-lh acceptance view "$ACCEPTANCE_ID" --json
-```
-
-- Omit checks whose latest `userReview.action` is `accept` unless the repair can
-  regress them.
-- Address non-stale rejects and reuse their exact stable check ids.
-- A semantic replacement declares `supersedes: ["old-id"]`; every later round
-  reusing the successor id repeats its full `supersedes` chain.
-
 ## Directory layout
 
 Rounds live under `.acceptances/`, grouped by the delivery they belong to:
@@ -128,10 +105,12 @@ but then keeping it out of git is on you.
 supersedes? }`.
    A planned item that never produces a case renders as **未执行** rather than
    vanishing — cut coverage in the open.
-   **HARD RULE: every item must be an outcome the reader can judge.** Never
-   plan a programmatic gate (tests / type-check / lint / build) as a check —
-   ingest drops them, and a gates-only round fails to publish. See
-   [what is not an acceptance check](#hard-rule--what-is-not-an-acceptance-check).
+   Every item is an outcome the reader can judge — never a programmatic gate
+   ([what is not an acceptance check](#what-is-not-an-acceptance-check)).
+   **Copy the shapes in this file rather than reconstructing them**: a
+   plausible-but-wrong nested shape parses as JSON, is dropped on ingest, and
+   the round publishes green with its evidence silently degraded. Read every
+   ingest warning as a failed publish.
 2. **Collect evidence into `assets/` as you test.** Screenshots must be
    **visually verified with the Read tool before being cited** — never cite an
    image you haven't looked at. For metrics, time series, model or benchmark
@@ -167,10 +146,8 @@ supersedes? }`.
    Topic, or Document owns the work. To publish a repair into that same history, add
    `--acceptance <acceptanceId>` using the ID printed by the first ingest. The
    command uploads cases + evidence + report body and prints
-   `/acceptance/<acceptanceId>` plus its `?r=<roundIndex>` snapshot form. Include
-   only the full acceptance URL in your final reply; never expose local paths or
-   internal run-page paths. Never update a prior round after a fix; publish the
-   re-verification as the next round.
+   `/acceptance/<acceptanceId>` plus its `?r=<roundIndex>` snapshot form —
+   the only link the final reply exposes (SKILL.md, Final handoff).
 
 ## result.json schema
 
@@ -285,79 +262,26 @@ reference a field declared by that dataset.
 | `heatmap`           | `x`, `y`, `value`                                              | none                                                                                      |
 | `table`             | none; `encoding` itself may be omitted                         | non-empty `columns[]`; `highlights[]` entries require `field` and `mode` (`min` \| `max`) |
 
-Minimal valid encoding examples (replace every field-name string with a key
-declared in the referenced dataset):
+One shape for every renderer — `id`, `type`, `version: 1`, `dataset`, and an
+`encoding` whose field names are keys of that dataset (see the `line-chart`
+below; the other types differ only in the encoding keys listed above):
 
 ```json
-[
-  {
-    "id": "quality-delta",
-    "type": "metric-comparison",
-    "version": 1,
-    "dataset": "metrics",
-    "encoding": { "label": "metric", "before": "baseline", "after": "candidate" }
+{
+  "dataset": "training",
+  "encoding": {
+    "x": "step",
+    "series": [
+      { "field": "baselineLoss", "label": "Baseline", "style": "muted" },
+      { "field": "candidateLoss", "label": "Candidate", "style": "primary" }
+    ],
+    "xLabel": "Step",
+    "yLabel": "Loss"
   },
-  {
-    "id": "loss-over-time",
-    "type": "line-chart",
-    "version": 1,
-    "dataset": "training",
-    "encoding": {
-      "x": "step",
-      "series": [
-        { "field": "baselineLoss", "label": "Baseline", "style": "muted" },
-        { "field": "candidateLoss", "label": "Candidate", "style": "primary" }
-      ],
-      "xLabel": "Step",
-      "yLabel": "Loss"
-    }
-  },
-  {
-    "id": "scores-by-model",
-    "type": "bar-chart",
-    "version": 1,
-    "dataset": "scores",
-    "encoding": {
-      "category": "model",
-      "series": [{ "field": "score", "label": "Score" }],
-      "valueLabel": "Accuracy"
-    }
-  },
-  {
-    "id": "latency-quality",
-    "type": "scatter-plot",
-    "version": 1,
-    "dataset": "runs",
-    "encoding": {
-      "x": "latency",
-      "y": "quality",
-      "color": "model",
-      "label": "run",
-      "xLabel": "Latency (ms)",
-      "yLabel": "Quality"
-    }
-  },
-  {
-    "id": "error-matrix",
-    "type": "heatmap",
-    "version": 1,
-    "dataset": "errors",
-    "encoding": { "x": "predicted", "y": "actual", "value": "count" }
-  },
-  {
-    "id": "benchmark-table",
-    "type": "table",
-    "version": 1,
-    "dataset": "benchmarks",
-    "encoding": {
-      "columns": ["model", "latency", "score"],
-      "highlights": [
-        { "field": "latency", "mode": "min" },
-        { "field": "score", "mode": "max" }
-      ]
-    }
-  }
-]
+  "id": "loss-over-time",
+  "type": "line-chart",
+  "version": 1
+}
 ```
 
 Dataset field `type` is one of `boolean`, `category`, `number`, `string`, or
@@ -377,36 +301,13 @@ row limit is 10,000.
 `Rate-limit recovery`) — never a technical surface. `method` / `expected` stay
 free prose; they render under the check next to the outcome.
 
-### HARD RULE — what is not an acceptance check
+### What is not an acceptance check
 
-An acceptance check is something a **person decides about the delivery**. The
-repo's own automated gates are not that, and they are actively harmful on the
-page: twenty green "unit tests pass" rows bury the two checks that actually
-needed someone to look.
-
-**These MUST NOT appear as `plan[]` / `cases[]` items, under any phrasing:**
-
-| Not a check                                                | Where it belongs                                     |
-| ---------------------------------------------------------- | ---------------------------------------------------- |
-| Unit / integration / regression / snapshot tests, coverage | one line in `report.md` → **Verification**           |
-| `type-check`, `tsc`, `eslint`, lint, format, a clean build | same — a precondition of shipping, not a deliverable |
-| "the test suite is green", "CI passes"                     | same                                                 |
-
-This is enforced, not advisory. `lh acceptance run ingest` **drops every
-matching item** — matched on title, category, AND `method`, so writing
-"run `bun run test`" into `method` under a product-sounding title still
-matches — warns with the dropped ids, and recounts `summary` from the checks
-that remain. A round consisting **only** of such checks **fails to publish**.
-Either way, a gate written as a check is effort spent proving something nobody
-accepts: apply the rule at plan time, before the first case runs.
-
-The line is the _subject_ of the check, not who judged it: a CLI behavior check
-asserted by a command is a fine acceptance item (`verifier: "program"`). "Run
-`bun run test`" is not.
-
-**What IS an acceptance check:** what the user sees, hears, reads, or receives —
-a rendered screen, a produced file, an API response shape a client depends on,
-an audio clip that actually plays, a failure state that recovers.
+The repo's own gates — tests, coverage, `type-check`, lint, format, a clean
+build, "CI passes" — are never `plan[]` / `cases[]` items, under any phrasing;
+they are one line in `report.md` under **Verification**. Ingest drops matching
+items (matched on title, category, AND `method`), warns, and recounts `summary`;
+a gates-only round fails to publish. Full rule: SKILL.md.
 
 ### Before/after comparison pairs
 
@@ -445,9 +346,6 @@ flow are ordinary ordered evidence with captions, not a pair.
   reviewer-facing reasoning document and a separate audit-facing execution
   artifact containing the exact command/request and observed values. Neither
   unsupported prose nor an unexplained log dump is sufficient.
-- **Final handoff exposes only Acceptance** — use `/acceptance/<acceptanceId>` or
-  its `?r=<roundIndex>` snapshot. Never include images, local paths, local file
-  links, or internal run-page paths in chat.
 - **Report failures faithfully** — a failing case with clear evidence is a good
   report; a vague green one is not.
 - If coverage was cut, say so in `report.md` — silent truncation reads as


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

The acceptance skill's two living logs (`common-mistakes.md`, generic + project layer) were injected by reading them in full before every round — about 13k words — and had no exit path. Entries stayed after their mechanism moved into ingest or a script, cross-references pointed at steps that no longer exist (`SKILL.md Step 0/5`), the generic layer named project-only scripts, and two project ids collided (`L-S17`).

This PR changes **what** is injected and **how entries leave**:

- **Checklist + entries.** Both `common-mistakes.md` files now open with a one-line-per-mistake Checklist that is read in full (once the target is known, and again before any `pass`). Entry bodies are pulled by id only when a line applies. Per-round cost: generic 234 words, project 753 words.
- **`since` / `holds-while` on every entry.** `holds-while` names the script default, validator gap, or platform behavior the rule depends on (`always` = pure judgment). The bucket-1/2 entries (e.g. L-E11 upload WARN exits 0, L-S9 shared Postgres, L-S5 CDP port owner) keep their `holds-while` as the to-do for follow-up linter/script PRs; each lands → delete the entry.
- **Discipline rules leave the log.** Rules an agent skips under pressure (M2/M3/M4/M8/M17/M21, project L-S4/S10/S13/S18) become rationalization tables in `SKILL.md` and `PROCESS.md`. L-S18 ("reproduce the precondition first") is promoted to generic M31.
- **20 project entries retired verbatim** into `references/common-mistakes-field-notes.md`, grouped by reason: already enforced by code (L-E11b, L-E12), feature-spec facts (L-E7/E8/E14/E18, L-D2/3/4/5/8/9, L-S11/12), other skills' knowledge (L-D1/10/13, L-S0/6/15).
- **Admission + exit rule** in `PROCESS.md` Step 0: a sixth question ("can you write its `holds-while`?") and "delete the entry the day its mechanism lands in code". `skills-audit` gains a living-log freshness step.
- **SKILL.md** now leads with the authored (default) path; the plan-driven `--operation` steps move to `plan-format.md`; `report.md` no longer restates immutability and handoff. Version 0.2.0 → 0.3.0.
- Fixes: duplicate `L-S17` → `L-S21`; stale `M18`/`M19` references in `probe-mock-patterns.md` / `llm-stub.mjs`; canary's new `L-E20`/`L-S20` folded in with `holds-while`.

Word counts, HEAD → now: `SKILL.md` 2866 → 1813 · generic `common-mistakes.md` 5156 → 1434 · project `common-mistakes.md` 9075 → 4012 (of which the always-read Checklist is 753).

#### 📝 补充信息 | Additional Information

`packages/builtin-skills` acceptance tests pass (6/6). This is step 1 of 3; the ingest checks (L-E11, L-S19, M5) and the script defaults (L-S5/S7/S9) follow in separate PRs, each deleting the entries whose `holds-while` it retires.

https://claude.ai/code/session_01FSsxkv3rBMN6hYjZfY6qEA
