### PR TITLE
🐛 fix(openapi): relay Gemini parts through Responses

### DIFF
--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -706,6 +706,51 @@ describe('heterogeneous direct invocation protocol', () => {
     });
   });
 
+  it('encodes Gemini text and reasoning parts as Responses output', async () => {
+    const events = parseSseEvents(
+      await readText(
+        responsesSse(
+          protocolStream([
+            {
+              data: { content: 'thinking', inReasoning: true, partType: 'text' },
+              type: 'reasoning_part',
+            },
+            { data: { content: 'answer', partType: 'text' }, type: 'content_part' },
+            {
+              data: { content: 'base64-image', mimeType: 'image/png', partType: 'image' },
+              type: 'content_part',
+            },
+          ]),
+        ),
+      ),
+    );
+    const textDeltas = events
+      .filter(({ type }) => type === 'response.output_text.delta')
+      .map(({ data }) => data.delta);
+    const reasoningDeltas = events
+      .filter(({ type }) => type === 'response.reasoning_summary_text.delta')
+      .map(({ data }) => data.delta);
+    const completed = events.find(({ type }) => type === 'response.completed');
+
+    expect(textDeltas).toEqual(['answer']);
+    expect(reasoningDeltas).toEqual(['thinking']);
+    expect(completed?.data.response.output).toEqual([
+      {
+        id: expect.any(String),
+        status: 'completed',
+        summary: [{ text: 'thinking', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      {
+        content: [{ annotations: [], text: 'answer', type: 'output_text' }],
+        id: expect.any(String),
+        role: 'assistant',
+        status: 'completed',
+        type: 'message',
+      },
+    ]);
+  });
+
   it('encodes Responses incomplete and failed terminal lifecycle events', async () => {
     const incomplete = await readText(
       responsesSse(

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -738,8 +738,23 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
         },
         transform(event, controller) {
           if (finalized) return;
-          if (event.type === 'text' && typeof event.data === 'string' && event.data) {
-            outputText += event.data;
+          const part =
+            (event.type === 'content_part' || event.type === 'reasoning_part') &&
+            isRecord(event.data) &&
+            event.data.partType === 'text'
+              ? event.data
+              : undefined;
+          const content =
+            event.type === 'text' || event.type === 'reasoning'
+              ? typeof event.data === 'string'
+                ? event.data
+                : undefined
+              : typeof part?.content === 'string'
+                ? part.content
+                : undefined;
+          const isReasoning = event.type === 'reasoning' || event.type === 'reasoning_part';
+          if (content && !isReasoning) {
+            outputText += content;
             if (textOutputIndex === undefined) {
               textOutputIndex = nextOutputIndex++;
               controller.enqueue(
@@ -768,14 +783,14 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
             controller.enqueue(
               responseSse('response.output_text.delta', {
                 content_index: 0,
-                delta: event.data,
+                delta: content,
                 item_id: `msg_${responseId}`,
                 output_index: textOutputIndex,
                 type: 'response.output_text.delta',
               }),
             );
-          } else if (event.type === 'reasoning' && typeof event.data === 'string' && event.data) {
-            reasoningText += event.data;
+          } else if (content && isReasoning) {
+            reasoningText += content;
             if (reasoningOutputIndex === undefined) {
               reasoningItemId = event.id || `rs_${responseId}`;
               reasoningOutputIndex = nextOutputIndex++;
@@ -794,7 +809,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model:
             }
             controller.enqueue(
               responseSse('response.reasoning_summary_text.delta', {
-                delta: event.data,
+                delta: content,
                 item_id: reasoningItemId,
                 output_index: reasoningOutputIndex,
                 summary_index: 0,


### PR DESCRIPTION
<!-- Brief and heads-up -->

Gemini 3 emits textual model output as internal `content_part` and `reasoning_part` stream events. The OpenAI Responses relay only handled legacy string `text` and `reasoning` events, so the request completed successfully with an empty `output` array. Grok Build then treated the response as `no_visible_content` and retried until timeout.

This change recognizes textual part events, maps them to Responses text/reasoning deltas, and keeps non-text image parts out of the textual response.

| Before | After |
| ------ | ----- |
| Gemini Responses streams completed with no visible output | Gemini text and reasoning parts are emitted as Responses output |

#### Test

- `bun run check packages/openapi/src/services/heterogeneous-direct.service.ts packages/openapi/src/services/heterogeneous-direct.service.test.ts`
- 31 related tests passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Related to #18932
