### PR TITLE
🐛 fix(chat): stop gateway Stop from replaying drafts and leaving a stuck spinner

### DIFF
--- a/src/hooks/useOperationState.test.ts
+++ b/src/hooks/useOperationState.test.ts
@@ -109,6 +109,42 @@ describe('useOperationState', () => {
         expect(state.isGenerating).toBe(false);
       });
 
+      it('should return false when a running runtime op is marked isAborting', () => {
+        // LOBE-13794 regression: when a gateway Stop's device cancellation is
+        // unconfirmed, cancelOperation rolls the op back to `running` while
+        // keeping `isAborting: true`. Every loading selector excludes such ops;
+        // the per-message generating state must too, or the bubble keeps
+        // spinning forever after Stop.
+        const messageId = 'test-message-id';
+
+        act(() => {
+          useChatStore.setState({
+            operations: {
+              'op-1': {
+                id: 'op-1',
+                type: 'execServerAgentRuntime',
+                status: 'running',
+                context: { messageId },
+                abortController: new AbortController(),
+                metadata: { startTime: Date.now(), isAborting: true },
+              },
+            },
+            operationsByMessage: {
+              [messageId]: ['op-1'],
+            },
+          });
+        });
+
+        const { result } = renderHook(() => useOperationState(TEST_CONTEXT));
+
+        const state = result.current.getMessageOperationState(messageId);
+        expect(state.isGenerating).toBe(false);
+        // The unconfirmed cancel keeps the op `running` (with `isAborting`),
+        // so it is neither generating nor terminal-interrupted — the bubble
+        // just stops spinning instead of staying stuck.
+        expect(state.isInterrupted).toBe(false);
+      });
+
       it('should return false when no operations exist for the message', () => {
         const { result } = renderHook(() => useOperationState(TEST_CONTEXT));
 

--- a/src/hooks/useOperationState.ts
+++ b/src/hooks/useOperationState.ts
@@ -78,7 +78,14 @@ export const useOperationState = (context: ConversationContext): OperationState 
         const messageOps = operationIds.map((id) => operations[id]).filter(Boolean);
         const runningOps = messageOps.filter((op) => op.status === 'running');
 
-        const visibleRunningOps = runningOps.filter((op) => !op.metadata.visibleLoadingDone);
+        // `isAborting` ops are user-cancelled runs whose transport shutdown is
+        // still unconfirmed (e.g. a gateway interrupt the local device never
+        // acknowledged, see cancelOperation's rollback). Every loading selector
+        // already excludes them; the per-message generating state must too, or
+        // the bubble keeps spinning forever after a Stop (LOBE-13794).
+        const visibleRunningOps = runningOps.filter(
+          (op) => !op.metadata.isAborting && !op.metadata.visibleLoadingDone,
+        );
 
         const isGenerating = visibleRunningOps.some((op) =>
           AI_RUNTIME_OPERATION_TYPES.includes(op.type),

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -534,6 +534,60 @@ describe('ConversationLifecycle actions', () => {
         expect(sendMessageOperation?.metadata.inputSendErrorMsg).toBeUndefined();
       });
 
+      it('should clear the editor temp state after a gateway send persists the message', async () => {
+        // LOBE-13794 regression: the gateway branch returned straight after
+        // executeGatewayAgent resolved without clearing `inputEditorTempState`.
+        // A later Stop click then replayed that snapshot into the composer via
+        // cancelSendMessageInServer, which looked like the app re-sent the
+        // already-persisted message. The client path (`if (data)`) and the
+        // hetero branch (line ~1532) both clear it; the gateway branch must too.
+        const { result } = renderHook(() => useChatStore());
+        const inputEditorState = { root: { children: [], type: 'root', version: 1 } };
+        const executeGatewayAgentSpy = vi.fn().mockImplementation(async (params) => {
+          params.onMessageAccepted();
+          return {
+            assistantMessageId: 'assistant-gateway',
+            createdThreadId: undefined,
+            topicId: 'tpc_gateway',
+            userMessageId: 'user-gateway',
+          };
+        });
+
+        act(() => {
+          useChatStore.setState({
+            executeGatewayAgent: executeGatewayAgentSpy,
+            isGatewayModeEnabled: () => true,
+            mainInputEditor: {
+              getJSONState: vi.fn().mockReturnValue(inputEditorState),
+              setDocument: vi.fn(),
+              setJSONState: vi.fn(),
+            } as any,
+          });
+        });
+
+        await act(async () => {
+          await result.current.sendMessage({
+            context: createTestContext(),
+            editorData: inputEditorState as any,
+            message: 'Persisted via gateway',
+          });
+        });
+
+        const sendMessageOperation = Object.values(result.current.operations).find(
+          (operation) => operation.type === 'sendMessage',
+        );
+
+        // Prove the gateway branch actually ran and succeeded. (The real
+        // executeGatewayAgent completes its parent op at phase-1 hand-off; the
+        // mock doesn't simulate that, so the parent may still read `running`
+        // here — irrelevant to what this regression pins.)
+        expect(executeGatewayAgentSpy).toHaveBeenCalledOnce();
+
+        // The snapshot is dropped once persistence lands, so a later Stop can
+        // never replay it into the composer.
+        expect(sendMessageOperation?.metadata.inputEditorTempState).toBeNull();
+      });
+
       it('should restore the pre-send editor snapshot when a hetero send fails', async () => {
         // Same silent-discard shape as the gateway branch above: persistence
         // throws, the temp rows are cleaned up, and the typed text is gone.

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1779,6 +1779,15 @@ export class ConversationLifecycleActionImpl {
 
         notifyMessagePersisted();
 
+        // Clear editor temp state — the user's message is persisted by the
+        // time executeGatewayAgent resolves (execAgentTask persists both rows),
+        // so a later Stop click must NOT restore it into the input (would feel
+        // like the app re-sent the message). The hetero branch clears this at
+        // line 1532 for the same reason, and the client path's `if (data)` clear
+        // below covers its own; the gateway branch returns early here and never
+        // reached either, which is exactly what LOBE-13794 reproduced.
+        this.#get().updateOperationMetadata(operationId, { inputEditorTempState: null });
+
         return {
           assistantMessageId: result.assistantMessageId,
           createdThreadId: result.createdThreadId,


### PR DESCRIPTION
<!-- Brief and heads-up -->

Two defects on the interrupt path, both surfaced when clicking **Stop** on a Gateway-mode run (LOBE-13794):

| Before | After |
| ------ | ----- |
| After Stop, the already-persisted message text reappears in the composer (looks like the app re-sent it) | Composer stays empty |
| Assistant bubble keeps spinning after Stop when the gateway device-cancel is unconfirmed | Spinner stops immediately |

#### Root causes

1. **Draft replay** — the gateway send branch returned right after `executeGatewayAgent` resolved without clearing the operation's `inputEditorTempState`. A later Stop click replays that snapshot into the composer via `cancelSendMessageInServer`. The client branch clears the snapshot after persistence and the hetero branch does so explicitly; the gateway branch now clears it at the same point.
2. **Stuck spinner** — when a gateway Stop's device cancellation is unconfirmed, `cancelOperation` rolls the op back to `running` while keeping `isAborting: true`. Every loading selector excludes such ops, but the per-message `getMessageOperationState` did not, so the assistant bubble kept spinning forever. `visibleRunningOps` now filters `isAborting` like the rest of the loading surface.

#### Test

- [x] Tested locally
- [x] Added/updated tests
  - `conversationLifecycle.test.ts`: gateway send clears `inputEditorTempState` once persistence lands (LOBE-13794 regression)
  - `useOperationState.test.ts`: running runtime op with `isAborting` no longer reports `isGenerating`
  - Full suites green: `conversationLifecycle` (95), `useOperationState` (13), `conversationControl` + `cancel-functionality` + `generation/action` (134)

#### 🔗 Related Issue

Fixes LOBE-13794