### PR TITLE
✨ feat(verify): pin the verify judge model to a vision-capable constant

### DIFF
--- a/apps/desktop/stubs/business-const/src/index.ts
+++ b/apps/desktop/stubs/business-const/src/index.ts
@@ -7,6 +7,8 @@ export const DEFAULT_MODEL = 'deepseek-v4-flash';
 export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';
 export const DEFAULT_ONBOARDING_PROVIDER = 'google';
 export const DEFAULT_PROVIDER = 'deepseek';
+export const DEFAULT_VERIFY_MODEL = 'glm-5.3-flash';
+export const DEFAULT_VERIFY_PROVIDER = 'zhipu';
 export const ORG_NAME = 'LobeHub';
 // mirrored from packages/business/const — model-bank gates the LobeHub
 // provider entry on this flag; the OSS desktop build keeps it off

--- a/apps/server/src/services/verify/__tests__/modelConfig.test.ts
+++ b/apps/server/src/services/verify/__tests__/modelConfig.test.ts
@@ -1,12 +1,11 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
-import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   isHeterogeneousVerifyProvider,
   resolveVerifyModelConfig,
   REVIEW_PREDICT_MODEL_CONFIG,
+  VERIFY_FALLBACK_MODEL_CONFIG,
 } from '../modelConfig';
 
 const { getAgentModelConfigMock, getBuiltinAgentMock } = vi.hoisted(() => ({
@@ -38,7 +37,7 @@ describe('resolveVerifyModelConfig', () => {
     expect(isHeterogeneousVerifyProvider(null)).toBe(false);
   });
 
-  it('uses a pinned verifier agent model before the parent run model', async () => {
+  it('uses a pinned verifier agent model before the builtin verify agent', async () => {
     getAgentModelConfigMock.mockResolvedValueOnce({
       model: 'deepseek-v4-pro',
       provider: 'lobehub',
@@ -61,11 +60,14 @@ describe('resolveVerifyModelConfig', () => {
     expect(getBuiltinAgentMock).not.toHaveBeenCalled();
   });
 
-  it('filters a heterogeneous parent and falls back to the builtin verifier model', async () => {
-    getAgentModelConfigMock.mockResolvedValueOnce({
-      model: 'deepseek-v4-pro',
-      provider: 'lobehub',
-    });
+  it('falls back to the builtin verify agent model for a heterogeneous parent', async () => {
+    getAgentModelConfigMock
+      // 1st call: no pinned verifier (undefined → not called), so the mock
+      // queue starts at the builtin slug lookup.
+      .mockResolvedValueOnce({
+        model: 'deepseek-v4-pro',
+        provider: 'lobehub',
+      });
 
     await expect(
       resolveVerifyModelConfig(db, 'u', {
@@ -78,16 +80,26 @@ describe('resolveVerifyModelConfig', () => {
     expect(getAgentModelConfigMock).toHaveBeenCalledWith(BUILTIN_AGENT_SLUGS.verifyAgent);
   });
 
-  it('keeps a normal parent model when no verifier agent is pinned', async () => {
+  /**
+   * Regression: the resolver used to inherit the parent run's model, so the
+   * verification bar drifted with whichever chat model spawned the task. The
+   * parent model is no longer a resolution source — verification judges on
+   * the verifier chain exclusively.
+   */
+  it('ignores a usable parent model and judges on the verifier chain', async () => {
+    getAgentModelConfigMock.mockResolvedValueOnce({
+      model: 'deepseek-v4-pro',
+      provider: 'lobehub',
+    });
+
     await expect(
       resolveVerifyModelConfig(db, 'u', {
         parentModel: 'gpt-5.4',
         parentProvider: 'openai',
       }),
-    ).resolves.toEqual({ model: 'gpt-5.4', provider: 'openai' });
+    ).resolves.toEqual({ model: 'deepseek-v4-pro', provider: 'lobehub' });
 
-    expect(getBuiltinAgentMock).not.toHaveBeenCalled();
-    expect(getAgentModelConfigMock).not.toHaveBeenCalled();
+    expect(getAgentModelConfigMock).toHaveBeenCalledWith(BUILTIN_AGENT_SLUGS.verifyAgent);
   });
 
   it('does not fall back to the parent model when a pinned verifier model is unusable', async () => {
@@ -113,7 +125,7 @@ describe('resolveVerifyModelConfig', () => {
     expect(getAgentModelConfigMock).toHaveBeenNthCalledWith(2, BUILTIN_AGENT_SLUGS.verifyAgent);
   });
 
-  it('falls back to the platform defaults when no runnable agent model is available', async () => {
+  it('falls back to the pinned verify model when no runnable agent model is available', async () => {
     getAgentModelConfigMock.mockResolvedValueOnce({
       model: 'claude-opus-4-8',
       provider: 'claude-code',
@@ -124,7 +136,32 @@ describe('resolveVerifyModelConfig', () => {
         parentModel: null,
         parentProvider: null,
       }),
-    ).resolves.toEqual({ model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER });
+    ).resolves.toEqual(VERIFY_FALLBACK_MODEL_CONFIG);
+  });
+});
+
+describe('VERIFY_FALLBACK_MODEL_CONFIG', () => {
+  /**
+   * Regression: the verify fallback once rode the platform default chat
+   * model (deepseek-v4-pro). It has no native vision, so agent-type checks
+   * detoured screenshot evidence through a vision sub-agent and the tail of
+   * that long chain dropped the verdict submission — every r6 check errored
+   * in production. The pinned model must be able to actually see the frames.
+   */
+  it('pins a model that model-bank says can read images', async () => {
+    const { LOBE_DEFAULT_MODEL_LIST } = await import('model-bank');
+
+    const card = LOBE_DEFAULT_MODEL_LIST.find(
+      (model) =>
+        model.id === VERIFY_FALLBACK_MODEL_CONFIG.model &&
+        model.providerId === VERIFY_FALLBACK_MODEL_CONFIG.provider &&
+        model.type === 'chat',
+    );
+    expect(
+      card,
+      `${VERIFY_FALLBACK_MODEL_CONFIG.provider}/${VERIFY_FALLBACK_MODEL_CONFIG.model} is not a chat model in model-bank`,
+    ).toBeDefined();
+    expect(card!.abilities?.vision).toBe(true);
   });
 });
 

--- a/apps/server/src/services/verify/modelConfig.ts
+++ b/apps/server/src/services/verify/modelConfig.ts
@@ -1,10 +1,10 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
 import {
-  DEFAULT_PROVIDER,
   DEFAULT_REVIEW_PREDICT_MODEL,
   DEFAULT_REVIEW_PREDICT_PROVIDER,
+  DEFAULT_VERIFY_MODEL,
+  DEFAULT_VERIFY_PROVIDER,
 } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
 
 import { AgentModel } from '@/database/models/agent';
 import type { LobeChatDatabase } from '@/database/type';
@@ -60,9 +60,35 @@ const isUsableVerifyModelConfig = (
   Boolean(config?.model && config?.provider && !isHeterogeneousVerifyProvider(config.provider));
 
 /**
+ * The fallback model used by Verify's LobeHub LLM calls when neither a pinned
+ * verifier agent nor the builtin verify agent provides a runnable config —
+ * and the floor under the whole resolution chain.
+ *
+ * MUST be vision-capable in model-bank: agent-type checks attach screenshot
+ * evidence, and a text-only verifier cannot read the frames it is judging (it
+ * has to detour through a vision sub-agent, and the long tail is exactly
+ * where verdict submission breaks down — deepseek-v4-pro errored every r6
+ * check in production this way). Pinned here so every build judges on the
+ * same model regardless of which parent happened to spawn the run; the value
+ * lives in `@lobechat/business-const` so the cloud build can override it
+ * without touching this service. A model-bank test guards the vision ability.
+ */
+export const VERIFY_FALLBACK_MODEL_CONFIG: VerifyModelConfig = {
+  model: DEFAULT_VERIFY_MODEL,
+  provider: DEFAULT_VERIFY_PROVIDER,
+};
+
+/**
  * Pick the model used by Verify's LobeHub LLM calls. Heterogeneous parent runs
  * expose CLI/runtime identifiers (e.g. `claude-code`) that are not valid model
  * runtime providers, so Verify must resolve its own runnable provider/model.
+ *
+ * Resolution order: pinned verifier agent → builtin verify agent →
+ * VERIFY_FALLBACK_MODEL_CONFIG. The parent run model is deliberately NOT a
+ * source: verification is the quality gate, so it judges on one consistent
+ * model instead of inheriting whichever chat model the task happened to run
+ * on (drifts the bar between runs, and heterogeneous parents can't be
+ * inherited at all).
  */
 export const resolveVerifyModelConfig = async (
   db: LobeChatDatabase,
@@ -72,22 +98,14 @@ export const resolveVerifyModelConfig = async (
 ): Promise<VerifyModelConfig> => {
   const agentModel = new AgentModel(db, userId, workspaceId);
 
-  const hasPinnedVerifier = Boolean(params.verifierAgentId);
-
   if (params.verifierAgentId) {
     const verifierConfig = await agentModel.getAgentModelConfig(params.verifierAgentId);
     if (isUsableVerifyModelConfig(verifierConfig)) return verifierConfig;
   }
 
-  const parentConfig = {
-    model: params.parentModel,
-    provider: params.parentProvider,
-  };
-  if (!hasPinnedVerifier && isUsableVerifyModelConfig(parentConfig)) return parentConfig;
-
   await agentModel.getBuiltinAgent(BUILTIN_AGENT_SLUGS.verifyAgent);
   const builtinConfig = await agentModel.getAgentModelConfig(BUILTIN_AGENT_SLUGS.verifyAgent);
   if (isUsableVerifyModelConfig(builtinConfig)) return builtinConfig;
 
-  return { model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER };
+  return VERIFY_FALLBACK_MODEL_CONFIG;
 };

--- a/packages/business/const/src/llm.ts
+++ b/packages/business/const/src/llm.ts
@@ -16,3 +16,16 @@ export const DEFAULT_ONBOARDING_PROVIDER = 'google';
  */
 export const DEFAULT_REVIEW_PREDICT_MODEL = 'gemini-3.6-flash';
 export const DEFAULT_REVIEW_PREDICT_PROVIDER = 'google';
+
+/**
+ * The model the Verify LobeHub LLM calls judge a deliverable with when neither
+ * a pinned verifier agent nor a usable parent model is available. MUST be
+ * vision-capable — agent-type checks attach screenshot evidence, and a
+ * text-only verifier cannot read the frames it is judging (it has to detour
+ * through a vision sub-agent, and the long tail is exactly where verdict
+ * submission breaks down). Kept here next to REVIEW_PREDICT so the cloud
+ * build can pin both judge models in one place; a model-bank test in
+ * apps/server guards the vision ability.
+ */
+export const DEFAULT_VERIFY_MODEL = 'glm-5.3-flash';
+export const DEFAULT_VERIFY_PROVIDER = 'zhipu';


### PR DESCRIPTION
<!-- Brief and heads-up -->

Verification judge model was not uniformly controlled: `resolveVerifyModelConfig` inherited the **parent run's chat model**, so the verification bar drifted with whichever model spawned the task. On heterogeneous parents (`codex` / `claude-code` — not valid LLM providers) the resolver fell through to the builtin verify agent's **materialized DB snapshot**, which had been riding the platform default (`deepseek-v4-pro`, no vision, June-era) ever since it was first materialized.

**Production impact** (goal `goal_sCM0okkbYMT5`, 2026-09-03): agent-type checks attach **screenshot evidence**. A text-only judge cannot read the frames it is judging — it detours through a vision sub-agent per screenshot, and the tail of that long chain dropped the verdict submission (`Verifier completed without submitting a verdict`), erroring **all four r6 Excel checks** and parking the whole goal on a human decision gate.

| Before | After |
| ------ | ----- |
| Judge model = parent's chat model, or a stale materialized snapshot, or platform default (`deepseek-v4-pro`, text-only) | Judge model = pinned verifier chain, floored by a **vision-capable constant** (`glm-5.3-flash` @ `zhipu`) in `@lobechat/business-const` |

#### What changed

- **`packages/business/const/src/llm.ts`** — add `DEFAULT_VERIFY_MODEL` / `DEFAULT_VERIFY_PROVIDER` next to `DEFAULT_REVIEW_PREDICT_*`, the same build-time override slot the review predictor already uses (cloud build can pin both judge models in one place, without touching this service).
- **`apps/server/src/services/verify/modelConfig.ts`** — new `VERIFY_FALLBACK_MODEL_CONFIG` as the floor of the resolution chain; **drop the parent run model from the chain** so verification judges on one consistent model instead of inheriting whichever chat model the task ran on. Resolution is now: pinned verifier agent → builtin verify agent config → pinned constant.
- **`apps/desktop/stubs/business-const/src/index.ts`** — mirror the new constants for the OSS desktop build.
- **`apps/server/src/services/verify/__tests__/modelConfig.test.ts`** — guard the fallback with a model-bank vision test (same pattern as the review-predict guard); add a regression test asserting a usable parent model is **not** inherited.

#### Test

How this was tested:

- [x] Tested locally — `bunx vitest run` on the full verify service suite: **28 files / 186 tests pass**
- [x] Added/updated tests — new vision-ability guard + parent-inheritance regression; updated the resolution-order assertions to the new chain
- [ ] No tests needed

`bun run check` on the four touched files: lint clean, tests pass, type-check clean.

#### 🔗 Related Issue

None filed yet — root cause surfaced from a goal-run incident analysis (r6 verifier ops `op_1788406950*` all errored with `Verifier completed without submitting a verdict`; judge was `deepseek-v4-pro @ lobehub`, no native vision, detouring screenshots through a vision sub-agent).
