### PR TITLE
🐛 fix(openapi): defer heterogeneous upstream protocol routing

### DIFF
--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -107,18 +107,28 @@ describe('LobeAnthropicAI', () => {
       expect(result).toBeInstanceOf(Response);
     });
 
-    it('should map routed reasoning effort to Anthropic output config', async () => {
-      await instance.chat({
-        messages: [{ content: 'Hello', role: 'user' }],
-        model: 'claude-opus-4-6',
-        reasoning_effort: 'high',
-      });
+    it.each([
+      ['claude-opus-4-6', 'high', 'high'],
+      ['claude-haiku-4-5-20251001', 'high', undefined],
+      ['claude-sonnet-4-6', 'xhigh', undefined],
+      ['claude-opus-4-7', 'xhigh', 'xhigh'],
+    ] as const)(
+      'should map routed effort %s / %s to Anthropic output config %s',
+      async (model, reasoningEffort, expectedEffort) => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model,
+          reasoning_effort: reasoningEffort,
+        });
 
-      const payload = (instance['client'].messages.create as Mock).mock.calls[0][0];
+        const payload = (instance['client'].messages.create as Mock).mock.calls[0][0];
 
-      expect(payload).toMatchObject({ output_config: { effort: 'high' } });
-      expect(payload).not.toHaveProperty('reasoning_effort');
-    });
+        expect(payload.output_config).toEqual(
+          expectedEffort ? { effort: expectedEffort } : undefined,
+        );
+        expect(payload).not.toHaveProperty('reasoning_effort');
+      },
+    );
 
     it('should handle system prompt correctly', async () => {
       // Arrange

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -107,6 +107,19 @@ describe('LobeAnthropicAI', () => {
       expect(result).toBeInstanceOf(Response);
     });
 
+    it('should map routed reasoning effort to Anthropic output config', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'claude-opus-4-6',
+        reasoning_effort: 'high',
+      });
+
+      const payload = (instance['client'].messages.create as Mock).mock.calls[0][0];
+
+      expect(payload).toMatchObject({ output_config: { effort: 'high' } });
+      expect(payload).not.toHaveProperty('reasoning_effort');
+    });
+
     it('should handle system prompt correctly', async () => {
       // Arrange
       const mockStream = new ReadableStream({

--- a/packages/model-runtime/src/providers/anthropic/index.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.ts
@@ -7,12 +7,12 @@ import {
 } from '../../core/anthropicCompatibleFactory';
 import type { ChatStreamPayload } from '../../types';
 import { normalizeClaudeThinkingHistoryMessages } from './claudeThinkingHistory';
+import { supportsClaudeEffortLevel } from './modelId';
 
 const buildAnthropicPayload = (payload: ChatStreamPayload) => {
-  const reasoningEffort =
-    payload.reasoning_effort === 'none' || payload.reasoning_effort === 'minimal'
-      ? undefined
-      : payload.reasoning_effort;
+  const reasoningEffort = supportsClaudeEffortLevel(payload.model, payload.reasoning_effort)
+    ? payload.reasoning_effort
+    : undefined;
   return buildDefaultAnthropicPayload({
     ...payload,
     effort: payload.effort ?? reasoningEffort,

--- a/packages/model-runtime/src/providers/anthropic/index.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.ts
@@ -9,8 +9,13 @@ import type { ChatStreamPayload } from '../../types';
 import { normalizeClaudeThinkingHistoryMessages } from './claudeThinkingHistory';
 
 const buildAnthropicPayload = (payload: ChatStreamPayload) => {
+  const reasoningEffort =
+    payload.reasoning_effort === 'none' || payload.reasoning_effort === 'minimal'
+      ? undefined
+      : payload.reasoning_effort;
   return buildDefaultAnthropicPayload({
     ...payload,
+    effort: payload.effort ?? reasoningEffort,
     messages: normalizeClaudeThinkingHistoryMessages(payload.messages),
   });
 };

--- a/packages/model-runtime/src/providers/anthropic/modelId.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.test.ts
@@ -12,6 +12,7 @@ import {
   rejectsForcedToolChoice,
   shouldDropUnsupportedClaudeAssistantPrefill,
   shouldOmitSamplingParams,
+  supportsClaudeEffortLevel,
 } from './modelId';
 
 describe('parseClaudeModelId', () => {
@@ -186,6 +187,23 @@ describe('isThinkingDisplayOmittedByDefaultModel', () => {
     expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-5-20251101')).toBe(false);
     expect(isThinkingDisplayOmittedByDefaultModel('claude-haiku-4-5-20251001')).toBe(false);
     expect(isThinkingDisplayOmittedByDefaultModel('gpt-5')).toBe(false);
+  });
+});
+
+describe('supportsClaudeEffortLevel', () => {
+  it.each([
+    ['claude-opus-4-6', 'high', true],
+    ['claude-haiku-4-5-20251001', 'high', false],
+    ['claude-sonnet-4-6', 'xhigh', false],
+    ['anthropic/claude-opus-4-7', 'xhigh', true],
+    ['claude-opus-4-5-20251101', 'max', false],
+    ['global.anthropic.claude-sonnet-4-6', 'max', true],
+    ['claude-fable-5-1', 'xhigh', true],
+    ['claude-mythos-preview', 'max', true],
+    ['claude-mythos-preview', 'xhigh', false],
+    ['gpt-5', 'high', false],
+  ])('should report model %s effort %s support as %s', (model, effort, expected) => {
+    expect(supportsClaudeEffortLevel(model, effort)).toBe(expected);
   });
 });
 

--- a/packages/model-runtime/src/providers/anthropic/modelId.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.ts
@@ -178,7 +178,10 @@ const EFFORTS_INCOMPATIBLE_WITH_DISABLED_THINKING = new Set(['xhigh', 'max']);
  * Unsupported routed values are omitted rather than allowing the provider to reject the request.
  * @see https://platform.claude.com/docs/en/build-with-claude/effort
  */
-export const supportsClaudeEffortLevel = (model: string, effort: string | undefined): boolean => {
+export const supportsClaudeEffortLevel = (
+  model: string,
+  effort: string | undefined,
+): effort is 'high' | 'low' | 'max' | 'medium' | 'xhigh' => {
   if (!effort) return false;
 
   const normalizedModelId = model

--- a/packages/model-runtime/src/providers/anthropic/modelId.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.ts
@@ -169,7 +169,50 @@ export const isThinkingDisplayOmittedByDefaultModel = (model: string): boolean =
   return parsed.family === 'opus' && parsed.majorVersion === 4 && hasMinorVersionAtLeast(parsed, 7);
 };
 
+const CLAUDE_COMMON_EFFORT_LEVELS = new Set(['low', 'medium', 'high']);
+const CLAUDE_5_EFFORT_FAMILIES = ['fable', 'mythos', 'opus', 'sonnet'] as const;
 const EFFORTS_INCOMPATIBLE_WITH_DISABLED_THINKING = new Set(['xhigh', 'max']);
+
+/**
+ * Whether an Anthropic model accepts an `output_config.effort` level.
+ * Unsupported routed values are omitted rather than allowing the provider to reject the request.
+ * @see https://platform.claude.com/docs/en/build-with-claude/effort
+ */
+export const supportsClaudeEffortLevel = (model: string, effort: string | undefined): boolean => {
+  if (!effort) return false;
+
+  const normalizedModelId = model
+    .trim()
+    .toLowerCase()
+    .replace(/^anthropic\//, '');
+  if (normalizedModelId === 'claude-mythos-preview') {
+    return CLAUDE_COMMON_EFFORT_LEVELS.has(effort) || effort === 'max';
+  }
+
+  const parsed = parseClaudeModelId(model);
+  if (!parsed) return false;
+
+  const isSupportedModel =
+    (parsed.majorVersion === 5 && isClaudeFamily(parsed, CLAUDE_5_EFFORT_FAMILIES)) ||
+    (parsed.majorVersion === 4 &&
+      ((parsed.family === 'opus' &&
+        parsed.minorVersion !== undefined &&
+        parsed.minorVersion >= 5 &&
+        parsed.minorVersion <= 8) ||
+        (parsed.family === 'sonnet' && parsed.minorVersion === 6)));
+  if (!isSupportedModel) return false;
+
+  if (CLAUDE_COMMON_EFFORT_LEVELS.has(effort)) return true;
+  if (effort === 'max') {
+    return !(parsed.majorVersion === 4 && parsed.family === 'opus' && parsed.minorVersion === 5);
+  }
+  if (effort !== 'xhigh') return false;
+
+  return (
+    parsed.majorVersion === 5 ||
+    (parsed.family === 'opus' && parsed.majorVersion === 4 && (parsed.minorVersion ?? 0) >= 7)
+  );
+};
 
 /**
  * Claude Fable 5.1 / Mythos 5.1 reject forced tool use. `tool_choice` of type `any`

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -189,7 +189,12 @@ describe('heterogeneous direct invocation protocol', () => {
       agentType: 'grok-build',
       model: 'kimi-k3',
       payload: normalizeResponsesRequest(
-        { input: 'hello', model: 'lobehub-default', stream: true },
+        {
+          input: 'hello',
+          model: 'lobehub-default',
+          reasoning: { effort: 'high', summary: 'auto' },
+          stream: true,
+        },
         'lobehub-default',
       ),
       signal: new AbortController().signal,
@@ -199,9 +204,11 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(chat.mock.calls[0][0]).toMatchObject({
       messages: [{ content: 'hello', role: 'user' }],
       model: 'kimi-k3',
+      reasoning_effort: 'high',
       stream: true,
     });
     expect(chat.mock.calls[0][0]).not.toHaveProperty('apiMode');
+    expect(chat.mock.calls[0][0]).not.toHaveProperty('reasoning');
   });
 
   it('adapts custom Codex relay models to chat completions with their reasoning effort', async () => {

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -153,7 +153,6 @@ describe('heterogeneous direct invocation protocol', () => {
       agentType: 'codex',
       model: 'gpt-5.4',
       payload: {
-        apiMode: 'responses',
         messages: [],
         model: 'lobehub-default',
         reasoning: { effort: 'high', summary: 'detailed' },
@@ -173,6 +172,36 @@ describe('heterogeneous direct invocation protocol', () => {
       stream: true,
     });
     expect(runtimePayload).not.toHaveProperty('deploymentName');
+  });
+
+  it('lets non-Codex Responses relays use the upstream protocol selected by the router', async () => {
+    const chat = vi.fn().mockResolvedValue(new Response('stream'));
+    vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
+      model: 'kimi-k3',
+      provider: 'lobehub',
+      supportsAdaptiveThinking: false,
+    });
+    vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
+      chat,
+    } as unknown as Awaited<ReturnType<typeof initModelRuntimeFromServerConfig>>);
+
+    await invokeServerDefaultModel({
+      agentType: 'grok-build',
+      model: 'kimi-k3',
+      payload: normalizeResponsesRequest(
+        { input: 'hello', model: 'lobehub-default', stream: true },
+        'lobehub-default',
+      ),
+      signal: new AbortController().signal,
+      userId: 'user-1',
+    });
+
+    expect(chat.mock.calls[0][0]).toMatchObject({
+      messages: [{ content: 'hello', role: 'user' }],
+      model: 'kimi-k3',
+      stream: true,
+    });
+    expect(chat.mock.calls[0][0]).not.toHaveProperty('apiMode');
   });
 
   it('adapts custom Codex relay models to chat completions with their reasoning effort', async () => {
@@ -334,6 +363,7 @@ describe('heterogeneous direct invocation protocol', () => {
       { content: 'LOBEHUB_HETERO_SMOKE_OK', role: 'user' },
     ]);
     expect(payload.max_tokens).toBe(16_384);
+    expect(payload).not.toHaveProperty('apiMode');
   });
 
   it('normalizes two-round Responses reasoning and function call continuity', () => {

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -267,7 +267,6 @@ export const normalizeResponsesRequest = (request: Record<string, unknown>, mode
       )
     : undefined;
   return {
-    apiMode: 'responses',
     max_tokens:
       typeof request.max_output_tokens === 'number' ? request.max_output_tokens : undefined,
     messages,
@@ -920,14 +919,18 @@ export const invokeServerDefaultModel = async (params: {
   )
     ? (requestedReasoningEffort as ChatStreamPayload['reasoning_effort'])
     : undefined;
-  const payload =
-    params.agentType === 'codex' && isCodexServerDefaultCustomModel(params.model)
+  // Responses describes the CLI-facing ingress, not necessarily the selected provider's API.
+  // Keep it upstream only for native Codex models; the deployment router owns every other choice.
+  let payload = normalizedPayload;
+  if (params.agentType === 'codex') {
+    payload = isCodexServerDefaultCustomModel(params.model)
       ? {
           ...chatCompletionsPayload,
           apiMode: 'chatCompletion' as const,
           reasoning_effort: normalizedPayload.reasoning_effort ?? reasoningEffort,
         }
-      : normalizedPayload;
+      : { ...normalizedPayload, apiMode: 'responses' };
+  }
   const response = await runtime.chat(
     {
       ...payload,

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -919,9 +919,15 @@ export const invokeServerDefaultModel = async (params: {
   )
     ? (requestedReasoningEffort as ChatStreamPayload['reasoning_effort'])
     : undefined;
+  const routedReasoningEffort =
+    normalizedPayload.reasoning_effort ??
+    (requestedReasoningEffort as ChatStreamPayload['reasoning_effort']);
   // Responses describes the CLI-facing ingress, not necessarily the selected provider's API.
   // Keep it upstream only for native Codex models; the deployment router owns every other choice.
-  let payload = normalizedPayload;
+  let payload = {
+    ...chatCompletionsPayload,
+    ...(routedReasoningEffort ? { reasoning_effort: routedReasoningEffort } : {}),
+  };
   if (params.agentType === 'codex') {
     payload = isCodexServerDefaultCustomModel(params.model)
       ? {


### PR DESCRIPTION
<!-- Brief and heads-up -->

The OpenAI Responses endpoint is the CLI-facing protocol for Grok Build, Pi, and TRAE, but it does not imply that the selected deployment provider also supports a native Responses upstream. `normalizeResponsesRequest` previously pinned every request to `apiMode: responses`; for Kimi routes this bypassed the Moonshot Chat Completions adapter and produced completed responses with no visible content, causing Grok Build to retry until timeout.

This change leaves upstream protocol selection to the deployment router for non-Codex relays. Native Codex models still explicitly use Responses, while custom Codex models retain their Chat Completions adaptation.

| Before | After |
| ------ | ----- |
| Every Responses ingress forced the upstream `/responses` path | Non-Codex relays use the protocol selected by their provider router |

#### Test

- `bun run check packages/openapi/src/services/heterogeneous-direct.service.ts packages/openapi/src/services/heterogeneous-direct.service.test.ts`
- 31 related tests passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up to #18932
