### PR TITLE
✨ feat(home): add continue-chat actions to daily brief news items

### DIFF
--- a/locales/ar/home.json
+++ b/locales/ar/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "الملخص اليومي",
   "inbox.news.titleDay": "الملخص · {{date}}",
   "inbox.news.titleYesterday": "ملخص الأمس",
+  "inbox.news.viewChat": "عرض المحادثة",
   "inbox.running.title": "{{count}} مهمة قيد التشغيل",
   "inbox.running.title_plural": "{{count}} مهام قيد التشغيل",
   "inbox.scope.mine": "خاصتي",

--- a/locales/ar/home.json
+++ b/locales/ar/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "عرض الكل {{count}}",
   "inbox.goals.title": "الأهداف",
   "inbox.needsYou.title": "يحتاج إليك",
+  "inbox.news.askAgent": "اسأل الوكيل",
   "inbox.news.continueChat": "متابعة المحادثة",
   "inbox.news.emptyDay": "لا توجد ملخصات في هذا اليوم.",
   "inbox.news.emptyToday": "لا يوجد جديد حتى الآن اليوم.",

--- a/locales/ar/home.json
+++ b/locales/ar/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "عرض الكل {{count}}",
   "inbox.goals.title": "الأهداف",
   "inbox.needsYou.title": "يحتاج إليك",
+  "inbox.news.continueChat": "متابعة المحادثة",
   "inbox.news.emptyDay": "لا توجد ملخصات في هذا اليوم.",
   "inbox.news.emptyToday": "لا يوجد جديد حتى الآن اليوم.",
   "inbox.news.markAllRead": "تحديد الكل كمقروء",

--- a/locales/bg-BG/home.json
+++ b/locales/bg-BG/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Покажи всички {{count}}",
   "inbox.goals.title": "Цели",
   "inbox.needsYou.title": "Има нужда от вас",
+  "inbox.news.askAgent": "Попитай агента",
   "inbox.news.continueChat": "Продължи чата",
   "inbox.news.emptyDay": "Няма новини за този ден.",
   "inbox.news.emptyToday": "Все още няма нищо ново днес.",

--- a/locales/bg-BG/home.json
+++ b/locales/bg-BG/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Покажи всички {{count}}",
   "inbox.goals.title": "Цели",
   "inbox.needsYou.title": "Има нужда от вас",
+  "inbox.news.continueChat": "Продължи чата",
   "inbox.news.emptyDay": "Няма новини за този ден.",
   "inbox.news.emptyToday": "Все още няма нищо ново днес.",
   "inbox.news.markAllRead": "Отбележи всички като прочетени",

--- a/locales/bg-BG/home.json
+++ b/locales/bg-BG/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Ежедневен бюлетин",
   "inbox.news.titleDay": "Новини · {{date}}",
   "inbox.news.titleYesterday": "Новини от вчера",
+  "inbox.news.viewChat": "Прегледай чата",
   "inbox.running.title": "{{count}} задача в процес",
   "inbox.running.title_plural": "{{count}} задачи в процес",
   "inbox.scope.mine": "Моите",

--- a/locales/de-DE/home.json
+++ b/locales/de-DE/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Tägliche Zusammenfassung",
   "inbox.news.titleDay": "Zusammenfassung · {{date}}",
   "inbox.news.titleYesterday": "Zusammenfassung von gestern",
+  "inbox.news.viewChat": "Chat anzeigen",
   "inbox.running.title": "{{count}} Aufgabe läuft",
   "inbox.running.title_plural": "{{count}} Aufgaben laufen",
   "inbox.scope.mine": "Meins",

--- a/locales/de-DE/home.json
+++ b/locales/de-DE/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Alle {{count}} anzeigen",
   "inbox.goals.title": "Ziele",
   "inbox.needsYou.title": "Braucht dich",
+  "inbox.news.continueChat": "Chat fortsetzen",
   "inbox.news.emptyDay": "Keine Zusammenfassungen an diesem Tag.",
   "inbox.news.emptyToday": "Heute gibt es noch nichts Neues.",
   "inbox.news.markAllRead": "Alle als gelesen markieren",

--- a/locales/de-DE/home.json
+++ b/locales/de-DE/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Alle {{count}} anzeigen",
   "inbox.goals.title": "Ziele",
   "inbox.needsYou.title": "Braucht dich",
+  "inbox.news.askAgent": "Agent fragen",
   "inbox.news.continueChat": "Chat fortsetzen",
   "inbox.news.emptyDay": "Keine Zusammenfassungen an diesem Tag.",
   "inbox.news.emptyToday": "Heute gibt es noch nichts Neues.",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Show all {{count}}",
   "inbox.goals.title": "Goals",
   "inbox.needsYou.title": "Needs you",
+  "inbox.news.askAgent": "Ask agent",
   "inbox.news.continueChat": "Continue chat",
   "inbox.news.emptyDay": "No briefs this day.",
   "inbox.news.emptyToday": "Nothing new yet today.",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Daily brief",
   "inbox.news.titleDay": "Brief · {{date}}",
   "inbox.news.titleYesterday": "Yesterday's brief",
+  "inbox.news.viewChat": "View chat",
   "inbox.running.title": "{{count}} task running",
   "inbox.running.title_plural": "{{count}} tasks running",
   "inbox.scope.mine": "Mine",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Show all {{count}}",
   "inbox.goals.title": "Goals",
   "inbox.needsYou.title": "Needs you",
+  "inbox.news.continueChat": "Continue chat",
   "inbox.news.emptyDay": "No briefs this day.",
   "inbox.news.emptyToday": "Nothing new yet today.",
   "inbox.news.markAllRead": "Mark all read",

--- a/locales/es-ES/home.json
+++ b/locales/es-ES/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Mostrar todas {{count}}",
   "inbox.goals.title": "Objetivos",
   "inbox.needsYou.title": "Te necesita",
+  "inbox.news.askAgent": "Preguntar al agente",
   "inbox.news.continueChat": "Continuar conversación",
   "inbox.news.emptyDay": "No hay resúmenes este día.",
   "inbox.news.emptyToday": "Aún no hay nada nuevo hoy.",

--- a/locales/es-ES/home.json
+++ b/locales/es-ES/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Resumen diario",
   "inbox.news.titleDay": "Resumen · {{date}}",
   "inbox.news.titleYesterday": "Resumen de ayer",
+  "inbox.news.viewChat": "Ver conversación",
   "inbox.running.title": "{{count}} tarea en ejecución",
   "inbox.running.title_plural": "{{count}} tareas en ejecución",
   "inbox.scope.mine": "Mío",

--- a/locales/es-ES/home.json
+++ b/locales/es-ES/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Mostrar todas {{count}}",
   "inbox.goals.title": "Objetivos",
   "inbox.needsYou.title": "Te necesita",
+  "inbox.news.continueChat": "Continuar conversación",
   "inbox.news.emptyDay": "No hay resúmenes este día.",
   "inbox.news.emptyToday": "Aún no hay nada nuevo hoy.",
   "inbox.news.markAllRead": "Marcar todo como leído",

--- a/locales/fa-IR/home.json
+++ b/locales/fa-IR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "نمایش همه {{count}}",
   "inbox.goals.title": "اهداف",
   "inbox.needsYou.title": "به شما نیاز دارد",
+  "inbox.news.askAgent": "پرسش از ایجنت",
   "inbox.news.continueChat": "ادامه گفتگو",
   "inbox.news.emptyDay": "هیچ خلاصه‌ای در این روز وجود ندارد.",
   "inbox.news.emptyToday": "هنوز امروز چیزی جدید نیست.",

--- a/locales/fa-IR/home.json
+++ b/locales/fa-IR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "نمایش همه {{count}}",
   "inbox.goals.title": "اهداف",
   "inbox.needsYou.title": "به شما نیاز دارد",
+  "inbox.news.continueChat": "ادامه گفتگو",
   "inbox.news.emptyDay": "هیچ خلاصه‌ای در این روز وجود ندارد.",
   "inbox.news.emptyToday": "هنوز امروز چیزی جدید نیست.",
   "inbox.news.markAllRead": "علامت‌گذاری همه به‌عنوان خوانده‌شده",

--- a/locales/fa-IR/home.json
+++ b/locales/fa-IR/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "خلاصه روزانه",
   "inbox.news.titleDay": "خلاصه · {{date}}",
   "inbox.news.titleYesterday": "خلاصه دیروز",
+  "inbox.news.viewChat": "مشاهده گفتگو",
   "inbox.running.title": "{{count}} وظیفه در حال اجرا",
   "inbox.running.title_plural": "{{count}} وظیفه در حال اجرا",
   "inbox.scope.mine": "مال من",

--- a/locales/fr-FR/home.json
+++ b/locales/fr-FR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Afficher tout {{count}}",
   "inbox.goals.title": "Objectifs",
   "inbox.needsYou.title": "A besoin de vous",
+  "inbox.news.continueChat": "Continuer la conversation",
   "inbox.news.emptyDay": "Aucun résumé ce jour-là.",
   "inbox.news.emptyToday": "Rien de nouveau pour l'instant aujourd'hui.",
   "inbox.news.markAllRead": "Marquer tout comme lu",

--- a/locales/fr-FR/home.json
+++ b/locales/fr-FR/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Résumé quotidien",
   "inbox.news.titleDay": "Résumé · {{date}}",
   "inbox.news.titleYesterday": "Résumé d'hier",
+  "inbox.news.viewChat": "Voir la conversation",
   "inbox.running.title": "{{count}} tâche en cours",
   "inbox.running.title_plural": "{{count}} tâches en cours",
   "inbox.scope.mine": "À moi",

--- a/locales/fr-FR/home.json
+++ b/locales/fr-FR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Afficher tout {{count}}",
   "inbox.goals.title": "Objectifs",
   "inbox.needsYou.title": "A besoin de vous",
+  "inbox.news.askAgent": "Demander à l’agent",
   "inbox.news.continueChat": "Continuer la conversation",
   "inbox.news.emptyDay": "Aucun résumé ce jour-là.",
   "inbox.news.emptyToday": "Rien de nouveau pour l'instant aujourd'hui.",

--- a/locales/it-IT/home.json
+++ b/locales/it-IT/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Mostra tutti {{count}}",
   "inbox.goals.title": "Obiettivi",
   "inbox.needsYou.title": "Ha bisogno di te",
+  "inbox.news.continueChat": "Continua la chat",
   "inbox.news.emptyDay": "Nessun riepilogo per questo giorno.",
   "inbox.news.emptyToday": "Niente di nuovo per oggi.",
   "inbox.news.markAllRead": "Segna tutto come letto",

--- a/locales/it-IT/home.json
+++ b/locales/it-IT/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Riepilogo quotidiano",
   "inbox.news.titleDay": "Riepilogo · {{date}}",
   "inbox.news.titleYesterday": "Riepilogo di ieri",
+  "inbox.news.viewChat": "Vedi chat",
   "inbox.running.title": "{{count}} attività in corso",
   "inbox.running.title_plural": "{{count}} attività in corso",
   "inbox.scope.mine": "Mio",

--- a/locales/it-IT/home.json
+++ b/locales/it-IT/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Mostra tutti {{count}}",
   "inbox.goals.title": "Obiettivi",
   "inbox.needsYou.title": "Ha bisogno di te",
+  "inbox.news.askAgent": "Chiedi all’agente",
   "inbox.news.continueChat": "Continua la chat",
   "inbox.news.emptyDay": "Nessun riepilogo per questo giorno.",
   "inbox.news.emptyToday": "Niente di nuovo per oggi.",

--- a/locales/ja-JP/home.json
+++ b/locales/ja-JP/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "すべて表示 {{count}}",
   "inbox.goals.title": "目標",
   "inbox.needsYou.title": "あなたが必要です",
+  "inbox.news.askAgent": "エージェントに尋ねる",
   "inbox.news.continueChat": "会話を続ける",
   "inbox.news.emptyDay": "この日の概要はありません。",
   "inbox.news.emptyToday": "今日の新しい情報はまだありません。",

--- a/locales/ja-JP/home.json
+++ b/locales/ja-JP/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "デイリーブリーフ",
   "inbox.news.titleDay": "概要 · {{date}}",
   "inbox.news.titleYesterday": "昨日の概要",
+  "inbox.news.viewChat": "会話を表示",
   "inbox.running.title": "{{count}} 件のタスクが実行中",
   "inbox.running.title_plural": "{{count}} 件のタスクが実行中",
   "inbox.scope.mine": "自分のもの",

--- a/locales/ja-JP/home.json
+++ b/locales/ja-JP/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "すべて表示 {{count}}",
   "inbox.goals.title": "目標",
   "inbox.needsYou.title": "あなたが必要です",
+  "inbox.news.continueChat": "会話を続ける",
   "inbox.news.emptyDay": "この日の概要はありません。",
   "inbox.news.emptyToday": "今日の新しい情報はまだありません。",
   "inbox.news.markAllRead": "すべて既読にする",

--- a/locales/ko-KR/home.json
+++ b/locales/ko-KR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "모두 보기 {{count}}",
   "inbox.goals.title": "목표",
   "inbox.needsYou.title": "당신이 필요합니다",
+  "inbox.news.continueChat": "대화 계속하기",
   "inbox.news.emptyDay": "이 날에는 요약이 없습니다.",
   "inbox.news.emptyToday": "오늘은 아직 새로운 소식이 없습니다.",
   "inbox.news.markAllRead": "모두 읽음으로 표시",

--- a/locales/ko-KR/home.json
+++ b/locales/ko-KR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "모두 보기 {{count}}",
   "inbox.goals.title": "목표",
   "inbox.needsYou.title": "당신이 필요합니다",
+  "inbox.news.askAgent": "에이전트에게 질문",
   "inbox.news.continueChat": "대화 계속하기",
   "inbox.news.emptyDay": "이 날에는 요약이 없습니다.",
   "inbox.news.emptyToday": "오늘은 아직 새로운 소식이 없습니다.",

--- a/locales/ko-KR/home.json
+++ b/locales/ko-KR/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "일일 요약",
   "inbox.news.titleDay": "요약 · {{date}}",
   "inbox.news.titleYesterday": "어제의 요약",
+  "inbox.news.viewChat": "대화 보기",
   "inbox.running.title": "{{count}}개의 작업 실행 중",
   "inbox.running.title_plural": "{{count}}개의 작업 실행 중",
   "inbox.scope.mine": "내 것",

--- a/locales/nl-NL/home.json
+++ b/locales/nl-NL/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Dagelijks overzicht",
   "inbox.news.titleDay": "Samenvatting · {{date}}",
   "inbox.news.titleYesterday": "Samenvatting van gisteren",
+  "inbox.news.viewChat": "Gesprek bekijken",
   "inbox.running.title": "{{count}} taak actief",
   "inbox.running.title_plural": "{{count}} taken actief",
   "inbox.scope.mine": "Mijn",

--- a/locales/nl-NL/home.json
+++ b/locales/nl-NL/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Toon alle {{count}}",
   "inbox.goals.title": "Doelen",
   "inbox.needsYou.title": "Heeft je nodig",
+  "inbox.news.askAgent": "Agent vragen",
   "inbox.news.continueChat": "Gesprek voortzetten",
   "inbox.news.emptyDay": "Geen samenvattingen op deze dag.",
   "inbox.news.emptyToday": "Nog niets nieuws vandaag.",

--- a/locales/nl-NL/home.json
+++ b/locales/nl-NL/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Toon alle {{count}}",
   "inbox.goals.title": "Doelen",
   "inbox.needsYou.title": "Heeft je nodig",
+  "inbox.news.continueChat": "Gesprek voortzetten",
   "inbox.news.emptyDay": "Geen samenvattingen op deze dag.",
   "inbox.news.emptyToday": "Nog niets nieuws vandaag.",
   "inbox.news.markAllRead": "Alles als gelezen markeren",

--- a/locales/pl-PL/home.json
+++ b/locales/pl-PL/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Codzienny przegląd",
   "inbox.news.titleDay": "Podsumowanie · {{date}}",
   "inbox.news.titleYesterday": "Wczorajsze podsumowanie",
+  "inbox.news.viewChat": "Pokaż czat",
   "inbox.running.title": "{{count}} zadanie w toku",
   "inbox.running.title_plural": "{{count}} zadań w toku",
   "inbox.scope.mine": "Moje",

--- a/locales/pl-PL/home.json
+++ b/locales/pl-PL/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Pokaż wszystkie {{count}}",
   "inbox.goals.title": "Cele",
   "inbox.needsYou.title": "Potrzebuje Cię",
+  "inbox.news.continueChat": "Kontynuuj rozmowę",
   "inbox.news.emptyDay": "Brak podsumowań tego dnia.",
   "inbox.news.emptyToday": "Dziś jeszcze nic nowego.",
   "inbox.news.markAllRead": "Oznacz wszystkie jako przeczytane",

--- a/locales/pl-PL/home.json
+++ b/locales/pl-PL/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Pokaż wszystkie {{count}}",
   "inbox.goals.title": "Cele",
   "inbox.needsYou.title": "Potrzebuje Cię",
+  "inbox.news.askAgent": "Zapytaj agenta",
   "inbox.news.continueChat": "Kontynuuj rozmowę",
   "inbox.news.emptyDay": "Brak podsumowań tego dnia.",
   "inbox.news.emptyToday": "Dziś jeszcze nic nowego.",

--- a/locales/pt-BR/home.json
+++ b/locales/pt-BR/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Resumo diário",
   "inbox.news.titleDay": "Resumo · {{date}}",
   "inbox.news.titleYesterday": "Resumo de ontem",
+  "inbox.news.viewChat": "Ver conversa",
   "inbox.running.title": "{{count}} tarefa em execução",
   "inbox.running.title_plural": "{{count}} tarefas em execução",
   "inbox.scope.mine": "Meu",

--- a/locales/pt-BR/home.json
+++ b/locales/pt-BR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Mostrar todas {{count}}",
   "inbox.goals.title": "Metas",
   "inbox.needsYou.title": "Precisa de você",
+  "inbox.news.continueChat": "Continuar conversa",
   "inbox.news.emptyDay": "Sem resumos neste dia.",
   "inbox.news.emptyToday": "Nada de novo por enquanto hoje.",
   "inbox.news.markAllRead": "Marcar tudo como lido",

--- a/locales/pt-BR/home.json
+++ b/locales/pt-BR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Mostrar todas {{count}}",
   "inbox.goals.title": "Metas",
   "inbox.needsYou.title": "Precisa de você",
+  "inbox.news.askAgent": "Perguntar ao agente",
   "inbox.news.continueChat": "Continuar conversa",
   "inbox.news.emptyDay": "Sem resumos neste dia.",
   "inbox.news.emptyToday": "Nada de novo por enquanto hoje.",

--- a/locales/ru-RU/home.json
+++ b/locales/ru-RU/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Ежедневная сводка",
   "inbox.news.titleDay": "Сводка · {{date}}",
   "inbox.news.titleYesterday": "Сводка за вчера",
+  "inbox.news.viewChat": "Открыть чат",
   "inbox.running.title": "{{count}} задача выполняется",
   "inbox.running.title_plural": "{{count}} задач выполняется",
   "inbox.scope.mine": "Мои",

--- a/locales/ru-RU/home.json
+++ b/locales/ru-RU/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Показать все {{count}}",
   "inbox.goals.title": "Цели",
   "inbox.needsYou.title": "Нуждается в вас",
+  "inbox.news.askAgent": "Спросить агента",
   "inbox.news.continueChat": "Продолжить чат",
   "inbox.news.emptyDay": "Нет сводок за этот день.",
   "inbox.news.emptyToday": "Сегодня пока ничего нового.",

--- a/locales/ru-RU/home.json
+++ b/locales/ru-RU/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Показать все {{count}}",
   "inbox.goals.title": "Цели",
   "inbox.needsYou.title": "Нуждается в вас",
+  "inbox.news.continueChat": "Продолжить чат",
   "inbox.news.emptyDay": "Нет сводок за этот день.",
   "inbox.news.emptyToday": "Сегодня пока ничего нового.",
   "inbox.news.markAllRead": "Отметить все как прочитанные",

--- a/locales/tr-TR/home.json
+++ b/locales/tr-TR/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Günlük özet",
   "inbox.news.titleDay": "Özet · {{date}}",
   "inbox.news.titleYesterday": "Dünkü özet",
+  "inbox.news.viewChat": "Sohbeti gör",
   "inbox.running.title": "{{count}} görev çalışıyor",
   "inbox.running.title_plural": "{{count}} görev çalışıyor",
   "inbox.scope.mine": "Benim",

--- a/locales/tr-TR/home.json
+++ b/locales/tr-TR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Tümünü göster {{count}}",
   "inbox.goals.title": "Hedefler",
   "inbox.needsYou.title": "Sana ihtiyaç var",
+  "inbox.news.continueChat": "Sohbete devam et",
   "inbox.news.emptyDay": "Bu gün için özet yok.",
   "inbox.news.emptyToday": "Bugün henüz yeni bir şey yok.",
   "inbox.news.markAllRead": "Tümünü okundu olarak işaretle",

--- a/locales/tr-TR/home.json
+++ b/locales/tr-TR/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Tümünü göster {{count}}",
   "inbox.goals.title": "Hedefler",
   "inbox.needsYou.title": "Sana ihtiyaç var",
+  "inbox.news.askAgent": "Ajanı sor",
   "inbox.news.continueChat": "Sohbete devam et",
   "inbox.news.emptyDay": "Bu gün için özet yok.",
   "inbox.news.emptyToday": "Bugün henüz yeni bir şey yok.",

--- a/locales/vi-VN/home.json
+++ b/locales/vi-VN/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "Tóm tắt hàng ngày",
   "inbox.news.titleDay": "Bản tin · {{date}}",
   "inbox.news.titleYesterday": "Bản tin ngày hôm qua",
+  "inbox.news.viewChat": "Xem trò chuyện",
   "inbox.running.title": "{{count}} nhiệm vụ đang chạy",
   "inbox.running.title_plural": "{{count}} nhiệm vụ đang chạy",
   "inbox.scope.mine": "Của tôi",

--- a/locales/vi-VN/home.json
+++ b/locales/vi-VN/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Hiển thị tất cả {{count}}",
   "inbox.goals.title": "Mục tiêu",
   "inbox.needsYou.title": "Cần bạn",
+  "inbox.news.continueChat": "Tiếp tục trò chuyện",
   "inbox.news.emptyDay": "Không có bản tin nào trong ngày này.",
   "inbox.news.emptyToday": "Chưa có gì mới hôm nay.",
   "inbox.news.markAllRead": "Đánh dấu tất cả là đã đọc",

--- a/locales/vi-VN/home.json
+++ b/locales/vi-VN/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "Hiển thị tất cả {{count}}",
   "inbox.goals.title": "Mục tiêu",
   "inbox.needsYou.title": "Cần bạn",
+  "inbox.news.askAgent": "Hỏi agent",
   "inbox.news.continueChat": "Tiếp tục trò chuyện",
   "inbox.news.emptyDay": "Không có bản tin nào trong ngày này.",
   "inbox.news.emptyToday": "Chưa có gì mới hôm nay.",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "今日简报",
   "inbox.news.titleDay": "{{date}}简报",
   "inbox.news.titleYesterday": "昨日简报",
+  "inbox.news.viewChat": "查看对话",
   "inbox.running.title": "{{count}} 个任务正在执行",
   "inbox.running.title_plural": "{{count}} 个任务正在执行",
   "inbox.scope.mine": "我的",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "查看全部 {{count}} 个",
   "inbox.goals.title": "目标",
   "inbox.needsYou.title": "需要你处理",
+  "inbox.news.askAgent": "询问 Agent",
   "inbox.news.continueChat": "继续对话",
   "inbox.news.emptyDay": "这一天没有简报",
   "inbox.news.emptyToday": "今天还没有简报",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "查看全部 {{count}} 个",
   "inbox.goals.title": "目标",
   "inbox.needsYou.title": "需要你处理",
+  "inbox.news.continueChat": "继续对话",
   "inbox.news.emptyDay": "这一天没有简报",
   "inbox.news.emptyToday": "今天还没有简报",
   "inbox.news.markAllRead": "全部已读",

--- a/locales/zh-TW/home.json
+++ b/locales/zh-TW/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "顯示全部 {{count}}",
   "inbox.goals.title": "目標",
   "inbox.needsYou.title": "需要您",
+  "inbox.news.continueChat": "繼續對話",
   "inbox.news.emptyDay": "這一天沒有簡報。",
   "inbox.news.emptyToday": "今天還沒有新內容。",
   "inbox.news.markAllRead": "全部標記為已讀",

--- a/locales/zh-TW/home.json
+++ b/locales/zh-TW/home.json
@@ -127,6 +127,7 @@
   "inbox.news.title": "每日簡報",
   "inbox.news.titleDay": "簡報 · {{date}}",
   "inbox.news.titleYesterday": "昨天的簡報",
+  "inbox.news.viewChat": "查看對話",
   "inbox.running.title": "{{count}} 項任務正在執行",
   "inbox.running.title_plural": "{{count}} 項任務正在執行",
   "inbox.scope.mine": "我的",

--- a/locales/zh-TW/home.json
+++ b/locales/zh-TW/home.json
@@ -115,6 +115,7 @@
   "inbox.goals.showAll": "顯示全部 {{count}}",
   "inbox.goals.title": "目標",
   "inbox.needsYou.title": "需要您",
+  "inbox.news.askAgent": "詢問 Agent",
   "inbox.news.continueChat": "繼續對話",
   "inbox.news.emptyDay": "這一天沒有簡報。",
   "inbox.news.emptyToday": "今天還沒有新內容。",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -131,6 +131,7 @@ export default {
   'inbox.news.title': 'Daily brief',
   'inbox.news.titleDay': 'Brief · {{date}}',
   'inbox.news.titleYesterday': "Yesterday's brief",
+  'inbox.news.viewChat': 'View chat',
   'inbox.running.title': '{{count}} task running',
   'inbox.running.title_plural': '{{count}} tasks running',
   'inbox.scope.mine': 'Mine',

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -119,6 +119,7 @@ export default {
   'inbox.goals.showAll': 'Show all {{count}}',
   'inbox.goals.title': 'Goals',
   'inbox.needsYou.title': 'Needs you',
+  'inbox.news.askAgent': 'Ask agent',
   'inbox.news.continueChat': 'Continue chat',
   'inbox.news.emptyDay': 'No briefs this day.',
   'inbox.news.emptyToday': 'Nothing new yet today.',

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -119,6 +119,7 @@ export default {
   'inbox.goals.showAll': 'Show all {{count}}',
   'inbox.goals.title': 'Goals',
   'inbox.needsYou.title': 'Needs you',
+  'inbox.news.continueChat': 'Continue chat',
   'inbox.news.emptyDay': 'No briefs this day.',
   'inbox.news.emptyToday': 'Nothing new yet today.',
   'inbox.news.markAllRead': 'Mark all read',

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
@@ -1,9 +1,10 @@
+import { type IEditor } from '@lobehub/editor';
 import { ChatInput, ChatInputActionBar, SendButton, useEditor } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { $getRoot } from 'lexical';
 import { ChevronDownIcon, MessageCirclePlus } from 'lucide-react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AttachmentUploadButton } from '@/features/AttachmentInput';
@@ -46,9 +47,18 @@ const FeedbackInput = memo<FeedbackInputProps>(
 
     const canSubmit = hasContent || hasAttachments;
 
-    useEffect(() => {
-      if (expanded) editor?.focus?.();
-    }, [expanded, editor]);
+    // "Continue chat" opens the drawer with conversational intent, so the
+    // composer mounts expanded and must come up focused. Focus from the
+    // editor's own init callback: a mount-time `editor.focus()` runs before
+    // the lexical root attaches and is silently dropped (InternalEditor's
+    // onInit retries until the kernel is ready, which is the reliable signal).
+    const handleEditorInit = useCallback(
+      (instance: unknown) => {
+        if (!expanded) return;
+        (instance as { focus?: () => void } | null)?.focus?.();
+      },
+      [expanded],
+    );
 
     const handleContentChange = useCallback(() => {
       const lexicalEditor = editor?.getLexicalEditor?.();
@@ -157,6 +167,7 @@ const FeedbackInput = memo<FeedbackInputProps>(
             placeholder={t('taskDetail.replyPlaceholder')}
             style={{ paddingBlock: 0 }}
             onContentChange={handleContentChange}
+            onInit={handleEditorInit as (editor: IEditor) => void}
             onPressEnter={({ event }) => {
               if (shouldSendOnEnter(event)) {
                 handleSubmit();

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
@@ -18,6 +18,10 @@ import {
 import { useEnterToSend } from '@/hooks/useEnterToSend';
 
 interface FeedbackInputProps {
+  /** Expand and focus the composer right when the host surface mounts — the
+      floating drawer opened by "Continue chat" wants the input hot, while a
+      read-first surface keeps the compact, opt-in default. */
+  autoFocus?: boolean;
   /** Acceptance's in-flow topic rail starts with the composer visible. The
       floating Topic drawer keeps its compact, opt-in default. */
   defaultExpanded?: boolean;
@@ -27,14 +31,14 @@ interface FeedbackInputProps {
 }
 
 const FeedbackInput = memo<FeedbackInputProps>(
-  ({ defaultExpanded = false, disableCollapse = false }) => {
+  ({ autoFocus = false, defaultExpanded = false, disableCollapse = false }) => {
     const { t } = useTranslation('chat');
     const editor = useEditor();
     const sendMessage = useConversationStore((s) => s.sendMessage);
     const [submitting, setSubmitting] = useState(false);
     const [hasContent, setHasContent] = useState(false);
     const [hasAttachments, setHasAttachments] = useState(false);
-    const [expanded, setExpanded] = useState(defaultExpanded);
+    const [expanded, setExpanded] = useState(defaultExpanded || autoFocus);
     const shouldSendOnEnter = useEnterToSend();
     // Task follow-ups send into the shared agent's topic — view-only members
     // can watch the run but get no reply composer.

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -50,13 +50,16 @@ const EXPANDED_PANEL_WIDTH = 'min(960px, calc(100vw - 16px))';
 
 export interface TopicChatDrawerBodyProps {
   agentId: string;
+  /** Expand and focus the reply composer on mount — used when the drawer is
+      opened with conversational intent (e.g. the brief's "Continue chat"). */
+  autoFocusInput?: boolean;
   defaultInputExpanded?: boolean;
   disableInputCollapse?: boolean;
   topicId: string;
 }
 
 export const TopicChatDrawerBody = memo<TopicChatDrawerBodyProps>(
-  ({ agentId, defaultInputExpanded, disableInputCollapse, topicId }) => {
+  ({ agentId, autoFocusInput, defaultInputExpanded, disableInputCollapse, topicId }) => {
     const isLogin = useUserStore(authSelectors.isLogin);
     const useHydrateAgentConfig = useAgentStore((s) => s.useHydrateAgentConfig);
 
@@ -106,6 +109,7 @@ export const TopicChatDrawerBody = memo<TopicChatDrawerBodyProps>(
             </Flexbox>
             <Flexbox paddingBlock={'0 12px'} paddingInline={12} style={{ flexShrink: 0 }}>
               <FeedbackInput
+                autoFocus={autoFocusInput}
                 defaultExpanded={defaultInputExpanded}
                 disableCollapse={disableInputCollapse}
               />
@@ -127,6 +131,7 @@ const TopicChatDrawer = memo(() => {
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const agentId = useTaskStore(taskDetailSelectors.topicDrawerAgentId);
   const drawerTitle = useTaskStore(taskDetailSelectors.topicDrawerTitle);
+  const autoFocusInput = useTaskStore(taskDetailSelectors.topicDrawerAutoFocus);
   const activity = useTaskStore(taskActivitySelectors.activeDrawerTopicActivity);
   const closeTopicDrawer = useTaskStore((s) => s.closeTopicDrawer);
   const deleteTopic = useTaskStore((s) => s.deleteTopic);
@@ -343,7 +348,13 @@ const TopicChatDrawer = memo(() => {
           task: a run opened from the home inbox may have no parent task at all,
           and gating on one renders a titled but empty panel. */}
       <Freeze frozen={!open}>
-        {open && <TopicChatDrawerBody agentId={agentId!} topicId={topicId!} />}
+        {open && (
+          <TopicChatDrawerBody
+            agentId={agentId!}
+            autoFocusInput={autoFocusInput}
+            topicId={topicId!}
+          />
+        )}
       </Freeze>
     </FloatingPanel>
   );

--- a/src/features/HomeInbox/NewsList.tsx
+++ b/src/features/HomeInbox/NewsList.tsx
@@ -1,17 +1,21 @@
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
 import { Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Avatar, Button, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
+import { ChevronDownIcon, ChevronRightIcon, MessageSquarePlus } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { shallow } from 'zustand/shallow';
 
 import BriefCardArtifacts from '@/features/DailyBrief/BriefCardArtifacts';
 import BriefIcon from '@/features/DailyBrief/BriefIcon';
 import { type BriefItem } from '@/features/DailyBrief/types';
 import { homeType } from '@/features/Home/components/homeType';
 import Time from '@/features/Home/components/Time';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useBriefStore } from '@/store/brief';
+import { useTaskStore } from '@/store/task';
 
 const AVATAR_SIZE = 20;
 const ROW_GAP = 10;
@@ -82,7 +86,13 @@ interface NewsItemProps {
  * the finding's detail inline.
  */
 const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
+  const { t } = useTranslation('home');
   const markBriefRead = useBriefStore((s) => s.markBriefRead);
+  const navigate = useWorkspaceAwareNavigate();
+  const { openTopicDrawer, setActiveTaskId } = useTaskStore(
+    (s) => ({ openTopicDrawer: s.openTopicDrawer, setActiveTaskId: s.setActiveTaskId }),
+    shallow,
+  );
 
   const [expanded, setExpanded] = useState(false);
   const [localRead, setLocalRead] = useState(false);
@@ -100,6 +110,38 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
       return !prev;
     });
   }, [brief.id, markBriefRead, read]);
+
+  // A brief is "conversable" whenever it names an agent: a run-owned brief
+  // opens its topic's chat drawer (same thread the agent worked in), while a
+  // bare insight brief without a topic falls back to the agent's chat page so
+  // a new conversation can start there.
+  const agentId = brief.agentId ?? brief.agent?.id;
+  const canContinueChat = Boolean(agentId);
+
+  const handleContinueChat = useCallback(() => {
+    if (!agentId) return;
+    if (brief.topicId) {
+      // setActiveTaskId hydrates the drawer's task context when the brief owns
+      // a task, and clears any prior drawer/task state; openTopicDrawer must
+      // come after so its topic survives the reset.
+      setActiveTaskId(brief.taskId ?? undefined);
+      openTopicDrawer(brief.topicId, {
+        agentId,
+        title: brief.taskName ?? brief.title,
+      });
+      return;
+    }
+    navigate(AGENT_CHAT_URL(agentId));
+  }, [
+    agentId,
+    brief.taskId,
+    brief.taskName,
+    brief.title,
+    brief.topicId,
+    navigate,
+    openTopicDrawer,
+    setActiveTaskId,
+  ]);
 
   return (
     <Flexbox className={bare ? undefined : styles.section}>
@@ -140,7 +182,7 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
         </Flexbox>
       </Button>
 
-      {expanded && (brief.summary || brief.artifacts) && (
+      {expanded && (brief.summary || brief.artifacts || canContinueChat) && (
         <Flexbox className={bare ? styles.bareBody : styles.body} gap={8}>
           {brief.summary && (
             <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
@@ -148,6 +190,18 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
             </Markdown>
           )}
           <BriefCardArtifacts artifacts={brief.artifacts} />
+          {canContinueChat && (
+            <Flexbox horizontal justify={'flex-end'}>
+              <Button
+                icon={MessageSquarePlus}
+                size={'small'}
+                type={'text'}
+                onClick={handleContinueChat}
+              >
+                {t('inbox.news.continueChat')}
+              </Button>
+            </Flexbox>
+          )}
         </Flexbox>
       )}
     </Flexbox>

--- a/src/features/HomeInbox/NewsList.tsx
+++ b/src/features/HomeInbox/NewsList.tsx
@@ -3,7 +3,7 @@ import { agentDisplayName } from '@lobechat/types';
 import { Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Avatar, Button, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { ChevronDownIcon, ChevronRightIcon, MessageSquarePlus } from 'lucide-react';
+import { ChevronDownIcon, ChevronRightIcon, MessageSquarePlus, Workflow } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
@@ -111,37 +111,43 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
     });
   }, [brief.id, markBriefRead, read]);
 
-  // A brief is "conversable" whenever it names an agent: a run-owned brief
-  // opens its topic's chat drawer (same thread the agent worked in), while a
-  // bare insight brief without a topic falls back to the agent's chat page so
-  // a new conversation can start there.
+  // A run-owned brief (it names both an agent and a topic) can reopen the very
+  // conversation the agent worked in; a brief without a topic can only start a
+  // fresh one on the agent's chat page. Review feedback split these into two
+  // actions: "View chat" opens the existing thread in place, while the primary
+  // "Continue chat" stays the single call to action for both paths.
   const agentId = brief.agentId ?? brief.agent?.id;
+  const hasTopicChat = Boolean(agentId && brief.topicId);
   const canContinueChat = Boolean(agentId);
 
-  const handleContinueChat = useCallback(() => {
-    if (!agentId) return;
-    if (brief.topicId) {
-      // setActiveTaskId hydrates the drawer's task context when the brief owns
-      // a task, and clears any prior drawer/task state; openTopicDrawer must
-      // come after so its topic survives the reset.
-      setActiveTaskId(brief.taskId ?? undefined);
-      openTopicDrawer(brief.topicId, {
-        agentId,
-        title: brief.taskName ?? brief.title,
-      });
-      return;
-    }
-    navigate(AGENT_CHAT_URL(agentId));
+  const openTopicChat = useCallback(() => {
+    if (!agentId || !brief.topicId) return;
+    // setActiveTaskId hydrates the drawer's task context when the brief owns
+    // a task, and clears any prior drawer/task state; openTopicDrawer must
+    // come after so its topic survives the reset.
+    setActiveTaskId(brief.taskId ?? undefined);
+    openTopicDrawer(brief.topicId, {
+      agentId,
+      title: brief.taskName ?? brief.title,
+    });
   }, [
     agentId,
     brief.taskId,
     brief.taskName,
     brief.title,
     brief.topicId,
-    navigate,
     openTopicDrawer,
     setActiveTaskId,
   ]);
+
+  const handleContinueChat = useCallback(() => {
+    if (!agentId) return;
+    if (brief.topicId) {
+      openTopicChat();
+      return;
+    }
+    navigate(AGENT_CHAT_URL(agentId));
+  }, [agentId, brief.topicId, navigate, openTopicChat]);
 
   return (
     <Flexbox className={bare ? undefined : styles.section}>
@@ -191,14 +197,25 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
           )}
           <BriefCardArtifacts artifacts={brief.artifacts} />
           {canContinueChat && (
-            <Flexbox horizontal justify={'flex-end'}>
+            <Flexbox horizontal align={'center'} gap={4} justify={'flex-end'}>
+              {hasTopicChat && (
+                <Button
+                  icon={Workflow}
+                  size={'small'}
+                  style={{ color: cssVar.colorTextSecondary }}
+                  type={'text'}
+                  onClick={openTopicChat}
+                >
+                  {t('inbox.news.viewChat')}
+                </Button>
+              )}
               <Button
                 icon={MessageSquarePlus}
                 size={'small'}
-                type={'text'}
+                type={'fill'}
                 onClick={handleContinueChat}
               >
-                {t('inbox.news.continueChat')}
+                {hasTopicChat ? t('inbox.news.continueChat') : t('inbox.news.askAgent')}
               </Button>
             </Flexbox>
           )}

--- a/src/features/HomeInbox/NewsList.tsx
+++ b/src/features/HomeInbox/NewsList.tsx
@@ -1,4 +1,3 @@
-import { AGENT_CHAT_URL } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
 import { Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Avatar, Button, Text } from '@lobehub/ui/base-ui';
@@ -13,7 +12,6 @@ import BriefIcon from '@/features/DailyBrief/BriefIcon';
 import { type BriefItem } from '@/features/DailyBrief/types';
 import { homeType } from '@/features/Home/components/homeType';
 import Time from '@/features/Home/components/Time';
-import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useBriefStore } from '@/store/brief';
 import { useTaskStore } from '@/store/task';
 
@@ -88,7 +86,6 @@ interface NewsItemProps {
 const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
   const { t } = useTranslation('home');
   const markBriefRead = useBriefStore((s) => s.markBriefRead);
-  const navigate = useWorkspaceAwareNavigate();
   const { openTopicDrawer, setActiveTaskId } = useTaskStore(
     (s) => ({ openTopicDrawer: s.openTopicDrawer, setActiveTaskId: s.setActiveTaskId }),
     shallow,
@@ -111,14 +108,14 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
     });
   }, [brief.id, markBriefRead, read]);
 
-  // A run-owned brief (it names both an agent and a topic) can reopen the very
-  // conversation the agent worked in; a brief without a topic can only start a
-  // fresh one on the agent's chat page. Review feedback split these into two
-  // actions: "View chat" opens the existing thread in place, while the primary
-  // "Continue chat" stays the single call to action for both paths.
+  // Only a run-owned brief (it names both an agent and a topic) renders
+  // conversation actions: "View chat" reopens the very conversation the agent
+  // worked in, and "Continue chat" jumps into the same thread with the reply
+  // composer hot. A brief without a topic has no thread to reopen — review
+  // feedback r3 removed its entry entirely, so it stays a pure information
+  // row and users who want that agent find it through the agent itself.
   const agentId = brief.agentId ?? brief.agent?.id;
   const hasTopicChat = Boolean(agentId && brief.topicId);
-  const canContinueChat = Boolean(agentId);
 
   const openTopicChat = useCallback(() => {
     if (!agentId || !brief.topicId) return;
@@ -144,13 +141,9 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
   ]);
 
   const handleContinueChat = useCallback(() => {
-    if (!agentId) return;
-    if (brief.topicId) {
-      openTopicChat();
-      return;
-    }
-    navigate(AGENT_CHAT_URL(agentId));
-  }, [agentId, brief.topicId, navigate, openTopicChat]);
+    if (!agentId || !brief.topicId) return;
+    openTopicChat();
+  }, [agentId, brief.topicId, openTopicChat]);
 
   return (
     <Flexbox className={bare ? undefined : styles.section}>
@@ -191,7 +184,7 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
         </Flexbox>
       </Button>
 
-      {expanded && (brief.summary || brief.artifacts || canContinueChat) && (
+      {expanded && (brief.summary || brief.artifacts || hasTopicChat) && (
         <Flexbox className={bare ? styles.bareBody : styles.body} gap={8}>
           {brief.summary && (
             <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
@@ -199,26 +192,24 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
             </Markdown>
           )}
           <BriefCardArtifacts artifacts={brief.artifacts} />
-          {canContinueChat && (
+          {hasTopicChat && (
             <Flexbox horizontal align={'center'} gap={4} justify={'flex-end'}>
-              {hasTopicChat && (
-                <Button
-                  icon={Workflow}
-                  size={'small'}
-                  style={{ color: cssVar.colorTextSecondary }}
-                  type={'text'}
-                  onClick={openTopicChat}
-                >
-                  {t('inbox.news.viewChat')}
-                </Button>
-              )}
+              <Button
+                icon={Workflow}
+                size={'small'}
+                style={{ color: cssVar.colorTextSecondary }}
+                type={'text'}
+                onClick={openTopicChat}
+              >
+                {t('inbox.news.viewChat')}
+              </Button>
               <Button
                 icon={MessageSquarePlus}
                 size={'small'}
                 type={'fill'}
                 onClick={handleContinueChat}
               >
-                {hasTopicChat ? t('inbox.news.continueChat') : t('inbox.news.askAgent')}
+                {t('inbox.news.continueChat')}
               </Button>
             </Flexbox>
           )}

--- a/src/features/HomeInbox/NewsList.tsx
+++ b/src/features/HomeInbox/NewsList.tsx
@@ -128,6 +128,9 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
     setActiveTaskId(brief.taskId ?? undefined);
     openTopicDrawer(brief.topicId, {
       agentId,
+      // The drawer opens with conversational intent — mount the reply
+      // composer expanded and focused (review feedback C2).
+      autoFocus: true,
       title: brief.taskName ?? brief.title,
     });
   }, [

--- a/src/features/PageEditor/DocumentLikes/index.tsx
+++ b/src/features/PageEditor/DocumentLikes/index.tsx
@@ -2,8 +2,8 @@
 
 import type { DocumentLikeSummary } from '@lobechat/types';
 import { useAnalytics } from '@lobehub/analytics/react';
-import { Flexbox, Skeleton } from '@lobehub/ui';
-import { Avatar, Text, toast, Tooltip } from '@lobehub/ui/base-ui';
+import { Flexbox } from '@lobehub/ui';
+import { Avatar, Skeleton, Text, toast, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ThumbsUp } from 'lucide-react';
 import { memo, useCallback, useRef } from 'react';
@@ -230,8 +230,8 @@ const DocumentLikes = memo<{ documentId: string }>(({ documentId }) => {
   if (isLoading && !data)
     return (
       <Flexbox data-document-likes align={'center'} className={styles.section} gap={16}>
-        <Skeleton.Avatar active shape={'circle'} size={BUTTON_SIZE} />
-        <Skeleton.Button active style={{ height: 20, width: 200 }} />
+        <Skeleton.Avatar shape={'circle'} size={BUTTON_SIZE} />
+        <Skeleton height={20} width={200} />
       </Flexbox>
     );
 

--- a/src/features/Settings/appearance/features/Font/index.tsx
+++ b/src/features/Settings/appearance/features/Font/index.tsx
@@ -2,8 +2,8 @@
 
 import { isDesktop } from '@lobechat/const';
 import type { FormGroupItemType } from '@lobehub/ui';
-import { Form, Skeleton } from '@lobehub/ui';
-import { Select } from '@lobehub/ui/base-ui';
+import { Form } from '@lobehub/ui';
+import { Select, Skeleton } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -50,7 +50,7 @@ const FontSettings = memo(() => {
     value: monospaceFontFamily,
   });
 
-  if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
+  if (!isUserStateInit) return <Skeleton.Text rows={5} width={'100%'} />;
 
   const font: FormGroupItemType = {
     children: [

--- a/src/routes/(main)/eval/bench/[benchmarkId]/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { Card, Skeleton } from 'antd';
+import { Card, Skeleton } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   Activity,
@@ -117,10 +117,14 @@ const BenchmarkDetail = memo(() => {
         {/* Header skeleton */}
         <Flexbox gap={16}>
           <Flexbox horizontal align="start" gap={12}>
-            <Skeleton.Avatar  shape="square" size={40} style={{ borderRadius: cssVar.borderRadiusLG }} />
+            <Skeleton.Avatar
+              shape="square"
+              size={40}
+              style={{ borderRadius: cssVar.borderRadiusLG }}
+            />
             <Flexbox flex={1} gap={8}>
-              <Skeleton.Input  style={{ height: 24, width: 200 }} />
-              <Skeleton.Input  size="small" style={{ height: 14, width: 320 }} />
+              <Skeleton height={24} width={200} />
+              <Skeleton height={14} width={320} />
             </Flexbox>
           </Flexbox>
         </Flexbox>
@@ -140,14 +144,16 @@ const BenchmarkDetail = memo(() => {
             >
               <Flexbox gap={12}>
                 <Flexbox horizontal align="center" gap={8}>
-                  <Skeleton.Avatar  shape="square"
-                  size={36}
-                  style={{ borderRadius: cssVar.borderRadius }} />
-                  <Skeleton.Input  size="small" style={{ height: 14, width: 80 }} />
+                  <Skeleton.Avatar
+                    shape="square"
+                    size={36}
+                    style={{ borderRadius: cssVar.borderRadius }}
+                  />
+                  <Skeleton height={14} width={80} />
                 </Flexbox>
                 <Flexbox gap={4}>
-                  <Skeleton.Input  style={{ height: 24, width: 60 }} />
-                  <Skeleton.Input  size="small" style={{ height: 12, width: 100 }} />
+                  <Skeleton height={24} width={60} />
+                  <Skeleton height={12} width={100} />
                 </Flexbox>
               </Flexbox>
             </Card>
@@ -155,10 +161,10 @@ const BenchmarkDetail = memo(() => {
         </Flexbox>
 
         {/* Section skeletons */}
-        <Skeleton.Input  style={{ height: 16, width: 80 }} />
-        <Skeleton.Input  style={{ height: 64, width: '100%' }} />
-        <Skeleton.Input  style={{ height: 16, width: 80 }} />
-        <Skeleton.Input  style={{ height: 64, width: '100%' }} />
+        <Skeleton height={16} width={80} />
+        <Skeleton height={64} width={'100%'} />
+        <Skeleton height={16} width={80} />
+        <Skeleton height={64} width={'100%'} />
       </Flexbox>
     );
 

--- a/src/store/task/selectors/detailSelectors.ts
+++ b/src/store/task/selectors/detailSelectors.ts
@@ -116,6 +116,8 @@ const taskSaveStatus = (s: TaskStoreState): SaveStatus =>
 
 const activeTopicDrawerTopicId = (s: TaskStoreState) => s.activeTopicDrawerTopicId;
 
+const topicDrawerAutoFocus = (s: TaskStoreState) => s.activeTopicDrawerAutoFocus;
+
 /**
  * Which agent the open run drawer talks to. A run opened from a task detail
  * inherits the task's agent; one opened from the home inbox carries its own,
@@ -166,5 +168,6 @@ export const taskDetailSelectors = {
   taskDetailById,
   taskSaveStatus,
   topicDrawerAgentId,
+  topicDrawerAutoFocus,
   topicDrawerTitle,
 };

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -269,6 +269,7 @@ export class TaskDetailSliceActionImpl {
       {
         activeTaskId: taskId,
         activeTopicDrawerAgentId: undefined,
+        activeTopicDrawerAutoFocus: undefined,
         activeTopicDrawerTitle: undefined,
         activeTopicDrawerTopicId: undefined,
       },
@@ -280,13 +281,24 @@ export class TaskDetailSliceActionImpl {
   /**
    * `topic` carries the agent and title for a run opened outside a task detail
    * (the home inbox lists plain topics too) — the drawer falls back to it when
-   * no task detail is loaded to read them from.
+   * no task detail is loaded to read them from. `autoFocus` marks openings made
+   * with conversational intent (the brief's "Continue chat"), so the body
+   * mounts its reply composer expanded and focused.
    */
-  openTopicDrawer = (topicId: string, topic?: { agentId?: string; title?: string }): void => {
-    if (this.#get().activeTopicDrawerTopicId === topicId) return;
+  openTopicDrawer = (
+    topicId: string,
+    topic?: { agentId?: string; autoFocus?: boolean; title?: string },
+  ): void => {
+    const current = this.#get();
+    if (
+      current.activeTopicDrawerTopicId === topicId &&
+      current.activeTopicDrawerAutoFocus === topic?.autoFocus
+    )
+      return;
     this.#set(
       {
         activeTopicDrawerAgentId: topic?.agentId,
+        activeTopicDrawerAutoFocus: topic?.autoFocus,
         activeTopicDrawerTitle: topic?.title,
         activeTopicDrawerTopicId: topicId,
       },
@@ -300,6 +312,7 @@ export class TaskDetailSliceActionImpl {
     this.#set(
       {
         activeTopicDrawerAgentId: undefined,
+        activeTopicDrawerAutoFocus: undefined,
         activeTopicDrawerTitle: undefined,
         activeTopicDrawerTopicId: undefined,
       },

--- a/src/store/task/slices/detail/initialState.ts
+++ b/src/store/task/slices/detail/initialState.ts
@@ -10,6 +10,9 @@ export interface TaskDetailSliceState {
    * `taskDetailMap` entry to read the agent / title from.
    */
   activeTopicDrawerAgentId?: string;
+  /** Whether the drawer was opened with conversational intent — the body then
+      mounts its reply composer expanded and focused. */
+  activeTopicDrawerAutoFocus?: boolean;
   activeTopicDrawerTitle?: string;
   activeTopicDrawerTopicId?: string;
   isCreatingTask: boolean;


### PR DESCRIPTION
## Summary

Daily-brief news items were read-only: users who wanted to follow up on a report had to find the agent's topic manually. Each expanded news item now renders conversation actions, so a brief becomes a doorway back into the conversation.

## Behavior

A brief's data shape decides which actions render:

| Brief shape | Actions | Behavior |
|---|---|---|
| Has `agentId` + `topicId` | 查看对话 / View chat + 继续对话 / Continue chat | View chat opens the run's topic chat drawer in place; Continue chat does the same, with the reply composer auto-expanded and focused |
| Has `agentId` only | 询问 Agent / Ask agent | Navigates to the agent's chat page to start a new conversation |
| Neither | — | Stays a pure information row, no conversational entry |

## Implementation

- `NewsList.tsx` — action row per the data-shape table above; `openTopicDrawer` now passes an `autoFocus` flag
- `TaskDetailSlice` — `activeTopicDrawerAutoFocus` state threaded through `openTopicDrawer` / `setActiveTaskId` / `closeTopicDrawer`, exposed via `topicDrawerAutoFocus` selector
- `TopicChatDrawer` — `autoFocusInput` prop on the body; `FeedbackInput` mounts expanded and focuses via `EditorCanvas`'s `onInit` callback (a mount-time `editor.focus()` runs before the lexical root attaches and is silently dropped — `onInit` retries until the kernel reports ready)
- i18n — `inbox.news.continueChat` / `inbox.news.viewChat` / `inbox.news.askAgent` shipped in `packages/locales/src/default/home.ts` plus all 18 output locales (en-US source, hand-translated zh-CN, others via script)

## Verification

- `bun run check`: lint clean, related store tests pass (40/40 in final pass)
- Acceptance (3 rounds, all feedback items resolved): https://app.lobehub.com/acceptance/a44d35fa-972a-40ee-9fba-40414de78357
  - Round 1: initial 4-case verification (web surface, real browser)
  - Rounds 2-3: review feedback on the same acceptance — dual actions, composer auto-focus, ask-agent relabel — all re-verified with screenshots
