### PR TITLE
♻️ refactor(auth): drop og metadata from auth SPA seo injection

### DIFF
--- a/src/app/spa-auth/[locale]/[[...path]]/seoMeta.test.ts
+++ b/src/app/spa-auth/[locale]/[[...path]]/seoMeta.test.ts
@@ -45,11 +45,13 @@ describe('buildAuthSeoEntry', () => {
 });
 
 describe('buildSeoMeta', () => {
-  it('joins canonical path onto official url for mapped paths', async () => {
+  it('generates title and description for mapped paths', async () => {
     const meta = await buildSeoMeta('en-US', '/signin');
 
     expect(meta).toContain('<title>Sign In</title>');
-    expect(meta).toContain('property="og:url" content="https://app.lobehub.com/signin"');
+    expect(meta).toContain('<meta name="description" content="');
+    expect(meta).not.toContain('og:');
+    expect(meta).not.toContain('twitter:');
   });
 
   it('normalizes hostile locale input to an allowlisted value', async () => {
@@ -58,13 +60,14 @@ describe('buildSeoMeta', () => {
 
     expect(meta).not.toContain(hostile);
     expect(meta).not.toContain('alert(1)');
-    expect(meta).toContain('property="og:locale" content="en-US"');
+    expect(meta).toContain('<title>Sign In</title>');
   });
 
-  it('uses official url for unmapped paths', async () => {
+  it('falls back to branding for unmapped paths', async () => {
     const meta = await buildSeoMeta('en-US', '/verify-email');
 
-    expect(meta).toContain('property="og:url" content="https://app.lobehub.com"');
-    expect(meta).toContain('property="og:locale" content="en-US"');
+    expect(meta).toContain('<title>');
+    expect(meta).not.toContain('og:');
+    expect(meta).not.toContain('twitter:');
   });
 });

--- a/src/app/spa-auth/[locale]/[[...path]]/seoMeta.ts
+++ b/src/app/spa-auth/[locale]/[[...path]]/seoMeta.ts
@@ -1,9 +1,5 @@
-import { APPLE_APP_STORE_ID, BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
-import { OG_URL } from '@lobechat/const';
-import urlJoin from 'url-join';
+import { APPLE_APP_STORE_ID, BRANDING_NAME } from '@lobechat/business-const';
 
-import { OFFICIAL_URL } from '@/const/url';
-import { isCustomORG } from '@/const/version';
 import { translation } from '@/libs/i18n/serverTranslation';
 import { normalizeLocale } from '@/locales/resources';
 
@@ -44,25 +40,9 @@ export async function buildAuthSeoEntry(locale: string, pathname: string): Promi
 
 export async function buildSeoMeta(locale: string, pathname: string): Promise<string> {
   const lng = normalizeLocale(locale);
-  const { title, description, canonicalPath } = await buildAuthSeoEntry(lng, pathname);
-  const ogUrl = canonicalPath ? urlJoin(OFFICIAL_URL, canonicalPath) : OFFICIAL_URL;
+  const { title, description } = await buildAuthSeoEntry(lng, pathname);
 
-  const metas = [
-    `<title>${title}</title>`,
-    `<meta name="description" content="${description}" />`,
-    `<meta property="og:title" content="${title}" />`,
-    `<meta property="og:description" content="${description}" />`,
-    `<meta property="og:type" content="website" />`,
-    `<meta property="og:url" content="${ogUrl}" />`,
-    `<meta property="og:image" content="${OG_URL}" />`,
-    `<meta property="og:site_name" content="${BRANDING_NAME}" />`,
-    `<meta property="og:locale" content="${lng}" />`,
-    `<meta name="twitter:card" content="summary_large_image" />`,
-    `<meta name="twitter:title" content="${title}" />`,
-    `<meta name="twitter:description" content="${description}" />`,
-    `<meta name="twitter:image" content="${OG_URL}" />`,
-    `<meta name="twitter:site" content="${isCustomORG ? `@${ORG_NAME}` : '@lobehub'}" />`,
-  ];
+  const metas = [`<title>${title}</title>`, `<meta name="description" content="${description}" />`];
 
   if (APPLE_APP_STORE_ID) {
     metas.push(`<meta name="apple-itunes-app" content="app-id=${APPLE_APP_STORE_ID}" />`);


### PR DESCRIPTION
<!-- Brief and heads-up -->
Drop Open Graph and Twitter Card metadata from `index.auth.html` SEO injection, retaining only essential `<title>`, `<meta name="description">`, and optional Apple Smart App Banner.

#### Key Decisions / Non-goals
- Authentication pages (sign in, sign up, callback, password reset) do not need rich social sharing preview cards.
- Dropped all `og:*` and `twitter:*` tags from `buildSeoMeta`, along with unused constants.
- Title and description localization remain intact for search indexing on `/signin` and `/signup`.

#### Test
- [x] Added/updated tests

Tested locally with vitest (`seoMeta.test.ts` passes 8/8 tests).