### PR TITLE
🐛 fix(agent-share): clear visitor topic running marks and refuse stale reconnects

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { TopicModel } from '@/database/models/topic';
 import type { LobeChatDatabase } from '@/database/type';
 
 import { ServerOperationStore } from './ServerOperationStore';
@@ -32,6 +33,22 @@ describe('ServerOperationStore', () => {
   });
 
   describe('clearRunningMark', () => {
+    // Regression: agent-share visitor runs execute under the creator's userId
+    // on a topic whose `senderId` is the visitor. The default topic scope hides
+    // those rows, so `findById` returned nothing, the clear silently bailed,
+    // and every visitor topic kept a stale `runningOperation` forever — each
+    // later open reconnected to a finished run and froze the message list.
+    it('looks the topic up with the share-visitor scope so visitor topics can be cleared', async () => {
+      topicMock.findById.mockResolvedValue(markedWith('op-main'));
+
+      await createStore('op-main').clearRunningMark();
+
+      expect(TopicModel).toHaveBeenCalledWith(db, 'user-1', undefined, undefined, {
+        includeShareVisitor: true,
+      });
+      expect(topicMock.settleRunningOperation).toHaveBeenCalledWith('topic-1', 'op-main', 'unread');
+    });
+
     it('clears the mark when this operation owns it', async () => {
       topicMock.findById.mockResolvedValue(markedWith('op-main'));
 

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
@@ -35,7 +35,17 @@ export class ServerOperationStore implements OperationStore {
   async clearRunningMark(): Promise<void> {
     if (!this.topicId || !this.userId) return;
     try {
-      const topicModel = new TopicModel(this.serverDB, this.userId, this.workspaceId);
+      // Agent-share visitor runs execute under the CREATOR's userId on a topic
+      // whose `senderId` is the visitor. The default topic scope hides those
+      // rows, so without the opt-in `findById` returned nothing here, the
+      // early return below treated it as "already cleared", and every visitor
+      // topic kept its `runningOperation` marker forever — each later open
+      // reconnected to a finished run and froze the visitor's message list.
+      // Widening is safe: the compare-and-clear below still requires the mark
+      // to name this very operation.
+      const topicModel = new TopicModel(this.serverDB, this.userId, this.workspaceId, undefined, {
+        includeShareVisitor: true,
+      });
       const topic = await topicModel.findById(this.topicId);
       const marker = topic?.metadata?.runningOperation;
       const markedOperationId = marker?.operationId;

--- a/apps/server/src/routers/lambda/__tests__/shareChat.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/shareChat.test.ts
@@ -53,9 +53,11 @@ vi.mock('@/database/models/agentShare', () => ({
 const mockFindById = vi.fn();
 const mockCountBySender = vi.fn();
 const mockQueryBySender = vi.fn();
+const mockIsRunningOperationAlive = vi.fn();
 const TopicModelMock = vi.fn(() => ({
   countBySender: mockCountBySender,
   findById: mockFindById,
+  isRunningOperationAlive: mockIsRunningOperationAlive,
   queryBySender: mockQueryBySender,
 }));
 vi.mock('@/database/models/topic', () => ({
@@ -144,6 +146,7 @@ describe('shareChatRouter', () => {
     mockGetFeatureFlagsState.mockResolvedValue({ enableAgentShare: true });
     mockAccessCheck.mockResolvedValue(share);
     mockFindById.mockResolvedValue(visitorTopic);
+    mockIsRunningOperationAlive.mockResolvedValue(true);
     mockCountBySender.mockResolvedValue(0);
     mockQueryBySender.mockResolvedValue([]);
     mockMessageCountByTopic.mockResolvedValue(0);
@@ -536,6 +539,23 @@ describe('shareChatRouter', () => {
       await expect(
         caller.refreshGatewayToken({ shareId: 'share-1', topicId: 'tpc_visitor' }),
       ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+      expect(mockSignUserJWT).not.toHaveBeenCalled();
+    });
+
+    // The marker is cleared best-effort at finish, so a stale one must not
+    // send the visitor's browser to reconnect to a finished run (it would
+    // register the topic as "running" locally and freeze its message list).
+    it('rejects when the marker points at a run that already ended', async () => {
+      mockIsRunningOperationAlive.mockResolvedValue(false);
+      const caller = await createCaller();
+
+      await expect(
+        caller.refreshGatewayToken({ shareId: 'share-1', topicId: 'tpc_visitor' }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+      expect(mockIsRunningOperationAlive).toHaveBeenCalledWith(
+        expect.anything(),
+        visitorTopic.metadata.runningOperation,
+      );
       expect(mockSignUserJWT).not.toHaveBeenCalled();
     });
   });

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -3700,7 +3700,14 @@ export const aiAgentRouter = router({
       // `shareChat.refreshGatewayToken` instead.
       const topic = await ctx.topicModel.findOwnTopicById(input.topicId);
 
-      if (!topic?.metadata?.runningOperation) {
+      // Same liveness check as `shareChat.refreshGatewayToken`: the marker is
+      // cleared best-effort, so refuse to reconnect a client to a run that has
+      // already ended — the client treats NOT_FOUND as "stale marker, clear it".
+      const runningOperation = topic?.metadata?.runningOperation;
+      if (
+        !runningOperation ||
+        !(await ctx.topicModel.isRunningOperationAlive(ctx.serverDB, runningOperation))
+      ) {
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'No running operation found on this topic',

--- a/apps/server/src/routers/lambda/shareChat.ts
+++ b/apps/server/src/routers/lambda/shareChat.ts
@@ -505,7 +505,16 @@ export const shareChatRouter = router({
         visitorUserId: ctx.userId,
       });
 
-      if (!topic.metadata?.runningOperation) {
+      // A present marker is not proof of a live run: it is cleared best-effort
+      // at finish, so a stale one would send the visitor's browser to reconnect
+      // to a finished operation, register it as "running" locally, and drop the
+      // topic's fetched history as in-flight noise (a frozen skeleton list).
+      // NOT_FOUND is what the client already treats as "stale marker, clear it".
+      const runningOperation = topic.metadata?.runningOperation;
+      if (
+        !runningOperation ||
+        !(await topicModel.isRunningOperationAlive(ctx.serverDB, runningOperation))
+      ) {
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'No running operation found on this topic',

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -2072,6 +2072,10 @@ export class TopicModel {
    * Whether the run a `runningOperation` marker points at is still the topic's
    * legitimate owner.
    *
+   * Public so the gateway-token refresh routers can refuse to reconnect a
+   * client to a marker whose run has already ended (the marker is cleared
+   * best-effort, so a stale one must not be taken at face value).
+   *
    * The marker itself cannot answer this — it carries no heartbeat and is
    * cleared best-effort — so the authority is the operation row, which both the
    * in-process runtime (`createOperation`) and the heterogeneous path
@@ -2082,7 +2086,7 @@ export class TopicModel {
    * with a marker and no row. A marker with neither a row nor a stamp cannot be
    * proven live and must not keep an already-stuck topic stuck.
    */
-  private isRunningOperationAlive = async (
+  isRunningOperationAlive = async (
     tx: Pick<LobeChatDatabase, 'select'>,
     runningOperation: NonNullable<ChatTopicMetadata['runningOperation']>,
   ): Promise<boolean> => {


### PR DESCRIPTION
Agent-share visitors could only open the topic they were currently chatting in; every other topic in their list stayed on a loading skeleton forever.

**Root cause.** Each run stamps `metadata.runningOperation` on its topic so a reload can reconnect to the live stream, and `ServerOperationStore.clearRunningMark` drops it at finish. That adapter built its own `TopicModel` without `includeShareVisitor`, so for visitor topics (`senderId` set, owned by the creator) `findById` returned nothing, the compare-and-clear bailed as "already cleared", and the mark never went away. The client-side settle backstop is deliberately skipped for visitors (they cannot write the creator's topic row), so nothing else could clear it either.

On the next open of such a topic, `useGatewayReconnect` saw the stale mark → `shareChat.refreshGatewayToken` only checked that a mark exists → the client registered the topic as running → `useFetchMessages` dropped the fetched history as in-flight noise → permanent skeleton.

**Fix.**

- `ServerOperationStore.clearRunningMark` looks the topic up with the share-visitor scope. Safe for owner runs: the clear still requires the mark to name this very operation.
- `shareChat.refreshGatewayToken` and `aiAgent.refreshGatewayToken` additionally check the marked run is still alive via `TopicModel.isRunningOperationAlive` (made public; it already backs `tryReserveTaskCallback`). A stale mark now yields `NOT_FOUND`, which the client already treats as "clear the local marker", so topics stamped before this fix self-heal on first open.

#### Test

- [x] Added/updated tests — `ServerOperationStore.test.ts` (visitor scope), `shareChat.test.ts` (stale mark → NOT_FOUND)
- [x] `bun run check` lint + tests + full type-check pass

#### 🔗 Related Issue

Follow-up to #18998 (Agent Share v2).