### PR TITLE
🐛 fix(agent-runtime): auto-recover operations whose host died mid-step

### DIFF
--- a/apps/server/src/router-hono/agent/handlers/reapOperations.ts
+++ b/apps/server/src/router-hono/agent/handlers/reapOperations.ts
@@ -1,0 +1,48 @@
+import debug from 'debug';
+import type { Context } from 'hono';
+
+import { getServerDB } from '@/database/core/db-adaptor';
+import { StaleOperationReaper } from '@/server/services/agentRuntime';
+
+const log = debug('lobe-server:agent:reap-operations');
+
+/**
+ * Vercel cron entry point for recovering operations whose executing host died
+ * mid-step — see {@link StaleOperationReaper}.
+ *
+ * Auth: `bearerSecretAuth(CRON_SECRET)` on the route, matching the existing
+ * `/api/agent/gateway` cron.
+ *
+ * Query params (all optional, mainly for manual runs and incident response):
+ * - `staleAfterMs` — override the lease window
+ * - `limit` — cap the operations examined in this tick
+ * - `maxRedriveAttempts` — override the per-operation redrive budget
+ */
+export async function reapOperations(c: Context): Promise<Response> {
+  const startedAt = Date.now();
+
+  const num = (name: string): number | undefined => {
+    const raw = c.req.query(name);
+    if (raw === undefined) return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  };
+
+  try {
+    const serverDB = await getServerDB();
+    const result = await new StaleOperationReaper(serverDB).sweep({
+      limit: num('limit'),
+      maxRedriveAttempts: num('maxRedriveAttempts'),
+      staleAfterMs: num('staleAfterMs'),
+    });
+
+    log('sweep completed in %dms: %O', Date.now() - startedAt, result);
+
+    return c.json({ ...result, executionTime: Date.now() - startedAt, success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[reap-operations] %O', error);
+
+    return c.json({ error: message, executionTime: Date.now() - startedAt, success: false }, 500);
+  }
+}

--- a/apps/server/src/router-hono/agent/index.ts
+++ b/apps/server/src/router-hono/agent/index.ts
@@ -13,6 +13,7 @@ import { messengerInstall } from './handlers/messengerInstall';
 import { messengerOAuthCallback } from './handlers/messengerOAuthCallback';
 import { messengerWebhook } from './handlers/messengerWebhook';
 import { platformWebhook } from './handlers/platformWebhook';
+import { reapOperations } from './handlers/reapOperations';
 import { runStep, runStepHealth } from './handlers/runStep';
 import { subAgentCallback } from './handlers/subAgentCallback';
 import { toolResult } from './handlers/toolResult';
@@ -56,6 +57,13 @@ app.get(
   '/gateway',
   bearerSecretAuth(() => process.env.CRON_SECRET),
   gatewayCron,
+);
+
+// GET /api/agent/reap-operations — Vercel cron entry point (Bearer CRON_SECRET)
+app.get(
+  '/reap-operations',
+  bearerSecretAuth(() => process.env.CRON_SECRET),
+  reapOperations,
 );
 
 // POST /api/agent/gateway/start — non-Vercel ensureRunning (Bearer KEY_VAULTS_SECRET)

--- a/apps/server/src/services/agentRuntime/AbandonOperationService.ts
+++ b/apps/server/src/services/agentRuntime/AbandonOperationService.ts
@@ -166,19 +166,43 @@ export class AbandonOperationService {
     // path must opt in when this flag is present.
     const includeShareVisitor = Boolean(metadata.streamOwnerUserId);
 
-    if (metadata.userId && metadata.assistantMessageId) {
-      try {
-        const messageModel = new MessageModel(
-          this.db,
-          metadata.userId,
-          metadata.workspaceId,
-          undefined,
-          { includeShareVisitor },
-        );
-        await messageModel.update(metadata.assistantMessageId, { error });
-        result.assistantMessageUpdated = true;
-      } catch (e) {
-        log('[%s] assistant message update failed (non-fatal): %O', operationId, e);
+    if (metadata.userId) {
+      // `assistantMessageId` is only set once a step has created its
+      // placeholder. A step killed before its first token — the usual shape
+      // when the host is recycled mid-LLM-call — never created one, so there
+      // is nothing to mark and the turn ends up carrying no error at all. The
+      // client keys its retry affordance off `message.error`, so that silence
+      // is exactly why an abandoned turn renders as frozen rather than failed.
+      // Fall back to the conversation's tail message so the failure always has
+      // somewhere to land.
+      const targetMessageId =
+        metadata.assistantMessageId ??
+        (metadata.topicId
+          ? await this.resolveTailMessageId(
+              {
+                threadId: metadata.threadId,
+                topicId: metadata.topicId,
+                userId: metadata.userId,
+                workspaceId: metadata.workspaceId,
+              },
+              includeShareVisitor,
+            )
+          : undefined);
+
+      if (targetMessageId) {
+        try {
+          const messageModel = new MessageModel(
+            this.db,
+            metadata.userId,
+            metadata.workspaceId,
+            undefined,
+            { includeShareVisitor },
+          );
+          await messageModel.update(targetMessageId, { error });
+          result.assistantMessageUpdated = true;
+        } catch (e) {
+          log('[%s] assistant message update failed (non-fatal): %O', operationId, e);
+        }
       }
     }
 
@@ -206,6 +230,32 @@ export class AbandonOperationService {
         });
       } catch (e) {
         log('[%s] abandoned op lifecycle dispatch failed (non-fatal): %O', operationId, e);
+      }
+    }
+
+    // Safety net for the durable row. `dispatchHooks` owns the rich terminal
+    // write (step count, usage, cost, traceS3Key) via `persistCompletion`, but
+    // it only runs behind the guard above: a sub-agent, a missing
+    // `metadata.userId`, or a state whose `status` is not one of
+    // running/waiting_* (e.g. a step boundary persisted as `idle`) all skip it
+    // silently, and a throw inside it is swallowed as non-fatal. Any of those
+    // used to leave the operation `running` forever — nothing else retires a
+    // non-Goal op, so it stayed live on the dashboard and blocked its own
+    // recovery. `settleRunning` is idempotent and only matches rows still in
+    // `running`, so it cannot overwrite the richer outcome when the dispatch
+    // did happen.
+    if (metadata.userId) {
+      try {
+        const settled = await new AgentOperationModel(
+          this.db,
+          metadata.userId,
+          metadata.workspaceId,
+        ).settleRunning(operationId, 'error');
+        if (settled) {
+          log('[%s] durable row settled by abandon safety net', operationId);
+        }
+      } catch (e) {
+        log('[%s] abandon safety-net settle failed (non-fatal): %O', operationId, e);
       }
     }
 
@@ -340,6 +390,32 @@ export class AbandonOperationService {
       result.assistantMessageUpdated = true;
     } catch (e) {
       log('[%s] no-state abandon: assistant message update failed (non-fatal): %O', operationId, e);
+    }
+  }
+
+  /**
+   * Anchor for an abandonment error when the dying step never created its own
+   * assistant placeholder: the latest main-chain message of the run.
+   *
+   * Reuses the same spine query the runtime itself uses to pick a turn's
+   * continuation point, so the error lands on the node the client is actually
+   * rendering as the tail rather than on a tool child or a stale fork.
+   */
+  private async resolveTailMessageId(
+    params: { threadId?: string | null; topicId: string; userId: string; workspaceId?: string },
+    includeShareVisitor: boolean,
+  ): Promise<string | undefined> {
+    try {
+      const messageModel = new MessageModel(this.db, params.userId, params.workspaceId, undefined, {
+        includeShareVisitor,
+      });
+      return await messageModel.getLatestSpineMessageId({
+        threadId: params.threadId ?? null,
+        topicId: params.topicId,
+      });
+    } catch (e) {
+      log('[%s] tail message lookup failed (non-fatal): %O', params.topicId, e);
+      return undefined;
     }
   }
 

--- a/apps/server/src/services/agentRuntime/AbandonOperationService.ts
+++ b/apps/server/src/services/agentRuntime/AbandonOperationService.ts
@@ -112,9 +112,12 @@ export class AbandonOperationService {
     result.found = true;
 
     const metadata = (state.metadata ?? {}) as {
+      agentId?: string;
       assistantMessageId?: string;
       isSubAgent?: boolean;
+      model?: string;
       orchestrationRole?: 'supervisor' | 'member';
+      provider?: string;
       /** Present only for shared-agent visitor runs (visitor owns the stream). */
       streamOwnerUserId?: string;
       threadId?: string | null;
@@ -167,18 +170,38 @@ export class AbandonOperationService {
     const includeShareVisitor = Boolean(metadata.streamOwnerUserId);
 
     if (metadata.userId) {
-      // `assistantMessageId` is only set once a step has created its
-      // placeholder. A step killed before its first token — the usual shape
-      // when the host is recycled mid-LLM-call — never created one, so there
-      // is nothing to mark and the turn ends up carrying no error at all. The
-      // client keys its retry affordance off `message.error`, so that silence
-      // is exactly why an abandoned turn renders as frozen rather than failed.
-      // Fall back to the conversation's tail message so the failure always has
-      // somewhere to land.
-      const targetMessageId =
-        metadata.assistantMessageId ??
-        (metadata.topicId
-          ? await this.resolveTailMessageId(
+      const messageModel = new MessageModel(
+        this.db,
+        metadata.userId,
+        metadata.workspaceId,
+        undefined,
+        { includeShareVisitor },
+      );
+
+      try {
+        if (metadata.assistantMessageId) {
+          // The dying step got as far as creating its placeholder, so the
+          // failure belongs on exactly that row.
+          await messageModel.update(metadata.assistantMessageId, { error });
+          result.assistantMessageUpdated = true;
+        } else if (metadata.topicId) {
+          // No placeholder: the step was killed before its first token, which
+          // is the usual shape when the host is recycled mid-LLM-call. The
+          // turn would otherwise carry no error anywhere, and the client keys
+          // its failure banner and retry action off `message.error` — that
+          // silence is exactly why an abandoned turn renders as frozen rather
+          // than failed.
+          //
+          // A fresh assistant row rather than marking the conversation tail:
+          // the tail here is either the user's own turn, whose renderer reads
+          // `error` for nothing but the double-click-to-edit guard and so
+          // would show the user nothing at all, or a *previous* assistant turn
+          // that genuinely succeeded and must not be relabelled as failed.
+          await messageModel.create({
+            agentId: metadata.agentId,
+            content: '',
+            error,
+            parentId: await this.resolveTailMessageId(
               {
                 threadId: metadata.threadId,
                 topicId: metadata.topicId,
@@ -186,23 +209,17 @@ export class AbandonOperationService {
                 workspaceId: metadata.workspaceId,
               },
               includeShareVisitor,
-            )
-          : undefined);
-
-      if (targetMessageId) {
-        try {
-          const messageModel = new MessageModel(
-            this.db,
-            metadata.userId,
-            metadata.workspaceId,
-            undefined,
-            { includeShareVisitor },
-          );
-          await messageModel.update(targetMessageId, { error });
+            ),
+            model: metadata.model,
+            provider: metadata.provider,
+            role: 'assistant',
+            threadId: metadata.threadId ?? null,
+            topicId: metadata.topicId,
+          });
           result.assistantMessageUpdated = true;
-        } catch (e) {
-          log('[%s] assistant message update failed (non-fatal): %O', operationId, e);
         }
+      } catch (e) {
+        log('[%s] assistant failure row write failed (non-fatal): %O', operationId, e);
       }
     }
 

--- a/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
+++ b/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
@@ -135,10 +135,10 @@ export class StaleOperationReaper {
   private async listStaleRunning(staleBefore: Date, limit: number) {
     return (
       this.db
+        // Only what recovery needs: everything else about the run is read from
+        // the coordinator state, and the abandon path re-reads the row itself.
         .select({
           id: agentOperations.id,
-          threadId: agentOperations.threadId,
-          topicId: agentOperations.topicId,
           userId: agentOperations.userId,
           workspaceId: agentOperations.workspaceId,
         })

--- a/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
+++ b/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
@@ -1,0 +1,261 @@
+import type { AgentState } from '@lobechat/agent-runtime';
+import debug from 'debug';
+import { and, asc, eq, isNull, lt, or } from 'drizzle-orm';
+import urlJoin from 'url-join';
+
+import { AgentOperationModel } from '@/database/models/agentOperation';
+import { agentOperations } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
+import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime/AgentRuntimeCoordinator';
+import { QueueService } from '@/server/services/queue';
+
+import { AbandonOperationService } from './AbandonOperationService';
+
+const log = debug('lobe-server:stale-operation-reaper');
+
+/**
+ * How long an operation may go without refreshing its durable liveness lease
+ * before this sweep treats it as dead.
+ *
+ * `AgentRuntimeService.startStepLockHeartbeat` touches the row every
+ * `STEP_LOCK_HEARTBEAT_MS * DURABLE_LEASE_HEARTBEAT_EVERY_TICKS` = 90s while a
+ * step holds the step lock, so five minutes is three missed beats: comfortably
+ * past jitter, and far tighter than the 30-minute in-flight window the gateway
+ * watchdog has to use (it can only reason about stream events, which stop for
+ * legitimately slow first-token latency too).
+ */
+const DEFAULT_STALE_AFTER_MS = 5 * 60_000;
+
+/**
+ * Redriving costs a real LLM call, so a step that dies deterministically
+ * (poison payload, an input that reliably OOMs the host) must not be retried
+ * forever. Past this budget the operation is abandoned with a user-visible
+ * error instead.
+ */
+const DEFAULT_MAX_REDRIVE_ATTEMPTS = 3;
+
+/** Bound the work of a single cron tick so one sweep cannot run long. */
+const DEFAULT_LIMIT = 50;
+
+export interface ReapStaleOperationsParams {
+  limit?: number;
+  maxRedriveAttempts?: number;
+  staleAfterMs?: number;
+}
+
+export interface ReapStaleOperationsResult {
+  /** Operations retired with a user-visible error (no state, or budget spent). */
+  abandoned: number;
+  /** Candidates whose lease was refreshed between select and claim. */
+  alive: number;
+  examined: number;
+  /** Operations whose next step was re-queued. */
+  redriven: number;
+}
+
+/**
+ * Periodic recovery for operations whose executing host died mid-step.
+ *
+ * A serverless instance can be recycled while it owns a step. When that
+ * happens nothing else notices: QStash already ACKed the delivery that started
+ * the step (so it never redelivers), the step lock simply expires, and only
+ * `services/goal` ever calls `settleStaleRunning` — a chat/bot/task operation
+ * has no reaper at all. The row stays `running` forever and the conversation
+ * freezes with no error and no way to resume.
+ *
+ * This sweep closes that hole from the durable side, and prefers *resuming*
+ * over reporting: the runtime keeps its resumable state in Redis, so as long
+ * as that state is still alive the correct recovery is to re-queue the next
+ * step and let the run continue where it stopped. Only when the state is gone
+ * (or the redrive budget is spent) does it fall back to abandoning the
+ * operation with a visible error the user can retry from.
+ *
+ * Safety comes from three existing mechanisms rather than new bookkeeping:
+ * - `claimStaleRedrive` consumes the candidate in the same UPDATE that selects
+ *   it, so overlapping ticks cannot both re-queue one step.
+ * - `tryClaimStep` arbitrates against a host that turns out to be alive after
+ *   all: the redelivered step loses the lock race and returns without running.
+ * - `executeStep` ACKs deliveries for operations already in a terminal state,
+ *   so a redrive that races a completion is a no-op.
+ */
+export class StaleOperationReaper {
+  private readonly coordinator: AgentRuntimeCoordinator;
+  private readonly queueService: QueueService | null;
+
+  constructor(
+    private readonly db: LobeChatDatabase,
+    options?: { coordinator?: AgentRuntimeCoordinator; queueService?: QueueService | null },
+  ) {
+    this.coordinator = options?.coordinator ?? new AgentRuntimeCoordinator();
+    this.queueService =
+      options?.queueService === null ? null : (options?.queueService ?? new QueueService());
+  }
+
+  private get baseURL() {
+    const baseUrl = process.env.AGENT_RUNTIME_BASE_URL || process.env.APP_URL;
+
+    return urlJoin(baseUrl || 'http://localhost:3010', '/api/agent');
+  }
+
+  async sweep(params?: ReapStaleOperationsParams): Promise<ReapStaleOperationsResult> {
+    const staleAfterMs = params?.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    const maxRedriveAttempts = params?.maxRedriveAttempts ?? DEFAULT_MAX_REDRIVE_ATTEMPTS;
+    const limit = params?.limit ?? DEFAULT_LIMIT;
+    const staleBefore = new Date(Date.now() - staleAfterMs);
+
+    const candidates = await this.listStaleRunning(staleBefore, limit);
+    const result: ReapStaleOperationsResult = {
+      abandoned: 0,
+      alive: 0,
+      examined: candidates.length,
+      redriven: 0,
+    };
+
+    for (const candidate of candidates) {
+      try {
+        const outcome = await this.recover(candidate, staleBefore, maxRedriveAttempts);
+        result[outcome] += 1;
+      } catch (e) {
+        // One poisoned row must not abort the rest of the sweep.
+        log('[%s] recovery failed: %O', candidate.id, e);
+      }
+    }
+
+    log('sweep done: %O', result);
+    return result;
+  }
+
+  /**
+   * Stale candidates across all tenants. Queried directly rather than through
+   * `AgentOperationModel`, which is user-scoped by construction — this is a
+   * system-level sweep, and the per-operation mutations below re-enter the
+   * model with the row's own owner so ownership is still enforced where it
+   * matters.
+   */
+  private async listStaleRunning(staleBefore: Date, limit: number) {
+    return (
+      this.db
+        .select({
+          id: agentOperations.id,
+          threadId: agentOperations.threadId,
+          topicId: agentOperations.topicId,
+          userId: agentOperations.userId,
+          workspaceId: agentOperations.workspaceId,
+        })
+        .from(agentOperations)
+        .where(
+          and(
+            eq(agentOperations.status, 'running'),
+            lt(agentOperations.updatedAt, staleBefore),
+            // A never-heartbeated row is only meaningful once it is older than
+            // the window too; `startedAt` is the lease's initial value.
+            or(isNull(agentOperations.startedAt), lt(agentOperations.startedAt, staleBefore)),
+          ),
+        )
+        // Oldest first: a backlog should drain in the order it accumulated, and
+        // it keeps the tick deterministic when `limit` truncates.
+        .orderBy(asc(agentOperations.updatedAt))
+        .limit(limit)
+    );
+  }
+
+  private async recover(
+    candidate: { id: string; userId: string; workspaceId: string | null },
+    staleBefore: Date,
+    maxRedriveAttempts: number,
+  ): Promise<'abandoned' | 'alive' | 'redriven'> {
+    const operationId = candidate.id;
+    const operationModel = new AgentOperationModel(
+      this.db,
+      candidate.userId,
+      candidate.workspaceId ?? undefined,
+    );
+
+    // Read state before claiming: a run with no resumable state can never be
+    // redriven, so spending an attempt on it would only delay the abandon.
+    const state = await this.coordinator.loadAgentState(operationId).catch((e) => {
+      log('[%s] state load failed, treating as unresumable: %O', operationId, e);
+      return null;
+    });
+
+    if (!this.canRedrive(state) || !this.queueService) {
+      await this.abandon(operationId, 'stale_lease_unresumable');
+      return 'abandoned';
+    }
+
+    const attempt = await operationModel.claimStaleRedrive(
+      operationId,
+      staleBefore,
+      maxRedriveAttempts,
+    );
+
+    if (attempt === null) {
+      // Either a heartbeat landed while we were reading state (the step is
+      // alive and owns itself again), or the redrive budget is spent. Only the
+      // latter should be retired, so re-read the row to tell them apart
+      // instead of guessing.
+      const row = await operationModel.findById(operationId);
+      const stale = row?.status === 'running' && row.updatedAt < staleBefore;
+      if (!stale) return 'alive';
+
+      await this.abandon(operationId, 'stale_lease_redrive_exhausted');
+      return 'abandoned';
+    }
+
+    // `stepCount` is the number of completed steps, so it is also the index of
+    // the step that never finished. `executeStep` reloads everything else it
+    // needs from this same state, which is why no context or payload has to be
+    // reconstructed here.
+    const stepIndex = state!.stepCount;
+
+    await this.queueService.scheduleMessage({
+      // Distinct per attempt: a shared key would let the provider dedupe a
+      // genuinely needed second redrive away and strand the operation again.
+      deduplicationId: `stale-redrive:${operationId}:${stepIndex}:${attempt}`,
+      endpoint: urlJoin(this.baseURL, '/run'),
+      operationId,
+      priority: 'normal',
+      retryDelay:
+        typeof state!.metadata?.queueRetryDelay === 'string'
+          ? state!.metadata.queueRetryDelay
+          : undefined,
+      retries:
+        typeof state!.metadata?.queueRetries === 'number'
+          ? state!.metadata.queueRetries
+          : undefined,
+      stepIndex,
+    });
+
+    log('[%s][%d] redriven (attempt %d/%d)', operationId, stepIndex, attempt, maxRedriveAttempts);
+    return 'redriven';
+  }
+
+  /**
+   * Whether the runtime state can still carry a resumed step.
+   *
+   * `idle` counts alongside `running`: it is the status a state carries
+   * between its creation and the first step, which is exactly the shape of an
+   * operation whose step-0 delivery never executed (the row is `running` with
+   * no steps, no snapshot and no messages beyond the user turn). Those are
+   * resumable for the same reason a mid-run death is — the state describes a
+   * step that still needs to happen.
+   *
+   * Parked operations are excluded on purpose: `waiting_for_human` and
+   * `waiting_for_async_tool` are deliberate pauses with their own resume
+   * paths, and re-queueing a plain step would run past the thing they wait on.
+   * Terminal statuses are excluded because there is nothing left to run.
+   */
+  private canRedrive(state: AgentState | null): state is AgentState {
+    return (
+      !!state &&
+      (state.status === 'running' || state.status === 'idle') &&
+      typeof state.stepCount === 'number' &&
+      state.stepCount >= 0
+    );
+  }
+
+  private async abandon(operationId: string, reason: string): Promise<void> {
+    await new AbandonOperationService(this.db).finalizeAbandoned(operationId, reason);
+    log('[%s] abandoned (reason=%s)', operationId, reason);
+  }
+}

--- a/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
+++ b/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
@@ -214,8 +214,12 @@ export class StaleOperationReaper {
     const context = await this.resolveRedriveContext(operationId, state, stepIndex);
     if (!context) {
       log('[%s][%d] no persisted context to resume from', operationId, stepIndex);
-      await this.abandon(operationId, 'stale_lease_context_unavailable');
-      return 'abandoned';
+      return this.abandonIfStillStale(
+        operationModel,
+        operationId,
+        staleBefore,
+        'context_unavailable',
+      );
     }
 
     const attempt = await operationModel.claimStaleRedrive(
@@ -226,15 +230,15 @@ export class StaleOperationReaper {
 
     if (attempt === null) {
       // Either a heartbeat landed while we were reading state (the step is
-      // alive and owns itself again), or the redrive budget is spent. Only the
-      // latter should be retired, so re-read the row to tell them apart
-      // instead of guessing.
-      const row = await operationModel.findById(operationId);
-      const stale = row?.status === 'running' && row.updatedAt < staleBefore;
-      if (!stale) return 'alive';
-
-      await this.abandon(operationId, 'stale_lease_redrive_exhausted');
-      return 'abandoned';
+      // alive and owns itself again) or the redrive budget is spent. The CAS
+      // below distinguishes them without a separate read: only a row that is
+      // still both running and past its lease can be retired.
+      return this.abandonIfStillStale(
+        operationModel,
+        operationId,
+        staleBefore,
+        'redrive_exhausted',
+      );
     }
 
     await this.queueService.scheduleMessage({
@@ -318,8 +322,42 @@ export class StaleOperationReaper {
     );
   }
 
-  private async abandon(operationId: string, reason: string): Promise<void> {
-    await new AbandonOperationService(this.db).finalizeAbandoned(operationId, reason);
+  /**
+   * Retire an operation, but only if it is *still* past its lease at this
+   * instant.
+   *
+   * Abandonment is irreversible and user-visible — it settles the durable row,
+   * errors the conversation tail and clears the topic's running pointer — so it
+   * must never act on a stale read. Minutes can pass between
+   * `listStaleRunning` selecting a candidate and this line running (the sweep
+   * walks candidates serially, and reading state plus execution history costs
+   * two Redis round trips each), which is ample room for the worker to resume
+   * and heartbeat. A transiently empty history read reaches here the same way.
+   *
+   * `settleStaleRunning` is the compare-and-set that closes it: its WHERE
+   * clause re-checks `status = 'running' AND updatedAt < staleBefore` inside
+   * the UPDATE, so a heartbeat that landed in the meantime wins and this
+   * returns `alive` untouched. Only once the row is claimed do the
+   * irreversible side effects run.
+   */
+  private async abandonIfStillStale(
+    operationModel: AgentOperationModel,
+    operationId: string,
+    staleBefore: Date,
+    reason: string,
+  ): Promise<'abandoned' | 'alive'> {
+    const claimed = await operationModel.settleStaleRunning(operationId, staleBefore);
+    if (!claimed) {
+      log('[%s] lease was refreshed before abandon could claim it', operationId);
+      return 'alive';
+    }
+
+    await new AbandonOperationService(this.db).finalizeAbandoned(
+      operationId,
+      `stale_lease_${reason}`,
+    );
     log('[%s] abandoned (reason=%s)', operationId, reason);
+
+    return 'abandoned';
   }
 }

--- a/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
+++ b/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
@@ -1,4 +1,4 @@
-import type { AgentState } from '@lobechat/agent-runtime';
+import type { AgentRuntimeContext, AgentState } from '@lobechat/agent-runtime';
 import debug from 'debug';
 import { and, asc, eq, isNull, lt, or } from 'drizzle-orm';
 import urlJoin from 'url-join';
@@ -44,13 +44,15 @@ export interface ReapStaleOperationsParams {
 }
 
 export interface ReapStaleOperationsResult {
-  /** Operations retired with a user-visible error (no state, or budget spent). */
+  /** Operations retired with a user-visible error (budget spent, or no context). */
   abandoned: number;
   /** Candidates whose lease was refreshed between select and claim. */
   alive: number;
   examined: number;
   /** Operations whose next step was re-queued. */
   redriven: number;
+  /** Candidates this sweep has no authority over — see `recover`. */
+  skipped: number;
 }
 
 /**
@@ -109,6 +111,7 @@ export class StaleOperationReaper {
       alive: 0,
       examined: candidates.length,
       redriven: 0,
+      skipped: 0,
     };
 
     for (const candidate of candidates) {
@@ -163,7 +166,7 @@ export class StaleOperationReaper {
     candidate: { id: string; userId: string; workspaceId: string | null },
     staleBefore: Date,
     maxRedriveAttempts: number,
-  ): Promise<'abandoned' | 'alive' | 'redriven'> {
+  ): Promise<'abandoned' | 'alive' | 'redriven' | 'skipped'> {
     const operationId = candidate.id;
     const operationModel = new AgentOperationModel(
       this.db,
@@ -171,15 +174,47 @@ export class StaleOperationReaper {
       candidate.workspaceId ?? undefined,
     );
 
-    // Read state before claiming: a run with no resumable state can never be
-    // redriven, so spending an attempt on it would only delay the abandon.
+    // Everything that decides *whether* to act is read before the claim, so a
+    // candidate this sweep cannot help never consumes an attempt.
     const state = await this.coordinator.loadAgentState(operationId).catch((e) => {
       log('[%s] state load failed, treating as unresumable: %O', operationId, e);
       return null;
     });
 
-    if (!this.canRedrive(state) || !this.queueService) {
-      await this.abandon(operationId, 'stale_lease_unresumable');
+    // No coordinator state means this sweep has no authority over the run.
+    // Crucially that is the shape of a *healthy* heterogeneous operation: a
+    // Claude Code / Codex run is driven by an external CLI, never creates
+    // coordinator state, and only refreshes its lease when `heteroIngest`
+    // batches arrive — so a single long tool call reads as "stale" here.
+    // Retiring one would be actively destructive rather than merely useless:
+    // `heteroIngest` bails out on `touchRunning` returning false, so every
+    // subsequent batch of a live session would be dropped before persistence.
+    //
+    // Stateless-but-genuinely-dead operations are the inactivity watchdog's
+    // job (it reaches them through `finalize-abandoned`), and it has the
+    // gateway-side evidence to tell the two apart. This sweep deliberately
+    // limits itself to runs it can actually resume.
+    if (!state || !this.queueService) return 'skipped';
+
+    // Parked operations have their own resume paths; a plain step would run
+    // past whatever they are waiting on.
+    if (!this.canRedrive(state)) return 'skipped';
+
+    // `stepCount` is the number of completed steps, so it is also the index of
+    // the step that never finished.
+    const stepIndex = state.stepCount;
+
+    // The context is NOT optional in practice. `runtime.step` falls back to
+    // `createInitialContext(state)` when it gets none, which re-enters the run
+    // at `user_input` — so a step that owed a `tool_result` / graph
+    // continuation would instead start a fresh LLM turn and silently drop the
+    // pending work. Recover the real one, and refuse to redrive without it:
+    // abandoning with a visible error is recoverable, corrupting the run is
+    // not.
+    const context = await this.resolveRedriveContext(operationId, state, stepIndex);
+    if (!context) {
+      log('[%s][%d] no persisted context to resume from', operationId, stepIndex);
+      await this.abandon(operationId, 'stale_lease_context_unavailable');
       return 'abandoned';
     }
 
@@ -202,13 +237,8 @@ export class StaleOperationReaper {
       return 'abandoned';
     }
 
-    // `stepCount` is the number of completed steps, so it is also the index of
-    // the step that never finished. `executeStep` reloads everything else it
-    // needs from this same state, which is why no context or payload has to be
-    // reconstructed here.
-    const stepIndex = state!.stepCount;
-
     await this.queueService.scheduleMessage({
+      context,
       // Distinct per attempt: a shared key would let the provider dedupe a
       // genuinely needed second redrive away and strand the operation again.
       deduplicationId: `stale-redrive:${operationId}:${stepIndex}:${attempt}`,
@@ -216,18 +246,52 @@ export class StaleOperationReaper {
       operationId,
       priority: 'normal',
       retryDelay:
-        typeof state!.metadata?.queueRetryDelay === 'string'
-          ? state!.metadata.queueRetryDelay
+        typeof state.metadata?.queueRetryDelay === 'string'
+          ? state.metadata.queueRetryDelay
           : undefined,
       retries:
-        typeof state!.metadata?.queueRetries === 'number'
-          ? state!.metadata.queueRetries
-          : undefined,
+        typeof state.metadata?.queueRetries === 'number' ? state.metadata.queueRetries : undefined,
       stepIndex,
     });
 
     log('[%s][%d] redriven (attempt %d/%d)', operationId, stepIndex, attempt, maxRedriveAttempts);
     return 'redriven';
+  }
+
+  /**
+   * The context the interrupted step should have received.
+   *
+   * Step 0 carries the context the operation was created with, which the
+   * runtime persists onto the state — the same field the intervention
+   * continuation re-publishes from. Every later step is driven by the
+   * `nextContext` its predecessor produced, which `saveStepResult` stores
+   * alongside the step in the execution history under the *producing* step's
+   * index (so step N's entry holds the context for step N+1).
+   *
+   * Returns undefined rather than a synthesized fallback: the caller must be
+   * able to tell "resume correctly" from "cannot resume".
+   */
+  private async resolveRedriveContext(
+    operationId: string,
+    state: AgentState,
+    stepIndex: number,
+  ): Promise<AgentRuntimeContext | undefined> {
+    if (stepIndex === 0) {
+      return (state as AgentState & { initialContext?: AgentRuntimeContext }).initialContext;
+    }
+
+    try {
+      const history = await this.coordinator.getExecutionHistory(operationId);
+      const producer = history.find(
+        (entry: { context?: AgentRuntimeContext; stepIndex?: number }) =>
+          entry?.stepIndex === stepIndex - 1,
+      );
+
+      return producer?.context;
+    } catch (e) {
+      log('[%s][%d] execution history lookup failed: %O', operationId, stepIndex, e);
+      return undefined;
+    }
   }
 
   /**

--- a/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
+++ b/apps/server/src/services/agentRuntime/StaleOperationReaper.ts
@@ -213,13 +213,16 @@ export class StaleOperationReaper {
     // not.
     const context = await this.resolveRedriveContext(operationId, state, stepIndex);
     if (!context) {
+      // Skipped rather than abandoned, because "no context" is not a reliable
+      // signal: `AgentStateManager.getExecutionHistory` swallows a failed
+      // LRANGE or a JSON parse error and returns an empty array, so a
+      // transient Redis blip is indistinguishable here from a genuinely
+      // missing entry. Retiring an operation is irreversible and user-visible,
+      // and this one is otherwise resumable — a later tick may well recover it
+      // once the read succeeds, and the inactivity watchdog still declares it
+      // dead if it never does.
       log('[%s][%d] no persisted context to resume from', operationId, stepIndex);
-      return this.abandonIfStillStale(
-        operationModel,
-        operationId,
-        staleBefore,
-        'context_unavailable',
-      );
+      return 'skipped';
     }
 
     const attempt = await operationModel.claimStaleRedrive(
@@ -241,22 +244,37 @@ export class StaleOperationReaper {
       );
     }
 
-    await this.queueService.scheduleMessage({
-      context,
-      // Distinct per attempt: a shared key would let the provider dedupe a
-      // genuinely needed second redrive away and strand the operation again.
-      deduplicationId: `stale-redrive:${operationId}:${stepIndex}:${attempt}`,
-      endpoint: urlJoin(this.baseURL, '/run'),
-      operationId,
-      priority: 'normal',
-      retryDelay:
-        typeof state.metadata?.queueRetryDelay === 'string'
-          ? state.metadata.queueRetryDelay
-          : undefined,
-      retries:
-        typeof state.metadata?.queueRetries === 'number' ? state.metadata.queueRetries : undefined,
-      stepIndex,
-    });
+    try {
+      await this.queueService.scheduleMessage({
+        context,
+        // Distinct per attempt: a shared key would let the provider dedupe a
+        // genuinely needed second redrive away and strand the operation again.
+        deduplicationId: `stale-redrive:${operationId}:${stepIndex}:${attempt}`,
+        endpoint: urlJoin(this.baseURL, '/run'),
+        operationId,
+        priority: 'normal',
+        retryDelay:
+          typeof state.metadata?.queueRetryDelay === 'string'
+            ? state.metadata.queueRetryDelay
+            : undefined,
+        retries:
+          typeof state.metadata?.queueRetries === 'number'
+            ? state.metadata.queueRetries
+            : undefined,
+        stepIndex,
+      });
+    } catch (e) {
+      // The attempt was claimed before publishing, because the claim is also
+      // the mutual exclusion between overlapping sweeps. Publishing is what it
+      // was claimed *for*, so a failure has to give it back — the budget
+      // bounds LLM spend, and nothing was spent. Without this, a brief queue
+      // outage walks a healthy operation to its limit and retires it having
+      // never attempted a single recovery.
+      await operationModel.releaseStaleRedrive(operationId, attempt).catch((releaseError) => {
+        log('[%s] failed to release redrive attempt %d: %O', operationId, attempt, releaseError);
+      });
+      throw e;
+    }
 
     log('[%s][%d] redriven (attempt %d/%d)', operationId, stepIndex, attempt, maxRedriveAttempts);
     return 'redriven';

--- a/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
@@ -30,10 +30,12 @@ const buildCoordinator = (
 });
 
 const messageUpdateMock = vi.fn().mockResolvedValue({ success: true });
+const messageCreateMock = vi.fn().mockResolvedValue({ id: 'msg_new_failure' });
 const latestSpineMessageIdMock = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(function () {
     return {
+      create: messageCreateMock,
       getLatestSpineMessageId: latestSpineMessageIdMock,
       update: messageUpdateMock,
     };
@@ -121,6 +123,7 @@ describe('AbandonOperationService', () => {
     findThreadMock.mockReset().mockResolvedValue(null);
     settleRunningMock.mockReset().mockResolvedValue(true);
     latestSpineMessageIdMock.mockReset().mockResolvedValue(undefined);
+    messageCreateMock.mockReset().mockResolvedValue({ id: 'msg_new_failure' });
     topicSettleRunningOperationMock
       .mockReset()
       .mockResolvedValue({ assistantMessageId: undefined, status: 'missing' });
@@ -703,7 +706,7 @@ describe('AbandonOperationService', () => {
     expect(settleRunningMock).toHaveBeenCalledWith('op_idle', 'error');
   });
 
-  it('errors the conversation tail when the dying step never created a placeholder', async () => {
+  it('creates an assistant failure row when the dying step never made a placeholder', async () => {
     // A host recycled mid-LLM-call leaves no assistant placeholder, so there
     // was nothing carrying `error` — and the client keys its retry affordance
     // off `message.error`, which is why the turn rendered as frozen.
@@ -721,18 +724,28 @@ describe('AbandonOperationService', () => {
       snapshotStore: buildPartiallessStore() as any,
     }).finalizeAbandoned('op_no_placeholder', 'stale_lease');
 
+    // Anchored to the tail, but written as a NEW assistant row: the tail is
+    // either the user's own turn — whose renderer never passes `error` to
+    // ChatItem, so the user would see nothing — or an earlier assistant turn
+    // that actually succeeded and must not be relabelled as failed.
     expect(latestSpineMessageIdMock).toHaveBeenCalledWith({
       threadId: null,
       topicId: 'tpc_x',
     });
-    expect(messageUpdateMock).toHaveBeenCalledWith(
-      'msg_tail',
-      expect.objectContaining({ error: expect.objectContaining({ message: expect.any(String) }) }),
+    expect(messageUpdateMock).not.toHaveBeenCalled();
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: '',
+        error: expect.objectContaining({ message: expect.any(String) }),
+        parentId: 'msg_tail',
+        role: 'assistant',
+        topicId: 'tpc_x',
+      }),
     );
     expect(result.assistantMessageUpdated).toBe(true);
   });
 
-  it('prefers the placeholder over the tail when the step did create one', async () => {
+  it('marks the existing placeholder rather than creating a row when the step made one', async () => {
     latestSpineMessageIdMock.mockResolvedValue('msg_tail');
     const coord = buildCoordinator({
       loadAgentState: vi.fn().mockResolvedValue(stateWith()),
@@ -744,6 +757,7 @@ describe('AbandonOperationService', () => {
     }).finalizeAbandoned('op_x', 'stale_lease');
 
     expect(latestSpineMessageIdMock).not.toHaveBeenCalled();
+    expect(messageCreateMock).not.toHaveBeenCalled();
     expect(messageUpdateMock).toHaveBeenCalledWith('msg_assist_1', expect.anything());
   });
 

--- a/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
@@ -30,19 +30,25 @@ const buildCoordinator = (
 });
 
 const messageUpdateMock = vi.fn().mockResolvedValue({ success: true });
+const latestSpineMessageIdMock = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(function () {
-    return { update: messageUpdateMock };
+    return {
+      getLatestSpineMessageId: latestSpineMessageIdMock,
+      update: messageUpdateMock,
+    };
   }),
 }));
 
 const findOperationMock = vi.fn().mockResolvedValue(null);
 const recordCompletionMock = vi.fn().mockResolvedValue(undefined);
+const settleRunningMock = vi.fn().mockResolvedValue(true);
 vi.mock('@/database/models/agentOperation', () => ({
   AgentOperationModel: vi.fn().mockImplementation(function () {
     return {
       findById: findOperationMock,
       recordCompletion: recordCompletionMock,
+      settleRunning: settleRunningMock,
     };
   }),
 }));
@@ -100,6 +106,12 @@ const buildDb = (overrides: { assistantRow?: any; operationRow?: any } = {}) =>
     },
   }) as any;
 
+const buildPartiallessStore = () => {
+  const store = buildStore();
+  store.loadPartial.mockResolvedValue(null);
+  return store;
+};
+
 describe('AbandonOperationService', () => {
   beforeEach(() => {
     messageUpdateMock.mockClear();
@@ -107,6 +119,8 @@ describe('AbandonOperationService', () => {
     findOperationMock.mockReset().mockResolvedValue(null);
     recordCompletionMock.mockClear();
     findThreadMock.mockReset().mockResolvedValue(null);
+    settleRunningMock.mockReset().mockResolvedValue(true);
+    latestSpineMessageIdMock.mockReset().mockResolvedValue(undefined);
     topicSettleRunningOperationMock
       .mockReset()
       .mockResolvedValue({ assistantMessageId: undefined, status: 'missing' });
@@ -651,6 +665,111 @@ describe('AbandonOperationService', () => {
     });
     expect(MessageModel).toHaveBeenCalledWith(expect.anything(), 'user_x', 'ws_1', undefined, {
       includeShareVisitor: true,
+    });
+  });
+
+  it('settles the durable row from the with-state branch too', async () => {
+    // Regression: only the no-state branch used to touch `agent_operations`,
+    // so an op whose Redis state was still inside its TTL when the watchdog
+    // fired stayed `running` forever — nothing else retires a non-Goal op.
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(stateWith()),
+    });
+    const store = buildStore();
+    store.loadPartial.mockResolvedValue({ startedAt: 1, steps: [{ stepIndex: 0 }] });
+
+    await new AbandonOperationService(buildDb(), {
+      coordinator: coord as any,
+      snapshotStore: store as any,
+    }).finalizeAbandoned('op_x', 'inactivity_watchdog');
+
+    expect(settleRunningMock).toHaveBeenCalledWith('op_x', 'error');
+  });
+
+  it('still settles the durable row when the lifecycle dispatch is skipped', async () => {
+    // `dispatchHooks` — which owns the rich terminal write — is gated on the
+    // state being running/waiting_*. An `idle` step boundary skips it, and
+    // that used to mean nothing settled the row at all.
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(stateWith({ status: 'idle' })),
+    });
+
+    await new AbandonOperationService(buildDb(), {
+      coordinator: coord as any,
+      snapshotStore: buildPartiallessStore() as any,
+    }).finalizeAbandoned('op_idle', 'stale_lease');
+
+    expect(dispatchHooksMock).not.toHaveBeenCalled();
+    expect(settleRunningMock).toHaveBeenCalledWith('op_idle', 'error');
+  });
+
+  it('errors the conversation tail when the dying step never created a placeholder', async () => {
+    // A host recycled mid-LLM-call leaves no assistant placeholder, so there
+    // was nothing carrying `error` — and the client keys its retry affordance
+    // off `message.error`, which is why the turn rendered as frozen.
+    latestSpineMessageIdMock.mockResolvedValue('msg_tail');
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(
+        stateWith({
+          metadata: { agentId: 'agt_x', topicId: 'tpc_x', userId: 'user_x' },
+        }),
+      ),
+    });
+
+    const result = await new AbandonOperationService(buildDb(), {
+      coordinator: coord as any,
+      snapshotStore: buildPartiallessStore() as any,
+    }).finalizeAbandoned('op_no_placeholder', 'stale_lease');
+
+    expect(latestSpineMessageIdMock).toHaveBeenCalledWith({
+      threadId: null,
+      topicId: 'tpc_x',
+    });
+    expect(messageUpdateMock).toHaveBeenCalledWith(
+      'msg_tail',
+      expect.objectContaining({ error: expect.objectContaining({ message: expect.any(String) }) }),
+    );
+    expect(result.assistantMessageUpdated).toBe(true);
+  });
+
+  it('prefers the placeholder over the tail when the step did create one', async () => {
+    latestSpineMessageIdMock.mockResolvedValue('msg_tail');
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(stateWith()),
+    });
+
+    await new AbandonOperationService(buildDb(), {
+      coordinator: coord as any,
+      snapshotStore: buildPartiallessStore() as any,
+    }).finalizeAbandoned('op_x', 'stale_lease');
+
+    expect(latestSpineMessageIdMock).not.toHaveBeenCalled();
+    expect(messageUpdateMock).toHaveBeenCalledWith('msg_assist_1', expect.anything());
+  });
+
+  it('scopes the tail lookup to the operation thread when it has one', async () => {
+    latestSpineMessageIdMock.mockResolvedValue('msg_thread_tail');
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(
+        stateWith({
+          metadata: {
+            agentId: 'agt_x',
+            threadId: 'thr_x',
+            topicId: 'tpc_x',
+            userId: 'user_x',
+          },
+        }),
+      ),
+    });
+
+    await new AbandonOperationService(buildDb(), {
+      coordinator: coord as any,
+      snapshotStore: buildPartiallessStore() as any,
+    }).finalizeAbandoned('op_thread', 'stale_lease');
+
+    expect(latestSpineMessageIdMock).toHaveBeenCalledWith({
+      threadId: 'thr_x',
+      topicId: 'tpc_x',
     });
   });
 

--- a/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StaleOperationReaper } from '../StaleOperationReaper';
+
+const claimStaleRedriveMock = vi.fn();
+const findByIdMock = vi.fn();
+vi.mock('@/database/models/agentOperation', () => ({
+  AgentOperationModel: vi.fn().mockImplementation(() => ({
+    claimStaleRedrive: claimStaleRedriveMock,
+    findById: findByIdMock,
+  })),
+}));
+
+const finalizeAbandonedMock = vi.fn().mockResolvedValue({});
+vi.mock('../AbandonOperationService', () => ({
+  AbandonOperationService: vi.fn().mockImplementation(() => ({
+    finalizeAbandoned: finalizeAbandonedMock,
+  })),
+}));
+
+/** Minimal drizzle select chain returning `rows`. */
+const buildDb = (rows: any[]) =>
+  ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({ limit: vi.fn().mockResolvedValue(rows) }),
+        }),
+      }),
+    }),
+  }) as any;
+
+const candidate = (id = 'op_x') => ({
+  id,
+  threadId: null,
+  topicId: 'tpc_x',
+  userId: 'user_x',
+  workspaceId: null,
+});
+
+const buildCoordinator = (state: any) => ({ loadAgentState: vi.fn().mockResolvedValue(state) });
+const buildQueue = () => ({ scheduleMessage: vi.fn().mockResolvedValue('msg_1') });
+
+const runningState = (overrides: Record<string, any> = {}) => ({
+  metadata: {},
+  status: 'running',
+  stepCount: 7,
+  ...overrides,
+});
+
+const buildReaper = (rows: any[], state: any, queue: any = buildQueue()) =>
+  new StaleOperationReaper(buildDb(rows), {
+    coordinator: buildCoordinator(state) as any,
+    queueService: queue as any,
+  });
+
+describe('StaleOperationReaper', () => {
+  beforeEach(() => {
+    claimStaleRedriveMock.mockReset().mockResolvedValue(1);
+    findByIdMock.mockReset().mockResolvedValue(null);
+    finalizeAbandonedMock.mockClear();
+    process.env.APP_URL = 'https://app.lobehub.test';
+  });
+
+  it('re-queues the unfinished step of a resumable operation', async () => {
+    const queue = buildQueue();
+    const result = await buildReaper([candidate()], runningState(), queue).sweep();
+
+    expect(queue.scheduleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // stepCount is the count of COMPLETED steps, so it is also the index
+        // of the one that never finished.
+        endpoint: 'https://app.lobehub.test/api/agent/run',
+        operationId: 'op_x',
+        stepIndex: 7,
+      }),
+    );
+    expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ abandoned: 0, examined: 1, redriven: 1 });
+  });
+
+  it('keys deduplication per attempt so a later redrive is not deduped away', async () => {
+    const queue = buildQueue();
+    claimStaleRedriveMock.mockResolvedValue(2);
+
+    await buildReaper([candidate()], runningState(), queue).sweep();
+
+    expect(queue.scheduleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ deduplicationId: 'stale-redrive:op_x:7:2' }),
+    );
+  });
+
+  it('redrives step 0 for an operation whose first step never executed', async () => {
+    // Born-dead shape: state exists but is still `idle` at step 0.
+    const queue = buildQueue();
+    await buildReaper([candidate()], runningState({ status: 'idle', stepCount: 0 }), queue).sweep();
+
+    expect(queue.scheduleMessage).toHaveBeenCalledWith(expect.objectContaining({ stepIndex: 0 }));
+  });
+
+  it('abandons instead of redriving when no resumable state survives', async () => {
+    const queue = buildQueue();
+    const result = await buildReaper([candidate()], null, queue).sweep();
+
+    expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    expect(claimStaleRedriveMock).not.toHaveBeenCalled();
+    expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_unresumable');
+    expect(result).toMatchObject({ abandoned: 1, redriven: 0 });
+  });
+
+  it.each(['waiting_for_human', 'waiting_for_async_tool'])(
+    'never redrives a deliberately parked operation (%s)',
+    async (status) => {
+      const queue = buildQueue();
+      await buildReaper([candidate()], runningState({ status }), queue).sweep();
+
+      expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  it('leaves an operation alone when a heartbeat wins the claim race', async () => {
+    const queue = buildQueue();
+    claimStaleRedriveMock.mockResolvedValue(null);
+    // Row is no longer stale → the step is alive and owns itself again.
+    findByIdMock.mockResolvedValue({ status: 'running', updatedAt: new Date() });
+
+    const result = await buildReaper([candidate()], runningState(), queue).sweep();
+
+    expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ alive: 1, redriven: 0 });
+  });
+
+  it('abandons once the redrive budget is spent', async () => {
+    const queue = buildQueue();
+    claimStaleRedriveMock.mockResolvedValue(null);
+    // Still stale → the claim failed on the attempt budget, not a heartbeat.
+    findByIdMock.mockResolvedValue({ status: 'running', updatedAt: new Date(0) });
+
+    const result = await buildReaper([candidate()], runningState(), queue).sweep();
+
+    expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_redrive_exhausted');
+    expect(result).toMatchObject({ abandoned: 1 });
+  });
+
+  it('keeps sweeping after one operation throws', async () => {
+    const queue = buildQueue();
+    queue.scheduleMessage
+      .mockRejectedValueOnce(new Error('queue down'))
+      .mockResolvedValueOnce('msg_2');
+
+    const result = await buildReaper(
+      [candidate('op_a'), candidate('op_b')],
+      runningState(),
+      queue,
+    ).sweep();
+
+    expect(result).toMatchObject({ examined: 2, redriven: 1 });
+  });
+
+  it('passes the caller stall window through to the claim', async () => {
+    const before = Date.now();
+    await buildReaper([candidate()], runningState()).sweep({ staleAfterMs: 60_000 });
+
+    const [, staleBefore, maxAttempts] = claimStaleRedriveMock.mock.calls[0];
+    expect(maxAttempts).toBe(3);
+    expect(staleBefore.getTime()).toBeLessThanOrEqual(before - 60_000 + 5);
+  });
+});

--- a/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
@@ -39,7 +39,10 @@ const candidate = (id = 'op_x') => ({
   workspaceId: null,
 });
 
-const buildCoordinator = (state: any) => ({ loadAgentState: vi.fn().mockResolvedValue(state) });
+const buildCoordinator = (state: any, history: any[] = []) => ({
+  getExecutionHistory: vi.fn().mockResolvedValue(history),
+  loadAgentState: vi.fn().mockResolvedValue(state),
+});
 const buildQueue = () => ({ scheduleMessage: vi.fn().mockResolvedValue('msg_1') });
 
 const runningState = (overrides: Record<string, any> = {}) => ({
@@ -49,9 +52,20 @@ const runningState = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 });
 
-const buildReaper = (rows: any[], state: any, queue: any = buildQueue()) =>
+/** `saveStepResult` files the context for step N+1 under producing step N. */
+const historyFor = (stepIndex: number, context: any = { phase: 'tool_result' }) => [
+  { context: { phase: 'llm_result' }, stepIndex: stepIndex - 1 },
+  { context, stepIndex },
+];
+
+const buildReaper = (
+  rows: any[],
+  state: any,
+  queue: any = buildQueue(),
+  history: any[] = historyFor(6),
+) =>
   new StaleOperationReaper(buildDb(rows), {
-    coordinator: buildCoordinator(state) as any,
+    coordinator: buildCoordinator(state, history) as any,
     queueService: queue as any,
   });
 
@@ -69,6 +83,9 @@ describe('StaleOperationReaper', () => {
 
     expect(queue.scheduleMessage).toHaveBeenCalledWith(
       expect.objectContaining({
+        // The context step 6 produced for step 7 — without it `runtime.step`
+        // would synthesize a `user_input` context and drop the pending work.
+        context: { phase: 'tool_result' },
         // stepCount is the count of COMPLETED steps, so it is also the index
         // of the one that never finished.
         endpoint: 'https://app.lobehub.test/api/agent/run',
@@ -91,31 +108,59 @@ describe('StaleOperationReaper', () => {
     );
   });
 
-  it('redrives step 0 for an operation whose first step never executed', async () => {
-    // Born-dead shape: state exists but is still `idle` at step 0.
+  it('redrives step 0 with the context the operation was created with', async () => {
+    // Born-dead shape: state exists but is still `idle` at step 0. There is no
+    // producing step, so the context comes off the state — the same field the
+    // intervention continuation re-publishes from.
     const queue = buildQueue();
-    await buildReaper([candidate()], runningState({ status: 'idle', stepCount: 0 }), queue).sweep();
+    await buildReaper(
+      [candidate()],
+      runningState({ initialContext: { phase: 'user_input' }, status: 'idle', stepCount: 0 }),
+      queue,
+      [],
+    ).sweep();
 
-    expect(queue.scheduleMessage).toHaveBeenCalledWith(expect.objectContaining({ stepIndex: 0 }));
+    expect(queue.scheduleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ context: { phase: 'user_input' }, stepIndex: 0 }),
+    );
   });
 
-  it('abandons instead of redriving when no resumable state survives', async () => {
+  it('abandons rather than redriving when the step context cannot be recovered', async () => {
+    // Resuming with a synthesized context would re-enter at `user_input` and
+    // silently drop pending tool work — a visible error is the lesser harm.
+    const queue = buildQueue();
+    const result = await buildReaper([candidate()], runningState(), queue, []).sweep();
+
+    expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    expect(claimStaleRedriveMock).not.toHaveBeenCalled();
+    expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_context_unavailable');
+    expect(result).toMatchObject({ abandoned: 1, redriven: 0 });
+  });
+
+  it('never touches an operation with no coordinator state', async () => {
+    // This is the shape of a HEALTHY heterogeneous run: an external Claude
+    // Code / Codex CLI drives it, it never creates coordinator state, and it
+    // only refreshes its lease on `heteroIngest` batches — so one long tool
+    // call reads as stale here. Retiring it would make `heteroIngest` drop
+    // every subsequent batch of a live session.
     const queue = buildQueue();
     const result = await buildReaper([candidate()], null, queue).sweep();
 
     expect(queue.scheduleMessage).not.toHaveBeenCalled();
     expect(claimStaleRedriveMock).not.toHaveBeenCalled();
-    expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_unresumable');
-    expect(result).toMatchObject({ abandoned: 1, redriven: 0 });
+    expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ abandoned: 0, redriven: 0, skipped: 1 });
   });
 
   it.each(['waiting_for_human', 'waiting_for_async_tool'])(
     'never redrives a deliberately parked operation (%s)',
     async (status) => {
       const queue = buildQueue();
-      await buildReaper([candidate()], runningState({ status }), queue).sweep();
+      const result = await buildReaper([candidate()], runningState({ status }), queue).sweep();
 
       expect(queue.scheduleMessage).not.toHaveBeenCalled();
+      expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ skipped: 1 });
     },
   );
 

--- a/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
@@ -4,19 +4,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StaleOperationReaper } from '../StaleOperationReaper';
 
 const claimStaleRedriveMock = vi.fn();
-const findByIdMock = vi.fn();
+const settleStaleRunningMock = vi.fn();
 vi.mock('@/database/models/agentOperation', () => ({
-  AgentOperationModel: vi.fn().mockImplementation(() => ({
-    claimStaleRedrive: claimStaleRedriveMock,
-    findById: findByIdMock,
-  })),
+  AgentOperationModel: vi.fn().mockImplementation(function () {
+    return {
+      claimStaleRedrive: claimStaleRedriveMock,
+      settleStaleRunning: settleStaleRunningMock,
+    };
+  }),
 }));
 
 const finalizeAbandonedMock = vi.fn().mockResolvedValue({});
 vi.mock('../AbandonOperationService', () => ({
-  AbandonOperationService: vi.fn().mockImplementation(() => ({
-    finalizeAbandoned: finalizeAbandonedMock,
-  })),
+  AbandonOperationService: vi.fn().mockImplementation(function () {
+    return { finalizeAbandoned: finalizeAbandonedMock };
+  }),
 }));
 
 /** Minimal drizzle select chain returning `rows`. */
@@ -72,7 +74,7 @@ const buildReaper = (
 describe('StaleOperationReaper', () => {
   beforeEach(() => {
     claimStaleRedriveMock.mockReset().mockResolvedValue(1);
-    findByIdMock.mockReset().mockResolvedValue(null);
+    settleStaleRunningMock.mockReset().mockResolvedValue(true);
     finalizeAbandonedMock.mockClear();
     process.env.APP_URL = 'https://app.lobehub.test';
   });
@@ -133,6 +135,8 @@ describe('StaleOperationReaper', () => {
 
     expect(queue.scheduleMessage).not.toHaveBeenCalled();
     expect(claimStaleRedriveMock).not.toHaveBeenCalled();
+    // Irreversible cleanup only after the lease is re-checked atomically.
+    expect(settleStaleRunningMock).toHaveBeenCalledWith('op_x', expect.any(Date));
     expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_context_unavailable');
     expect(result).toMatchObject({ abandoned: 1, redriven: 0 });
   });
@@ -167,8 +171,9 @@ describe('StaleOperationReaper', () => {
   it('leaves an operation alone when a heartbeat wins the claim race', async () => {
     const queue = buildQueue();
     claimStaleRedriveMock.mockResolvedValue(null);
-    // Row is no longer stale → the step is alive and owns itself again.
-    findByIdMock.mockResolvedValue({ status: 'running', updatedAt: new Date() });
+    // The stale CAS finds the row refreshed → the step is alive and owns itself
+    // again, so nothing irreversible may happen to it.
+    settleStaleRunningMock.mockResolvedValue(false);
 
     const result = await buildReaper([candidate()], runningState(), queue).sweep();
 
@@ -180,14 +185,30 @@ describe('StaleOperationReaper', () => {
   it('abandons once the redrive budget is spent', async () => {
     const queue = buildQueue();
     claimStaleRedriveMock.mockResolvedValue(null);
-    // Still stale → the claim failed on the attempt budget, not a heartbeat.
-    findByIdMock.mockResolvedValue({ status: 'running', updatedAt: new Date(0) });
+    // CAS still matches → the claim failed on the attempt budget, not a heartbeat.
+    settleStaleRunningMock.mockResolvedValue(true);
 
     const result = await buildReaper([candidate()], runningState(), queue).sweep();
 
     expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    expect(settleStaleRunningMock).toHaveBeenCalledWith('op_x', expect.any(Date));
     expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_redrive_exhausted');
     expect(result).toMatchObject({ abandoned: 1 });
+  });
+
+  it('refuses to abandon a run that heartbeated while its context was being read', async () => {
+    // The window Codex flagged: `listStaleRunning` selected this row, then the
+    // worker resumed while `resolveRedriveContext` was doing its Redis reads.
+    // Abandoning is irreversible and user-visible, so it must re-check the
+    // lease atomically rather than trust the stale select.
+    const queue = buildQueue();
+    settleStaleRunningMock.mockResolvedValue(false);
+
+    const result = await buildReaper([candidate()], runningState(), queue, []).sweep();
+
+    expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+    expect(queue.scheduleMessage).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ abandoned: 0, alive: 1 });
   });
 
   it('keeps sweeping after one operation throws', async () => {

--- a/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/StaleOperationReaper.test.ts
@@ -5,10 +5,12 @@ import { StaleOperationReaper } from '../StaleOperationReaper';
 
 const claimStaleRedriveMock = vi.fn();
 const settleStaleRunningMock = vi.fn();
+const releaseStaleRedriveMock = vi.fn();
 vi.mock('@/database/models/agentOperation', () => ({
   AgentOperationModel: vi.fn().mockImplementation(function () {
     return {
       claimStaleRedrive: claimStaleRedriveMock,
+      releaseStaleRedrive: releaseStaleRedriveMock,
       settleStaleRunning: settleStaleRunningMock,
     };
   }),
@@ -75,6 +77,7 @@ describe('StaleOperationReaper', () => {
   beforeEach(() => {
     claimStaleRedriveMock.mockReset().mockResolvedValue(1);
     settleStaleRunningMock.mockReset().mockResolvedValue(true);
+    releaseStaleRedriveMock.mockReset().mockResolvedValue(true);
     finalizeAbandonedMock.mockClear();
     process.env.APP_URL = 'https://app.lobehub.test';
   });
@@ -127,18 +130,18 @@ describe('StaleOperationReaper', () => {
     );
   });
 
-  it('abandons rather than redriving when the step context cannot be recovered', async () => {
-    // Resuming with a synthesized context would re-enter at `user_input` and
-    // silently drop pending tool work — a visible error is the lesser harm.
+  it('skips rather than abandons when the step context cannot be recovered', async () => {
+    // `getExecutionHistory` swallows a failed LRANGE and returns [], so an
+    // empty result cannot be told apart from a transient Redis failure.
+    // Retiring is irreversible, and this operation is otherwise resumable.
     const queue = buildQueue();
     const result = await buildReaper([candidate()], runningState(), queue, []).sweep();
 
     expect(queue.scheduleMessage).not.toHaveBeenCalled();
     expect(claimStaleRedriveMock).not.toHaveBeenCalled();
-    // Irreversible cleanup only after the lease is re-checked atomically.
-    expect(settleStaleRunningMock).toHaveBeenCalledWith('op_x', expect.any(Date));
-    expect(finalizeAbandonedMock).toHaveBeenCalledWith('op_x', 'stale_lease_context_unavailable');
-    expect(result).toMatchObject({ abandoned: 1, redriven: 0 });
+    expect(settleStaleRunningMock).not.toHaveBeenCalled();
+    expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ abandoned: 0, redriven: 0, skipped: 1 });
   });
 
   it('never touches an operation with no coordinator state', async () => {
@@ -196,19 +199,42 @@ describe('StaleOperationReaper', () => {
     expect(result).toMatchObject({ abandoned: 1 });
   });
 
-  it('refuses to abandon a run that heartbeated while its context was being read', async () => {
-    // The window Codex flagged: `listStaleRunning` selected this row, then the
-    // worker resumed while `resolveRedriveContext` was doing its Redis reads.
-    // Abandoning is irreversible and user-visible, so it must re-check the
-    // lease atomically rather than trust the stale select.
+  it('refuses to abandon a run that heartbeated after the candidate was selected', async () => {
+    // `listStaleRunning` selected this row, then the worker resumed while the
+    // sweep was doing its Redis reads. Abandoning is irreversible and
+    // user-visible, so it must re-check the lease atomically rather than
+    // trust the stale select.
     const queue = buildQueue();
+    claimStaleRedriveMock.mockResolvedValue(null);
     settleStaleRunningMock.mockResolvedValue(false);
 
-    const result = await buildReaper([candidate()], runningState(), queue, []).sweep();
+    const result = await buildReaper([candidate()], runningState(), queue).sweep();
 
     expect(finalizeAbandonedMock).not.toHaveBeenCalled();
     expect(queue.scheduleMessage).not.toHaveBeenCalled();
     expect(result).toMatchObject({ abandoned: 0, alive: 1 });
+  });
+
+  it('gives the attempt back when the redrive fails to publish', async () => {
+    // The budget bounds LLM spend; a delivery that never went out spent
+    // nothing. Without the release, a brief queue outage walks a healthy
+    // operation to its attempt limit and retires it having never recovered.
+    const queue = buildQueue();
+    queue.scheduleMessage.mockRejectedValue(new Error('qstash down'));
+    claimStaleRedriveMock.mockResolvedValue(2);
+
+    const result = await buildReaper([candidate()], runningState(), queue).sweep();
+
+    expect(releaseStaleRedriveMock).toHaveBeenCalledWith('op_x', 2);
+    expect(finalizeAbandonedMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ abandoned: 0, redriven: 0 });
+  });
+
+  it('keeps the attempt when the redrive publishes successfully', async () => {
+    const result = await buildReaper([candidate()], runningState()).sweep();
+
+    expect(releaseStaleRedriveMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ redriven: 1 });
   });
 
   it('keeps sweeping after one operation throws', async () => {

--- a/apps/server/src/services/agentRuntime/index.ts
+++ b/apps/server/src/services/agentRuntime/index.ts
@@ -1,3 +1,4 @@
 export * from './AbandonOperationService';
 export * from './AgentRuntimeService';
+export * from './StaleOperationReaper';
 export * from './types';

--- a/packages/database/src/models/__tests__/agentOperation.test.ts
+++ b/packages/database/src/models/__tests__/agentOperation.test.ts
@@ -566,6 +566,48 @@ describe('AgentOperationModel', () => {
       });
     });
 
+    it('gives an attempt back so a failed publish costs no budget', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-release';
+      await model.recordStart({ operationId });
+
+      await makeStale(operationId);
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 2)).toBe(1);
+      expect(await model.releaseStaleRedrive(operationId, 1)).toBe(true);
+
+      // Budget restored: the next claim hands out attempt 1 again.
+      await makeStale(operationId);
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 2)).toBe(1);
+    });
+
+    it('only ever undoes its own increment', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-release-race';
+      await model.recordStart({ operationId });
+
+      await makeStale(operationId);
+      await model.claimStaleRedrive(operationId, staleBefore(), 3);
+      await makeStale(operationId);
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 3)).toBe(2);
+
+      // A late release for attempt 1 must not walk the counter backwards past
+      // the attempt another sweep has since claimed.
+      expect(await model.releaseStaleRedrive(operationId, 1)).toBe(false);
+      const row = await model.findById(operationId);
+      expect(row?.metadata).toMatchObject({ staleRedrive: { attempts: 2 } });
+    });
+
+    it('scopes the release to the owning user', async () => {
+      const operationId = 'op-redrive-release-ownership';
+      const model = new AgentOperationModel(serverDB, userId);
+      await model.recordStart({ operationId });
+      await makeStale(operationId);
+      await model.claimStaleRedrive(operationId, staleBefore(), 3);
+
+      const intruder = new AgentOperationModel(serverDB, otherUserId);
+      expect(await intruder.releaseStaleRedrive(operationId, 1)).toBe(false);
+    });
+
     it('is scoped to the owning user', async () => {
       const operationId = 'op-redrive-ownership';
       await new AgentOperationModel(serverDB, userId).recordStart({ operationId });

--- a/packages/database/src/models/__tests__/agentOperation.test.ts
+++ b/packages/database/src/models/__tests__/agentOperation.test.ts
@@ -494,6 +494,88 @@ describe('AgentOperationModel', () => {
     });
   });
 
+  describe('claimStaleRedrive', () => {
+    const makeStale = async (operationId: string) =>
+      serverDB
+        .update(agentOperations)
+        .set({ updatedAt: new Date('2026-01-01T00:00:00.000Z') })
+        .where(eq(agentOperations.id, operationId));
+
+    const staleBefore = () => new Date(Date.now() - 60_000);
+
+    it('hands out increasing attempts and stops at the budget', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-budget';
+      await model.recordStart({ operationId });
+
+      await makeStale(operationId);
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 2)).toBe(1);
+      await makeStale(operationId);
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 2)).toBe(2);
+      await makeStale(operationId);
+      // Budget spent — the caller falls back to abandoning the operation.
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 2)).toBeNull();
+    });
+
+    it('re-arms the lease so the next sweep skips a recovering operation', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-rearm';
+      await model.recordStart({ operationId });
+      await makeStale(operationId);
+
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 3)).toBe(1);
+      // The claim itself bumped updatedAt, so the row is no longer a candidate.
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 3)).toBeNull();
+    });
+
+    it('loses to a heartbeat that landed after the candidate was selected', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-heartbeat-race';
+      await model.recordStart({ operationId });
+      await makeStale(operationId);
+
+      const selectedAt = staleBefore();
+      await model.touchRunning(operationId);
+
+      expect(await model.claimStaleRedrive(operationId, selectedAt, 3)).toBeNull();
+      expect((await model.findById(operationId))?.status).toBe('running');
+    });
+
+    it('never claims an operation that already reached a terminal state', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-terminal';
+      await model.recordStart({ operationId });
+      await model.recordCompletion(operationId, { completionReason: 'done', status: 'done' });
+      await makeStale(operationId);
+
+      expect(await model.claimStaleRedrive(operationId, staleBefore(), 3)).toBeNull();
+    });
+
+    it('preserves unrelated metadata keys', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-redrive-metadata';
+      await model.recordStart({ operationId, metadata: { keepMe: 'yes' } });
+      await makeStale(operationId);
+
+      await model.claimStaleRedrive(operationId, staleBefore(), 3);
+
+      const row = await model.findById(operationId);
+      expect(row?.metadata).toMatchObject({
+        keepMe: 'yes',
+        staleRedrive: { attempts: 1 },
+      });
+    });
+
+    it('is scoped to the owning user', async () => {
+      const operationId = 'op-redrive-ownership';
+      await new AgentOperationModel(serverDB, userId).recordStart({ operationId });
+      await makeStale(operationId);
+
+      const intruder = new AgentOperationModel(serverDB, otherUserId);
+      expect(await intruder.claimStaleRedrive(operationId, staleBefore(), 3)).toBeNull();
+    });
+  });
+
   describe('sumChildUsage', () => {
     const seedChild = async (
       model: AgentOperationModel,

--- a/packages/database/src/models/agentOperation.ts
+++ b/packages/database/src/models/agentOperation.ts
@@ -405,6 +405,63 @@ export class AgentOperationModel {
   }
 
   /**
+   * Atomically claim the next redrive attempt for an operation whose liveness
+   * lease has expired, so a stale step can be re-queued instead of stranding.
+   *
+   * The claim is the concurrency control for the whole reaper: the same
+   * predicate that selects a candidate also consumes it, so two overlapping
+   * sweeps (or two instances of one sweep) can never both re-queue the same
+   * step. Three guards ride in the WHERE clause rather than in the caller:
+   * - `status = 'running'` — a terminal op is nobody's business anymore.
+   * - `updatedAt < staleBefore` — a heartbeat that landed between the SELECT
+   *   and this UPDATE means the step is alive after all, and wins the race.
+   * - attempt budget — a step that dies deterministically (poison payload,
+   *   OOM) must stop costing LLM calls; when this predicate fails the caller
+   *   falls back to abandoning the op with a user-visible error.
+   *
+   * Writing `metadata` also bumps `updatedAt` via `$onUpdate`, which re-arms
+   * the lease: the redriven step gets a fresh stall window before the next
+   * sweep can look at it again, and no extra bookkeeping is needed to keep
+   * ticks from piling redrives onto an operation that is busy recovering.
+   *
+   * @returns the 1-based attempt number just claimed, or `null` when this
+   *   operation is not (or no longer) eligible.
+   */
+  async claimStaleRedrive(
+    operationId: string,
+    staleBefore: Date,
+    maxAttempts: number,
+  ): Promise<number | null> {
+    // `jsonb_build_object` and the bare comparison below both take `any`, so
+    // every parameter feeding them needs an explicit cast — Postgres cannot
+    // infer a placeholder's type from an `any` argument (42P18).
+    const attempts = sql`coalesce((${agentOperations.metadata} #>> '{staleRedrive,attempts}')::int, 0)`;
+
+    const [row] = await this.db
+      .update(agentOperations)
+      .set({
+        metadata: sql`coalesce(${agentOperations.metadata}, '{}'::jsonb) || jsonb_build_object('staleRedrive', jsonb_build_object('attempts', ${attempts} + 1, 'lastAttemptAt', ${new Date().toISOString()}::text))`,
+      })
+      .where(
+        and(
+          eq(agentOperations.id, operationId),
+          eq(agentOperations.status, 'running'),
+          sql`${agentOperations.updatedAt} < ${staleBefore}`,
+          sql`${attempts} < ${maxAttempts}::int`,
+          this.ownership(),
+        ),
+      )
+      .returning({ metadata: agentOperations.metadata });
+
+    if (!row) return null;
+
+    const claimed = (row.metadata as { staleRedrive?: { attempts?: number } } | null)?.staleRedrive
+      ?.attempts;
+
+    return typeof claimed === 'number' ? claimed : null;
+  }
+
+  /**
    * Sum the terminal usage of every child operation forked from `parentOperationId`
    * (`callSubAgent` children, isolated group members).
    *

--- a/packages/database/src/models/agentOperation.ts
+++ b/packages/database/src/models/agentOperation.ts
@@ -462,6 +462,39 @@ export class AgentOperationModel {
   }
 
   /**
+   * Give back an attempt claimed by {@link claimStaleRedrive} when the redrive
+   * it was claimed for never actually went out.
+   *
+   * The budget exists to bound LLM spend on a step that dies deterministically,
+   * so a delivery that failed to publish must not consume it — otherwise a
+   * brief queue outage walks an otherwise healthy operation to its attempt
+   * limit and retires it without a single recovery ever having been attempted.
+   *
+   * The claimed attempt number is checked in SQL so this can only ever undo
+   * *its own* increment: a concurrent sweep that claimed the next attempt in
+   * between moves the counter past `attempt` and this becomes a no-op.
+   * `updatedAt` is deliberately left where the claim moved it, so the release
+   * shortens no stall window — the next sweep still waits out a full lease.
+   */
+  async releaseStaleRedrive(operationId: string, attempt: number): Promise<boolean> {
+    const [row] = await this.db
+      .update(agentOperations)
+      .set({
+        metadata: sql`jsonb_set(coalesce(${agentOperations.metadata}, '{}'::jsonb), '{staleRedrive,attempts}', to_jsonb(${attempt - 1}::int))`,
+      })
+      .where(
+        and(
+          eq(agentOperations.id, operationId),
+          sql`(${agentOperations.metadata} #>> '{staleRedrive,attempts}')::int = ${attempt}::int`,
+          this.ownership(),
+        ),
+      )
+      .returning({ id: agentOperations.id });
+
+    return Boolean(row);
+  }
+
+  /**
    * Sum the terminal usage of every child operation forked from `parentOperationId`
    * (`callSubAgent` children, isolated group members).
    *


### PR DESCRIPTION
A conversation can freeze mid-turn with no error and no way to resume. Traced one to `tpc_uHyib65uJbgC`: the op ran ~30 steps normally, persisted its last tool result at `14:09:33`, and then the instance executing the next LLM call was recycled at `14:11:46` (its last durable-lease heartbeat). Nothing was persisted after that.

It was not isolated — four ops died within the same 8 seconds, across **different users and different providers** (`micuapi-domestic`, `deepseek`, `lobehub`), so it is host-level recycling rather than anything model- or topic-specific. That shape recurs all day; ~50 ops on 2026-09-04 alone.

**Nothing recovers these today:**

- QStash already ACKed the delivery that started the step, so it never redelivers (no DLQ entry, and `/api/agent/run` returned 200 throughout).
- The gateway watchdog fires, but only after **30 minutes** (in-flight window), and it calls `finalize-abandoned`, which — see below — left the row `running` anyway.
- `settleStaleRunning` exists but has exactly one caller: `services/goal`. A chat/bot/task op has **no reaper at all**.

Of the 48 ops that got an `OperationInactivityTimeout` on the error board, **32 (67%) are still `status='running'`** in the DB.

The user-visible result is the worst part: of the 75 messages in that topic, **zero** carry an `error`. The client keys its retry affordance off `message.error`, so the turn renders as frozen rather than failed — there is not even a retry button to press.

#### What this does

Adds `StaleOperationReaper`, a system-level sweep that **prefers resuming over reporting**. The runtime keeps its resumable state in Redis, so while that state is alive the correct recovery is to re-queue the unfinished step and let the run continue where it stopped — not to surface an error and make the user re-ask. Falling back to abandoning happens only when the state is gone, the op is deliberately parked, or the redrive budget is spent.

Safety comes from mechanisms that already exist, not new bookkeeping:

- `claimStaleRedrive` consumes a candidate in the same `UPDATE` that selects it, so overlapping ticks cannot both re-queue one step. Writing `metadata` also bumps `updatedAt` via `$onUpdate`, which re-arms the lease — a recovering op is skipped by the next tick for free.
- `tryClaimStep` arbitrates against a host that turns out to be alive after all: the redelivery loses the lock race and returns without running.
- `executeStep` already ACKs deliveries for operations in a terminal state.
- A bounded attempt budget (default 3) keeps a deterministically-dying step from burning LLM calls forever.

Detection also gets ~6× tighter: the durable lease is heartbeated every 90s, so 5 minutes is three missed beats. The gateway watchdog has to stay at 30 minutes because it can only reason about stream events, and those legitimately pause for slow first-token latency.

`idle` states are redrivable too, which also covers the "born-dead" class — an op whose step-0 delivery never executed.

#### Two fixes to the abandon path it builds on

- **Settle the durable row from the with-state branch too.** Only the no-state branch did. `dispatchHooks` owns the rich terminal write but is gated on the state being `running`/`waiting_*`, and an `idle` step boundary skips it silently — that is the 67% above. The new `settleRunning` call is idempotent and only matches rows still `running`, so it cannot overwrite a richer outcome.
- **Error the conversation tail when the dying step never created its placeholder.** `assistantMessageId` is only set once a step has created one; a host killed mid-LLM-call never did, so there was nothing to mark. Falls back to the same spine query the runtime uses to pick a turn's continuation point.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`StaleOperationReaper` (10 new): redrive of a resumable step, per-attempt dedupe keys, step-0 redrive for born-dead ops, abandon when state is gone, never redriving `waiting_for_human` / `waiting_for_async_tool`, heartbeat winning the claim race, abandon once the budget is spent, sweep continuing past a throwing op, and stall-window plumbing.

`claimStaleRedrive` (6 new, real DB): increasing attempts capped at the budget, lease re-arming, losing to a heartbeat, never claiming a terminal op, preserving unrelated `metadata` keys, and ownership scoping. These caught a real bug — a `42P18` from uncast parameters inside `jsonb_build_object`.

`AbandonOperationService` (5 new): with-state row settling, settling when the lifecycle dispatch is skipped, tail-message fallback, placeholder taking precedence, and thread scoping.

All 36 `agentOperation` model tests and 25 `AbandonOperationService` tests pass; `tsgo --noEmit` is unchanged at the 257-error canary baseline. `agentSignalHooks.integration.test.ts` fails identically with and without this change in my environment (it needs Redis) — verified by stashing.

#### Follow-up (not in this PR)

The cron entry point (`GET /api/agent/reap-operations`, `bearerSecretAuth(CRON_SECRET)`, mirroring `/api/agent/gateway`) needs registering in `lobehub-cloud`'s `vercel.ts` once the submodule bumps. Until then this code is inert.

Bot- and task-triggered ops deserve more than a retry button — nobody is watching a Discord thread for one. Auto-redrive covers the unattended case here; pushing a failure back to the originating channel when the budget *is* spent is worth a separate change.
