### PR TITLE
⚡️ perf(spa): cut first-screen boot renders by 80%

### DIFF
--- a/packages/locales/src/create.test.ts
+++ b/packages/locales/src/create.test.ts
@@ -1,8 +1,9 @@
+import type { InitOptions } from 'i18next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { emit, init, on, reloadResources, storeOn, use } = vi.hoisted(() => ({
   emit: vi.fn(),
-  init: vi.fn(() => Promise.resolve()),
+  init: vi.fn((_options: InitOptions) => Promise.resolve()),
   on: vi.fn(),
   reloadResources: vi.fn(() => Promise.resolve()),
   storeOn: vi.fn(),
@@ -42,7 +43,7 @@ describe('createI18nNext', () => {
 
     // `bindI18nStore: 'added'` re-renders every `useTranslation` consumer once per
     // lazily-loaded bundle — ~30 full-tree passes during boot.
-    expect(init.mock.calls[0][0].react).not.toHaveProperty('bindI18nStore');
+    expect(init.mock.calls[0]![0].react).not.toHaveProperty('bindI18nStore');
   });
 
   it('emits one languageChanged after the fallback resources are replaced', async () => {

--- a/packages/locales/src/create.test.ts
+++ b/packages/locales/src/create.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { emit, init, on, reloadResources, storeOn, use } = vi.hoisted(() => ({
+  emit: vi.fn(),
+  init: vi.fn(() => Promise.resolve()),
+  on: vi.fn(),
+  reloadResources: vi.fn(() => Promise.resolve()),
+  storeOn: vi.fn(),
+  use: vi.fn(),
+}));
+
+vi.mock('i18next', () => {
+  const instance: any = {
+    emit,
+    init,
+    language: 'zh-CN',
+    on,
+    reloadResources,
+    store: { on: storeOn },
+    use: (...args: unknown[]) => {
+      use(...args);
+      return instance;
+    },
+  };
+  return { default: instance };
+});
+vi.mock('i18next-browser-languagedetector', () => ({ default: {} }));
+vi.mock('i18next-resources-to-backend', () => ({ default: () => ({}) }));
+vi.mock('react-i18next', () => ({ initReactI18next: {} }));
+
+const { createI18nNext } = await import('./create');
+
+describe('createI18nNext', () => {
+  beforeEach(() => {
+    init.mockClear();
+    emit.mockClear();
+    reloadResources.mockClear();
+  });
+
+  it('does not bind every consumer to the resource store', () => {
+    createI18nNext('zh-CN').init();
+
+    // `bindI18nStore: 'added'` re-renders every `useTranslation` consumer once per
+    // lazily-loaded bundle — ~30 full-tree passes during boot.
+    expect(init.mock.calls[0][0].react).not.toHaveProperty('bindI18nStore');
+  });
+
+  it('emits one languageChanged after the fallback resources are replaced', async () => {
+    await createI18nNext('zh-CN').init();
+    await vi.waitFor(() => expect(reloadResources).toHaveBeenCalled());
+
+    expect(emit).toHaveBeenCalledWith('languageChanged', 'zh-CN');
+    expect(emit.mock.calls.filter(([event]) => event === 'languageChanged')).toHaveLength(1);
+  });
+
+  it('skips the refresh when the app already runs the default language', async () => {
+    await createI18nNext('en-US').init();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(reloadResources).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/locales/src/create.ts
+++ b/packages/locales/src/create.ts
@@ -100,10 +100,13 @@ export const createI18nNext = (lang?: string) => {
         interpolation: {
           escapeValue: false,
         },
-        // Re-render components when new language resources are loaded from backend,
-        // so preloaded en-US fallback gets replaced by the user's actual language.
         react: {
-          bindI18nStore: 'added',
+          // NOT `bindI18nStore: 'added'`: that subscribes every `useTranslation` consumer
+          // to every lazily-loaded bundle, so each namespace arrival re-renders the whole
+          // app — ~30 full-tree passes during boot. Components waiting on their own
+          // namespace are already covered by react-i18next's `!ready` path; the only
+          // event that must reach everyone is the one-time en-US -> user-language swap,
+          // emitted once after `reloadResources` below.
           useSuspense: false,
         },
         keySeparator: false,
@@ -114,8 +117,11 @@ export const createI18nNext = (lang?: string) => {
       });
 
       if (initialLang !== DEFAULT_LANG) {
-        initPromise.then(() => {
-          void instance.reloadResources([initialLang], bundledNamespaces);
+        initPromise.then(async () => {
+          await instance.reloadResources([initialLang], bundledNamespaces);
+          // One refresh for the whole tree instead of one per bundle: `bindI18n`
+          // defaults to `languageChanged`, which every `useTranslation` already binds.
+          instance.emit('languageChanged', instance.language);
         });
       }
 

--- a/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -353,6 +353,42 @@ describe('AgentDocumentsGroup', () => {
     expect(screen.getByText('device-writer')).toBeInTheDocument();
   });
 
+  it('keeps the filesystem skill scan inert while the pane is disabled', () => {
+    const projectItem = {
+      description: 'writes things',
+      fileCount: 2,
+      files: [],
+      id: 'project-skill',
+      name: 'project-writer',
+      scope: 'project' as const,
+    };
+    useProjectSkillsMock.mockReturnValue({
+      deviceItems: [],
+      error: undefined,
+      getRowActions: () => [],
+      isLoading: false,
+      items: [projectItem],
+      mutate: vi.fn(),
+      onOpenFile: () => undefined,
+      onOpenSkill: () => undefined,
+      projectItems: [projectItem],
+      raw: undefined,
+    });
+    useClientDataSWR.mockReturnValue({
+      data: [],
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    render(<AgentDocumentsGroup showLocalProjectSkills enabled={false} workingDirectory="/repo" />);
+
+    // `undefined` workingDirectory is the hook's documented inert mode: no scan fires.
+    expect(useProjectSkillsMock).toHaveBeenCalledWith(undefined, undefined);
+    expect(screen.queryByTestId('skills-list')).not.toBeInTheDocument();
+    expect(screen.queryByText('project-writer')).not.toBeInTheDocument();
+  });
+
   it('opens the SKILL.md document in the portal when clicking a skill bundle row', () => {
     useClientDataSWR.mockReturnValue({
       data: [skillBundleRow, skillIndexRow],

--- a/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -330,13 +330,16 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
     }, [controlledFilter, isDocumentMode]);
 
     // Local desktop reads skills over IPC; a bound device reads over RPC.
+    // `enabled` is false while the pane sits hidden behind `<Activity>`. Without it
+    // a closed panel still ran the filesystem skill scan and mounted a row subtree
+    // per skill — thousands of zero-box components the user never sees.
     const showProjectSkills =
-      (showLocalProjectSkills || isLocalEnabled || !!deviceId) && !!workingDirectory;
+      enabled && (showLocalProjectSkills || isLocalEnabled || !!deviceId) && !!workingDirectory;
 
     // Mirror what each child component reads so the parent can decide the
     // section layout (flat when a single source has items, sectioned otherwise).
     // Both hooks are SWR-deduped against their respective child fetches.
-    const userSkillItems = useUserSkills();
+    const userSkillItems = useUserSkills(enabled);
     const {
       deviceItems: deviceSkillItems,
       error: projectSkillsError,

--- a/src/features/Conversation/WorkingSidebar/ResourcesSection/UserLevelSkills.tsx
+++ b/src/features/Conversation/WorkingSidebar/ResourcesSection/UserLevelSkills.tsx
@@ -20,6 +20,8 @@ import { agentSkillsSelectors } from '@/store/tool/selectors';
 
 const AgentSkillDetail = lazy(() => import('@/features/AgentSkillDetail'));
 
+const EMPTY_ITEMS: SkillListItem[] = [];
+
 const handleSkillDragStart = (item: SkillListItem, event: React.DragEvent) => {
   startSkillDrag(event, {
     category: 'skill',
@@ -51,21 +53,23 @@ const openSkillDetailModal = (skillId: string) =>
  * data even when the Tools popover hasn't been opened in this session. The key
  * is deduplicated, so co-mounting with `useControls` doesn't double-fetch.
  */
-export const useUserSkills = (): SkillListItem[] => {
-  useToolStore((s) => s.useFetchAgentSkills)(true);
+export const useUserSkills = (enabled = true): SkillListItem[] => {
+  useToolStore((s) => s.useFetchAgentSkills)(enabled);
   const agentSkills = useToolStore(agentSkillsSelectors.getAgentSkills, isEqual);
 
   return useMemo(
     () =>
-      agentSkills.map((skill) => ({
-        description: skill.description ?? undefined,
-        // `identifier` is what the runtime resolves through the skill registry,
-        // and is unique per skill — reuse it as both the React key and the
-        // drag payload's `type`.
-        id: skill.identifier,
-        name: skill.name,
-      })),
-    [agentSkills],
+      !enabled
+        ? EMPTY_ITEMS
+        : agentSkills.map((skill) => ({
+            description: skill.description ?? undefined,
+            // `identifier` is what the runtime resolves through the skill registry,
+            // and is unique per skill — reuse it as both the React key and the
+            // drag payload's `type`.
+            id: skill.identifier,
+            name: skill.name,
+          })),
+    [agentSkills, enabled],
   );
 };
 

--- a/src/layout/SPAGlobalProvider/Locale.test.tsx
+++ b/src/layout/SPAGlobalProvider/Locale.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, waitFor } from '@testing-library/react';
+import { type PropsWithChildren, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAntdLocale } = vi.hoisted(() => ({ getAntdLocale: vi.fn() }));
+
+vi.mock('@/utils/locale', () => ({ getAntdLocale }));
+vi.mock('@/utils/dayjsLocale', () => ({
+  loadDayjsLocaleModule: vi.fn(async () => ({ default: {} })),
+  normalizeDayjsLocale: (lang: string) => lang,
+}));
+vi.mock('@/locales/create', () => ({
+  createI18nNext: () => ({
+    init: vi.fn(async () => {}),
+    instance: { isInitialized: true, language: 'zh-CN', off: vi.fn(), on: vi.fn() },
+  }),
+}));
+vi.mock('@/layout/GlobalProvider/Editor', () => ({
+  default: ({ children }: PropsWithChildren) => children,
+}));
+
+const Locale = (await import('./Locale')).default;
+
+let mounts = 0;
+
+const MountCounter = () => {
+  useEffect(() => {
+    mounts += 1;
+  }, []);
+  return <div>child</div>;
+};
+
+describe('Locale', () => {
+  beforeEach(() => {
+    mounts = 0;
+    getAntdLocale.mockReset();
+  });
+
+  it('keeps the subtree mounted when the antd locale resolves', async () => {
+    let resolveLocale: (value: unknown) => void = () => {};
+    getAntdLocale.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLocale = resolve;
+      }),
+    );
+
+    render(
+      <Locale defaultLang="zh-CN">
+        <MountCounter />
+      </Locale>,
+    );
+    expect(mounts).toBe(1);
+
+    resolveLocale({ locale: 'zh-cn' });
+    await waitFor(() => expect(getAntdLocale).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+
+    // antd's ConfigProvider only wraps children in `LocaleProvider` when `locale` is
+    // truthy — a falsy-to-resolved transition would insert a node and remount everything.
+    expect(mounts).toBe(1);
+  });
+});

--- a/src/layout/SPAGlobalProvider/Locale.tsx
+++ b/src/layout/SPAGlobalProvider/Locale.tsx
@@ -1,4 +1,5 @@
 import { ConfigProvider } from 'antd';
+import enUS from 'antd/locale/en_US';
 import dayjs from 'dayjs';
 import type { PropsWithChildren } from 'react';
 import { memo, useEffect, useState } from 'react';
@@ -106,7 +107,10 @@ const Locale = memo<LocaleLayoutProps>(({ children, defaultLang, antdLocale }) =
   return (
     <ConfigProvider
       direction={documentDir}
-      locale={locale}
+      // antd only wraps children in `LocaleProvider` when `locale` is truthy. Going
+      // from undefined to a resolved locale therefore inserts a node into the tree and
+      // remounts every provider below — the whole app boots twice. Keep the shape stable.
+      locale={locale ?? enUS}
       theme={{
         components: {
           Button: {


### PR DESCRIPTION
Three independent boot-path fixes found by counting every React render on the first screen (react-scan `onRender`, keyed per fiber instance, armed at boot through `REACT_SCAN=true`).

No behavior changes, no UI changes — the same screen is produced with a fraction of the work.

#### 📊 First-screen boot, measured in the desktop app over CDP

| | before | after | |
| --- | ---: | ---: | ---: |
| renders (en-US) | 27,154 | **5,425** | **−80%** |
| renders (zh-CN) | 36,728 | **~5,300** | **−86%** |
| component instances | 5,201 | **2,920** | **−44%** |
| IPC/RPC skill scans on a closed panel | 1 | **0** | — |

Same page, same sample length, both runs verified `loaded=true` (not a run that stalled on a skeleton). Steady state was already 0 renders/10s before and after — all of this is boot cost.

Mount timeline also flattens: the wave of **2,574 components arriving 14s after load** is gone.

---

#### 1. `bindI18nStore: 'added'` re-rendered the whole app per namespace — **−70%**

`react: { bindI18nStore: 'added' }` subscribes *every* `useTranslation` consumer to *every* lazily-loaded resource bundle. With ~30 namespaces plus `reloadResources`, that is ~30 full-tree passes.

Evidence on `MarketAuthProvider` (36 renders during boot):

- `propsSame = 34/36` — the parent never re-rendered, it was self-driven
- its own `useState` slots (session / status / oidcClient) changed **once each**
- the slot that changed **30 times** was `{ t, ready, lng, keyPrefix, revision }` — `useTranslation`'s internal state

Components waiting on their own namespace are already handled by react-i18next's `!ready` path. The only event that must reach everyone is the one-time en-US → user-language swap, so it now emits a single `languageChanged` after `reloadResources`.

#### 2. antd `ConfigProvider` remounted the entire app once — **−2%, but 2× every store init and fetch**

antd only wraps children in `LocaleProvider` when `locale` is truthy:

```js
if (locale) childNode = React.createElement(LocaleProvider, { locale, _ANT_MARK__ }, childNode);
```

`Locale` started at `undefined` and set the locale once `getAntdLocale()` resolved — a falsy→truthy flip that **inserts a node** and unmounts everything below it. Every global provider existed as two instances, ~130ms apart:

```
inst=2 renders=9  | MarketAuthProvider   | firstMs=72/215
inst=2 renders=7  | LobeThemeProvider    | firstMs=71/215
inst=2 renders=11 | ElectronAppStateSync | firstMs=72/215
```

Passing `locale ?? enUS` at the render site keeps the tree shape stable. The state is untouched so the async locale load still fires, and antd already fell back to en_US during that window — nothing changes visually.

#### 3. A closed working panel still scanned skills and mounted 3,512 invisible components — **−29%**

`ResourcesSection` already gets `enabled` (false while the pane sits hidden behind `<Activity>`), and `AgentDocumentsGroup` used it for the document list — but not for the filesystem skill scan. So on the home screen, with the panel closed:

- `listProjectSkills` ran over IPC/RPC
- 72 skill rows mounted ~13.7s in, ~48 components each
- `SkillRows=72 visible=0 zeroBox=72` — every one of them measured zero

`enabled` now reaches `showProjectSkills` and `useUserSkills`. When disabled, `useProjectSkills` receives an undefined working directory (its documented inert mode), so no scan fires and none of the three `*LevelSkills` sections render.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Each fix has a red→green regression test:

| test | asserts | before the fix |
| --- | --- | --- |
| `packages/locales/src/create.test.ts` | no `bindI18nStore`; exactly one `languageChanged`; nothing emitted on the default language | ❌ 2 failed |
| `src/layout/SPAGlobalProvider/Locale.test.tsx` | a child's mount count stays 1 across the async locale resolve | ❌ `expected 2 to be 1` |
| `AgentDocumentsGroup.test.tsx` | disabled ⇒ `useProjectSkills(undefined, undefined)` and no `skills-list` | ❌ spy called with `/repo` |

Suites run green: `packages/locales` (34), `WorkingSidebar` (49), `ResourcesSection` (19), `SkillsList`, `SPAGlobalProvider` (23). `tsc --noEmit` clean.

Manual, in the desktop app:

- en-US and zh-CN both boot with correct copy, no raw keys, `lang` attribute correct — the fallback→zh-CN swap still lands
- panel closed ⇒ 0 skill rows mounted; panel open ⇒ 72 rows mount as before

#### 🔗 Related Issue

<!-- none -->

https://claude.ai/code/session_01T3HJtyn9NkH8aW6NwxCNF9
