### PR TITLE
💄 style(agent-share): import Skeleton from base-ui

### DIFF
--- a/src/features/AgentShareSettings/UsageSection.tsx
+++ b/src/features/AgentShareSettings/UsageSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Flexbox, Skeleton } from '@lobehub/ui';
-import { Text } from '@lobehub/ui/base-ui';
+import { Flexbox } from '@lobehub/ui';
+import { SkeletonText, Text } from '@lobehub/ui/base-ui';
 import { Progress } from 'antd';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -54,7 +54,7 @@ const UsageSection = memo<UsageSectionProps>(({ agentId, monthlySpendLimit }) =>
   return (
     <Section desc={t('share.settings.usage.desc')} title={t('share.settings.usage.title')}>
       {isLoading ? (
-        <Skeleton active paragraph={{ rows: 2 }} title={false} />
+        <SkeletonText rows={2} />
       ) : hasLoadError ? (
         <AsyncError
           error={error}

--- a/src/features/AgentShareVisitor/TopicPanel.tsx
+++ b/src/features/AgentShareVisitor/TopicPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Center, Flexbox, SkeletonTitle } from '@lobehub/ui';
-import { ActionIcon, Text } from '@lobehub/ui/base-ui';
+import { Center, Flexbox } from '@lobehub/ui';
+import { ActionIcon, SkeletonText, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { MessageSquarePlus } from 'lucide-react';
 import { memo } from 'react';
@@ -77,7 +77,7 @@ const TopicPanel = memo<{
         <Flexbox gap={4}>
           {LOADING_ROW_WIDTHS.map((width, index) => (
             <Flexbox key={index} paddingBlock={6} paddingInline={8}>
-              <SkeletonTitle style={{ marginBottom: 0, width }} />
+              <SkeletonText style={{ marginBottom: 0, width }} />
             </Flexbox>
           ))}
         </Flexbox>


### PR DESCRIPTION
`canary` is red at `Test Database › Lint` since #18998 (`4b409744f2`): `no-restricted-imports` rejects the antd-based `Skeleton` / `SkeletonTitle` from `@lobehub/ui` in `AgentShareSettings/UsageSection.tsx` and `AgentShareVisitor/TopicPanel.tsx` (canary run 33750442369; every PR rebased on canary fails the same step, e.g. #19091 run 33755626328 and #19104).

Switch both to `SkeletonText` from `@lobehub/ui/base-ui`, matching the existing usages in the repo (`rows={2}` for the two-line paragraph placeholder; the single-line default for the topic title).

#### Test

- [x] Tested locally (`bun run check --lint` on both files)
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Unblocks CI for PRs rebased on canary after #18998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5hYkUf1jSg2fDiQh72FWV