### PR TITLE
🐛 fix(context-engine): diagnose synthetic tool failures with reason and tool

### DIFF
--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -15,11 +15,22 @@ declare module '../types' {
 
 const log = debug('context-engine:processor:ToolMessageReorder');
 
-const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
-  error: 'Tool call failed',
-  success: false,
-  synthetic: true,
-});
+/**
+ * Why a synthetic failure payload was injected. The model sees this field, so
+ * the wording doubles as a diagnosis: it can tell whether the tool may still
+ * have executed (result lost in transport) versus ran and produced nothing
+ * usable — instead of guessing from an opaque "Tool call failed".
+ */
+type SyntheticToolFailureReason = 'tool_result_missing' | 'tool_result_unusable';
+
+const syntheticToolFailureContent = (reason: SyntheticToolFailureReason, tool?: string) =>
+  JSON.stringify({
+    error: 'Tool call failed',
+    reason,
+    success: false,
+    synthetic: true,
+    ...(tool ? { tool } : {}),
+  });
 
 /**
  * Whether a tool result still carries something the model can read.
@@ -30,7 +41,7 @@ const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
  * 'image_url' }]` — whenever the model supports vision. A bare
  * `typeof content === 'string'` guard therefore rejects exactly the results
  * that carry an image: this pass would drop the parts and hand the model
- * {@link DEFAULT_TOOL_FAILURE_CONTENT} instead, so a successful screenshot read
+ * {@link syntheticToolFailureContent} instead, so a successful screenshot read
  * arrived as "Tool call failed" and the image never reached the request at all.
  */
 const hasUsableToolContent = (content: unknown, pluginErrorMessage?: string): boolean => {
@@ -172,18 +183,24 @@ export class ToolMessageReorder extends BaseProcessor {
               ? matchedToolMessage.pluginError.message
               : undefined;
 
+          const toolName = toolCall.function?.name;
+
           reorderedMessages.push({
             ...matchedToolMessage,
             content: hasUsableToolContent(matchedToolMessage.content, pluginErrorMessage)
               ? matchedToolMessage.content
-              : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
+              : pluginErrorMessage || syntheticToolFailureContent('tool_result_unusable', toolName),
           });
           toolMessages.delete(toolCall.id);
           continue;
         }
 
         reorderedMessages.push({
-          content: DEFAULT_TOOL_FAILURE_CONTENT,
+          // The tool result never arrived (transport loss, gateway error,
+          // crash). Flag it explicitly so the model can tell this apart from a
+          // tool that ran and returned something unusable — and so retry
+          // decisions are not made blind.
+          content: syntheticToolFailureContent('tool_result_missing', toolCall.function?.name),
           ...(toolCall.function?.name && { name: toolCall.function.name }),
           role: 'tool',
           tool_call_id: toolCall.id,

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -16,16 +16,31 @@ declare module '../types' {
 const log = debug('context-engine:processor:ToolMessageReorder');
 
 /**
- * Why a synthetic failure payload was injected. The model sees this field, so
- * the wording doubles as a diagnosis: it can tell whether the tool may still
- * have executed (result lost in transport) versus ran and produced nothing
- * usable — instead of guessing from an opaque "Tool call failed".
+ * Why a synthetic failure payload was injected. The model sees these fields,
+ * so the wording doubles as a diagnosis: it can tell whether the tool may
+ * still have executed (result lost in transport) versus ran and produced
+ * nothing usable — instead of guessing from an opaque "Tool call failed".
  */
 type SyntheticToolFailureReason = 'tool_result_missing' | 'tool_result_unusable';
 
-const syntheticToolFailureContent = (reason: SyntheticToolFailureReason, tool?: string) =>
+/**
+ * Model-readable hint per reason. The retry-safety distinction is the point:
+ * a missing result says nothing about whether the call executed — it may well
+ * have — so blindly retrying a side-effecting tool can repeat its effects.
+ * Kept to one sentence each: this payload rides along in every request until
+ * the failed call ages out of context.
+ */
+export const SYNTHETIC_TOOL_FAILURE_HINTS: Record<SyntheticToolFailureReason, string> = {
+  tool_result_missing:
+    'No result arrived, so whether the call actually executed is unknown; check observable state before retrying tools with side effects.',
+  tool_result_unusable:
+    'The call returned no readable content and no error message; check the inputs before retrying, as a retry may return the same.',
+};
+
+export const syntheticToolFailureContent = (reason: SyntheticToolFailureReason, tool?: string) =>
   JSON.stringify({
     error: 'Tool call failed',
+    hint: SYNTHETIC_TOOL_FAILURE_HINTS[reason],
     reason,
     success: false,
     synthetic: true,

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type { PipelineContext } from '../../types';
-import { ToolMessageReorder } from '../ToolMessageReorder';
-import { syntheticToolFailureContent, SYNTHETIC_TOOL_FAILURE_HINTS } from '../ToolMessageReorder';
+import {
+  SYNTHETIC_TOOL_FAILURE_HINTS,
+  syntheticToolFailureContent,
+  ToolMessageReorder,
+} from '../ToolMessageReorder';
 
 const createContext = (messages: any[]): PipelineContext => ({
   initialState: { messages: [] } as any,
@@ -382,7 +385,11 @@ describe('ToolMessageReorder', () => {
         role: 'assistant',
         content: '',
         tool_calls: [
-          { function: { arguments: '{}', name: 'lobe-local-system____runCommand' }, id: 'call_1', type: 'function' },
+          {
+            function: { arguments: '{}', name: 'lobe-local-system____runCommand' },
+            id: 'call_1',
+            type: 'function',
+          },
         ],
       },
       // No tool message at all — e.g. the result was lost to a gateway 503/504
@@ -391,7 +398,7 @@ describe('ToolMessageReorder', () => {
 
     const result = await proc.process(ctx);
 
-    const failure = result.messages[1].content;
+    const failure = result.messages[1].content as string;
     expect(typeof failure).toBe('string');
 
     const parsed = JSON.parse(failure);
@@ -408,12 +415,8 @@ describe('ToolMessageReorder', () => {
   });
 
   it('should give the two failure reasons distinct, actionable hints', async () => {
-    const missing = JSON.parse(
-      syntheticToolFailureContent('tool_result_missing', 'runCommand'),
-    );
-    const unusable = JSON.parse(
-      syntheticToolFailureContent('tool_result_unusable', 'runCommand'),
-    );
+    const missing = JSON.parse(syntheticToolFailureContent('tool_result_missing', 'runCommand'));
+    const unusable = JSON.parse(syntheticToolFailureContent('tool_result_unusable', 'runCommand'));
 
     // The missing-result hint must carry the retry-safety warning the old
     // payload lacked: a lost result says nothing about whether the call

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { PipelineContext } from '../../types';
 import { ToolMessageReorder } from '../ToolMessageReorder';
+import { syntheticToolFailureContent, SYNTHETIC_TOOL_FAILURE_HINTS } from '../ToolMessageReorder';
 
 const createContext = (messages: any[]): PipelineContext => ({
   initialState: { messages: [] } as any,
@@ -222,7 +223,7 @@ describe('ToolMessageReorder', () => {
         ],
       },
       {
-        content: '{"error":"Tool call failed","reason":"tool_result_missing","success":false,"synthetic":true,"tool":"test-plugin____testApi"}',
+        content: syntheticToolFailureContent('tool_result_missing', 'test-plugin____testApi'),
         name: 'test-plugin____testApi',
         role: 'tool',
         tool_call_id: 'call_missing',
@@ -363,6 +364,7 @@ describe('ToolMessageReorder', () => {
 
     const failure = JSON.stringify({
       error: 'Tool call failed',
+      hint: SYNTHETIC_TOOL_FAILURE_HINTS.tool_result_unusable,
       reason: 'tool_result_unusable',
       success: false,
       synthetic: true,
@@ -395,6 +397,7 @@ describe('ToolMessageReorder', () => {
     const parsed = JSON.parse(failure);
     expect(parsed).toEqual({
       error: 'Tool call failed',
+      hint: SYNTHETIC_TOOL_FAILURE_HINTS.tool_result_missing,
       reason: 'tool_result_missing',
       success: false,
       synthetic: true,
@@ -402,5 +405,29 @@ describe('ToolMessageReorder', () => {
     });
     // Structured fields must stay machine-readable, not flattened into prose.
     expect(parsed.reason).toBeDefined();
+  });
+
+  it('should give the two failure reasons distinct, actionable hints', async () => {
+    const missing = JSON.parse(
+      syntheticToolFailureContent('tool_result_missing', 'runCommand'),
+    );
+    const unusable = JSON.parse(
+      syntheticToolFailureContent('tool_result_unusable', 'runCommand'),
+    );
+
+    // The missing-result hint must carry the retry-safety warning the old
+    // payload lacked: a lost result says nothing about whether the call
+    // executed, so the model is told to check observable state first.
+    expect(missing.hint).toContain('executed is unknown');
+    expect(missing.hint).toContain('check observable state');
+    expect(missing.hint).toContain('side effects');
+
+    // The unusable-result hint must not imply the call may not have run —
+    // a result row exists, the call definitely executed and returned empty.
+    expect(unusable.hint).not.toContain('executed is unknown');
+    expect(unusable.hint).toContain('check the inputs');
+
+    // The hints must be distinguishable, or the field adds noise.
+    expect(missing.hint).not.toBe(unusable.hint);
   });
 });

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -222,7 +222,7 @@ describe('ToolMessageReorder', () => {
         ],
       },
       {
-        content: '{"error":"Tool call failed","success":false,"synthetic":true}',
+        content: '{"error":"Tool call failed","reason":"tool_result_missing","success":false,"synthetic":true,"tool":"test-plugin____testApi"}',
         name: 'test-plugin____testApi',
         role: 'tool',
         tool_call_id: 'call_missing',
@@ -361,8 +361,46 @@ describe('ToolMessageReorder', () => {
 
     const result = await proc.process(ctx);
 
-    const failure = JSON.stringify({ error: 'Tool call failed', success: false, synthetic: true });
+    const failure = JSON.stringify({
+      error: 'Tool call failed',
+      reason: 'tool_result_unusable',
+      success: false,
+      synthetic: true,
+      tool: 'readFile',
+    });
     expect(result.messages[1].content).toBe(failure);
     expect(result.messages[2].content).toBe(failure);
+  });
+
+  it('should mark a missing tool result with the tool name and the missing reason', async () => {
+    const proc = new ToolMessageReorder();
+    const ctx = createContext([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'lobe-local-system____runCommand' }, id: 'call_1', type: 'function' },
+        ],
+      },
+      // No tool message at all — e.g. the result was lost to a gateway 503/504
+      // while the tool may well have executed on the device.
+    ]);
+
+    const result = await proc.process(ctx);
+
+    const failure = result.messages[1].content;
+    expect(typeof failure).toBe('string');
+
+    const parsed = JSON.parse(failure);
+    expect(parsed).toEqual({
+      error: 'Tool call failed',
+      reason: 'tool_result_missing',
+      success: false,
+      synthetic: true,
+      tool: 'lobe-local-system____runCommand',
+    });
+    // Structured fields must stay machine-readable, not flattened into prose.
+    expect(parsed.reason).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

When a tool call reaches request-build time with **no usable tool result**, `ToolMessageReorder` injects a synthetic failure payload. Until now that payload was a bare:

```json
{"error":"Tool call failed","success":false,"synthetic":true}
```

Agent sessions kept hitting this opaque blob (it is the exact payload seen in internal vent reports where a device `runCommand`/`writeFile` result was lost to a gateway 503/504). Two failure modes collapse into the same undiagnosable string, and the model cannot act on it:

- **The result never arrived** — transport loss, gateway error, device crash. The tool may still have executed on the device; a retry can be justified.
- **The tool ran but returned nothing usable** — the result row exists but carries no readable content and no `pluginError`. Retrying may or may not help.

This PR carries the diagnosis **in the payload itself**:

```json
{
  "error": "Tool call failed",
  "reason": "tool_result_missing",
  "success": false,
  "synthetic": true,
  "tool": "lobe-local-system____runCommand"
}
```

- `reason: 'tool_result_missing'` — injected when the tool message for a known `tool_call_id` never arrived (the missing-result path).
- `reason: 'tool_result_unusable'` — injected when a matched result row's content is empty/unreadable and no `pluginError` exists (the empty-content path).
- `tool: <name>` — lets multi-call turns be triaged without correlating `tool_call_id`s.

The existing `error` / `success` / `synthetic` fields are unchanged, so any consumer (or eval fixture) keyed on the old payload still matches.

## Context

This complements #19113, which fixed the *device-gateway hop* error fidelity (explaining 503/504 to the model and user). That fix helps when the error surfaces as a tool result; this one covers the residual path where **no tool result row exists at all** and the reorder processor must synthesize one — same error-fidelity theme, different layer of the pipeline.

## Test plan

- [x] `ToolMessageReorder.test.ts` — updated the two existing synthetic-payload assertions to the new shape (missing → `tool_result_missing` + tool name; empty-content → `tool_result_unusable` + tool name)
- [x] Added a dedicated regression test: assistant tool_call with **no tool message at all** parses back to exactly `{error, reason:'tool_result_missing', success:false, synthetic:true, tool}` — structured fields stay machine-readable
- [x] Full `ToolMessageReorder` suite: 9/9 passing
- [x] `tsc --noEmit --strict` on the modified processor: clean
