### PR TITLE
chore: remove LOBE-XXX ticket references from code comments

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/shareChat.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/shareChat.test.ts
@@ -263,7 +263,7 @@ describe('shareChatRouter', () => {
       );
     });
 
-    // Regression for Codex P1 (LOBE-11930, `shareChat.ts` prompt schema): a
+    // Regression for Codex P1 (`shareChat.ts` prompt schema): a
     // direct RPC caller (bypassing any client-side textarea limit) could
     // previously submit an HTTP-infrastructure-limit-sized `prompt`, which
     // `AiAgentService.execAgent` would persist verbatim into the CREATOR's
@@ -290,7 +290,7 @@ describe('shareChatRouter', () => {
       ).resolves.toMatchObject({ operationId: 'op-1' });
     });
 
-    // Regression for Codex P2 (LOBE-11930): a startup failure BEFORE Gateway
+    // Regression for Codex P2: a startup failure BEFORE Gateway
     // streaming begins (e.g. the queue/runtime backend returning a raw
     // diagnostic) must not reach the visitor verbatim — the run executes
     // under the CREATOR's identity, so `error.message` here can carry
@@ -313,7 +313,7 @@ describe('shareChatRouter', () => {
       });
     });
 
-    // Regression for Codex P2 follow-up (LOBE-11930, `shareChat.ts:249`):
+    // Regression for Codex P2 follow-up (`shareChat.ts:249`):
     // `AiAgentService.execAgent` RESOLVES (rather than throws) with
     // `{ success: false, error }` when `createOperation` itself fails to
     // start (see `aiAgent/index.ts`'s `execAgent` catch block) — a case the
@@ -350,7 +350,7 @@ describe('shareChatRouter', () => {
     });
 
     it('never sets interactiveStart, so concurrent visitor sends contend on the real runningOperation liveness instead of only the short reservation', async () => {
-      // Regression for Codex P1 (LOBE-11930, `shareChat.ts:186`): `interactiveStart:
+      // Regression for Codex P1 (`shareChat.ts:186`): `interactiveStart:
       // true` makes `TopicModel.tryReserveTaskCallback` skip its `runningOperation`
       // liveness check entirely (`ignoreRunningOperation`) and contend only on the
       // short-lived `taskCallbackReservation`, which is released right after the
@@ -422,7 +422,7 @@ describe('shareChatRouter', () => {
       expect(mockInterruptTask).not.toHaveBeenCalled();
     });
 
-    // Regression for Codex P2 (LOBE-11930): same startup-failure redaction as
+    // Regression for Codex P2: same startup-failure redaction as
     // `execAgent` — `AiAgentService.interruptTask` also runs creator-scoped
     // and can throw a raw infra/provider diagnostic before any Gateway event
     // exists to sanitize.

--- a/src/features/ChatInput/ControlBar/__tests__/useWorkspaceSurface.test.ts
+++ b/src/features/ChatInput/ControlBar/__tests__/useWorkspaceSurface.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 });
 
 describe('useWorkspaceSurface (desktop)', () => {
-  // Regression for LOBE-13771: a workspace member's "Local device" pick lives in
+  // Regression: a workspace member's "Local device" pick lives in
   // their per-user override, never in the shared row. The surface must follow
   // the effective target — a shared-row-only runtime mode can never be `local`
   // for a workspace agent, which hid the directory picker.

--- a/src/store/task/slices/list/action.test.ts
+++ b/src/store/task/slices/list/action.test.ts
@@ -458,7 +458,7 @@ describe('TaskListSliceAction', () => {
   // has no pagination. Without `complete` it only ever saw the first server
   // page (50 newest by creation), so older tasks silently vanished once a
   // workspace grew past that — e.g. a private task assigned to the viewer
-  // showing under "Private" (few rows) but not under "All" (LOBE-13779).
+  // showing under "Private" (few rows) but not under "All".
   describe('useFetchTaskList complete mode', () => {
     interface Row {
       createdAt: Date;

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -395,7 +395,7 @@ export class TaskListSliceActionImpl {
        * Fetch every page instead of the first server page. The Tasks page
        * renders and groups the whole list client-side with no pagination, so
        * a single page silently dropped every task older than the newest 50
-       * once a workspace outgrew that (LOBE-13779). Embedded overviews that
+       * once a workspace outgrew that. Embedded overviews that
        * only show a slice keep the default single page.
        */
       complete?: boolean;


### PR DESCRIPTION
## Summary

Daily cleanup of `LOBE-XXX` ticket references embedded in code comments. This repo is open source, so internal Linear ticket IDs should not leak into the codebase — the scenario each comment guards against is already described inline, so the ticket references are redundant.

## Changes

Removed `LOBE-XXX` references from 8 comment locations across 4 files while preserving the surrounding regression descriptions:

- `apps/server/src/routers/lambda/__tests__/shareChat.test.ts` — dropped `LOBE-11930` from 5 regression comments (Agent Share System prompt-schema / startup-failure redaction / interactiveStart liveness).
- `src/features/ChatInput/ControlBar/__tests__/useWorkspaceSurface.test.ts` — dropped `LOBE-13771` from the working-directory picker regression comment.
- `src/store/task/slices/list/action.test.ts` — dropped `LOBE-13779` from the task-list pagination regression comment.
- `src/store/task/slices/list/action.ts` — dropped `LOBE-13779` from the `complete` option JSDoc.

No code behavior changed — comments only.

Generated on $(date '+%Y-%m-%d %H:%M:%S')