### PR TITLE
🐛 fix(model-runtime): route OpenCode Go Muse Spark through Responses

### DIFF
--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -123,6 +123,33 @@ describe('OpenAI audio models', () => {
   });
 });
 
+describe('OpenCode Go models', () => {
+  it('registers the Muse Spark Contributor series', () => {
+    const models = LOBE_DEFAULT_MODEL_LIST.filter(
+      (model) =>
+        model.providerId === ModelProvider.OpenCodeCodingPlan && model.id.startsWith('muse-spark-'),
+    );
+
+    expect(models.map(({ id }) => id)).toEqual([
+      'muse-spark-1.2-contributor',
+      'muse-spark-1.3-contributor',
+    ]);
+    expect(models.find(({ id }) => id === 'muse-spark-1.3-contributor')).toEqual(
+      expect.objectContaining({
+        abilities: expect.objectContaining({
+          functionCall: true,
+          reasoning: true,
+          structuredOutput: true,
+          vision: true,
+        }),
+        contextWindowTokens: 1_048_576,
+        enabled: true,
+        maxOutput: 131_072,
+      }),
+    );
+  });
+});
+
 describe('Moonshot models', () => {
   it('advertises Kimi K3 reasoning effort controls', () => {
     const kimiK3 = LOBE_DEFAULT_MODEL_LIST.find(

--- a/packages/model-bank/src/aiModels/opencodeCodingPlan.ts
+++ b/packages/model-bank/src/aiModels/opencodeCodingPlan.ts
@@ -238,6 +238,58 @@ const opencodeCodingPlanChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: { functionCall: true, reasoning: true, structuredOutput: true, vision: true },
+    contextWindowTokens: 1_048_576,
+    description:
+      'Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.',
+    displayName: 'Muse Spark 1.2 Contributor',
+    enabled: false,
+    family: 'muse',
+    generation: 'muse-spark-1.2',
+    id: 'muse-spark-1.2-contributor',
+    maxOutput: 131_072,
+    organization: 'Meta',
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.002, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-08-05',
+    settings: {
+      extendParams: ['reasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, structuredOutput: true, vision: true },
+    contextWindowTokens: 1_048_576,
+    description:
+      'Muse Spark 1.3 is a multimodal reasoning model from Meta for coding and agentic workflows.',
+    displayName: 'Muse Spark 1.3 Contributor',
+    enabled: true,
+    family: 'muse',
+    generation: 'muse-spark-1.3',
+    id: 'muse-spark-1.3-contributor',
+    maxOutput: 131_072,
+    organization: 'Meta',
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.002, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-09-02',
+    settings: {
+      extendParams: ['reasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
     abilities: { functionCall: true, reasoning: true, vision: true },
     contextWindowTokens: 262_144,
     description:

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
@@ -152,6 +152,41 @@ describe('sanitizeJsonSchema', () => {
   });
 });
 
+describe('Muse Spark Responses API routing', () => {
+  let chatCreateSpy: Mock;
+  let responsesCreateSpy: Mock;
+
+  beforeEach(() => {
+    loadModelsMock.mockResolvedValue([]);
+    chatCreateSpy = vi
+      .spyOn(OpenAI.Chat.Completions.prototype, 'create')
+      .mockResolvedValue(new ReadableStream() as any) as unknown as Mock;
+    responsesCreateSpy = vi
+      .spyOn(OpenAI.Responses.prototype, 'create')
+      .mockResolvedValue(new ReadableStream() as any) as unknown as Mock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(['muse-spark-1.2-contributor', 'muse-spark-1.3-contributor'])(
+    'routes %s through Responses even when the provider-level default is Chat Completions',
+    async (model) => {
+      const instance = new LobeOpenCodeCodingPlanAI({ apiKey: 'test' });
+
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        messages: [{ content: 'Hello', role: 'user' }],
+        model,
+      });
+
+      expect(responsesCreateSpy).toHaveBeenCalledOnce();
+      expect(chatCreateSpy).not.toHaveBeenCalled();
+    },
+  );
+});
+
 describe('buildOpenAIPayload Kimi thinking semantics', () => {
   let instance: InstanceType<typeof LobeOpenCodeCodingPlanAI>;
   let createSpy: Mock;

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
@@ -185,6 +185,104 @@ describe('Muse Spark Responses API routing', () => {
       expect(chatCreateSpy).not.toHaveBeenCalled();
     },
   );
+
+  describe.each(['muse-spark-1.2-contributor', 'muse-spark-1.3-contributor'])(
+    '%s structured generation with offline model discovery',
+    (model) => {
+      it('generates JSON through Responses without an explicit API override', async () => {
+        responsesCreateSpy.mockResolvedValue({ output_text: '{"answer":"Hello"}' });
+        const instance = new LobeOpenCodeCodingPlanAI({ apiKey: 'test' });
+
+        const result = await instance.generateObject({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model,
+          schema: {
+            name: 'answer',
+            schema: { properties: { answer: { type: 'string' } }, type: 'object' },
+          },
+        });
+
+        expect(result).toEqual({ answer: 'Hello' });
+        expect(responsesCreateSpy).toHaveBeenCalledOnce();
+        expect(chatCreateSpy).not.toHaveBeenCalled();
+      });
+
+      it('generates tool calls through Responses without an explicit API override', async () => {
+        responsesCreateSpy.mockResolvedValue({
+          output: [{ arguments: '{"answer":"Hello"}', name: 'answer', type: 'function_call' }],
+        });
+        const instance = new LobeOpenCodeCodingPlanAI({ apiKey: 'test' });
+
+        const result = await instance.generateObject({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model,
+          tools: [
+            {
+              function: {
+                name: 'answer',
+                parameters: { properties: { answer: { type: 'string' } }, type: 'object' },
+              },
+              type: 'function',
+            },
+          ],
+        });
+
+        expect(result).toEqual([{ arguments: { answer: 'Hello' }, name: 'answer' }]);
+        expect(responsesCreateSpy).toHaveBeenCalledOnce();
+        expect(chatCreateSpy).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it('keeps other models on Chat Completions for structured generation', async () => {
+    chatCreateSpy.mockResolvedValue({
+      choices: [{ message: { content: '{"answer":"Hello"}' } }],
+    });
+    const instance = new LobeOpenCodeCodingPlanAI({ apiKey: 'test' });
+
+    const result = await instance.generateObject({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'glm-5',
+      schema: {
+        name: 'answer',
+        schema: { properties: { answer: { type: 'string' } }, type: 'object' },
+      },
+    });
+
+    expect(result).toEqual({ answer: 'Hello' });
+    expect(chatCreateSpy).toHaveBeenCalledOnce();
+    expect(responsesCreateSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses Responses models discovered after runtime initialization', async () => {
+    vi.resetModules();
+    const { LobeOpenCodeCodingPlanAI: Runtime } = await import('./index');
+    const model = 'discovered-responses-model';
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          'opencode-go': {
+            models: { [model]: { id: model, provider: { npm: '@ai-sdk/openai' } } },
+          },
+        }),
+      ),
+    );
+    responsesCreateSpy.mockResolvedValue({ output_text: '{"answer":"Hello"}' });
+    const instance = new Runtime({ apiKey: 'test' });
+
+    const result = await instance.generateObject({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model,
+      schema: {
+        name: 'answer',
+        schema: { properties: { answer: { type: 'string' } }, type: 'object' },
+      },
+    });
+
+    expect(result).toEqual({ answer: 'Hello' });
+    expect(responsesCreateSpy).toHaveBeenCalledOnce();
+    expect(chatCreateSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('buildOpenAIPayload Kimi thinking semantics', () => {

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
@@ -61,6 +61,7 @@ interface ModelsCache {
    */
   interleavedIds: Set<string>;
   modelsDev: Record<string, ModelsDevModel>;
+  responsesIds: Set<string>;
 }
 
 // Fallback: models that need Anthropic SDK (used when models.dev is unavailable)
@@ -81,6 +82,13 @@ const FALLBACK_INTERLEAVED_IDS: ReadonlySet<string> = new Set([
   'mimo-v2.5-pro',
 ]);
 
+// Fallback: models that require OpenAI's Responses API when models.dev is
+// unreachable. Mirrors OpenCode Go's documented endpoint matrix.
+const FALLBACK_RESPONSES_IDS: ReadonlySet<string> = new Set([
+  'muse-spark-1.2-contributor',
+  'muse-spark-1.3-contributor',
+]);
+
 let cachedModelsData: ModelsCache | null = null;
 
 // ============================================================================
@@ -90,6 +98,7 @@ let cachedModelsData: ModelsCache | null = null;
 /**
  * Fetch models.dev data and derive all per-provider fields from it:
  *   - `anthropicModels`  (models whose `provider.npm` is the Anthropic SDK)
+ *   - `responsesIds`     (models whose `provider.npm` is the OpenAI SDK)
  *   - `interleavedIds`   (models with `interleaved.field` set, needing
  *                         special reasoning_content handling)
  *   - `modelsDev`        (raw model map for enrichment)
@@ -113,19 +122,25 @@ const fetchModelsDevData = async (): Promise<ModelsCache> => {
     const anthropicModels = Object.values(models)
       .filter((m) => m.provider?.npm === '@ai-sdk/anthropic')
       .map((m) => m.id);
+    const responsesIds = new Set(
+      Object.values(models)
+        .filter((m) => m.provider?.npm === '@ai-sdk/openai')
+        .map((m) => m.id),
+    );
 
     const interleavedIds = new Set<string>();
     for (const m of Object.values(models)) {
       if (m?.interleaved?.field) interleavedIds.add(m.id);
     }
 
-    cachedModelsData = { anthropicModels, interleavedIds, modelsDev: models };
+    cachedModelsData = { anthropicModels, interleavedIds, modelsDev: models, responsesIds };
     return cachedModelsData;
   } catch {
     cachedModelsData = {
       anthropicModels: [],
       interleavedIds: new Set(),
       modelsDev: {},
+      responsesIds: new Set(),
     };
     return cachedModelsData;
   }
@@ -142,6 +157,13 @@ const getInterleavedModelIds = (): ReadonlySet<string> => {
     return cachedModelsData.interleavedIds;
   }
   return FALLBACK_INTERLEAVED_IDS;
+};
+
+const getResponsesModelIds = (): ReadonlySet<string> => {
+  if (cachedModelsData && cachedModelsData.responsesIds.size > 0) {
+    return cachedModelsData.responsesIds;
+  }
+  return FALLBACK_RESPONSES_IDS;
 };
 
 /**
@@ -307,13 +329,17 @@ export const sanitizeJsonSchema = (schema: any): any => {
 // ============================================================================
 
 /**
- * Build OpenAI-compatible payload with reasoning_content handling.
- * Applies to models with interleaved reasoning_content and Kimi K2.x models.
+ * Select Responses-only models and build OpenAI-compatible payloads with
+ * reasoning_content handling for interleaved and Kimi K2.x models.
  */
 const buildOpenAIPayload = (
   payload: ChatStreamPayload,
 ): OpenAI.ChatCompletionCreateParamsStreaming => {
   const model = payload.model;
+  if (getResponsesModelIds().has(model)) {
+    return { ...payload, apiMode: 'responses' } as OpenAI.ChatCompletionCreateParamsStreaming;
+  }
+
   const isKimi = isKimiThinkingToggleModel(model);
   const interleaved = isInterleavedModel(model);
 

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
@@ -441,6 +441,11 @@ const LobeOpenCodeCodingPlanOpenAI = createOpenAICompatibleRuntime({
   debug: {
     chatCompletion: () => process.env.DEBUG_OPENCODE_GO_CHAT_COMPLETION === '1',
   },
+  generateObject: {
+    get useResponseModels() {
+      return [...getResponsesModelIds()];
+    },
+  },
 });
 
 // Anthropic SDK auto-appends /v1/messages to baseURL, so strip trailing /v1


### PR DESCRIPTION
Route OpenCode Go's Muse Spark Contributor models through the Responses API instead of the default OpenAI-compatible chat completions path.

- Respect per-model `models.dev` provider overrides that use `@ai-sdk/openai`
- Keep both Muse Spark model IDs as offline fallbacks when model discovery is unavailable
- Register Muse Spark 1.2 and 1.3 Contributor model metadata in the model bank
- Add regression coverage proving a provider-level `chatCompletion` setting cannot route these response-only models to `/chat/completions`

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

AI scenario: create both Muse Spark Contributor models with `apiMode: 'chatCompletion'`; each request invokes `OpenAI.Responses.create` and never invokes `OpenAI.Chat.Completions.create`.

- `bun run check packages/model-bank/src/aiModels/__tests__/index.test.ts packages/model-bank/src/aiModels/opencodeCodingPlan.ts packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts packages/model-runtime/src/providers/opencodeCodingPlan/index.ts` — 35 tests passed
- `cd packages/model-bank && bunx tsc --noEmit`

#### 🔗 Related Issue

No matching issue found.