### PR TITLE
🐛 fix(ci): keep desktop canary OTA progressing

### DIFF
--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -4,11 +4,12 @@ name: Release Desktop Canary
 # Canary 自动发版工作流
 # ============================================
 # 触发条件:
-#   1. canary 分支有 push (合入 PR) 且 commit 前缀为 style/feat/fix/perf/refactor/release (支持 gitmoji)
+#   1. canary 分支有 push (合入 PR) 且 commit type 为 style/feat/fix/perf/refactor/release
+#      (可带任意 gitmoji)
 #   2. 手动触发 (workflow_dispatch)
 #
 # 并发策略:
-#   同一 workflow 仅保留最新一次运行，自动取消排队中的旧 build
+#   运行中的发布不会被后续 push 取消；等待队列仅保留最新一次运行
 #
 # 版本策略:
 #   基于最新 stable tag 的 patch+1, postfix 为递增序号
@@ -30,7 +31,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  # ponytail: this also protects short OTA-only runs; split the full release only if they queue.
+  cancel-in-progress: false
 
 permissions: read-all
 
@@ -39,23 +41,19 @@ env:
 
 jobs:
   # ============================================
-  # 检查 commit 前缀并计算版本号
+  # 检查 commit type
   # ============================================
-  calculate-version:
-    name: Calculate Canary Version
+  check-trigger:
+    name: Check Canary Trigger
     runs-on: ubuntu-latest
     outputs:
-      cloud_ref: ${{ steps.cloud-ref.outputs.cloud_ref }}
-      release_notes: ${{ steps.release-notes.outputs.release_notes }}
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ steps.version.outputs.tag }}
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Check commit message prefix
+      - name: Check commit type
         id: check
         run: |
           # 手动触发 + force 时跳过检查
@@ -76,17 +74,43 @@ jobs:
           commit_msg=$(git log -1 --pretty=%s HEAD)
           echo "📝 Head commit: $commit_msg"
 
-          # 检查是否匹配 style/feat/fix/perf/refactor/release 前缀 (支持 gitmoji 前缀)
-          if echo "$commit_msg" | grep -qiE '^(💄\s*)?style(\(.+\))?:|^(✨\s*)?feat(\(.+\))?:|^(🐛\s*)?fix(\(.+\))?:|^(⚡️\s*)?perf(\(.+\))?:|^(♻️\s*)?refactor(\(.+\))?:|^(🚀\s*)?release(\(.+\))?:'; then
+          # 只检查 Conventional Commit type；前置 gitmoji 不参与 type 匹配。
+          if node scripts/desktopCanaryTrigger.cjs "$commit_msg"; then
             echo "should_build=true" >> $GITHUB_OUTPUT
             echo "✅ Commit matches canary build trigger: $commit_msg"
           else
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "⏭️ Commit does not match style/feat/fix/perf/refactor/release prefix, skipping: $commit_msg"
+            echo "⏭️ Commit type is not style/feat/fix/perf/refactor/release, skipping: $commit_msg"
           fi
 
+  renderer-ota:
+    name: Publish Renderer OTA
+    needs: [check-trigger]
+    if: needs.check-trigger.outputs.should_build == 'true'
+    uses: ./.github/workflows/release-desktop-renderer-ota.yml
+    with:
+      channel: canary
+    secrets: inherit
+
+  # ============================================
+  # OTA 无法覆盖当前 main 时，计算完整发布版本
+  # ============================================
+  calculate-version:
+    name: Calculate Canary Version
+    needs: [check-trigger, renderer-ota]
+    if: needs.check-trigger.outputs.should_build == 'true' && (github.event_name == 'workflow_dispatch' || needs.renderer-ota.outputs.requires_full_release == 'true')
+    runs-on: ubuntu-latest
+    outputs:
+      cloud_ref: ${{ steps.cloud-ref.outputs.cloud_ref }}
+      release_notes: ${{ steps.release-notes.outputs.release_notes }}
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Calculate canary version
-        if: steps.check.outputs.should_build == 'true'
         id: version
         run: |
           # 获取最新的 stable tag (排除 nightly/canary/beta 等)
@@ -125,7 +149,6 @@ jobs:
 
       - name: Resolve Cloud revision
         id: cloud-ref
-        if: steps.check.outputs.should_build == 'true'
         env:
           CLOUD_REPOSITORY: ${{ vars.OVERLAY_REPOSITORY }}
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
@@ -141,7 +164,6 @@ jobs:
           echo "cloud_ref=$cloud_ref" >> "$GITHUB_OUTPUT"
 
       - name: Generate canary release notes
-        if: steps.check.outputs.should_build == 'true'
         id: release-notes
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -200,22 +222,12 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
-  renderer-ota:
-    name: Publish Renderer OTA
-    needs: [calculate-version]
-    if: needs.calculate-version.outputs.should_build == 'true'
-    uses: ./.github/workflows/release-desktop-renderer-ota.yml
-    with:
-      channel: canary
-    secrets: inherit
-
   # ============================================
   # 代码质量检查
   # ============================================
   test:
     name: Code quality check
     needs: [calculate-version]
-    if: needs.calculate-version.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base
@@ -237,7 +249,6 @@ jobs:
   # ============================================
   build:
     needs: [calculate-version, test]
-    if: needs.calculate-version.outputs.should_build == 'true'
     name: Build Desktop App
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/release-desktop-renderer-ota.yml
+++ b/.github/workflows/release-desktop-renderer-ota.yml
@@ -19,6 +19,19 @@ on:
         description: 'Update channel'
         required: true
         type: string
+    outputs:
+      published:
+        description: 'Whether a renderer patch was uploaded'
+        value: ${{ jobs.publish-renderer-patch.outputs.published }}
+      reason:
+        description: 'Renderer OTA publication or skip reason'
+        value: ${{ jobs.publish-renderer-patch.outputs.reason }}
+      requires_full_release:
+        description: 'Whether the caller must publish a full desktop release'
+        value: ${{ jobs.publish-renderer-patch.outputs.requires_full_release }}
+      version:
+        description: 'Published renderer patch version'
+        value: ${{ jobs.publish-renderer-patch.outputs.version }}
   workflow_dispatch:
     inputs:
       channel:
@@ -44,6 +57,11 @@ jobs:
   publish-renderer-patch:
     name: Publish Renderer Patch (${{ inputs.channel }})
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.result.outputs.published }}
+      reason: ${{ steps.result.outputs.reason }}
+      requires_full_release: ${{ steps.result.outputs.requires_full_release }}
+      version: ${{ steps.result.outputs.version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -68,12 +86,14 @@ jobs:
           if [ -z "$BASE" ]; then
             echo "::warning::no renderer OTA base metadata found; run a full release first"
             echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "reason=base-missing" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "$(jq -r '.rendererProtocol // 0' <<< "$BASE")" != "2" ]; then
             echo "::warning::renderer OTA base is not V2; run a full release first"
             echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "reason=unsupported-base" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -117,6 +137,7 @@ jobs:
           if [ "$MAIN_HASH" != "$BASE_MAIN_HASH" ]; then
             echo "::warning::main changed since last full release — renderer patch is not allowed, run a full release instead"
             echo "allowed=false" >> "$GITHUB_OUTPUT"
+            echo "reason=main-changed" >> "$GITHUB_OUTPUT"
           else
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -166,6 +187,7 @@ jobs:
             --feed-url="$UPDATE_SERVER_BASE_URL/$CHANNEL/$APP_VERSION/renderer/v2"
 
       - name: Upload to S3
+        id: publish
         if: steps.gate.outputs.allowed == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
@@ -197,3 +219,52 @@ jobs:
             --cache-control no-store "${ENDPOINT_ARGS[@]}"
 
           echo "✅ Published renderer patch ${{ steps.version.outputs.version }} for $CHANNEL/$APP_VERSION"
+
+      - name: Report renderer OTA result
+        id: result
+        if: always()
+        env:
+          APP_VERSION: ${{ steps.base.outputs.app_version }}
+          BASE_FOUND: ${{ steps.base.outputs.found }}
+          BASE_REASON: ${{ steps.base.outputs.reason }}
+          GATE_ALLOWED: ${{ steps.gate.outputs.allowed }}
+          GATE_REASON: ${{ steps.gate.outputs.reason }}
+          PATCH_VERSION: ${{ steps.version.outputs.version }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+        run: |
+          published=false
+          requires_full_release=false
+          version=""
+
+          if [ "$BASE_FOUND" != "true" ]; then
+            reason="${BASE_REASON:-base-unavailable}"
+            requires_full_release=true
+          elif [ "$GATE_ALLOWED" != "true" ]; then
+            reason="${GATE_REASON:-gate-failed}"
+            requires_full_release=true
+          elif [ "$PUBLISH_OUTCOME" = "success" ]; then
+            published=true
+            reason=published
+            version="$PATCH_VERSION"
+          else
+            reason=publish-failed
+          fi
+
+          {
+            echo "published=$published"
+            echo "reason=$reason"
+            echo "requires_full_release=$requires_full_release"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Renderer OTA"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Published | \`$published\` |"
+            echo "| Version | \`${version:-(none)}\` |"
+            echo "| Reason | \`$reason\` |"
+            echo "| Requires full release | \`$requires_full_release\` |"
+            echo "| App version | \`${APP_VERSION:-(none)}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/desktopCanaryTrigger.cjs
+++ b/scripts/desktopCanaryTrigger.cjs
@@ -1,0 +1,10 @@
+const BUILD_TYPE_RE =
+  /^[^\p{L}\p{N}]*(?:style|feat|fix|perf|refactor|release)(?:\([^\r\n)]+\))?:/iu;
+
+const shouldBuildDesktopCanary = (subject) => BUILD_TYPE_RE.test(subject.trim());
+
+if (require.main === module) {
+  process.exitCode = shouldBuildDesktopCanary(process.argv.slice(2).join(' ')) ? 0 : 1;
+}
+
+module.exports = { shouldBuildDesktopCanary };

--- a/scripts/desktopCanaryTrigger.test.ts
+++ b/scripts/desktopCanaryTrigger.test.ts
@@ -1,0 +1,29 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { shouldBuildDesktopCanary } = require('./desktopCanaryTrigger.cjs') as {
+  shouldBuildDesktopCanary: (subject: string) => boolean;
+};
+
+describe('shouldBuildDesktopCanary', () => {
+  it.each([
+    'feat: add a feature',
+    'fix(scope): repair a bug',
+    '🔥 refactor(agentTasks): remove stale labels',
+    '💄 feat(chat): resolve entity links',
+    '🐛 perf(upload): hash files off the main thread',
+  ])('accepts release commit type independently of gitmoji: %s', (subject) => {
+    expect(shouldBuildDesktopCanary(subject)).toBe(true);
+  });
+
+  it.each([
+    'chore: update dependencies',
+    '🔥 chore: remove generated files',
+    'docs(scope): update release docs',
+    'chore: mention feat: in the release notes',
+  ])('rejects non-release commit type: %s', (subject) => {
+    expect(shouldBuildDesktopCanary(subject)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- match desktop Canary builds by Conventional Commit type, independent of gitmoji
- run Renderer OTA first and continue to the full release only when the OTA reports a main-lineage mismatch
- protect an in-progress release from cancellation while retaining the newest pending run
- expose the Renderer OTA outcome through reusable-workflow outputs and the job summary

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check .github/workflows/release-desktop-canary.yml .github/workflows/release-desktop-renderer-ota.yml scripts/desktopCanaryTrigger.cjs scripts/desktopCanaryTrigger.test.ts` (9 tests)
- `actionlint -ignore 'SC2086' -ignore 'SC2016' -ignore 'softprops/action-gh-release@v1' .github/workflows/release-desktop-canary.yml .github/workflows/release-desktop-renderer-ota.yml`
- verified all 17 commit titles since `v2.2.16-canary.25` match the updated type-based trigger

#### 🔗 Related Issue

N/A