### PR TITLE
🐛 fix(cli): match the canonical query contract and restrict the write log

### DIFF
--- a/apps/cli/src/runtime/LocalMessageStore.test.ts
+++ b/apps/cli/src/runtime/LocalMessageStore.test.ts
@@ -42,8 +42,8 @@ describe('LocalMessageStore query scoping', () => {
 
   it('keeps delegated-agent replies in a concrete-topic read', () => {
     const store = new LocalMessageStore();
-    store.insert(base);
-    store.insert({ ...base, agentId: 'delegate-9', content: 'callAgent reply' });
+    store.insert(base, 'id-a');
+    store.insert({ ...base, agentId: 'delegate-9', content: 'callAgent reply' }, 'id-b');
 
     // A concrete topic IS the conversation boundary and may legitimately hold
     // messages from several agents. Scoping a topic read by agentId deletes
@@ -71,8 +71,8 @@ describe('LocalMessageStore query scoping', () => {
 
   it('returns a thread together with its parent messages', () => {
     const store = new LocalMessageStore();
-    const parent = store.insert({ ...base, content: 'the message the thread hangs off' });
-    store.insert({ ...base, content: 'in thread', threadId: 'thread-1' });
+    const parent = store.insert({ ...base, content: 'the message the thread hangs off' }, 'id-a');
+    store.insert({ ...base, content: 'in thread', threadId: 'thread-1' }, 'id-b');
     store.registerThreadParents('thread-1', [parent.id]);
 
     // The server resolves the thread's source message and returns it alongside
@@ -96,16 +96,82 @@ describe('LocalMessageStore query scoping', () => {
     ).toEqual(['in thread']);
   });
 
-  it('orders by creation, keeping insertion order within the same millisecond', () => {
+  it('breaks a timestamp tie by id, not by arrival order', () => {
     const store = new LocalMessageStore();
-    for (const content of ['a', 'b', 'c', 'd']) store.insert({ ...base, content });
+    // Inserted out of id order, all in the same millisecond — what a parallel
+    // tool batch produces.
+    store.insert({ ...base, content: 'third' }, 'id-c');
+    store.insert({ ...base, content: 'first' }, 'id-a');
+    store.insert({ ...base, content: 'second' }, 'id-b');
 
-    expect(store.query({ agentId: 'agent-1', topicId: 'topic-1' }).map((m) => m.content)).toEqual([
-      'a',
-      'b',
-      'c',
-      'd',
+    // `queryWithWhere` orders `(createdAt, id)`. Ordering by arrival instead
+    // would feed the next LLM step a different sequence than the persisted
+    // transcript — and a different one again after a restart re-hydrates them.
+    expect(store.query({ topicId: 'topic-1' }).map((m) => m.content)).toEqual([
+      'first',
+      'second',
+      'third',
     ]);
+  });
+
+  it('survives a rehydration in the same order', () => {
+    const first = new LocalMessageStore();
+    first.insert({ ...base, content: 'b' }, 'id-b');
+    first.insert({ ...base, content: 'a' }, 'id-a');
+    const before = first.query({ topicId: 'topic-1' });
+
+    // Hydrated in the opposite order, as a fresh process reading them back.
+    const second = new LocalMessageStore();
+    second.hydrate([...before].reverse());
+
+    expect(second.query({ topicId: 'topic-1' }).map((m) => m.id)).toEqual(
+      before.map((m) => m.id),
+    );
+  });
+});
+
+describe('LocalMessageStore pagination', () => {
+  const fill = (store: LocalMessageStore, count: number) => {
+    for (let index = 0; index < count; index++) {
+      // Zero-padded so id order matches creation order.
+      store.insert({ ...base, content: `m${index}` }, `id-${String(index).padStart(4, '0')}`);
+    }
+  };
+
+  it('returns the newest page, not everything, at the canonical default', () => {
+    const store = new LocalMessageStore();
+    fill(store, 1200);
+
+    const messages = store.query({ topicId: 'topic-1' });
+
+    // `MessageModel.query` defaults to the newest 1,000 rows. Returning all
+    // 1,200 would give the device a wider context than the server ever has,
+    // and grow every per-step re-query without bound.
+    expect(messages).toHaveLength(1000);
+    expect(messages[0].content).toBe('m200');
+    expect(messages.at(-1)?.content).toBe('m1199');
+  });
+
+  it('honours an explicit page size and offset from the newest end', () => {
+    const store = new LocalMessageStore();
+    fill(store, 10);
+
+    expect(store.query({ pageSize: 3, topicId: 'topic-1' }).map((m) => m.content)).toEqual([
+      'm7',
+      'm8',
+      'm9',
+    ]);
+    // `current: 1` is the page before the newest one.
+    expect(
+      store.query({ current: 1, pageSize: 3, topicId: 'topic-1' }).map((m) => m.content),
+    ).toEqual(['m4', 'm5', 'm6']);
+  });
+
+  it('returns nothing past the last page', () => {
+    const store = new LocalMessageStore();
+    fill(store, 5);
+
+    expect(store.query({ current: 5, pageSize: 3, topicId: 'topic-1' })).toEqual([]);
   });
 });
 

--- a/apps/cli/src/runtime/LocalMessageStore.ts
+++ b/apps/cli/src/runtime/LocalMessageStore.ts
@@ -31,13 +31,13 @@ import { merge, nanoid } from '@lobechat/utils';
  *   - `flatten` runs the same `@lobechat/conversation-flow` parser the server
  *     adapter uses, so grouped/tool rows collapse identically.
  */
+/** Same default as `MessageModel.query`. */
+const DEFAULT_PAGE_SIZE = 1000;
+
 export class LocalMessageStore {
   private readonly messages = new Map<string, UIChatMessage>();
   /** `clientId` → message id, for idempotent re-creation of one logical step. */
   private readonly byClientId = new Map<string, string>();
-  /** Monotonic tiebreaker so messages created in the same millisecond keep insertion order. */
-  private sequence = 0;
-  private readonly sequenceById = new Map<string, number>();
   /**
    * `threadId` → the ids a thread read must include alongside its own rows.
    *
@@ -75,7 +75,6 @@ export class LocalMessageStore {
     } as UIChatMessage;
 
     this.messages.set(id, message);
-    this.sequenceById.set(id, this.sequence++);
     if (clientId) this.byClientId.set(clientId, id);
 
     return message;
@@ -87,7 +86,6 @@ export class LocalMessageStore {
 
   delete(id: string): void {
     this.messages.delete(id);
-    this.sequenceById.delete(id);
     for (const [clientId, mappedId] of this.byClientId) {
       if (mappedId === id) this.byClientId.delete(clientId);
     }
@@ -229,12 +227,19 @@ export class LocalMessageStore {
 
     matches.sort((a, b) => {
       if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
-      return (this.sequenceById.get(a.id) ?? 0) - (this.sequenceById.get(b.id) ?? 0);
+      // By id, matching `queryWithWhere`'s `(createdAt, id)` ordering — not by
+      // local insertion order. A parallel tool batch writes several rows in the
+      // same millisecond, and ordering those by arrival would feed the next LLM
+      // step a different sequence than the persisted transcript, and a
+      // different one again after a restart re-hydrates them.
+      return a.id < b.id ? -1 : 1;
     });
 
-    if (!options.flatten) return matches;
+    const page = this.paginate(matches, params);
 
-    const { flatList } = parse(matches as never);
+    if (!options.flatten) return page;
+
+    const { flatList } = parse(page as never);
     return flatList as unknown as UIChatMessage[];
   }
 
@@ -245,10 +250,7 @@ export class LocalMessageStore {
 
   /** Seed prior conversation history fetched once at run start. */
   hydrate(messages: UIChatMessage[]): void {
-    for (const message of messages) {
-      this.messages.set(message.id, message);
-      this.sequenceById.set(message.id, this.sequence++);
-    }
+    for (const message of messages) this.messages.set(message.id, message);
   }
 
   get size(): number {
@@ -257,5 +259,32 @@ export class LocalMessageStore {
 
   private matchesScope(value: string | null | undefined, filter: string | undefined): boolean {
     return filter ? value === filter : value === null || value === undefined;
+  }
+
+  /**
+   * Take the same page the canonical model would.
+   *
+   * `MessageModel.query` defaults to the NEWEST 1,000 rows — it orders
+   * descending, applies `limit`/`offset`, then restores ascending order. A
+   * local store that always returned everything would drift further from the
+   * server's context with every step of a long run, and grow the per-step
+   * re-query and flatten without bound.
+   *
+   * The canonical model additionally aligns a truncated page's lower boundary
+   * to a round start. That is deliberately not reproduced: its stated purpose
+   * is to stop the RENDERER stranding sibling chains, and reproducing it
+   * approximately would be worse than not at all. It only differs past the
+   * page size in a single conversation.
+   */
+  private paginate(matches: UIChatMessage[], params: QueryMessagesInput): UIChatMessage[] {
+    const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+    const current = params.current ?? 0;
+    if (pageSize <= 0) return [];
+
+    // Page from the newest end, then present ascending.
+    const end = matches.length - current * pageSize;
+    if (end <= 0) return [];
+
+    return matches.slice(Math.max(0, end - pageSize), end);
   }
 }

--- a/apps/cli/src/runtime/MessageWriteQueue.test.ts
+++ b/apps/cli/src/runtime/MessageWriteQueue.test.ts
@@ -195,6 +195,46 @@ describe('MessageWriteQueue', () => {
     await queue.drain();
   });
 
+  it('creates the log readable only by its owner', async () => {
+    const queue = new MessageWriteQueue({
+      logPath: path.join(dir, 'nested', 'pending.jsonl'),
+      sink: { flush: () => new Promise<void>(() => {}) },
+    });
+
+    await queue.enqueue(op('a'));
+
+    // Every pending operation carries raw conversation content, and a create
+    // may carry tool arguments. The default mode leaves that readable by every
+    // other user on a shared host.
+    const stat = await fs.stat(path.join(dir, 'nested', 'pending.jsonl'));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('keeps the log owner-only after a confirmed batch rewrites it', async () => {
+    let resolveFirst: () => void = () => {};
+    let calls = 0;
+    const queue = new MessageWriteQueue({
+      logPath,
+      sink: {
+        flush: async () => {
+          calls += 1;
+          if (calls === 1) await new Promise<void>((r) => (resolveFirst = r));
+        },
+      },
+    });
+
+    await queue.enqueue(op('a'));
+    await vi.waitFor(() => expect(calls).toBe(1));
+    await queue.enqueue(op('b'));
+    resolveFirst();
+    await vi.waitFor(async () => {
+      // The confirm path replaces the file; a fresh one must not widen it back.
+      const stat = await fs.stat(logPath).catch(() => null);
+      expect(stat === null || (stat.mode & 0o777) === 0o600).toBe(true);
+    });
+    await queue.drain();
+  });
+
   it('recovers the intact entries when the last log line was truncated', async () => {
     // A process killed mid-append leaves a partial trailing line. The entries
     // before it are still deliverable and must not be thrown away with it.

--- a/apps/cli/src/runtime/MessageWriteQueue.ts
+++ b/apps/cli/src/runtime/MessageWriteQueue.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 
 import { MAX_SYNC_BATCH, type MessageSyncOperation, type MessageSyncSink } from './messageSync';
 
+/** Owner-only: the log holds raw conversation content until it is replicated. */
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
 const FLUSH_INTERVAL_MS = 250;
 const MAX_RETRIES = 5;
 const INITIAL_BACKOFF_MS = 500;
@@ -236,8 +240,16 @@ export class MessageWriteQueue {
     if (!logPath) return;
 
     this.logWrites = this.logWrites.then(async () => {
-      await fs.mkdir(path.dirname(logPath), { recursive: true });
-      await fs.appendFile(logPath, `${JSON.stringify(operation)}\n`, 'utf8');
+      await fs.mkdir(path.dirname(logPath), { mode: DIR_MODE, recursive: true });
+      // Owner-only. Every pending operation carries raw conversation content,
+      // and a create may carry tool arguments and whatever they contain. The
+      // default (0o666 less the umask, so usually 0o644) leaves that readable
+      // by every other user on a shared host. `mode` applies on creation, so
+      // this is set on the first append.
+      await fs.appendFile(logPath, `${JSON.stringify(operation)}\n`, {
+        encoding: 'utf8',
+        mode: FILE_MODE,
+      });
     });
 
     try {
@@ -253,7 +265,10 @@ export class MessageWriteQueue {
   private async writeAtomic(filePath: string, content: string): Promise<void> {
     const tmp = `${filePath}.${process.pid}.tmp`;
     try {
-      await fs.writeFile(tmp, content, 'utf8');
+      // Same restriction as the append path — the rewrite replaces the log with
+      // a fresh file, so creating it world-readable would undo it every time a
+      // batch is confirmed.
+      await fs.writeFile(tmp, content, { encoding: 'utf8', mode: FILE_MODE });
       await fs.rename(tmp, filePath);
     } catch (error) {
       await fs.rm(tmp, { force: true }).catch(() => {});


### PR DESCRIPTION
The second review pass on #18908 landed three P2s after it was merged. All three are real; this is the follow-up.

**Ordering broke the contract the class documents.** It promised `(createdAt, id)` in its own doc comment and then sorted equal timestamps by local arrival order. A parallel tool batch writes several rows in the same millisecond, so the device would feed the next LLM step a different sequence than the persisted transcript — and a different one again once a restart re-hydrated them in another order. Ties now break on id and the arrival counter is gone.

**`query` ignored `current` and `pageSize`** and returned every match, while `MessageModel.query` returns the newest 1,000. A long run would drift steadily wider than the context the server would have built, and every per-step re-query and flatten would grow without bound. It now takes the same page from the newest end.

The canonical model additionally aligns a truncated page's lower boundary to a round start; that is deliberately **not** reproduced. Its stated purpose is to stop the renderer stranding sibling chains, and an approximate copy would be worse than none — noted in the code rather than left as a silent difference.

**The write log was created at the default mode** (0o666 less the umask, so usually 0o644), leaving it readable by every other user on a shared host. It holds raw conversation content until replication confirms it, and a create carries tool arguments and whatever they contain. Log and its atomic replacement are now `0o600` and the directory `0o700` — the replacement matters as much as the append, since confirming a batch rewrites the file.

#### Test

33 passing (was 30). New: the id tie-break, stability across a rehydration in the opposite order, the newest-page default at 1,200 rows, explicit page size and offset, reading past the last page, and both log-permission paths (first append and the post-confirm rewrite).

Two existing tests relied on insertion order with generated ids and now pass explicit ids — the ordering they asserted is precisely what changed, so leaving them as they were would have meant asserting the old contract.

Lint clean, type-check adds no errors.

#### Note

`#18908` was merged while this was being written, so this is a follow-up branch rather than more commits on that one. Nothing here is user-visible: the module still has no consumer, which is also why the three were safe to merge ahead of the fix.

#### 🔗 Related Issue

Follow-up to #18908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)