### PR TITLE
🐛 fix(goal): give the side conversation its own width identity and a header re-entry

### DIFF
--- a/packages/const/src/layoutTokens.ts
+++ b/packages/const/src/layoutTokens.ts
@@ -17,6 +17,12 @@ export const CHAT_PORTAL_TASK_WIDTH = 640;
 /** For portal views that read as a document (acceptance report, evidence, screenshots) */
 export const CHAT_PORTAL_WIDE_WIDTH = 840;
 /**
+ * Drag ceiling for a side conversation hosted in the portal panel (e.g. the
+ * goal page's "ask about progress" chat). A conversation column must never
+ * grow into a work surface, so it caps far below the work-view 1280.
+ */
+export const CHAT_PORTAL_CONVERSATION_MAX_WIDTH = 560;
+/**
  * Width the conversation column needs to stay usable next to an open portal.
  * Below this the working sidebar yields, leaving conversation + portal.
  */

--- a/src/features/AgentGoals/GoalDetailPage.tsx
+++ b/src/features/AgentGoals/GoalDetailPage.tsx
@@ -15,6 +15,7 @@ import NavHeader from '@/features/NavHeader';
 import { PortalContent } from '@/features/Portal/router';
 import { usePortalPanelWidth } from '@/features/Portal/usePortalPanelWidth';
 import RightPanel from '@/features/RightPanel';
+import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import { usePermission } from '@/hooks/usePermission';
@@ -151,6 +152,11 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
   const findings = nodes.filter((node) => node.kind === 'finding').length;
   const open = (metric: GoalMetricKind) => () => openGoalMetric(goalId, metric);
 
+  // The panel hosts the goal conversation only when the goal has a
+  // responsible agent; without one it is drill-down-only.
+  const panelExpandable = !!agentId;
+  const chatVisible = chatOpen && panelExpandable;
+
   const paused = goal.status === 'paused';
   // Pace control exists only while the coordinator loop is actually moving (or
   // explicitly paused). A goal in review awaits the human, and a closed goal
@@ -191,6 +197,26 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
                   be deletable, and this menu is the only place that can do it. */}
               <GoalDetailActions agentId={agentId} goalId={goal.id} projectId={goal.projectId} />
             </Flexbox>
+          }
+          right={
+            graphFullscreen ? undefined : (
+              /* Re-entry point for a collapsed panel: the GoalChat toolbar's
+                 close button (or a drag under the collapse threshold) hides
+                 the panel, and with `expandable={false}` on the panel itself
+                 this header button is the only way back. Hidden while a
+                 drill-down owns the panel — its header carries the close. */
+              <ToggleRightPanelButton
+                hideWhenExpanded
+                expand={showPortal || chatVisible}
+                onToggle={() => {
+                  if (showPortal) {
+                    clearPortalStack();
+                    return;
+                  }
+                  if (panelExpandable) setChatOpen(true);
+                }}
+              />
+            )
           }
         />
         <Flexbox flex={1} style={{ overflowY: 'auto' }}>
@@ -293,7 +319,7 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
           open, the panel hosts the conversation with the goal's responsible
           agent so a user can just ask about progress. */}
       <RightPanel
-        expand={(showPortal || (chatOpen && !!agentId)) && !graphFullscreen}
+        expand={(showPortal || chatVisible) && !graphFullscreen}
         maxWidth={maxWidth}
         minWidth={minWidth}
         width={width}

--- a/src/features/Portal/conversationWidth.test.ts
+++ b/src/features/Portal/conversationWidth.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+
+import {
+  getPortalViewMaxWidth,
+  getPortalViewMinWidth,
+  getPortalViewWidth,
+  portalWidthStorageKey,
+} from './portalWidth';
+
+/**
+ * The goal page hosts a plain conversation in the panel when no drill-down
+ * view is open (`viewType === null`). Before it had its own storage key it
+ * shared `home` with the work views and inherited the 1280 work-surface drag
+ * ceiling, so the conversation could be (and persist as) unreadably wide.
+ * These tests pin the conversation's independent width identity.
+ */
+describe('side conversation width identity', () => {
+  it('gives the conversation its own storage key, separate from home', () => {
+    const widths = { 'goal:conversation': 500, 'goal:home': 900 };
+
+    expect(getPortalViewWidth({ scope: 'goal', viewType: null, widths })).toBe(500);
+  });
+
+  it('stores the conversation under its own key', () => {
+    expect(portalWidthStorageKey(null, 'goal')).toBe('goal:conversation');
+    expect(portalWidthStorageKey(undefined, 'goal')).toBe('goal:conversation');
+    expect(portalWidthStorageKey(PortalViewType.Home, 'goal')).toBe('goal:home');
+    expect(portalWidthStorageKey(null)).toBe('conversation');
+  });
+
+  it('caps the conversation drag ceiling at the conversation width', () => {
+    expect(getPortalViewMaxWidth(null)).toBe(560);
+    expect(getPortalViewMaxWidth(undefined)).toBe(560);
+    // Home is the panel's "no drill-down" host state too (the Workspace view
+    // is never pushed by any live UI), so it shares the conversation bounds.
+    expect(getPortalViewMaxWidth(PortalViewType.Home)).toBe(560);
+    expect(getPortalViewMaxWidth(PortalViewType.TaskDetail)).toBe(1280);
+    expect(getPortalViewMaxWidth(PortalViewType.ToolUI)).toBe(1280);
+  });
+
+  it('clamps a previously over-wide conversation memory back into bounds', () => {
+    // A user who dragged the old unbounded conversation wide keeps a usable
+    // column instead of a work-surface-width chat; a too-narrow memory
+    // clamps back up to the reading width.
+    expect(
+      getPortalViewWidth({ scope: 'goal', viewType: null, widths: { 'goal:conversation': 930 } }),
+    ).toBe(560);
+    expect(
+      getPortalViewWidth({ scope: 'goal', viewType: null, widths: { 'goal:conversation': 200 } }),
+    ).toBe(400);
+  });
+
+  it('ignores the legacy shared width even when no conversation memory exists', () => {
+    expect(
+      getPortalViewWidth({ legacyWidth: 700, scope: 'goal', viewType: null, widths: {} }),
+    ).toBe(400);
+    expect(getPortalViewWidth({ legacyWidth: 480, viewType: null })).toBe(400);
+  });
+
+  it('keeps work-view fallbacks untouched by the conversation bounds', () => {
+    expect(getPortalViewWidth({ legacyWidth: 480, viewType: PortalViewType.Document })).toBe(480);
+    expect(getPortalViewMinWidth(PortalViewType.Document)).toBe(400);
+    expect(getPortalViewMinWidth(null)).toBe(400);
+  });
+});

--- a/src/features/Portal/portalWidth.test.ts
+++ b/src/features/Portal/portalWidth.test.ts
@@ -84,9 +84,11 @@ describe('getPortalViewWidth', () => {
   });
 
   it('falls back to the legacy width for views without an explicit default', () => {
-    expect(getPortalViewWidth({ legacyWidth: 520, viewType: PortalViewType.Home })).toBe(520);
-    expect(getPortalViewWidth({ viewType: PortalViewType.Home })).toBe(CHAT_PORTAL_WIDTH);
-    expect(getPortalViewWidth({})).toBe(CHAT_PORTAL_WIDTH);
+    // Document has no entry in the default-width map, so it rides the legacy
+    // chain. (Home is the conversation host state now — see
+    // conversationWidth.test.ts — so it deliberately ignores the legacy width.)
+    expect(getPortalViewWidth({ legacyWidth: 520, viewType: PortalViewType.Document })).toBe(520);
+    expect(getPortalViewWidth({ legacyWidth: 480, viewType: PortalViewType.Notebook })).toBe(480);
   });
 
   it('clamps to the view min width and the panel max width', () => {

--- a/src/features/Portal/portalWidth.ts
+++ b/src/features/Portal/portalWidth.ts
@@ -1,4 +1,5 @@
 import {
+  CHAT_PORTAL_CONVERSATION_MAX_WIDTH,
   CHAT_PORTAL_MAX_WIDTH,
   CHAT_PORTAL_TASK_WIDTH,
   CHAT_PORTAL_TOOL_UI_WIDTH,
@@ -8,11 +9,20 @@ import {
 import { PortalViewType } from '@/store/chat/slices/portal/initialState';
 
 /**
+ * Opening width for the panel when it hosts a side conversation instead of a
+ * portal view (the goal page's "ask about progress" chat). Stored under its
+ * own view key so a conversation's remembered width never bleeds into tool /
+ * detail views, and vice versa.
+ */
+export const PORTAL_CONVERSATION_VIEW_TYPE = 'conversation';
+
+/**
  * Persisted portal widths, keyed by `PortalViewType`. Each view remembers the
  * width the user dragged it to, so resizing the task detail pane no longer
- * shrinks the acceptance report the next time it opens.
+ * shrinks the acceptance report the next time it opens. Side conversations
+ * (`PORTAL_CONVERSATION_VIEW_TYPE`) share the same memory map.
  */
-export type PortalWidths = Partial<Record<PortalViewType, number>>;
+export type PortalWidths = Partial<Record<PortalViewType, number>> & Record<string, number>;
 
 /**
  * Views that can't be read in the default 400px reading column: they render
@@ -50,7 +60,18 @@ const VIEW_DEFAULT_WIDTH: PortalWidths = {
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
-const normalizeViewType = (viewType?: PortalViewType | null) => viewType ?? PortalViewType.Home;
+const CONVERSATION_MIN_WIDTH = CHAT_PORTAL_WIDTH;
+
+/**
+ * A side conversation renders in the panel when no drill-down view is open.
+ * It gets its own storage key and width bounds so the conversation column can
+ * never inherit — or be inflated into — a work-surface width.
+ */
+const isConversationViewType = (viewType?: PortalViewType | null): boolean =>
+  !viewType || viewType === PortalViewType.Home;
+
+const normalizeViewType = (viewType?: PortalViewType | null): string =>
+  viewType ?? PORTAL_CONVERSATION_VIEW_TYPE;
 
 /**
  * Surfaces that host the Portal remember widths independently: dragging the
@@ -63,7 +84,13 @@ export const portalWidthStorageKey = (viewType?: PortalViewType | null, scope?: 
 };
 
 export const getPortalViewMinWidth = (viewType?: PortalViewType | null): number =>
-  VIEW_MIN_WIDTH[normalizeViewType(viewType)] ?? CHAT_PORTAL_WIDTH;
+  isConversationViewType(viewType)
+    ? CONVERSATION_MIN_WIDTH
+    : (VIEW_MIN_WIDTH[normalizeViewType(viewType)] ?? CHAT_PORTAL_WIDTH);
+
+/** Drag ceiling for a view: conversations cap low, work views keep 1280. */
+export const getPortalViewMaxWidth = (viewType?: PortalViewType | null): number =>
+  isConversationViewType(viewType) ? CHAT_PORTAL_CONVERSATION_MAX_WIDTH : CHAT_PORTAL_MAX_WIDTH;
 
 interface GetPortalViewWidthParams {
   /**
@@ -84,11 +111,15 @@ export const getPortalViewWidth = ({
   widths,
 }: GetPortalViewWidthParams): number => {
   const key = normalizeViewType(viewType);
+  // A conversation never falls back to the legacy shared width: it always has
+  // its own default, so an old narrow drag can't shrink it and a work view's
+  // memory can't inflate it.
   const fallback = VIEW_DEFAULT_WIDTH[key] ?? legacyWidth ?? CHAT_PORTAL_WIDTH;
 
   return clamp(
-    widths?.[portalWidthStorageKey(key, scope)] || fallback,
-    getPortalViewMinWidth(key),
-    CHAT_PORTAL_MAX_WIDTH,
+    widths?.[portalWidthStorageKey(viewType, scope)] ||
+      (isConversationViewType(viewType) ? CHAT_PORTAL_WIDTH : fallback),
+    getPortalViewMinWidth(viewType),
+    getPortalViewMaxWidth(viewType),
   );
 };

--- a/src/features/Portal/usePortalPanelWidth.ts
+++ b/src/features/Portal/usePortalPanelWidth.ts
@@ -1,9 +1,13 @@
-import { CHAT_PORTAL_MAX_WIDTH } from '@/const/layoutTokens';
 import type { PortalViewType } from '@/store/chat/slices/portal/initialState';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
-import { getPortalViewMinWidth, getPortalViewWidth, portalWidthStorageKey } from './portalWidth';
+import {
+  getPortalViewMaxWidth,
+  getPortalViewMinWidth,
+  getPortalViewWidth,
+  portalWidthStorageKey,
+} from './portalWidth';
 
 /**
  * Shared width state for every surface that hosts the Portal in a right-hand
@@ -33,7 +37,10 @@ export const usePortalPanelWidth = (viewType?: PortalViewType | null, scope?: st
   };
 
   return {
-    maxWidth: CHAT_PORTAL_MAX_WIDTH,
+    // The ceiling follows the view: a side conversation caps at the
+    // conversation width, work views (tool UI, task detail, documents) keep
+    // the full portal range.
+    maxWidth: getPortalViewMaxWidth(viewType),
     minWidth: getPortalViewMinWidth(viewType),
     updateWidth,
     width,


### PR DESCRIPTION
## PR Body

<!-- Brief and heads-up -->

The goal detail page's right panel hosts two different things with the same width grammar: the side conversation ("ask about progress") and the drill-down work views (task detail, tool UI, documents). Both shared one storage key and the 1280 work-surface drag ceiling, so the conversation could be dragged — and persist — far wider than a chat column should ever be. And once the panel was collapsed from the conversation toolbar, there was no way back: the page header offered no toggle and the panel itself is `expandable={false}`.

| Before | After |
| ------ | ----- |
| Conversation shares the work-view storage key (`goal:home`) and the 1280 drag ceiling; a collapsed panel has no re-entry point | Conversation persists under its own key with a 560 ceiling; the page header shows a toggle when the panel is collapsed |

### What changed

- **Side conversations get their own width identity.** They now persist under a dedicated `conversation` key (min 400 / max 560) instead of borrowing `home`; work views keep the full 400–1280 range. A previously over-wide conversation memory is clamped back into bounds on read, so existing users need no migration.
- **Per-view drag ceiling.** `usePortalPanelWidth` now returns a `maxWidth` that follows the view type — 560 for conversations, 1280 for work views.
- **Header re-entry for a collapsed panel.** The goal page header gains a `ToggleRightPanelButton` (`hideWhenExpanded`): it appears only when the panel is collapsed, restores the conversation, closes an open drill-down instead, and hides while the exploration map is fullscreen or when the goal has no responsible agent (no dead button).

### How the bounds work

`isConversationViewType` treats `null` / `Home` as the panel's conversation host state — that is exactly the state the goal page renders its chat in. Every concrete drill-down view (`TaskDetail`, `ToolUI`, `Acceptance`, …) keeps its existing bounds untouched, and the scoped `goal:` width memory stays separate from the chat surface's keys.

### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New `src/features/Portal/conversationWidth.test.ts` pins the conversation's width identity: its own storage key, the 560 ceiling, clamping of over-wide/stale memories, legacy-width independence, and work-view isolation (6 tests). Existing `portalWidth.test.ts` legacy-fallback assertions moved from `Home` (now the conversation state) to genuinely default-less work views (`Document` / `Notebook`). Full suite: `bun run check --lint --test` on the touched files — 14 passed, lint clean.

Note: `packages/const/src/layoutTokens.test.ts`'s `HEADER_ICON_SIZE > desktop` assertion fails on `canary` already (expects `{36, 22}`, constant is `{32, 20}`) — pre-existing, untouched here.

### 🔗 Related Issue

None on file — reported via internal design review (goal detail panel width + collapsed re-entry).
