### PR TITLE
🐛 fix(chat): drop stale mid-turn message refetches

### DIFF
--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -1018,6 +1018,54 @@ describe('createGatewayEventHandler', () => {
     expect(lifecycle.completeRun).toHaveBeenCalled();
   });
 
+  // tool_end queues a full-topic getMessages. step_start is not queued and
+  // immediately replaceMessages's the pushed snapshot. If the earlier fetch is
+  // still in flight, last-write-wins lets its older list wipe the next step
+  // (and any stream_chunks already applied to it).
+  it('does not let a slower tool_end refetch overwrite a later step_start snapshot', async () => {
+    const staleSnapshot = [
+      { id: 'user-1', role: 'user' },
+      { id: 'asst-1', role: 'assistant' },
+      { id: 'tool-1', role: 'tool' },
+    ] as unknown as UIChatMessage[];
+    const nextStepSnapshot = [
+      ...staleSnapshot,
+      { content: 'next step', id: 'asst-2', role: 'assistant' },
+    ] as unknown as UIChatMessage[];
+
+    let resolveFetch: ((messages: UIChatMessage[]) => void) | undefined;
+    vi.spyOn(messageService, 'getMessages').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'asst-1',
+      context,
+      operationId: 'op-1',
+    });
+
+    handler(makeEvent('tool_end', { isSuccess: true }));
+    await flush();
+    expect(messageService.getMessages).toHaveBeenCalled();
+
+    handler(makeEvent('step_start', { uiMessages: nextStepSnapshot }));
+    expect(store.replaceMessages).toHaveBeenCalledWith(
+      nextStepSnapshot,
+      expect.objectContaining({ action: 'gateway/step_start' }),
+    );
+
+    resolveFetch?.(staleSnapshot);
+    await flush();
+
+    const lastCall = vi.mocked(store.replaceMessages).mock.calls.at(-1);
+    expect(lastCall?.[0]).toEqual(nextStepSnapshot);
+    expect(lastCall?.[0]).not.toEqual(staleSnapshot);
+  });
+
   it('falls back to the streamed accumulator when the terminal snapshot carries no assistant text', async () => {
     vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
     const lifecycle = createLifecycle();

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -1066,6 +1066,51 @@ describe('createGatewayEventHandler', () => {
     expect(lastCall?.[0]).not.toEqual(staleSnapshot);
   });
 
+  // Hetero / old-server stream_start has no assistantMessage.id, so it
+  // resolves the next bubble from the fetch return value. If that fetch
+  // started before step_start and we still returned the stale list, chunks
+  // would target an id the store no longer has.
+  it('does not resolve the next assistant id from a dropped stale refetch', async () => {
+    const staleSnapshot = [
+      { id: 'user-1', role: 'user' },
+      { id: 'asst-1', role: 'assistant' },
+      { id: 'asst-stale', role: 'assistant' },
+    ] as unknown as UIChatMessage[];
+    const nextStepSnapshot = [
+      { id: 'user-1', role: 'user' },
+      { id: 'asst-1', role: 'assistant' },
+      { id: 'tool-1', role: 'tool' },
+      { content: 'next step', id: 'asst-2', role: 'assistant' },
+    ] as unknown as UIChatMessage[];
+
+    let resolveFetch: ((messages: UIChatMessage[]) => void) | undefined;
+    vi.spyOn(messageService, 'getMessages').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'asst-1',
+      context,
+      operationId: 'op-1',
+    });
+
+    handler(makeEvent('stream_start', { newStep: true }));
+    await flush();
+    expect(messageService.getMessages).toHaveBeenCalled();
+
+    handler(makeEvent('step_start', { uiMessages: nextStepSnapshot }));
+    resolveFetch?.(staleSnapshot);
+    await flush();
+
+    expect(store.associateMessageWithOperation).not.toHaveBeenCalledWith('asst-stale', 'op-1');
+    const lastCall = vi.mocked(store.replaceMessages).mock.calls.at(-1);
+    expect(lastCall?.[0]).toEqual(nextStepSnapshot);
+  });
+
   it('falls back to the streamed accumulator when the terminal snapshot carries no assistant text', async () => {
     vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
     const lifecycle = createLifecycle();

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -66,6 +66,10 @@ const loadGetExecutor = async () => {
  * `snapshotGeneration` drops a fetch that lost the race against a newer
  * snapshot on the same handler (unqueued `step_start` vs in-flight `tool_end`).
  * Last-write-wins would otherwise paint the older list over the next step.
+ *
+ * A dropped fetch returns `undefined` so callers that resolve an assistant id
+ * from the result (hetero / old-server `stream_start`) keep the current id
+ * instead of steering later chunks onto a row the store no longer has.
  */
 const fetchAndReplaceMessages = async (
   get: () => ChatStore,
@@ -81,14 +85,14 @@ const fetchAndReplaceMessages = async (
     skipWorks?: boolean;
     snapshotGeneration?: { current: number };
   },
-) => {
+): Promise<UIChatMessage[] | undefined> => {
   const skipWorks = options?.skipWorks;
   const snapshotGeneration = options?.snapshotGeneration;
   const started = snapshotGeneration?.current;
   const messages = await messageService.getMessages(
     skipWorks ? { ...context, skipWorks } : context,
   );
-  if (snapshotGeneration && snapshotGeneration.current !== started) return messages;
+  if (snapshotGeneration && snapshotGeneration.current !== started) return undefined;
   if (snapshotGeneration) snapshotGeneration.current += 1;
   get().replaceMessages(messages, { context, preserveWorks: skipWorks });
   return messages;

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -62,6 +62,10 @@ const loadGetExecutor = async () => {
  * Fetch messages from DB and replace them in the chat store's dbMessagesMap.
  * This updates the ConversationArea component via React subscription:
  *   dbMessagesMap → ConversationArea (messages prop) → ConversationStore → UI
+ *
+ * `snapshotGeneration` drops a fetch that lost the race against a newer
+ * snapshot on the same handler (unqueued `step_start` vs in-flight `tool_end`).
+ * Last-write-wins would otherwise paint the older list over the next step.
  */
 const fetchAndReplaceMessages = async (
   get: () => ChatStore,
@@ -75,12 +79,17 @@ const fetchAndReplaceMessages = async (
      * agent_runtime_end refetch recomputes them for real.
      */
     skipWorks?: boolean;
+    snapshotGeneration?: { current: number };
   },
 ) => {
   const skipWorks = options?.skipWorks;
+  const snapshotGeneration = options?.snapshotGeneration;
+  const started = snapshotGeneration?.current;
   const messages = await messageService.getMessages(
     skipWorks ? { ...context, skipWorks } : context,
   );
+  if (snapshotGeneration && snapshotGeneration.current !== started) return messages;
+  if (snapshotGeneration) snapshotGeneration.current += 1;
   get().replaceMessages(messages, { context, preserveWorks: skipWorks });
   return messages;
 };
@@ -500,6 +509,22 @@ export const createGatewayEventHandler = (
     return processingChain;
   };
 
+  // Bumped on every snapshot this handler applies. `step_start` is not queued,
+  // so an earlier `tool_end` getMessages can still resolve after it and would
+  // otherwise last-write-wins the older list over the next step.
+  const snapshotGeneration = { current: 0 };
+
+  const refreshMessagesFromDb = (options?: { skipWorks?: boolean }) =>
+    fetchAndReplaceMessages(get, context, { ...options, snapshotGeneration });
+
+  const applyPushedSnapshot = (
+    messages: UIChatMessage[],
+    params: { action?: string; preserveWorks?: boolean },
+  ) => {
+    snapshotGeneration.current += 1;
+    get().replaceMessages(messages, { context, ...params });
+  };
+
   const writeTopicStatus = (status: 'running' | 'waitingForHuman') => {
     if (!context.topicId) return;
     const statusWrite = get().updateTopicStatus?.({
@@ -602,7 +627,7 @@ export const createGatewayEventHandler = (
     const bootstrapPromise = enqueue(async () => {
       // A preceding queued tools_calling handler may have brought the row in.
       if (!getToolMessageByCallId(data.toolCallId)) {
-        await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+        await refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
       }
       reconciled = applyLatestToolState(data.toolCallId, true);
     });
@@ -695,9 +720,7 @@ export const createGatewayEventHandler = (
                 // Older servers send only `{ id }` — fall back to a DB read.
                 // The row is inserted before stream_start is published, so the
                 // fetch is guaranteed to bring it into the store.
-                await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(
-                  console.error,
-                );
+                await refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
               }
             }
           }
@@ -726,7 +749,7 @@ export const createGatewayEventHandler = (
           // dispatch to it, and (b) resolves the next-step assistant id for
           // the `newStep` fallback.
           if (!newAssistantMessageId) {
-            const messages = await fetchAndReplaceMessages(get, context, {
+            const messages = await refreshMessagesFromDb({
               skipWorks: true,
             }).catch((error) => {
               console.error(error);
@@ -870,7 +893,7 @@ export const createGatewayEventHandler = (
             // lands — a fire-and-forget fetch would let the next event overtake
             // it and dispatch onto a message the store doesn't have yet.
             if ((data as any).toolMessageIds) {
-              await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+              await refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
             }
           }
         });
@@ -959,7 +982,7 @@ export const createGatewayEventHandler = (
         // both the inline tool and global InterventionBar see `pending`, even
         // when this request raced ahead of the provider's tools_calling event.
         enqueue(async () => {
-          await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+          await refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
           hasStreamedContent = true;
         });
         break;
@@ -1018,7 +1041,7 @@ export const createGatewayEventHandler = (
           // Successful Web submits, explicit cancellation, producer timeout,
           // and session teardown all converge on the durable tool row before
           // this refresh. Do not infer the terminal state from identifier.
-          await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+          await refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
           if (pendingInterventionToolCallIds.size === 0) writeTopicStatus('running');
         });
         break;
@@ -1047,9 +1070,8 @@ export const createGatewayEventHandler = (
         if (Array.isArray(data?.uiMessages)) {
           // step_start snapshots are fetched with `skipWorks` server-side —
           // graft the already-rendered works back so chips don't flicker.
-          get().replaceMessages(data.uiMessages, {
+          applyPushedSnapshot(data.uiMessages, {
             action: 'gateway/step_start',
-            context,
             preserveWorks: true,
           });
         }
@@ -1094,7 +1116,7 @@ export const createGatewayEventHandler = (
         enqueue(async () => {
           const maybeRefresh = shouldSkipMessageFetch(event, runtimeType)
             ? Promise.resolve()
-            : fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+            : refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
           const payload = unwrapToolPayload(data?.payload);
           const result = data?.result as
             { state?: unknown; workRegistration?: unknown } | undefined;
@@ -1175,7 +1197,7 @@ export const createGatewayEventHandler = (
               sourceType: 'client.gateway.step_complete',
             });
             if (!shouldSkipMessageFetch(event, runtimeType)) {
-              await fetchAndReplaceMessages(get, context, { skipWorks: true }).catch(console.error);
+              await refreshMessagesFromDb({ skipWorks: true }).catch(console.error);
             }
           });
         }
@@ -1227,9 +1249,8 @@ export const createGatewayEventHandler = (
             // turn's optimistic rows until refresh. Keep terminalMessages for
             // this run's notification, but do not mutate its successor's store.
             if (!isSuperseded) {
-              get().replaceMessages(data.uiMessages, {
+              applyPushedSnapshot(data.uiMessages, {
                 action: 'gateway/agent_runtime_end',
-                context,
               });
             }
           } else if (
@@ -1255,7 +1276,7 @@ export const createGatewayEventHandler = (
             // messages are the only in-memory state and they need the
             // refetch to be reconciled with the server-side rows.
           } else if (!isSuperseded) {
-            await fetchAndReplaceMessages(get, context).catch(console.error);
+            await refreshMessagesFromDb().catch(console.error);
           }
 
           if (runtimeType === 'gateway' && shouldRefreshWorkViews) {
@@ -1325,7 +1346,7 @@ export const createGatewayEventHandler = (
         // Remote hetero agent (openclaw / hermes) wrote a message to DB via
         // `lh notify`. DB is the source of truth — just refresh the message list.
         enqueue(async () => {
-          await fetchAndReplaceMessages(get, context).catch(console.error);
+          await refreshMessagesFromDb().catch(console.error);
         });
         break;
       }
@@ -1384,7 +1405,7 @@ export const createGatewayEventHandler = (
             get().replaceMessages(updateResult.messages, { context });
           } else {
             // Fallback when the mutation response doesn't include messages.
-            await fetchAndReplaceMessages(get, context).catch(console.error);
+            await refreshMessagesFromDb().catch(console.error);
           }
 
           // Then overlay the inline error. This ensures the UI always shows the


### PR DESCRIPTION
#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A — Discord report of mid-turn messages disappearing, then coming back after wait / refresh / send.

#### Description of Change

`tool_end` queues a full-topic `getMessages`. `step_start` is not queued and immediately `replaceMessages` the pushed snapshot. If the earlier fetch is still in flight, last-write-wins paints the older list over the next step (and any `stream_chunk`s already applied to it).

This PR gives the gateway handler a snapshot generation: applying `step_start` / terminal snapshots bumps it, and a fetch that started on an older generation is dropped instead of replacing the store.

#### How to Test

Regression in `gatewayEventHandler.test.ts`: hold `tool_end`'s `getMessages`, apply a later `step_start` snapshot that adds the next assistant, then resolve the stale fetch. The store must keep the `step_start` list.