### PR TITLE
✨ feat(topic): show CI status on pull request icons

### DIFF
--- a/src/features/AgentSidebar/Topic/List/Item/MetaHoverCard.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/MetaHoverCard.tsx
@@ -1,15 +1,8 @@
-import type { ChatTopicMetadata, DeviceGitPullRequestCiStatus } from '@lobechat/types';
+import type { ChatTopicMetadata } from '@lobechat/types';
 import { Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { Clock } from 'lucide-react';
-import {
-  CircleCheck,
-  CircleSlash,
-  CircleX,
-  GitBranchIcon,
-  GitForkIcon,
-  LoaderCircle,
-} from 'lucide-react';
+import { GitBranchIcon, GitForkIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +10,12 @@ import { useTranslation } from 'react-i18next';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useChatStore } from '@/store/chat';
 
-import { getPullRequestState, getTopicMetaCard, PR_STATE_VISUAL } from './metaCardData';
+import {
+  getCiVisual,
+  getPullRequestState,
+  getTopicMetaCard,
+  PR_STATE_VISUAL,
+} from './metaCardData';
 
 const styles = createStaticStyles(({ css }) => ({
   card: css`
@@ -89,29 +87,6 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
 }));
-
-interface CiVisual {
-  color: string;
-  icon: typeof Clock;
-  labelKey: string;
-}
-
-const getCiVisual = (status?: DeviceGitPullRequestCiStatus): CiVisual => {
-  switch (status) {
-    case 'success': {
-      return { color: cssVar.colorSuccess, icon: CircleCheck, labelKey: 'metaCard.ci.success' };
-    }
-    case 'failure': {
-      return { color: cssVar.colorError, icon: CircleX, labelKey: 'metaCard.ci.failure' };
-    }
-    case 'pending': {
-      return { color: cssVar.colorWarning, icon: LoaderCircle, labelKey: 'metaCard.ci.pending' };
-    }
-    default: {
-      return { color: cssVar.colorTextTertiary, icon: CircleSlash, labelKey: 'metaCard.ci.none' };
-    }
-  }
-};
 
 interface DetailRowProps {
   children: ReactNode;
@@ -239,7 +214,7 @@ const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time, topicId
 
       {ci && (
         <DetailRow icon={ci.icon} iconColor={ci.color}>
-          {t(ci.labelKey as 'metaCard.ci.none')}
+          {t(ci.labelKey)}
         </DetailRow>
       )}
     </div>

--- a/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
@@ -14,7 +14,9 @@ const agentRuntimeRunningMock = vi.hoisted(() => ({ value: false }));
 const runningStartTimeMock = vi.hoisted(() => ({ value: undefined as number | undefined }));
 const topicUnreadCompletedMock = vi.hoisted(() => ({ value: false }));
 const topicMetaCardMock = vi.hoisted(() => ({
-  value: undefined as { pullRequest?: { state: string } } | undefined,
+  value: undefined as
+    | { pullRequest?: { ciStatus?: 'failure' | 'pending' | 'success' | 'unknown'; state: string } }
+    | undefined,
 }));
 
 // Assertions key on the raw lucide displayName, which the real Icon does not
@@ -114,12 +116,22 @@ vi.mock('../../hooks/useTopicNavigation', () => ({
 vi.mock('./MetaHoverCard', () => ({
   default: () => null,
 }));
-vi.mock('./metaCardData', () => ({
-  PR_STATE_VISUAL: { open: { color: '#0a0', icon: () => null, labelKey: 'metaCard.pr.open' } },
-  getPullRequestState: () => 'open',
-  // Defaults to undefined so TopicItem skips the hover Popover wrapper in tests.
-  getTopicMetaCard: () => topicMetaCardMock.value,
-}));
+vi.mock('./metaCardData', () => {
+  const CiIcon = () => null;
+  CiIcon.displayName = 'CiIcon';
+  const PullRequestIcon = () => null;
+  PullRequestIcon.displayName = 'PullRequestIcon';
+
+  return {
+    PR_STATE_VISUAL: {
+      open: { color: '#0a0', icon: PullRequestIcon, labelKey: 'metaCard.pr.open' },
+    },
+    getCiVisual: () => ({ color: '#fa0', icon: CiIcon, labelKey: 'metaCard.ci.pending' }),
+    getPullRequestState: () => 'open',
+    // Defaults to undefined so TopicItem skips the hover Popover wrapper in tests.
+    getTopicMetaCard: () => topicMetaCardMock.value,
+  };
+});
 vi.mock('./Actions', () => ({
   default: () => null,
 }));
@@ -339,6 +351,23 @@ describe('TopicItem active state', () => {
 
     expect(screen.queryByTestId('topic-unread-dot')).not.toBeInTheDocument();
     expect(screen.getByTestId('topic-item-icon')).toBeInTheDocument();
+  });
+
+  it('adds the CI status to the pull request marker', () => {
+    topicMetaCardMock.value = { pullRequest: { ciStatus: 'pending', state: 'open' } };
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(<TopicItem id="tpc_test" title="Topic" />);
+
+    expect(screen.getAllByTestId('topic-item-icon').map((icon) => icon.dataset.icon)).toEqual([
+      'PullRequestIcon',
+      'CiIcon',
+    ]);
   });
 
   it.each([

--- a/src/features/AgentSidebar/Topic/List/Item/index.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/index.tsx
@@ -41,7 +41,12 @@ import { useTopicNavigation } from '../../hooks/useTopicNavigation';
 import ThreadList from '../../TopicListContent/ThreadList';
 import Actions from './Actions';
 import TopicItemContextMenu from './ContextMenu';
-import { getPullRequestState, getTopicMetaCard, PR_STATE_VISUAL } from './metaCardData';
+import {
+  getCiVisual,
+  getPullRequestState,
+  getTopicMetaCard,
+  PR_STATE_VISUAL,
+} from './metaCardData';
 import MetaHoverCard from './MetaHoverCard';
 
 // Base UI Popover plays an opacity/scale enter+exit transition driven by these
@@ -58,6 +63,37 @@ const META_HOVER_CARD_STYLES = {
 };
 
 const styles = createStaticStyles(({ css }) => ({
+  ciBadge: css`
+    position: absolute;
+    inset-block-end: -3px;
+    inset-inline-end: -3px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+
+    line-height: 0;
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  ciPending: css`
+    animation: ci-spin 1s linear infinite;
+
+    @keyframes ci-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  `,
+  prIcon: css`
+    position: relative;
+    display: inline-flex;
+    flex: none;
+  `,
   runningElapsedTime: css`
     flex: none;
 
@@ -416,9 +452,27 @@ const TopicItemRow = memo<TopicItemRowProps>(
       // as the leading icon.
       if (metaCard?.pullRequest) {
         const prVisual = PR_STATE_VISUAL[getPullRequestState(metaCard.pullRequest)];
+        const ciStatus = metaCard.pullRequest.ciStatus;
+        const ciVisual = getCiVisual(ciStatus);
+        const showCiBadge = ciStatus !== undefined && ciStatus !== 'unknown';
+        const tooltip = showCiBadge
+          ? `${t(prVisual.labelKey)} · ${t(ciVisual.labelKey)}`
+          : t(prVisual.labelKey);
         return (
-          <Tooltip title={t(prVisual.labelKey)}>
-            <Icon icon={prVisual.icon} size={'small'} style={{ color: prVisual.color }} />
+          <Tooltip title={tooltip}>
+            <span className={styles.prIcon}>
+              <Icon icon={prVisual.icon} size={'small'} style={{ color: prVisual.color }} />
+              {showCiBadge && (
+                <span className={styles.ciBadge}>
+                  <Icon
+                    className={ciStatus === 'pending' ? styles.ciPending : undefined}
+                    icon={ciVisual.icon}
+                    size={9}
+                    style={{ color: ciVisual.color }}
+                  />
+                </span>
+              )}
+            </span>
           </Tooltip>
         );
       }

--- a/src/features/AgentSidebar/Topic/List/Item/metaCardData.ts
+++ b/src/features/AgentSidebar/Topic/List/Item/metaCardData.ts
@@ -1,11 +1,23 @@
-import type { ChatTopicMetadata, DeviceGitLinkedPullRequest } from '@lobechat/types';
+import type {
+  ChatTopicMetadata,
+  DeviceGitLinkedPullRequest,
+  DeviceGitPullRequestCiStatus,
+} from '@lobechat/types';
 import {
   getTopicMetadataWorkingDirectoryEffectivePath,
   getTopicMetadataWorkingDirectorySourcePath,
 } from '@lobechat/utils/client/topic';
 import { cssVar } from 'antd-style';
 import type { LucideIcon } from 'lucide-react';
-import { GitMerge, GitPullRequestArrow, GitPullRequestClosed } from 'lucide-react';
+import {
+  CircleCheck,
+  CircleSlash,
+  CircleX,
+  GitMerge,
+  GitPullRequestArrow,
+  GitPullRequestClosed,
+  LoaderCircle,
+} from 'lucide-react';
 
 import {
   getConfigRepoType,
@@ -39,6 +51,30 @@ export const PR_STATE_VISUAL: Record<PullRequestState, PullRequestStateVisual> =
   closed: { color: cssVar.colorError, icon: GitPullRequestClosed, labelKey: 'metaCard.pr.closed' },
   merged: { color: MERGED_PURPLE, icon: GitMerge, labelKey: 'metaCard.pr.merged' },
   open: { color: cssVar.colorSuccess, icon: GitPullRequestArrow, labelKey: 'metaCard.pr.open' },
+};
+
+export interface CiVisual {
+  color: string;
+  icon: LucideIcon;
+  labelKey:
+    'metaCard.ci.failure' | 'metaCard.ci.none' | 'metaCard.ci.pending' | 'metaCard.ci.success';
+}
+
+export const getCiVisual = (status?: DeviceGitPullRequestCiStatus): CiVisual => {
+  switch (status) {
+    case 'success': {
+      return { color: cssVar.colorSuccess, icon: CircleCheck, labelKey: 'metaCard.ci.success' };
+    }
+    case 'failure': {
+      return { color: cssVar.colorError, icon: CircleX, labelKey: 'metaCard.ci.failure' };
+    }
+    case 'pending': {
+      return { color: cssVar.colorWarning, icon: LoaderCircle, labelKey: 'metaCard.ci.pending' };
+    }
+    default: {
+      return { color: cssVar.colorTextTertiary, icon: CircleSlash, labelKey: 'metaCard.ci.none' };
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary

- show running, successful, and failed CI badges on linked pull request icons in the topic sidebar
- keep the pull request lifecycle icon and combine PR/CI states in its tooltip
- share the CI visual mapping between the sidebar marker and metadata hover card

## Testing

- `bun run check src/features/AgentSidebar/Topic/List/Item/metaCardData.ts src/features/AgentSidebar/Topic/List/Item/MetaHoverCard.tsx src/features/AgentSidebar/Topic/List/Item/index.tsx src/features/AgentSidebar/Topic/List/Item/index.test.tsx` (18 tests passed)

## Acceptance

- [Acceptance report](https://app.lobehub.com/acceptance/3539cb73-b9c7-49a7-a354-9a292561f309) — 2/2 cases passed, covering pending, success, failure, and pending animation.