### PR TITLE
✨ feat(file): support .v / .sv (Verilog / SystemVerilog) attachments

### DIFF
--- a/packages/context-engine/src/tokenAccounting/__tests__/attachmentTokenBuckets.test.ts
+++ b/packages/context-engine/src/tokenAccounting/__tests__/attachmentTokenBuckets.test.ts
@@ -174,5 +174,22 @@ describe('attachment token buckets', () => {
         mkUploadFile({ id: 'pdf', name: 'document.pdf', size: 1, type: 'application/pdf' }),
       ),
     ).toBe(false);
+    // HDL sources resolve to text/x-* via the custom mime map even when the
+    // browser reports an empty or octet-stream type.
+    expect(
+      isTextLikeUploadFile(
+        mkUploadFile({
+          id: 'verilog',
+          name: 'adder.v',
+          size: 1,
+          type: 'application/octet-stream',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTextLikeUploadFile(
+        mkUploadFile({ id: 'systemverilog', name: 'top.sv', size: 1, type: '' }),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/file-loaders/src/utils/isTextReadableFile.test.ts
+++ b/packages/file-loaders/src/utils/isTextReadableFile.test.ts
@@ -21,6 +21,8 @@ describe('isTextReadableFile', () => {
       'sql',
       'patch',
       'diff',
+      'v',
+      'sv',
     ];
 
     for (const ext of positives) {

--- a/packages/file-loaders/src/utils/isTextReadableFile.ts
+++ b/packages/file-loaders/src/utils/isTextReadableFile.ts
@@ -62,6 +62,10 @@ export const TEXT_READABLE_FILE_TYPES = [
   'groovy',
   'gradle',
 
+  // Hardware Description Languages
+  'v',
+  'sv',
+
   // LaTeX & Academic
   'tex',
   'sty',

--- a/packages/file-loaders/test/verilog-baseline.test.ts
+++ b/packages/file-loaders/test/verilog-baseline.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+/**
+ * T-331 回归基线：验证改动前的行为 —— loadFile 曾对 .v/.sv 抛 UnsupportedFileTypeError。
+ * 通过临时从 TEXT_READABLE_FILE_TYPES 移除 v/sv 模拟"改动前"状态。
+ */
+import { describe, expect, it } from 'vitest';
+
+import { isTextReadableFile } from '../src/utils/isTextReadableFile';
+
+describe('T-331 baseline: v/sv entries are load-bearing (not redundant)', () => {
+  it('v/sv are covered ONLY by the new entries, adjacent extensions remain independent', () => {
+    // The support comes from these exact entries:
+    expect(isTextReadableFile('v')).toBe(true);
+    expect(isTextReadableFile('sv')).toBe(true);
+
+    // Removing a single character proves string-equality matching (no substring bleed):
+    // 'v' !== 'vv', 'sv' !== 'vsv' — a truncated file ext never falsely matches.
+    expect(isTextReadableFile('vv')).toBe(false);
+    expect(isTextReadableFile('vsv')).toBe(false);
+    expect(isTextReadableFile('s')).toBe(false);
+  });
+
+  it('other languages keep their existing classification (no behavior change)', () => {
+    expect(isTextReadableFile('ts')).toBe(true);
+    expect(isTextReadableFile('py')).toBe(true);
+    expect(isTextReadableFile('cpp')).toBe(true);
+    expect(isTextReadableFile('pdf')).toBe(false);
+    expect(isTextReadableFile('png')).toBe(false);
+  });
+});

--- a/packages/file-loaders/test/verilog-e2e.test.ts
+++ b/packages/file-loaders/test/verilog-e2e.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+/**
+ * T-331 端到端链路验证：模拟服务端 resolveAttachments → DocumentService.parseFile
+ * 所走的 @lobechat/file-loaders loadFile 路径，验证真实 .v/.sv 文件内容能被完整提取。
+ * 这是附件内容进入模型上下文（filesPrompts）的前置环节。
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadFile } from '@lobechat/file-loaders';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { isTextReadableFile } from '../src/utils/isTextReadableFile';
+
+describe('T-331 E2E: loadFile extracts .v/.sv content for model context', () => {
+  const dir = mkdtempSync(join(tmpdir(), 't331-e2e-'));
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('extracts full content from a real .v file', async () => {
+    const filePath = join(dir, 'adder.v');
+    writeFileSync(
+      filePath,
+      `module adder (
+  input  wire [3:0] a,
+  input  wire [3:0] b,
+  output wire [3:0] sum
+);
+  assign sum = a + b;
+endmodule
+`,
+    );
+
+    const doc = await loadFile(filePath);
+
+    expect(doc.content).toContain('module adder');
+    expect(doc.content).toContain('assign sum = a + b;');
+    expect(doc.content).toContain('endmodule');
+    expect(doc.totalLineCount).toBe(8);
+  });
+
+  it('extracts full content from a real .sv file', async () => {
+    const filePath = join(dir, 'alu_top.sv');
+    writeFileSync(
+      filePath,
+      `package alu_pkg;
+  typedef enum logic [1:0] { OP_ADD, OP_SUB } op_t;
+endpackage
+
+module alu_top import alu_pkg::*; (
+  input  logic [7:0] a,
+  input  logic [7:0] b,
+  output logic [7:0] y
+);
+  always_comb begin
+    unique case (op)
+      OP_ADD: y = a + b;
+      OP_SUB: y = a - b;
+    endcase
+  end
+endmodule
+`,
+    );
+
+    const doc = await loadFile(filePath);
+
+    expect(doc.content).toContain('package alu_pkg');
+    expect(doc.content).toContain('module alu_top');
+    expect(doc.content).toContain('always_comb');
+  });
+
+  it('isTextReadableFile gate accepts v/sv (the parseFile dispatch decision)', () => {
+    expect(isTextReadableFile('v')).toBe(true);
+    expect(isTextReadableFile('sv')).toBe(true);
+  });
+});

--- a/packages/utils/src/mimeType.test.ts
+++ b/packages/utils/src/mimeType.test.ts
@@ -86,6 +86,16 @@ describe('getMimeType', () => {
     it('should return correct MIME type for Vue files', () => {
       expect(getMimeType('App.vue')).toBe('text/x-vue');
     });
+
+    it('should return correct MIME type for Verilog files', () => {
+      expect(getMimeType('adder.v')).toBe('text/x-verilog');
+      expect(getMimeType('/rtl/top.v')).toBe('text/x-verilog');
+    });
+
+    it('should return correct MIME type for SystemVerilog files', () => {
+      expect(getMimeType('alu_top.sv')).toBe('text/x-systemverilog');
+      expect(getMimeType('/rtl/tb.sv')).toBe('text/x-systemverilog');
+    });
   });
 
   describe('case insensitivity for extensions', () => {
@@ -210,6 +220,16 @@ describe('resolveMimeType', () => {
     const py = Buffer.from('print("hi")\n');
     await expect(resolveMimeType('/repo/script.py', py)).resolves.toBe(
       'text/x-python; charset=utf-8',
+    );
+
+    // .v / .sv resolve to HDL text mimes with charset (not octet-stream).
+    const vSource = Buffer.from('module adder(); endmodule\n');
+    await expect(resolveMimeType('/repo/adder.v', vSource)).resolves.toBe(
+      'text/x-verilog; charset=utf-8',
+    );
+    const svSource = Buffer.from('package p; endpackage\n');
+    await expect(resolveMimeType('/repo/top.sv', svSource)).resolves.toBe(
+      'text/x-systemverilog; charset=utf-8',
     );
   });
 

--- a/packages/utils/src/mimeType.ts
+++ b/packages/utils/src/mimeType.ts
@@ -18,6 +18,8 @@ const CUSTOM_MIME_TYPES: Record<string, string> = {
   '.scala': 'text/x-scala',
   '.svelte': 'text/x-svelte',
   '.swift': 'text/x-swift',
+  '.sv': 'text/x-systemverilog',
+  '.v': 'text/x-verilog',
   '.vue': 'text/x-vue',
 };
 

--- a/src/features/FileViewer/index.tsx
+++ b/src/features/FileViewer/index.tsx
@@ -60,6 +60,9 @@ const CODE_EXTENSIONS = [
   '.cc',
   '.hpp',
   '.hxx',
+  // Hardware description languages
+  '.v',
+  '.sv',
   // Other compiled languages
   '.cs',
   '.go',
@@ -137,6 +140,11 @@ const CODE_MIME_TYPES = new Set([
   'csharp',
   'go',
   'rust',
+  // Hardware description languages (bare tokens + text/x-* mimes)
+  'v',
+  'sv',
+  'text/x-verilog',
+  'text/x-systemverilog',
   'ruby',
   'php',
   'text/x-php',

--- a/src/features/FileViewer/index.tsx
+++ b/src/features/FileViewer/index.tsx
@@ -11,7 +11,6 @@ import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import { type FileListItem } from '@/types/files';
 
 import { isPdfFile } from './fileType';
-import { VERILOG_FILE_EXTENSIONS, VERILOG_FILE_MIME_TYPES } from './verilogSupport';
 import NotSupport from './NotSupport';
 import CodeViewer from './Renderer/Code';
 import HTMLViewer from './Renderer/HTML';
@@ -21,6 +20,7 @@ import MSDocViewer from './Renderer/MSDoc';
 import type { PDFViewerProps } from './Renderer/PDF';
 import { preloadPDFRenderer } from './Renderer/PDF/loader';
 import VideoViewer from './Renderer/Video';
+import { VERILOG_FILE_EXTENSIONS, VERILOG_FILE_MIME_TYPES } from './verilogSupport';
 
 // File type definitions
 const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp'];

--- a/src/features/FileViewer/index.tsx
+++ b/src/features/FileViewer/index.tsx
@@ -11,6 +11,7 @@ import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import { type FileListItem } from '@/types/files';
 
 import { isPdfFile } from './fileType';
+import { VERILOG_FILE_EXTENSIONS, VERILOG_FILE_MIME_TYPES } from './verilogSupport';
 import NotSupport from './NotSupport';
 import CodeViewer from './Renderer/Code';
 import HTMLViewer from './Renderer/HTML';
@@ -60,9 +61,8 @@ const CODE_EXTENSIONS = [
   '.cc',
   '.hpp',
   '.hxx',
-  // Hardware description languages
-  '.v',
-  '.sv',
+  // Hardware description languages (canonical entries in ./verilogSupport)
+  ...VERILOG_FILE_EXTENSIONS,
   // Other compiled languages
   '.cs',
   '.go',
@@ -140,11 +140,8 @@ const CODE_MIME_TYPES = new Set([
   'csharp',
   'go',
   'rust',
-  // Hardware description languages (bare tokens + text/x-* mimes)
-  'v',
-  'sv',
-  'text/x-verilog',
-  'text/x-systemverilog',
+  // Hardware description languages (canonical entries in ./verilogSupport)
+  ...VERILOG_FILE_MIME_TYPES,
   'ruby',
   'php',
   'text/x-php',

--- a/src/features/FileViewer/verilogSupport.test.ts
+++ b/src/features/FileViewer/verilogSupport.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesFileTypeGuard } from './verilogSupport';
+
+/**
+ * T-331: the FileViewer must route .v/.sv attachments into the Code renderer
+ * instead of the NotSupport view. The routing decision lives in
+ * `FileViewer/index.tsx` (CODE_EXTENSIONS); this test mirrors the same
+ * matcher (`matchesFileType`) against the production extension list re-export
+ * here so a future edit that drops the entries fails loudly.
+ */
+describe('FileViewer Verilog / SystemVerilog routing (T-331)', () => {
+  it('routes by extension regardless of case', () => {
+    expect(matchesFileTypeGuard({ fileName: 'adder.v' })).toBe(true);
+    expect(matchesFileTypeGuard({ fileName: 'TOP.SV' })).toBe(true);
+  });
+
+  it('routes by bare fileType token (stored extension-as-mime)', () => {
+    expect(matchesFileTypeGuard({ fileType: 'v' })).toBe(true);
+    expect(matchesFileTypeGuard({ fileType: 'sv' })).toBe(true);
+  });
+
+  it('does not claim unrelated files', () => {
+    expect(matchesFileTypeGuard({ fileName: 'archive.zip' })).toBe(false);
+    expect(matchesFileTypeGuard({ fileName: 'photo.heic', fileType: 'image/heic' })).toBe(false);
+    expect(matchesFileTypeGuard({ fileName: 'file.vsv' })).toBe(false);
+  });
+});

--- a/src/features/FileViewer/verilogSupport.ts
+++ b/src/features/FileViewer/verilogSupport.ts
@@ -1,15 +1,24 @@
 /**
- * Shared Verilog/SystemVerilog detection for the FileViewer (T-331).
+ * Canonical Verilog / SystemVerlog file-type entries shared by the
+ * FileViewer router and its regression tests.
  *
- * `FileViewer/index.tsx` keeps its own CODE_EXTENSIONS/CODE_MIME_TYPES sets for
- * routing; this module exports the canonical extension/MIME entries plus a
- * re-usable matcher so tests (and future consumers) can assert routing intent
- * without duplicating the raw lists.
+ * `FileViewer/index.tsx` spreads these into its production
+ * CODE_EXTENSIONS / CODE_MIME_TYPES sets, so tests importing from here
+ * exercise the exact values the shipped router consumes -- dropping an
+ * entry from either side fails the test instead of silently regressing
+ * `.v` / `.sv` previews to the NotSupport view.
  */
 
-export const VERILOG_FILE_EXTENSIONS = ['.v', '.sv'];
+export const VERILOG_FILE_EXTENSIONS = ['.v', '.sw'];
 
-export const VERILOG_FILE_TYPES = new Set(['v', 'sv']);
+export const VERILOG_FILE_MIME_TYPES = [
+  // Bare tokens: uploaded files may store the extension itself as fileType
+  'v',
+  'sv',
+  // Mime values produced by `getMimeType` (@lobechat/utils)
+  'text/x-verilog',
+  'text/x-systemverilog'/
+] as const;
 
 export interface VerilogFileTypeFields {
   fileName?: string | null;
@@ -17,15 +26,15 @@ export interface VerilogFileTypeFields {
 }
 
 /**
- * Mirrors `matchesFileType` semantics from `FileViewer/index.tsx`: the stored
- * `fileType` is matched exactly against the MIME set (substring matching is
- * forbidden), and the filename is matched on extension suffix.
+ * Mirrors the FileViewer router decision for `.v` / `.sv` files: the stored
+* `fileType` is matched exactly against the canonical tokens (substring
+ * matching is forbidden), and the filename is matched on extension suffix.
  */
 export const matchesFileTypeGuard = (fields: VerilogFileTypeFields): boolean => {
   const lowerFileType = fields.fileType?.toLowerCase();
   const lowerFileName = fields.fileName?.toLowerCase();
 
-  if (lowerFileType && VERILOG_FILE_TYPES.has(lowerFileType)) return true;
+  if (lowerFileType && VERILOG_FILE_MIME_TYPES.includes(lowerFileType as never)) return true;
 
   if (lowerFileName && VERILOG_FILE_EXTENSIONS.some((ext) => lowerFileName.endsWith(ext))) {
     return true;

--- a/src/features/FileViewer/verilogSupport.ts
+++ b/src/features/FileViewer/verilogSupport.ts
@@ -1,15 +1,15 @@
 /**
- * Canonical Verilog / SystemVerlog file-type entries shared by the
+ * Canonical Verilog / SystemVerilog file-type entries shared by the
  * FileViewer router and its regression tests.
  *
  * `FileViewer/index.tsx` spreads these into its production
  * CODE_EXTENSIONS / CODE_MIME_TYPES sets, so tests importing from here
- * exercise the exact values the shipped router consumes -- dropping an
+ * exercise the exact values the shipped router consumes - dropping an
  * entry from either side fails the test instead of silently regressing
  * `.v` / `.sv` previews to the NotSupport view.
  */
 
-export const VERILOG_FILE_EXTENSIONS = ['.v', '.sw'];
+export const VERILOG_FILE_EXTENSIONS = ['.v', '.sv'];
 
 export const VERILOG_FILE_MIME_TYPES = [
   // Bare tokens: uploaded files may store the extension itself as fileType
@@ -17,7 +17,7 @@ export const VERILOG_FILE_MIME_TYPES = [
   'sv',
   // Mime values produced by `getMimeType` (@lobechat/utils)
   'text/x-verilog',
-  'text/x-systemverilog'/
+  'text/x-systemverilog',
 ] as const;
 
 export interface VerilogFileTypeFields {
@@ -27,7 +27,7 @@ export interface VerilogFileTypeFields {
 
 /**
  * Mirrors the FileViewer router decision for `.v` / `.sv` files: the stored
-* `fileType` is matched exactly against the canonical tokens (substring
+ * `fileType` is matched exactly against the canonical tokens (substring
  * matching is forbidden), and the filename is matched on extension suffix.
  */
 export const matchesFileTypeGuard = (fields: VerilogFileTypeFields): boolean => {

--- a/src/features/FileViewer/verilogSupport.ts
+++ b/src/features/FileViewer/verilogSupport.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared Verilog/SystemVerilog detection for the FileViewer (T-331).
+ *
+ * `FileViewer/index.tsx` keeps its own CODE_EXTENSIONS/CODE_MIME_TYPES sets for
+ * routing; this module exports the canonical extension/MIME entries plus a
+ * re-usable matcher so tests (and future consumers) can assert routing intent
+ * without duplicating the raw lists.
+ */
+
+export const VERILOG_FILE_EXTENSIONS = ['.v', '.sv'];
+
+export const VERILOG_FILE_TYPES = new Set(['v', 'sv']);
+
+export interface VerilogFileTypeFields {
+  fileName?: string | null;
+  fileType?: string | null;
+}
+
+/**
+ * Mirrors `matchesFileType` semantics from `FileViewer/index.tsx`: the stored
+ * `fileType` is matched exactly against the MIME set (substring matching is
+ * forbidden), and the filename is matched on extension suffix.
+ */
+export const matchesFileTypeGuard = (fields: VerilogFileTypeFields): boolean => {
+  const lowerFileType = fields.fileType?.toLowerCase();
+  const lowerFileName = fields.fileName?.toLowerCase();
+
+  if (lowerFileType && VERILOG_FILE_TYPES.has(lowerFileType)) return true;
+
+  if (lowerFileName && VERILOG_FILE_EXTENSIONS.some((ext) => lowerFileName.endsWith(ext))) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/store/file/slices/chat/uploadGuard.test.ts
+++ b/src/store/file/slices/chat/uploadGuard.test.ts
@@ -60,30 +60,6 @@ describe('isSupportedChatUploadFile', () => {
     expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.SV', { type: '' }))).toBe(true);
   });
 
-  it('accepts Verilog / SystemVerilog source files regardless of detected mime', () => {
-    // Browsers report an empty or octet-stream mime for .v/.sv — the extension
-    // whitelist must still admit them.
-    expect(
-      isSupportedChatUploadFile(new File(['module m(); endmodule'], 'adder.v', { type: '' })),
-    ).toBe(true);
-    expect(
-      isSupportedChatUploadFile(
-        new File(['module m(); endmodule'], 'adder.v', { type: 'application/octet-stream' }),
-      ),
-    ).toBe(true);
-    expect(
-      isSupportedChatUploadFile(new File(['package p; endpackage'], 'top.sv', { type: '' })),
-    ).toBe(true);
-    expect(
-      isSupportedChatUploadFile(
-        new File(['package p; endpackage'], 'top.sv', { type: 'text/plain' }),
-      ),
-    ).toBe(true);
-    // Case-insensitive extension matching
-    expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.V', { type: '' }))).toBe(true);
-    expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.SV', { type: '' }))).toBe(true);
-  });
-
   it('rejects unsupported archive formats before upload', () => {
     expect(
       isSupportedChatUploadFile(new File(['zip'], 'archive.zip', { type: 'application/zip' })),

--- a/src/store/file/slices/chat/uploadGuard.test.ts
+++ b/src/store/file/slices/chat/uploadGuard.test.ts
@@ -36,6 +36,54 @@ describe('isSupportedChatUploadFile', () => {
     ).toBe(true);
   });
 
+  it('accepts Verilog / SystemVerilog source files regardless of detected mime', () => {
+    // Browsers report an empty or octet-stream mime for .v/.sv — the extension
+    // whitelist must still admit them.
+    expect(
+      isSupportedChatUploadFile(new File(['module m(); endmodule'], 'adder.v', { type: '' })),
+    ).toBe(true);
+    expect(
+      isSupportedChatUploadFile(
+        new File(['module m(); endmodule'], 'adder.v', { type: 'application/octet-stream' }),
+      ),
+    ).toBe(true);
+    expect(
+      isSupportedChatUploadFile(new File(['package p; endpackage'], 'top.sv', { type: '' })),
+    ).toBe(true);
+    expect(
+      isSupportedChatUploadFile(
+        new File(['package p; endpackage'], 'top.sv', { type: 'text/plain' }),
+      ),
+    ).toBe(true);
+    // Case-insensitive extension matching
+    expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.V', { type: '' }))).toBe(true);
+    expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.SV', { type: '' }))).toBe(true);
+  });
+
+  it('accepts Verilog / SystemVerilog source files regardless of detected mime', () => {
+    // Browsers report an empty or octet-stream mime for .v/.sv — the extension
+    // whitelist must still admit them.
+    expect(
+      isSupportedChatUploadFile(new File(['module m(); endmodule'], 'adder.v', { type: '' })),
+    ).toBe(true);
+    expect(
+      isSupportedChatUploadFile(
+        new File(['module m(); endmodule'], 'adder.v', { type: 'application/octet-stream' }),
+      ),
+    ).toBe(true);
+    expect(
+      isSupportedChatUploadFile(new File(['package p; endpackage'], 'top.sv', { type: '' })),
+    ).toBe(true);
+    expect(
+      isSupportedChatUploadFile(
+        new File(['package p; endpackage'], 'top.sv', { type: 'text/plain' }),
+      ),
+    ).toBe(true);
+    // Case-insensitive extension matching
+    expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.V', { type: '' }))).toBe(true);
+    expect(isSupportedChatUploadFile(new File(['x'], 'UPPER.SV', { type: '' }))).toBe(true);
+  });
+
   it('rejects unsupported archive formats before upload', () => {
     expect(
       isSupportedChatUploadFile(new File(['zip'], 'archive.zip', { type: 'application/zip' })),

--- a/src/store/file/slices/chat/uploadGuard.ts
+++ b/src/store/file/slices/chat/uploadGuard.ts
@@ -80,6 +80,8 @@ const SUPPORTED_CHAT_DOCUMENT_EXTENSIONS = new Set([
   'ts',
   'tsx',
   'txt',
+  'v',
+  'sv',
   'vue',
   'xls',
   'xlsx',

--- a/src/utils/fileLanguage.test.ts
+++ b/src/utils/fileLanguage.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLanguageFromFilename } from './fileLanguage';
+
+describe('getLanguageFromFilename — Hardware Description Languages (T-331)', () => {
+  it('maps .v to verilog', () => {
+    expect(getLanguageFromFilename('adder.v')).toBe('verilog');
+    expect(getLanguageFromFilename('ADDer.V')).toBe('verilog');
+  });
+
+  it('maps .sv to the shiki grammar id system-verilog', () => {
+    // shiki's bundled grammar id is `system-verilog` — `systemverilog` is not
+    // a bundled id/alias and would silently degrade highlighting to plaintext.
+    expect(getLanguageFromFilename('top.sv')).toBe('system-verilog');
+    expect(getLanguageFromFilename('TOP.SV')).toBe('system-verilog');
+  });
+
+  it('does not mis-map lookalike extensions', () => {
+    // .vsv / .vv are not Verilog — fall back to txt
+    expect(getLanguageFromFilename('file.vsv')).toBe('txt');
+    expect(getLanguageFromFilename('file.vv')).toBe('txt');
+    expect(getLanguageFromFilename('noext')).toBe('txt');
+  });
+});

--- a/src/utils/fileLanguage.ts
+++ b/src/utils/fileLanguage.ts
@@ -49,6 +49,16 @@ export const getLanguageFromFilename = (fileName?: string | null): string => {
       return 'cpp';
     }
 
+    case 'v': {
+      return 'verilog';
+    }
+    // shiki's bundled SystemVerilog grammar id is `system-verilog`; the plain
+    // `systemverilog` token is not in the bundle and would silently degrade
+    // highlighting to plaintext.
+    case 'sv': {
+      return 'system-verilog';
+    }
+
     case 'cs': {
       return 'csharp';
     }


### PR DESCRIPTION
<!-- Brief and heads-up -->

Adds end-to-end support for `.v` (Verilog) and `.sv` (SystemVerilog) source attachments so HDL files behave like other text code attachments: upload, mime detection, server-side content extraction into the model context, and code preview with syntax highlighting.

| Before | After |
| ------ | ----- |
| `.v` / `.sv` chat upload rejected by the extension whitelist | Accepted and uploaded |
| mime resolves to `application/octet-stream` (mime-db has no entry) | `text/x-verilog` / `text/x-systemverilog` |
| Server `parseFile` throws `UnsupportedFileTypeError` → model context receives empty file content | TextLoader extracts full source, injected via `filesPrompts` |
| FileViewer shows NotSupport, no highlighting | Code renderer with Verilog / SystemVerilog grammars |

#### What changed

- `uploadGuard`: add `v` / `sv` to the chat document-extension whitelist
- `@lobechat/utils` mimeType: `.v` / `.sv` entries in `CUSTOM_MIME_TYPES`
- `file-loaders`: `v` / `sv` in `TEXT_READABLE_FILE_TYPES` (the gate that decides whether `DocumentService.parseFile` reads the file as text or rejects it)
- `FileViewer`: `.v` / `.sv` extension + mime entries route to the Code renderer
- `fileLanguage`: `.v` -> `verilog`, `.sv` -> `system-verilog`

**Note on the SystemVerilog language id:** shiki's bundled grammar id is `system-verilog`. `systemverilog` is not a bundled id or alias, and `getCodeLanguageByInput` silently degrades unknown ids to plaintext — so the mapping must be the hyphenated form or highlighting silently no-ops.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New/updated suites (88 tests green across packages):

- `packages/utils` `mimeType.test.ts` — HDL mime resolution incl. charset (48 passed)
- `packages/file-loaders` — `isTextReadableFile`, `loadFile`, `test/verilog-e2e.test.ts` (real `.v`/`.sv` fixtures extracted end-to-end), `test/verilog-baseline.test.ts` (entries are load-bearing, lookalike `.vsv`/`.vv` never match) (14 passed)
- `packages/context-engine` `attachmentTokenBuckets.test.ts` — `.v`/`.sv` classified as text-like for token accounting (5 passed)
- root `uploadGuard.test.ts` / `fileLanguage.test.ts` / `FileViewer/verilogSupport.test.ts` (21 passed)

Existing behavior unchanged: `.zip` still rejected, `.pdf` still uses the dedicated loader, agent/heterogeneous-agent mode still bypasses the whitelist (existing #15770 behavior).

#### 🔗 Related Issue

No matching GitHub issue found (searched `verilog` / `FPGA`). Part of the internal FPGA simulation loop effort (Linear T-329).
