### PR TITLE
chore(sandbox): bump @lobehub/market-sdk to 0.41.0 (WAF false-positive fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "@lobehub/desktop-ipc-typings": "workspace:*",
     "@lobehub/editor": "^4.23.1",
     "@lobehub/icons": "^5.15.0",
-    "@lobehub/market-sdk": "0.39.2",
+    "@lobehub/market-sdk": "0.41.0",
     "@lobehub/tts": "^5.1.2",
     "@lobehub/ui": "^5.38.0",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,7 @@
     "test:update": "vitest -u"
   },
   "dependencies": {
-    "@lobehub/market-sdk": "0.39.2",
+    "@lobehub/market-sdk": "0.41.0",
     "@lobehub/market-types": "^1.17.1",
     "ajv": "^8.20.0",
     "model-bank": "workspace:*",


### PR DESCRIPTION
## Summary
- `MarketSandboxProvider` (`apps/server/src/services/sandbox/providers/market.ts:65`) calls `sdk.plugins.runBuildInTool(toolName, params, ...)` directly — all the sandbox tool calls (`runCommand`, `executeCode`, etc.) go through this one SDK method.
- Root cause on the Market side: `runCommand`/`executeCode` params naturally contain shell metacharacters (`; curl`, backticks, pipes) that Cloudflare's managed command-injection WAF rule flags as an attack when they hit the wire as literal JSON text — even though carrying shell commands is the whole point of that endpoint. Root-caused on topic `tpc_rQ2lXneGO59w`: tool calls came back with a bare `Forbidden`, which the model misread as an auth problem and burned ~30 min retrying credential checks in a loop.
- Fixed on the Market side in [lobehub-biz/lobehub-market#420](https://github.com/lobehub-biz/lobehub-market/pull/420): the server now accepts params either as plain JSON (`params`) or base64-encoded (`paramsEncoding: 'base64'` + `paramsB64`), and `@lobehub/market-sdk@0.41.0`'s `runBuildInTool` always sends the new base64 form.
- **This PR is a pure dependency bump** (`0.39.2` → `0.41.0` in `package.json` and `packages/types/package.json`). No code change needed here — `MarketSandboxProvider` just forwards `toolName`/`params` straight through, so the base64 encoding is entirely internal to the SDK.

## Rollout safety (multi-instance / rolling Vercel deploy)
Market's `run-buildin-tools` endpoint accepts **both** the legacy plain-`params` body and the new base64 form simultaneously — this was built specifically so that a rolling deploy with old and new server instances briefly serving traffic side by side is not a compatibility hazard. Whichever instance (old SDK or new SDK) handles a given request, the server understands it.

## Test plan
- [x] Confirmed via `grep` that no other file in this repo imports the SDK types that changed (`RunBuildInToolsRequest` gained new *optional* fields only; `CodeInterpreterToolName` etc. are untouched) — only `MarketSandboxProvider` touches the runBuildInTool surface, and it does so generically (`toolName as CodeInterpreterToolName, params as never`)
- [x] `@lobehub/market-sdk@0.41.0`'s own test suite (server + SDK) was run and passed on the Market repo side before this bump
- [ ] Not run against this repo's own build/typecheck locally — this checkout has no installed `node_modules` (this repo doesn't commit a lockfile either), so CI is the first real build/typecheck signal for this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7U5raw93D3toG4gCcLKYE