### PR TITLE
🐛 fix: keep streamed reply visible after mid-turn compression

### DIFF
--- a/packages/agent-runtime/src/executors/compressContext.test.ts
+++ b/packages/agent-runtime/src/executors/compressContext.test.ts
@@ -335,6 +335,7 @@ describe('compressContext executor', () => {
       inFlightAssistant,
       inFlightTool,
     ]);
+    expect((result.nextContext?.payload as any).parentMessageId).toBe('msg-inflight-asst');
   });
 
   it('skips without compression side effects when topic context is missing', async () => {
@@ -436,7 +437,7 @@ describe('compressContext executor', () => {
       { content: 'recent question', id: 'msg-recent', role: 'user' },
       { content: 'recent answer', id: 'assistant-recent', role: 'assistant' },
     ]);
-    expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-in-source-2');
+    expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-recent');
   });
 
   it('can recompress summaries when there are no new persisted messages', async () => {

--- a/packages/agent-runtime/src/executors/compressContext.test.ts
+++ b/packages/agent-runtime/src/executors/compressContext.test.ts
@@ -271,12 +271,69 @@ describe('compressContext executor', () => {
 
     expect(compressionCreateGroup).toHaveBeenCalledWith(
       expect.objectContaining({
-        messageIds: ['msg-old', 'msg-assistant', 'msg-tool'],
+        messageIds: ['msg-old'],
       }),
     );
     expect(result.newState.messages).toEqual([
       { content: 'historical summary', id: 'group-123', role: 'compressedGroup' },
       activeContract,
+      { content: 'searching', id: 'msg-assistant', role: 'assistant' },
+      toolResult,
+    ]);
+  });
+
+  it('does not fold the in-flight assistant/tool turn after the latest user into the compression group', async () => {
+    const activeUser = {
+      content: 'continue with the other languages',
+      id: 'msg-current-user',
+      role: 'user',
+    };
+    const inFlightAssistant = {
+      content: 'Starting with Dutch, then the remaining four.',
+      id: 'msg-inflight-asst',
+      role: 'assistant',
+    };
+    const inFlightTool = { content: 'crawl result', id: 'msg-inflight-tool', role: 'tool' };
+
+    messagesQuery.mockResolvedValue([
+      { content: 'old history', id: 'msg-old', role: 'user' },
+      { content: 'old reply', id: 'msg-old-asst', role: 'assistant' },
+      activeUser,
+      inFlightAssistant,
+      inFlightTool,
+    ]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: [
+        { content: 'old history', id: 'msg-old', role: 'user' },
+        { content: 'old reply', id: 'msg-old-asst', role: 'assistant' },
+      ],
+    });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'historical summary', id: 'group-123', role: 'compressedGroup' }],
+    });
+
+    const state = createState({
+      messages: [
+        { content: 'old history', id: 'msg-old', role: 'user' },
+        { content: 'old reply', id: 'msg-old-asst', role: 'assistant' },
+        activeUser,
+        inFlightAssistant,
+        inFlightTool,
+      ],
+    });
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionCreateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageIds: ['msg-old', 'msg-old-asst'],
+      }),
+    );
+    expect(result.newState.messages).toEqual([
+      { content: 'historical summary', id: 'group-123', role: 'compressedGroup' },
+      activeUser,
+      inFlightAssistant,
+      inFlightTool,
     ]);
   });
 
@@ -377,8 +434,9 @@ describe('compressContext executor', () => {
     expect(result.newState.messages).toEqual([
       { content: 'combined summary', id: 'group-123', role: 'compressedGroup' },
       { content: 'recent question', id: 'msg-recent', role: 'user' },
+      { content: 'recent answer', id: 'assistant-recent', role: 'assistant' },
     ]);
-    expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-recent');
+    expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-in-source-2');
   });
 
   it('can recompress summaries when there are no new persisted messages', async () => {

--- a/packages/agent-runtime/src/executors/compressContext.ts
+++ b/packages/agent-runtime/src/executors/compressContext.ts
@@ -177,6 +177,15 @@ export const compressContext =
         return skippedResult();
       }
 
+      // Next call_llm parents the continuation on this id. Prefer the latest
+      // assistant still on the mainline (the preserved active turn); otherwise
+      // fall back to the last compressed assistant / group lastMessageId.
+      const latestPreservedAssistant = dbMessages.findLast(
+        (message) =>
+          message.role === 'assistant' &&
+          typeof message.id === 'string' &&
+          preservedMessageIds.has(message.id),
+      );
       const latestCompressedAssistant = dbMessages.findLast(
         (message) =>
           message.role === 'assistant' &&
@@ -184,6 +193,7 @@ export const compressContext =
           !preservedMessageIds.has(message.id),
       );
       const parentMessageId =
+        latestPreservedAssistant?.id ??
         latestCompressedAssistant?.id ??
         (sourceCompressionGroups.at(-1) as { lastMessageId?: string } | undefined)?.lastMessageId;
       const compressionModel =

--- a/packages/agent-runtime/src/executors/compressContext.ts
+++ b/packages/agent-runtime/src/executors/compressContext.ts
@@ -18,6 +18,20 @@ const getErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
+/**
+ * Latest user message plus any assistant/tool follow-ups after it.
+ * Compression must leave this turn on the mainline — folding it into the
+ * group hides the reply the user is already watching.
+ */
+const collectActiveTurnMessages = <T extends { id?: string; role?: string }>(
+  messages: T[],
+): T[] => {
+  if (messages.length <= 1) return [];
+  const latestUserIndex = messages.findLastIndex((message) => message.role === 'user');
+  if (latestUserIndex < 0) return [];
+  return messages.slice(latestUserIndex);
+};
+
 const dispatchLifecycle = (
   host: AgentRuntimeHost,
   type: Parameters<NonNullable<AgentRuntimeHost['lifecycle']>['dispatch']>[0]['type'],
@@ -55,17 +69,17 @@ export const compressContext =
     const compression = transports.compression;
     const llm = transports.llm;
     // The latest user turn is the active contract even after assistant/tool steps have followed it.
-    // Keep it verbatim and re-inject it after the summary so compression can never demote a Task's
-    // Current Work instruction into historical prose or reactivate an older objective.
-    const latestUserMessage =
-      messages.length > 1 ? messages.findLast((message) => message.role === 'user') : undefined;
-    const preservedMessages = latestUserMessage ? [latestUserMessage] : [];
+    // Keep the whole turn (user + already-streamed assistant/tool follow-ups) verbatim so
+    // compression cannot demote a Task's Current Work instruction — or swallow the reply
+    // the user is watching — into historical prose.
+    const preservedMessages = collectActiveTurnMessages(messages);
     const preservedMessageIds = new Set(
       preservedMessages.map((message) => message.id).filter((id): id is string => Boolean(id)),
     );
-    const messagesToCompress = latestUserMessage
-      ? messages.filter((message) => message !== latestUserMessage)
-      : messages;
+    const messagesToCompress =
+      preservedMessages.length > 0
+        ? messages.slice(0, messages.length - preservedMessages.length)
+        : messages;
     const createNextContext = ({
       groupId,
       parentMessageId,
@@ -136,11 +150,22 @@ export const compressContext =
         .filter(Boolean)
         .join('\n\n');
 
+      const latestUserId = preservedMessages.find((message) => message.role === 'user')?.id;
+      const dbActiveTurnStart = latestUserId
+        ? dbMessages.findIndex((message) => message.id === latestUserId)
+        : -1;
+      if (dbActiveTurnStart >= 0) {
+        for (const message of dbMessages.slice(dbActiveTurnStart)) {
+          if (message.role === 'compressedGroup' || !message.id) continue;
+          preservedMessageIds.add(message.id);
+        }
+      }
+
       const messageIds = dbMessages
         .filter(
-          (message) =>
+          (message): message is typeof message & { id: string } =>
             message.role !== 'compressedGroup' &&
-            Boolean(message.id) &&
+            typeof message.id === 'string' &&
             !preservedMessageIds.has(message.id),
         )
         .map((message) => message.id);
@@ -152,9 +177,14 @@ export const compressContext =
         return skippedResult();
       }
 
-      const latestAssistantMessage = dbMessages.findLast((message) => message.role === 'assistant');
+      const latestCompressedAssistant = dbMessages.findLast(
+        (message) =>
+          message.role === 'assistant' &&
+          typeof message.id === 'string' &&
+          !preservedMessageIds.has(message.id),
+      );
       const parentMessageId =
-        latestAssistantMessage?.id ??
+        latestCompressedAssistant?.id ??
         (sourceCompressionGroups.at(-1) as { lastMessageId?: string } | undefined)?.lastMessageId;
       const compressionModel =
         newState.modelRuntimeConfig?.compressionModel || newState.modelRuntimeConfig;
@@ -229,7 +259,14 @@ export const compressContext =
         compressionResult.messagesToSummarize;
       const compressedMessages = [...compressedMessagesBase];
 
-      for (const preservedMessage of preservedMessages) {
+      const preservedForReinjection =
+        dbActiveTurnStart >= 0
+          ? dbMessages
+              .slice(dbActiveTurnStart)
+              .filter((message) => message.role !== 'compressedGroup' && Boolean(message.id))
+          : preservedMessages;
+
+      for (const preservedMessage of preservedForReinjection) {
         if (
           !compressedMessages.some(
             (message) =>

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -134,7 +134,7 @@ export interface GeneralAgentCompressionResultPayload {
   compressedMessages?: any[];
   /** Compression group ID in database */
   groupId: string;
-  /** Parent message ID for subsequent LLM call (last assistant message before compression) */
+  /** Parent message ID for the post-compression LLM call (latest mainline assistant) */
   parentMessageId?: string;
   /** Whether compression was skipped (no messages to compress) */
   skipped?: boolean;

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -17,6 +17,7 @@ import {
 } from '@/services/message/cache';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
 import { type ChatStore } from '@/store/chat/store';
+import { graftInFlightTurnAfterLatestUser } from '@/store/chat/utils/compression';
 import {
   isLocalOnlyMessage,
   mergeLocalMessagesByCreatedAt,
@@ -203,9 +204,12 @@ export class MessageQueryActionImpl {
     // link while the tool row survives, which would orphan the tool bubble (see
     // reconcileAssistantToolLinks). Keeps dbMessagesMap (SoT) consistent for
     // optimistic updates, not just the parsed display.
-    const persistedIncoming = incoming.filter((message) => !isLocalOnlyMessage(message));
-    const persistedIds = new Set(persistedIncoming.map((message) => message.id));
     const currentMessages = this.#get().dbMessagesMap[messagesKey] ?? [];
+    const persistedIncoming = graftInFlightTurnAfterLatestUser(
+      incoming.filter((message) => !isLocalOnlyMessage(message)),
+      currentMessages.filter((message) => !isLocalOnlyMessage(message)),
+    );
+    const persistedIds = new Set(persistedIncoming.map((message) => message.id));
     const voiceMessageUploadMap = this.#get().voiceMessageUploadMap;
     const activeLocalMessagesById = new Map<string, UIChatMessage>();
 

--- a/src/store/chat/slices/message/replaceMessages.midTurnCompression.regression.test.ts
+++ b/src/store/chat/slices/message/replaceMessages.midTurnCompression.regression.test.ts
@@ -1,0 +1,142 @@
+import { type UIChatMessage } from '@lobechat/types';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+
+import { useChatStore } from '../../store';
+
+// `replaceMessages` is pure store + conversation-flow `parse` (no service
+// calls), but importing the chat store pulls the whole slice graph, so mirror
+// the minimal service / swr / zustand stubs the sibling action tests use.
+vi.mock('@/libs/swr', async () => {
+  const actual = await vi.importActual('@/libs/swr');
+  return { ...actual, mutate: vi.fn() };
+});
+vi.stubGlobal(
+  'fetch',
+  vi.fn(() => Promise.resolve(new Response('mock'))),
+);
+vi.mock('@/services/message', () => ({
+  messageService: {
+    createMessage: vi.fn(),
+    getMessages: vi.fn(),
+    updateMessage: vi.fn(),
+    updateMessageError: vi.fn(),
+  },
+}));
+vi.mock('@/services/topic', () => ({ topicService: {} }));
+
+const CTX = { agentId: 'agent-1', topicId: 'topic-1' };
+const KEY = messageMapKey(CTX);
+
+const STREAMED_REPLY = 'Starting with Dutch, then the remaining four.';
+
+const historyUser: UIChatMessage = {
+  content: 'old history',
+  createdAt: 1000,
+  id: 'msg-old',
+  role: 'user',
+  updatedAt: 1000,
+};
+const historyAssistant: UIChatMessage = {
+  content: 'old reply',
+  createdAt: 2000,
+  id: 'msg-old-asst',
+  parentId: 'msg-old',
+  role: 'assistant',
+  updatedAt: 2000,
+};
+const currentUser: UIChatMessage = {
+  content: 'continue with the other languages',
+  createdAt: 3000,
+  id: 'msg-current-user',
+  parentId: 'msg-old-asst',
+  role: 'user',
+  updatedAt: 3000,
+};
+const inFlightAssistant: UIChatMessage = {
+  content: STREAMED_REPLY,
+  createdAt: 4000,
+  id: 'msg-inflight-asst',
+  parentId: 'msg-current-user',
+  role: 'assistant',
+  tools: [
+    {
+      apiName: 'crawl',
+      arguments: '{}',
+      id: 'msg-inflight-tool',
+      identifier: 'lobe-web-browsing',
+      type: 'builtin',
+    },
+  ],
+  updatedAt: 4000,
+};
+const inFlightTool: UIChatMessage = {
+  content: 'crawl result',
+  createdAt: 4100,
+  id: 'msg-inflight-tool',
+  parentId: 'msg-inflight-asst',
+  role: 'tool',
+  tool_call_id: 'msg-inflight-tool',
+  updatedAt: 4100,
+};
+
+const liveTranscript = [
+  historyUser,
+  historyAssistant,
+  currentUser,
+  inFlightAssistant,
+  inFlightTool,
+];
+
+/**
+ * What a mid-turn compression snapshot looks like when the already-streamed
+ * turn is nested inside `compressedGroup` and only the latest user stays
+ * on the mainline.
+ */
+const postCompressionSnapshot: UIChatMessage[] = [
+  {
+    compressedMessages: [historyUser, historyAssistant, inFlightAssistant, inFlightTool],
+    content: 'historical summary',
+    createdAt: 1500,
+    id: 'mg-compress',
+    lastMessageId: 'msg-inflight-tool',
+    role: 'compressedGroup',
+    updatedAt: 4500,
+  } as UIChatMessage,
+  currentUser,
+];
+
+const displayHasStreamedReply = (messages: UIChatMessage[]) =>
+  messages.some((message) => {
+    if (message.id === 'msg-inflight-asst' || message.content === STREAMED_REPLY) return true;
+    if (message.role !== 'assistantGroup') return false;
+    return (message.children ?? []).some(
+      (child) => child.id === 'msg-inflight-asst' || child.content === STREAMED_REPLY,
+    );
+  });
+
+describe('replaceMessages — mid-turn compression swallows streamed reply', () => {
+  beforeEach(() => {
+    useChatStore.setState({ activeAgentId: 'agent-1', activeTopicId: 'topic-1' }, false);
+  });
+
+  it('keeps the streamed assistant visible after a post-compression snapshot omits it from the mainline', () => {
+    const { result } = renderHook(() => useChatStore());
+
+    act(() => {
+      result.current.replaceMessages(liveTranscript, { context: CTX });
+    });
+    expect(displayHasStreamedReply(result.current.messagesMap[KEY] ?? [])).toBe(true);
+
+    act(() => {
+      result.current.replaceMessages(postCompressionSnapshot, {
+        action: 'gateway/step_start',
+        context: CTX,
+      });
+    });
+
+    expect(displayHasStreamedReply(result.current.messagesMap[KEY] ?? [])).toBe(true);
+  });
+});

--- a/src/store/chat/utils/compression.test.ts
+++ b/src/store/chat/utils/compression.test.ts
@@ -125,6 +125,29 @@ describe('compression utils', () => {
     ).toEqual(['mg-compress', 'msg-user']);
   });
 
+  it('should not resurrect a locally present reply that the snapshot omitted without folding it', () => {
+    const currentUser = {
+      content: 'continue',
+      createdAt: 3000,
+      id: 'msg-user',
+      role: 'user' as const,
+    };
+    const inFlightAssistant = {
+      content: 'working',
+      createdAt: 4000,
+      id: 'msg-asst',
+      parentId: 'msg-user',
+      role: 'assistant' as const,
+    };
+
+    expect(
+      graftInFlightTurnAfterLatestUser(
+        [currentUser] as any,
+        [currentUser, inFlightAssistant] as any,
+      ).map((m) => m.id),
+    ).toEqual(['msg-user']);
+  });
+
   it('should build a pending compressedGroup message', () => {
     const message = createPendingCompressedGroup({
       agentId: 'agent-1',

--- a/src/store/chat/utils/compression.test.ts
+++ b/src/store/chat/utils/compression.test.ts
@@ -4,6 +4,7 @@ import { type Operation } from '../slices/operation/types';
 import {
   createPendingCompressedGroup,
   getCompressionCandidateMessageIds,
+  graftInFlightTurnAfterLatestUser,
   hasRunningCompressionOperation,
   isCompressionOperationType,
 } from './compression';
@@ -61,6 +62,67 @@ describe('compression utils', () => {
         topicId: 'topic-3',
       }),
     ).toBe(false);
+  });
+
+  it('should re-attach the in-flight turn omitted from a post-compression snapshot', () => {
+    const currentUser = {
+      content: 'continue',
+      createdAt: 3000,
+      id: 'msg-user',
+      role: 'user' as const,
+    };
+    const inFlightAssistant = {
+      content: 'working',
+      createdAt: 4000,
+      id: 'msg-asst',
+      parentId: 'msg-user',
+      role: 'assistant' as const,
+    };
+    const snapshot = [
+      {
+        compressedMessages: [inFlightAssistant],
+        content: 'summary',
+        createdAt: 1500,
+        id: 'mg-compress',
+        role: 'compressedGroup' as const,
+      },
+      currentUser,
+    ];
+    const local = [
+      { content: 'old', createdAt: 1000, id: 'msg-old', role: 'user' as const },
+      currentUser,
+      inFlightAssistant,
+    ];
+
+    expect(
+      graftInFlightTurnAfterLatestUser(snapshot as any, local as any).map((m) => m.id),
+    ).toEqual(['mg-compress', 'msg-user', 'msg-asst']);
+  });
+
+  it('should not resurrect history that was correctly folded into the compressed group', () => {
+    const currentUser = {
+      content: 'continue',
+      createdAt: 3000,
+      id: 'msg-user',
+      role: 'user' as const,
+    };
+    const history = { content: 'old', createdAt: 1000, id: 'msg-old', role: 'user' as const };
+    const snapshot = [
+      {
+        compressedMessages: [history],
+        content: 'summary',
+        createdAt: 1500,
+        id: 'mg-compress',
+        role: 'compressedGroup' as const,
+      },
+      currentUser,
+    ];
+
+    expect(
+      graftInFlightTurnAfterLatestUser(snapshot as any, [history, currentUser] as any).map(
+        (m) => m.id,
+      ),
+    ).toEqual(['mg-compress', 'msg-user']);
   });
 
   it('should build a pending compressedGroup message', () => {

--- a/src/store/chat/utils/compression.ts
+++ b/src/store/chat/utils/compression.ts
@@ -15,6 +15,39 @@ export const getCompressionCandidateMessageIds = (messages: UIChatMessage[]) =>
     .map((message) => message.id)
     .filter(Boolean);
 
+/**
+ * Mid-turn compression snapshots nest the already-streamed assistant/tool
+ * turn inside `compressedGroup` and leave only the latest user on the mainline.
+ * Re-attach local messages that follow that user so the reply the user is
+ * watching is not replaced away.
+ */
+export const graftInFlightTurnAfterLatestUser = (
+  snapshot: UIChatMessage[],
+  localMessages: UIChatMessage[],
+): UIChatMessage[] => {
+  const latestUser = snapshot.findLast((message) => message.role === 'user');
+  if (!latestUser?.id) return snapshot;
+
+  const snapshotIds = new Set(snapshot.map((message) => message.id));
+  const localUserIndex = localMessages.findIndex((message) => message.id === latestUser.id);
+  const inFlight =
+    localUserIndex >= 0
+      ? localMessages.slice(localUserIndex + 1)
+      : localMessages.filter(
+          (message) =>
+            message.createdAt > latestUser.createdAt ||
+            (message.createdAt === latestUser.createdAt && message.id > latestUser.id),
+        );
+
+  const missing = inFlight.filter(
+    (message) =>
+      Boolean(message.id) && !snapshotIds.has(message.id) && message.role !== 'compressedGroup',
+  );
+  if (missing.length === 0) return snapshot;
+
+  return [...snapshot, ...missing];
+};
+
 export const createPendingCompressedGroup = ({
   agentId,
   content = '...',

--- a/src/store/chat/utils/compression.ts
+++ b/src/store/chat/utils/compression.ts
@@ -15,11 +15,37 @@ export const getCompressionCandidateMessageIds = (messages: UIChatMessage[]) =>
     .map((message) => message.id)
     .filter(Boolean);
 
+const collectCompressedGroupMessageIds = (messages: UIChatMessage[]): Set<string> => {
+  const ids = new Set<string>();
+
+  const walk = (message: UIChatMessage | undefined) => {
+    if (!message) return;
+    if (message.id) ids.add(message.id);
+    if ('lastMessageId' in message && typeof message.lastMessageId === 'string') {
+      ids.add(message.lastMessageId);
+    }
+    message.compressedMessages?.forEach(walk);
+    message.children?.forEach(walk);
+    for (const pinned of message.pinnedMessages ?? []) {
+      if (pinned.id) ids.add(pinned.id);
+    }
+    for (const tool of message.tools ?? []) {
+      if (tool.result_msg_id) ids.add(tool.result_msg_id);
+    }
+  };
+
+  for (const message of messages) {
+    if (message.role === 'compressedGroup') walk(message);
+  }
+
+  return ids;
+};
+
 /**
  * Mid-turn compression snapshots nest the already-streamed assistant/tool
  * turn inside `compressedGroup` and leave only the latest user on the mainline.
- * Re-attach local messages that follow that user so the reply the user is
- * watching is not replaced away.
+ * Re-attach local messages that follow that user only when they are proven to
+ * live inside an incoming compressed group — never resurrect a server-deleted row.
  */
 export const graftInFlightTurnAfterLatestUser = (
   snapshot: UIChatMessage[],
@@ -27,6 +53,9 @@ export const graftInFlightTurnAfterLatestUser = (
 ): UIChatMessage[] => {
   const latestUser = snapshot.findLast((message) => message.role === 'user');
   if (!latestUser?.id) return snapshot;
+
+  const foldedIds = collectCompressedGroupMessageIds(snapshot);
+  if (foldedIds.size === 0) return snapshot;
 
   const snapshotIds = new Set(snapshot.map((message) => message.id));
   const localUserIndex = localMessages.findIndex((message) => message.id === latestUser.id);
@@ -41,7 +70,10 @@ export const graftInFlightTurnAfterLatestUser = (
 
   const missing = inFlight.filter(
     (message) =>
-      Boolean(message.id) && !snapshotIds.has(message.id) && message.role !== 'compressedGroup',
+      Boolean(message.id) &&
+      !snapshotIds.has(message.id) &&
+      foldedIds.has(message.id) &&
+      message.role !== 'compressedGroup',
   );
   if (missing.length === 0) return snapshot;
 


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [x] 🐛 fix

## 🔗 Related Links

- Linear / GitHub issue: N/A

## 🔀 Description of Change

When context compression runs in the middle of a turn, the already-streamed assistant/tool replies were folded into the compressed group. The next `step_start` snapshot then replaced the client's transcript, so the reply the user was watching disappeared until they sent another message (or a later refresh landed).

This keeps the latest user turn — including any assistant/tool follow-ups after it — on the mainline, and grafts that turn back if a compression snapshot still omits it.

## 🧭 Key Decisions / Non-goals

- Compression still summarizes history before the latest user message. Only the active turn is excluded.
- `replaceMessages` grafting is a client-side guard for snapshots that still nest the in-flight turn inside `compressedGroup`. It does not resurrect history that was correctly compressed.
- Does not settle stuck `running` operations; that remains a separate issue.

## 🧪 How to Test

- [x] Added/updated tests
- [ ] Tested locally

### Automated Tests

```bash
bunx vitest run --silent='passed-only' packages/agent-runtime/src/executors/compressContext.test.ts
bunx vitest run --silent='passed-only' src/store/chat/utils/compression.test.ts src/store/chat/slices/message/replaceMessages.midTurnCompression.regression.test.ts
```

### Manual Verification

In a long conversation, trigger auto compression while a reply is still streaming. The in-flight assistant bubble should stay visible after the compressed-history card appears.

### Post-Deploy Verification

N/A

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [ ] Environment variables: N/A
- [ ] Redis / Edge Config / feature flags: N/A
- [ ] Database migration or data backfill: N/A
- [ ] Third-party console changes: N/A
- [ ] Rollback plan: N/A