### PR TITLE
🐛 fix(model-runtime): surface Responses terminal errors

### DIFF
--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -891,6 +891,96 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks.some((chunk) => chunk.includes('unscoped-encrypted'))).toBe(false);
   });
 
+  it('should surface response.failed as an error while preserving usage', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        response: {
+          error: { code: 'server_error', message: 'Upstream generation failed' },
+          id: 'resp_failed',
+          status: 'failed',
+          usage: { input_tokens: 10, output_tokens: 0, total_tokens: 10 },
+        },
+        sequence_number: 1,
+        type: 'response.failed',
+      },
+    ]);
+
+    const chunks = await readStreamChunk(OpenAIResponsesStream(mockOpenAIStream));
+    const usageIndex = chunks.findIndex((chunk) => chunk.includes('event: usage'));
+    const errorIndex = chunks.findIndex((chunk) => chunk.includes('event: error'));
+
+    expect(usageIndex).toBeGreaterThan(-1);
+    expect(errorIndex).toBeGreaterThan(usageIndex);
+    expect(chunks.some((chunk) => chunk.includes('Upstream generation failed'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes(AgentRuntimeErrorType.ProviderBizError))).toBe(
+      true,
+    );
+  });
+
+  it('should surface Responses error events as protocol errors', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        code: 'rate_limit_exceeded',
+        message: 'Rate limit exceeded',
+        param: null,
+        sequence_number: 1,
+        type: 'error',
+      },
+    ]);
+
+    const chunks = await readStreamChunk(OpenAIResponsesStream(mockOpenAIStream));
+
+    expect(chunks.some((chunk) => chunk.includes('event: error'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('Rate limit exceeded'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes(AgentRuntimeErrorType.ProviderBizError))).toBe(
+      true,
+    );
+  });
+
+  it('should map max-output Responses incompletion to max_tokens and preserve usage', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        response: {
+          id: 'resp_incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+          status: 'incomplete',
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+        sequence_number: 1,
+        type: 'response.incomplete',
+      },
+    ]);
+
+    const chunks = await readStreamChunk(OpenAIResponsesStream(mockOpenAIStream));
+
+    expect(chunks.some((chunk) => chunk.includes('event: stop'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('max_tokens'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('event: usage'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('event: error'))).toBe(false);
+  });
+
+  it('should surface content-filter Responses incompletion as a policy error', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        response: {
+          id: 'resp_content_filter',
+          incomplete_details: { reason: 'content_filter' },
+          status: 'incomplete',
+        },
+        sequence_number: 1,
+        type: 'response.incomplete',
+      },
+    ]);
+
+    const chunks = await readStreamChunk(OpenAIResponsesStream(mockOpenAIStream));
+
+    expect(chunks.some((chunk) => chunk.includes('event: error'))).toBe(true);
+    expect(
+      chunks.some((chunk) => chunk.includes(AgentRuntimeErrorType.ProviderContentPolicyViolation)),
+    ).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('event: stop'))).toBe(false);
+  });
+
   it('should handle response.completed with usage', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -3,6 +3,7 @@ import type OpenAI from 'openai';
 import type { Stream } from 'openai/streaming';
 
 import { AgentRuntimeErrorType } from '../../../types/error';
+import { isErrorCausedByContentFilter } from '../../../utils/isErrorCausedByContentFilter';
 import { serializeScopedSignature } from '../../../utils/signatureScope';
 import { convertOpenAIResponseUsage } from '../../usageConverters';
 import type {
@@ -203,6 +204,79 @@ const transformOpenAIStream = (
         }
 
         return { data: null, id: chunk.item.id, type: 'text' };
+      }
+
+      case 'error': {
+        const errorData = {
+          body: chunk,
+          message: chunk.message,
+          type: isErrorCausedByContentFilter(chunk)
+            ? AgentRuntimeErrorType.ProviderContentPolicyViolation
+            : AgentRuntimeErrorType.ProviderBizError,
+        } satisfies ChatMessageError;
+
+        return { data: errorData, id: streamContext.id || 'response_error', type: 'error' };
+      }
+
+      case 'response.failed': {
+        const errorData = {
+          body: chunk,
+          message: chunk.response.error?.message || 'The model failed to generate a response.',
+          type: isErrorCausedByContentFilter(chunk.response.error)
+            ? AgentRuntimeErrorType.ProviderContentPolicyViolation
+            : AgentRuntimeErrorType.ProviderBizError,
+        } satisfies ChatMessageError;
+        const errorChunk = {
+          data: errorData,
+          id: chunk.response.id,
+          type: 'error' as const,
+        };
+
+        return chunk.response.usage
+          ? [
+              {
+                data: convertOpenAIResponseUsage(chunk.response.usage, payload),
+                id: chunk.response.id,
+                type: 'usage',
+              },
+              errorChunk,
+            ]
+          : errorChunk;
+      }
+
+      case 'response.incomplete': {
+        const reason = chunk.response.incomplete_details?.reason;
+        const usageChunk: StreamProtocolChunk | undefined = chunk.response.usage
+          ? {
+              data: convertOpenAIResponseUsage(chunk.response.usage, payload),
+              id: chunk.response.id,
+              type: 'usage',
+            }
+          : undefined;
+
+        if (reason === 'max_output_tokens') {
+          return [
+            { data: 'max_tokens', id: chunk.response.id, type: 'stop' },
+            ...(usageChunk ? [usageChunk] : []),
+          ];
+        }
+
+        const errorData = {
+          body: chunk,
+          message:
+            reason === 'content_filter'
+              ? 'Provider blocked the response due to content policy.'
+              : 'The model response ended incomplete.',
+          type:
+            reason === 'content_filter'
+              ? AgentRuntimeErrorType.ProviderContentPolicyViolation
+              : AgentRuntimeErrorType.ProviderBizError,
+        } satisfies ChatMessageError;
+
+        return [
+          ...(usageChunk ? [usageChunk] : []),
+          { data: errorData, id: chunk.response.id, type: 'error' },
+        ];
       }
 
       case 'response.completed': {


### PR DESCRIPTION
OpenAI Responses terminal events (error, response.failed, and response.incomplete) were previously forwarded as generic data. Downstream relays could ignore them and synthesize a successful empty completion, hiding the provider failure from heterogeneous-agent clients.

This PR:

- converts Responses error and failed events into runtime protocol errors
- classifies content-policy failures separately from generic provider errors
- maps max_output_tokens incompletions to a max_tokens stop
- preserves terminal-event usage before emitting errors

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

bun run check packages/model-runtime/src/core/streams/openai/responsesStream.ts packages/model-runtime/src/core/streams/openai/responsesStream.test.ts (32 tests passed)

A focused type check of the changed files also passed. The full repository type check could not be used from the isolated worktree because sharing the primary checkout node_modules creates duplicate Drizzle/React module identities across checkout paths.

#### 🔗 Related Issue

No matching issue found.