### PR TITLE
✨ feat(model): add GPT-6 Astra support

### DIFF
--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -236,6 +236,7 @@
   "providerModels.item.modelConfig.extendParams.options.gpt5_2ProReasoningEffort.hint": "For GPT-5.2 Pro series; controls reasoning intensity.",
   "providerModels.item.modelConfig.extendParams.options.gpt5_2ReasoningEffort.hint": "For GPT-5.2 series; controls reasoning intensity.",
   "providerModels.item.modelConfig.extendParams.options.gpt5_6ReasoningEffort.hint": "For GPT-5.6 series; controls reasoning intensity from None through Max.",
+  "providerModels.item.modelConfig.extendParams.options.gpt6ReasoningEffort.hint": "For GPT-6 series; controls reasoning intensity from Low through Max. Reasoning cannot be disabled.",
   "providerModels.item.modelConfig.extendParams.options.grok4_20ReasoningEffort.hint": "For Grok 4.20 series; controls reasoning intensity. Low/Medium uses 4 agents, High/XHigh uses 16 agents.",
   "providerModels.item.modelConfig.extendParams.options.grok4_3ReasoningEffort.hint": "For Grok 4.3 series; controls reasoning intensity.",
   "providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint": "For Grok 4.5 series; controls reasoning intensity (low/medium/high, default high).",

--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -862,6 +862,7 @@
   "lobehub.gpt-5.6-sol.description": "GPT-5.6 Sol is OpenAI's frontier model for complex reasoning, coding, and long-horizon agentic work. The gpt-5.6 alias routes to Sol.",
   "lobehub.gpt-5.6-terra.description": "GPT-5.6 Terra balances intelligence and cost for everyday professional work, competitive with GPT-5.5 at about half the price.",
   "lobehub.gpt-5.description": "The best model for cross-domain coding and agent tasks, with strong accuracy, speed, reasoning, and problem-solving capabilities.",
+  "lobehub.gpt-6-astra.description": "OpenAI's most intelligent and aligned model, state of the art on computer use and 3D work.",
   "lobehub.gpt-image-1.5.description": "An enhanced GPT Image 1 model with 4× faster generation, more precise editing, and improved text rendering.",
   "lobehub.gpt-image-1.description": "ChatGPT native multimodal image generation model.",
   "lobehub.gpt-image-2.description": "OpenAI's next-generation multimodal image model with native reasoning, up to 4K resolution, near-perfect text rendering, and high-fidelity multilingual support.",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -236,6 +236,7 @@
   "providerModels.item.modelConfig.extendParams.options.gpt5_2ProReasoningEffort.hint": "适用于 GPT-5.2 Pro 系列；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.gpt5_2ReasoningEffort.hint": "适用于 GPT-5.2 系列；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.gpt5_6ReasoningEffort.hint": "适用于 GPT-5.6 系列；控制推理强度，从无到最大。",
+  "providerModels.item.modelConfig.extendParams.options.gpt6ReasoningEffort.hint": "适用于 GPT-6 系列；控制推理强度，从低到最大，无法关闭推理。",
   "providerModels.item.modelConfig.extendParams.options.grok4_20ReasoningEffort.hint": "适用于 Grok 4.20 系列；控制推理强度。低/中档使用 4 个代理，高/超高使用 16 个代理。",
   "providerModels.item.modelConfig.extendParams.options.grok4_3ReasoningEffort.hint": "适用于 Grok 4.3 系列；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint": "适用于 Grok 4.5 系列；控制推理强度（低/中/高，默认高）。",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -862,6 +862,7 @@
   "lobehub.gpt-5.6-sol.description": "GPT-5.6 Sol 是 OpenAI 的前沿模型，适用于复杂推理、编码和长时间智能代理工作。gpt-5.6 别名指向 Sol。",
   "lobehub.gpt-5.6-terra.description": "GPT-5.6 Terra 在智能与成本之间实现平衡，适用于日常专业工作，其性能可与 GPT-5.5 竞争，但价格约为其一半。",
   "lobehub.gpt-5.description": "跨领域编码和智能代理任务的最佳模型，具备强大的准确性、速度、推理和问题解决能力。",
+  "lobehub.gpt-6-astra.description": "OpenAI 迄今最智能、对齐程度最高的模型，在电脑操作和三维建模上达到业界最强水平。",
   "lobehub.gpt-image-1.5.description": "GPT Image 1 的增强版本，生成速度提升 4 倍，编辑更精准，文本渲染效果更佳。",
   "lobehub.gpt-image-1.description": "ChatGPT 原生多模态图像生成模型。",
   "lobehub.gpt-image-2.description": "OpenAI 的下一代多模态图像模型，具备原生推理能力，支持最高 4K 分辨率、近乎完美的文字渲染及高保真多语言能力。",

--- a/packages/locales/src/default/modelProvider.ts
+++ b/packages/locales/src/default/modelProvider.ts
@@ -276,6 +276,8 @@ export default {
     'For GPT-5.2 series; controls reasoning intensity.',
   'providerModels.item.modelConfig.extendParams.options.gpt5_6ReasoningEffort.hint':
     'For GPT-5.6 series; controls reasoning intensity from None through Max.',
+  'providerModels.item.modelConfig.extendParams.options.gpt6ReasoningEffort.hint':
+    'For GPT-6 series; controls reasoning intensity from Low through Max. Reasoning cannot be disabled.',
   'providerModels.item.modelConfig.extendParams.options.glm5_2ReasoningEffort.hint':
     'For GLM-5.2; controls reasoning effort with High and Max levels.',
   'providerModels.item.modelConfig.extendParams.options.glm5_3ReasoningEffort.hint':

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -129,6 +129,8 @@ export const lobeHubOnlineModelDescriptions = {
     'GPT-5.6 Terra balances intelligence and cost for everyday professional work, competitive with GPT-5.5 at about half the price.',
   'lobehub.gpt-5.description':
     'The best model for cross-domain coding and agent tasks, with strong accuracy, speed, reasoning, and problem-solving capabilities.',
+  'lobehub.gpt-6-astra.description':
+    "OpenAI's most intelligent and aligned model, state of the art on computer use and 3D work.",
   'lobehub.gpt-image-1.5.description':
     'An enhanced GPT Image 1 model with 4× faster generation, more precise editing, and improved text rendering.',
   'lobehub.gpt-image-1.description': 'ChatGPT native multimodal image generation model.',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -348,6 +348,7 @@ export interface AiModelReasoningConfig {
   gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   gpt5_6ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
+  gpt6ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   grok4_3ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   grok4_5ReasoningEffort?: 'low' | 'medium' | 'high';
   grok4_6ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
@@ -373,6 +374,7 @@ export const AiModelReasoningConfigSchema = z.object({
   gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
   gpt5_6ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh', 'max']).optional(),
   gpt5ReasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+  gpt6ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
   grok4_3ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   grok4_5ReasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
   grok4_6ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
@@ -414,6 +416,7 @@ export const MODEL_REASONING_PARAM_LEVELS: {
   gpt5_2ReasoningEffort: ['none', 'low', 'medium', 'high', 'xhigh'],
   gpt5_6ReasoningEffort: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
   gpt5ReasoningEffort: ['minimal', 'low', 'medium', 'high'],
+  gpt6ReasoningEffort: ['low', 'medium', 'high', 'xhigh', 'max'],
   grok4_3ReasoningEffort: ['none', 'low', 'medium', 'high'],
   grok4_5ReasoningEffort: ['low', 'medium', 'high'],
   grok4_6ReasoningEffort: ['low', 'medium', 'high', 'xhigh'],
@@ -446,6 +449,7 @@ export const MODEL_REASONING_PARAM_DEFAULTS: {
   gpt5_2ReasoningEffort: 'none',
   gpt5_6ReasoningEffort: 'medium',
   gpt5ReasoningEffort: 'medium',
+  gpt6ReasoningEffort: 'medium',
   grok4_3ReasoningEffort: 'low',
   grok4_5ReasoningEffort: 'high',
   grok4_6ReasoningEffort: 'high',
@@ -497,6 +501,7 @@ export type ExtendParamsType =
   | 'gpt5_2ReasoningEffort'
   | 'gpt5_2ProReasoningEffort'
   | 'gpt5_6ReasoningEffort'
+  | 'gpt6ReasoningEffort'
   | 'glm5_2ReasoningEffort'
   | 'glm5_3ReasoningEffort'
   | 'grok4_20ReasoningEffort'
@@ -557,6 +562,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'gpt5_2ReasoningEffort',
   'gpt5_2ProReasoningEffort',
   'gpt5_6ReasoningEffort',
+  'gpt6ReasoningEffort',
   'glm5_2ReasoningEffort',
   'glm5_3ReasoningEffort',
   'grok4_20ReasoningEffort',

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -10,9 +10,9 @@ import type { Stream } from 'openai/streaming';
 
 import { ErrorClassifier, refineErrorCode } from '../../errors';
 import {
-  isGPT5ProResponsesModel,
+  isGPTProResponsesModel,
   isResponsesAPIModel,
-  supportsGPT5ResponsesReasoningEffortNone,
+  supportsGPTResponsesReasoningEffortNone,
 } from '../../providers/openai/modelId';
 import type {
   ASROptions,
@@ -164,12 +164,12 @@ const getGenerateObjectResponsesReasoningParams = ({
   reasoning_effort,
   thinking,
 }: GenerateObjectReasoningParams & { model: string }) => {
-  if (isGPT5ProResponsesModel(model)) {
+  if (isGPTProResponsesModel(model)) {
     return reasoning_effort && reasoning_effort !== 'max' ? { reasoning: { effort: 'high' } } : {};
   }
 
   if (thinking?.type === 'disabled') {
-    return supportsGPT5ResponsesReasoningEffortNone(model) ? { reasoning: { effort: 'none' } } : {};
+    return supportsGPTResponsesReasoningEffortNone(model) ? { reasoning: { effort: 'none' } } : {};
   }
 
   return reasoning_effort && reasoning_effort !== 'max'

--- a/packages/model-runtime/src/providers/azureOpenai/index.test.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.test.ts
@@ -156,6 +156,31 @@ describe('LobeAzureOpenAI', () => {
         });
       });
 
+      it('should prune the sampling params GPT-6 Astra rejects on the Responses API', async () => {
+        const mockStream = new ReadableStream() as any;
+        vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(mockStream);
+        vi.spyOn(getModelPricingModule, 'getModelPricing').mockResolvedValue(undefined);
+        vi.spyOn(streamsModule, 'OpenAIResponsesStream').mockReturnValue(new ReadableStream());
+
+        await instance.chat({
+          messages: [{ content: 'Review this migration.', role: 'system' }],
+          model: 'gpt-6-astra',
+          reasoning_effort: 'xhigh',
+          stream: true,
+          temperature: 0.7,
+          top_p: 0.9,
+        } as any);
+
+        const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+
+        expect(createCall.model).toBe('gpt-6-astra');
+        expect(createCall.reasoning).toEqual({ effort: 'xhigh', summary: 'auto' });
+        expect(createCall.input[0].role).toBe('developer');
+        expect(createCall.temperature).toBeUndefined();
+        expect(createCall.top_logprobs).toBeUndefined();
+        expect(createCall.top_p).toBeUndefined();
+      });
+
       it('should use deploymentName for Azure Responses API requests while keeping logical model for pricing', async () => {
         const mockStream = new ReadableStream() as any;
         const mockPricing = { units: [] };

--- a/packages/model-runtime/src/providers/azureOpenai/index.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.ts
@@ -14,8 +14,17 @@ import { isResponsesAPIModel, responsesAPIModels, systemToUserModels } from '../
 const azureImageLogger = debug('lobe-image:azure');
 const azureSearchContextSize = process.env.OPENAI_SEARCH_CONTEXT_SIZE;
 
+/**
+ * Azure reasoning models reject sampling/penalty params (`temperature` and friends
+ * 400 with "Unsupported parameter"). Matches GPT-5 and every later GPT generation —
+ * GPT-6 dropped the minor version (`gpt-6-astra`) but kept the same restriction.
+ *
+ * Substring matching is deliberate: Azure deployment names commonly wrap the model
+ * id (`prod-gpt-54`). The `[.-]`/end boundary keeps Azure's legacy `gpt-35-turbo`
+ * deployment name out.
+ */
 const isAzureReasoningModel = (model: string) =>
-  model.includes('gpt-5') || model.includes('o1') || model.includes('o3');
+  /gpt-[5-9](?:$|[.-])/.test(model) || model.includes('o1') || model.includes('o3');
 
 const supportsImageInputFidelity = (model: string) => /^gpt-image-1(?:$|[-.])/.test(model);
 

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -353,6 +353,20 @@ describe('LobeOpenAI', () => {
       expect(createCall.model).toBe('gpt-5.6-sol');
     });
 
+    it('should use responses API for GPT-6 family models', async () => {
+      const payload = {
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'gpt-6-astra',
+        temperature: 0.7,
+      };
+
+      await instance.chat(payload);
+
+      expect(instance['client'].responses.create).toHaveBeenCalled();
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.model).toBe('gpt-6-astra');
+    });
+
     it('should prune sampling parameters for Codex-prefixed GPT-5.6 models', async () => {
       const payload = {
         frequency_penalty: 0.5,
@@ -459,6 +473,27 @@ describe('LobeOpenAI', () => {
       expect(createCall.frequency_penalty).toBeUndefined();
       expect(createCall.presence_penalty).toBeUndefined();
       expect(createCall.temperature).toBeUndefined();
+      expect(createCall.top_p).toBeUndefined();
+    });
+
+    it('should prune the params GPT-6 Astra rejects and keep xhigh reasoning effort', async () => {
+      const payload = {
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'gpt-6-astra',
+        reasoning_effort: 'xhigh' as const,
+        temperature: 0.7,
+        top_p: 0.9,
+      };
+
+      await instance.chat(payload);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall).toMatchObject({
+        model: 'gpt-6-astra',
+        reasoning: { effort: 'xhigh', summary: 'auto' },
+      });
+      expect(createCall.temperature).toBeUndefined();
+      expect(createCall.top_logprobs).toBeUndefined();
       expect(createCall.top_p).toBeUndefined();
     });
 

--- a/packages/model-runtime/src/providers/openai/index.ts
+++ b/packages/model-runtime/src/providers/openai/index.ts
@@ -6,7 +6,7 @@ import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactor
 import type { ChatStreamPayload } from '../../types';
 import { processMultiProviderModelList } from '../../utils/modelParse';
 import {
-  isGPT5ProResponsesModel,
+  isGPTProResponsesModel,
   isOpenAIComputerUseModel,
   isOpenAIReasoningPayloadModel,
   isResponsesAPIModel,
@@ -108,7 +108,7 @@ export const params = {
         const reasoning = payload.reasoning
           ? { ...payload.reasoning, summary: 'auto' }
           : { summary: 'auto' };
-        if (isGPT5ProResponsesModel(model)) {
+        if (isGPTProResponsesModel(model)) {
           reasoning.effort = 'high';
         }
         return pruneReasoningPayload({

--- a/packages/model-runtime/src/providers/openai/modelId.test.ts
+++ b/packages/model-runtime/src/providers/openai/modelId.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  isGPT5ProResponsesModel,
-  isGPT5ResponsesModel,
+  isGPTProResponsesModel,
+  isGPTResponsesModel,
   isOpenAIComputerUseModel,
   isOpenAIReasoningPayloadModel,
   isResponsesAPIModel,
   parseOpenAIModelId,
-  supportsGPT5ResponsesReasoningEffortNone,
+  supportsGPTResponsesReasoningEffortNone,
   supportsOpenAIServiceTierFlex,
 } from './modelId';
 
@@ -66,84 +66,118 @@ describe('parseOpenAIModelId', () => {
     });
   });
 
+  it('should parse GPT-6 ids, which carry a codename instead of a minor version', () => {
+    expect(parseOpenAIModelId('gpt-6-astra')).toEqual({
+      family: 'gpt',
+      majorVersion: 6,
+      modifiers: ['astra'],
+      normalizedModelId: 'gpt-6-astra',
+      source: 'openai',
+    });
+  });
+
+  it('should not read Azure legacy GPT-3.5 deployment names as major version 35', () => {
+    expect(parseOpenAIModelId('gpt-35-turbo')).toBeUndefined();
+    expect(parseOpenAIModelId('gpt-35-turbo-16k')).toBeUndefined();
+  });
+
   it('should return undefined for non-GPT ids', () => {
     expect(parseOpenAIModelId('claude-opus-4-1')).toBeUndefined();
   });
 });
 
-describe('isGPT5ResponsesModel', () => {
+describe('isGPTResponsesModel', () => {
   it('should preserve current base GPT-5 chat-completions models', () => {
-    expect(isGPT5ResponsesModel('gpt-5')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-5-chat-latest')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-5.2-chat-latest')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-5.3-chat-latest')).toBe(false);
+    expect(isGPTResponsesModel('gpt-5')).toBe(false);
+    expect(isGPTResponsesModel('gpt-5-chat-latest')).toBe(false);
+    expect(isGPTResponsesModel('gpt-5.2-chat-latest')).toBe(false);
+    expect(isGPTResponsesModel('gpt-5.3-chat-latest')).toBe(false);
     expect(isResponsesAPIModel('gpt-5.2-chat-latest')).toBe(false);
   });
 
   it('should match existing GPT-5 Responses models', () => {
-    expect(isGPT5ResponsesModel('gpt-5-mini')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5-mini-2025-08-07')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5-foo-mini')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-5-pro')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5-pro-2025-10-06')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.1-codex-mini')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.2')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.4-mini')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.5-pro')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5-mini')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5-mini-2025-08-07')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5-foo-mini')).toBe(false);
+    expect(isGPTResponsesModel('gpt-5-pro')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5-pro-2025-10-06')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.1-codex-mini')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.2')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.4-mini')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.5-pro')).toBe(true);
   });
 
   it('should match the GPT-5.6 family without allowlist entries', () => {
-    expect(isGPT5ResponsesModel('gpt-5.6')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.6-sol')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.6-terra')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.6-luna')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.6')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.6-sol')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.6-terra')).toBe(true);
+    expect(isGPTResponsesModel('gpt-5.6-luna')).toBe(true);
   });
 
   it('should match Codex-prefixed GPT-5.6 models', () => {
-    expect(isGPT5ResponsesModel('codex/gpt-5.6-luna')).toBe(true);
+    expect(isGPTResponsesModel('codex/gpt-5.6-luna')).toBe(true);
     expect(isResponsesAPIModel('codex/gpt-5.6-luna')).toBe(true);
   });
 
   it('should not force OpenRouter GPT slugs into the built-in Responses API rules', () => {
-    expect(isGPT5ResponsesModel('openai/gpt-5.6-terra')).toBe(false);
+    expect(isGPTResponsesModel('openai/gpt-5.6-terra')).toBe(false);
     expect(isResponsesAPIModel('openai/gpt-5.6-terra')).toBe(false);
   });
 
-  it('should not match non-GPT-5 ids', () => {
-    expect(isGPT5ResponsesModel('gpt-4o')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-6')).toBe(false);
-    expect(isGPT5ResponsesModel('o3-pro')).toBe(false);
+  it('should match the GPT-6 family, which has no minor version and is Responses-only', () => {
+    expect(isGPTResponsesModel('gpt-6')).toBe(true);
+    expect(isGPTResponsesModel('gpt-6-astra')).toBe(true);
+    expect(isResponsesAPIModel('gpt-6-astra')).toBe(true);
+    expect(isGPTResponsesModel('codex/gpt-6-astra')).toBe(true);
+  });
+
+  it('should keep GPT-6 chat variants and OpenRouter slugs off the Responses endpoint', () => {
+    expect(isGPTResponsesModel('gpt-6-chat-latest')).toBe(false);
+    expect(isGPTResponsesModel('openai/gpt-6-astra')).toBe(false);
+  });
+
+  it('should not match pre-reasoning-era or non-GPT ids', () => {
+    expect(isGPTResponsesModel('gpt-4o')).toBe(false);
+    expect(isGPTResponsesModel('o3-pro')).toBe(false);
+    // Azure's legacy GPT-3.5 deployment name must stay on chat.completions.
+    expect(isGPTResponsesModel('gpt-35-turbo-16k')).toBe(false);
+    expect(isResponsesAPIModel('gpt-35-turbo-16k')).toBe(false);
   });
 });
 
-describe('isGPT5ProResponsesModel', () => {
+describe('isGPTProResponsesModel', () => {
   it('should match GPT-5 pro variants', () => {
-    expect(isGPT5ProResponsesModel('gpt-5-pro')).toBe(true);
-    expect(isGPT5ProResponsesModel('gpt-5.5-pro')).toBe(true);
+    expect(isGPTProResponsesModel('gpt-5-pro')).toBe(true);
+    expect(isGPTProResponsesModel('gpt-5.5-pro')).toBe(true);
   });
 
   it('should not match non-pro GPT-5 variants', () => {
-    expect(isGPT5ProResponsesModel('gpt-5.6')).toBe(false);
-    expect(isGPT5ProResponsesModel('gpt-5.6-sol')).toBe(false);
-    expect(isGPT5ProResponsesModel('gpt-5.6-terra')).toBe(false);
-    expect(isGPT5ProResponsesModel('gpt-5.6-luna')).toBe(false);
-    expect(isGPT5ProResponsesModel('openai/gpt-5.5-pro')).toBe(false);
+    expect(isGPTProResponsesModel('gpt-6-astra')).toBe(false);
+    expect(isGPTProResponsesModel('gpt-5.6')).toBe(false);
+    expect(isGPTProResponsesModel('gpt-5.6-sol')).toBe(false);
+    expect(isGPTProResponsesModel('gpt-5.6-terra')).toBe(false);
+    expect(isGPTProResponsesModel('gpt-5.6-luna')).toBe(false);
+    expect(isGPTProResponsesModel('openai/gpt-5.5-pro')).toBe(false);
   });
 });
 
-describe('supportsGPT5ResponsesReasoningEffortNone', () => {
+describe('supportsGPTResponsesReasoningEffortNone', () => {
   it('should support none reasoning effort for non-pro GPT-5 minor models', () => {
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6')).toBe(true);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-sol')).toBe(true);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-terra')).toBe(true);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-luna')).toBe(true);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-5.6')).toBe(true);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-5.6-sol')).toBe(true);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-5.6-terra')).toBe(true);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-5.6-luna')).toBe(true);
+  });
+
+  it('should not support none reasoning effort on GPT-6, which removed it', () => {
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-6-astra')).toBe(false);
   });
 
   it('should preserve unsupported cases', () => {
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5')).toBe(false);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.5-pro')).toBe(false);
-    expect(supportsGPT5ResponsesReasoningEffortNone('openai/gpt-5.6')).toBe(false);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-4o')).toBe(false);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-5')).toBe(false);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-5.5-pro')).toBe(false);
+    expect(supportsGPTResponsesReasoningEffortNone('openai/gpt-5.6')).toBe(false);
+    expect(supportsGPTResponsesReasoningEffortNone('gpt-4o')).toBe(false);
   });
 });
 
@@ -155,6 +189,7 @@ describe('isOpenAIReasoningPayloadModel', () => {
     expect(isOpenAIReasoningPayloadModel('codex-mini-latest')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('computer-use-preview')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('gpt-5.6-luna')).toBe(true);
+    expect(isOpenAIReasoningPayloadModel('gpt-6-astra')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('codex/gpt-5.6-luna')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('openai/gpt-5.6-sol')).toBe(true);
   });
@@ -179,6 +214,7 @@ describe('isOpenAIComputerUseModel', () => {
 describe('supportsOpenAIServiceTierFlex', () => {
   it('should support flex tier model families', () => {
     expect(supportsOpenAIServiceTierFlex('gpt-5.6-sol')).toBe(true);
+    expect(supportsOpenAIServiceTierFlex('gpt-6-astra')).toBe(true);
     expect(supportsOpenAIServiceTierFlex('openai/gpt-5.6-terra')).toBe(true);
     expect(supportsOpenAIServiceTierFlex('o3-pro')).toBe(true);
     expect(supportsOpenAIServiceTierFlex('o4-mini')).toBe(true);

--- a/packages/model-runtime/src/providers/openai/modelId.ts
+++ b/packages/model-runtime/src/providers/openai/modelId.ts
@@ -51,8 +51,14 @@ export const responsesAPIModels = new Set([
   'computer-use-preview-2025-03-11',
 ]);
 
+/**
+ * The major version is a single digit on purpose. Azure's legacy deployment name for
+ * GPT-3.5 drops the dot (`gpt-35-turbo`), and a `\d+` major would read that as major
+ * version 35 — which then satisfies every `majorVersion >= 5` reasoning-era check and
+ * wrongly routes a 2023 chat model to the Responses API.
+ */
 const GPT_MODEL_PATTERN =
-  /^gpt-(\d+)(?:\.(\d+))?(?:\b|[-.:])(?:-([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))?/;
+  /^gpt-(\d)(?:\.(\d+))?(?:\b|[-.:])(?:-([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))?/;
 
 /**
  * Codex-compatible gateways namespace OpenAI models as `codex/gpt-*`. These models still use
@@ -130,15 +136,21 @@ export const parseOpenAIModelId = (model: string): ParsedOpenAIModelId | undefin
   };
 };
 
-const isGPT5Model = (model: string): ParsedOpenAIModelId | undefined => {
+/**
+ * GPT-5 is the first generation that switched to the reasoning-model contract
+ * (reasoning payload, no temperature/top_p, Responses endpoint). Every later
+ * major version — GPT-6 and beyond — inherits that contract, so gate on
+ * `majorVersion >= 5` instead of pinning to 5.
+ */
+const isReasoningEraGPTModel = (model: string): ParsedOpenAIModelId | undefined => {
   const parsed = parseOpenAIModelId(model);
-  if (!parsed || parsed.majorVersion !== 5) return;
+  if (!parsed || parsed.majorVersion < 5) return;
 
   return parsed;
 };
 
-const isGPT5ResponsesEndpointModel = (model: string): ParsedOpenAIModelId | undefined => {
-  const parsed = isGPT5Model(model);
+const isResponsesEndpointGPTModel = (model: string): ParsedOpenAIModelId | undefined => {
+  const parsed = isReasoningEraGPTModel(model);
   if (!parsed || parsed.source === 'openRouter') return;
 
   return parsed;
@@ -149,28 +161,42 @@ const hasModifier = (parsed: ParsedOpenAIModelId, modifier: string): boolean =>
 
 const baseGPT5MiniResponsesModels = new Set(['gpt-5-mini', 'gpt-5-mini-2025-08-07']);
 
-export const isGPT5ResponsesModel = (model: string): boolean => {
-  const parsed = isGPT5ResponsesEndpointModel(model);
+export const isGPTResponsesModel = (model: string): boolean => {
+  const parsed = isResponsesEndpointGPTModel(model);
   if (!parsed) return false;
 
   if (hasModifier(parsed, 'chat')) return false;
   if (hasModifier(parsed, 'codex') || hasModifier(parsed, 'pro')) return true;
   if (baseGPT5MiniResponsesModels.has(parsed.normalizedModelId)) return true;
 
+  /**
+   * GPT-6 dropped the minor-version suffix (`gpt-6-astra`) and only ships tool
+   * calling on the Responses endpoint, so every GPT-6+ model is Responses-only.
+   *
+   * @see https://developers.openai.com/docs/guides/latest-model
+   */
+  if (parsed.majorVersion >= 6) return true;
+
   return parsed.minorVersion !== undefined && parsed.minorVersion >= 2;
 };
 
 export const isResponsesAPIModel = (model: string): boolean =>
-  responsesAPIModels.has(model) || isGPT5ResponsesModel(model);
+  responsesAPIModels.has(model) || isGPTResponsesModel(model);
 
-export const isGPT5ProResponsesModel = (model: string): boolean => {
-  const parsed = isGPT5ResponsesEndpointModel(model);
+export const isGPTProResponsesModel = (model: string): boolean => {
+  const parsed = isResponsesEndpointGPTModel(model);
   return !!parsed && hasModifier(parsed, 'pro');
 };
 
-export const supportsGPT5ResponsesReasoningEffortNone = (model: string): boolean => {
-  const parsed = isGPT5ResponsesEndpointModel(model);
-  if (!parsed || parsed.minorVersion === undefined) return false;
+/**
+ * `reasoning.effort: 'none'` is a GPT-5.x-only affordance. GPT-5 Pro never
+ * supported it, and GPT-6 Astra removed it — its lowest effort is `low`.
+ *
+ * @see https://developers.openai.com/docs/guides/latest-model
+ */
+export const supportsGPTResponsesReasoningEffortNone = (model: string): boolean => {
+  const parsed = isResponsesEndpointGPTModel(model);
+  if (!parsed || parsed.majorVersion !== 5 || parsed.minorVersion === undefined) return false;
 
   return !hasModifier(parsed, 'pro');
 };
@@ -180,7 +206,8 @@ export const isOpenAIReasoningPayloadModel = (model: string): boolean => {
   if (!normalizedModelId) return false;
 
   return (
-    !!isGPT5Model(model) || /^(?:o[134]|codex|computer-use)(?:$|[-.:])/.test(normalizedModelId)
+    !!isReasoningEraGPTModel(model) ||
+    /^(?:o[134]|codex|computer-use)(?:$|[-.:])/.test(normalizedModelId)
   );
 };
 
@@ -193,7 +220,7 @@ export const supportsOpenAIServiceTierFlex = (model: string): boolean => {
   const normalizedModelId = normalizeOpenAIModelId(model);
   if (!normalizedModelId) return false;
 
-  if (isGPT5Model(model)) return true;
+  if (isReasoningEraGPTModel(model)) return true;
   if (/^o3-mini(?:$|[-.:])/.test(normalizedModelId)) return false;
 
   return /^(?:o3|o4-mini)(?:$|[-.:])/.test(normalizedModelId);

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -182,6 +182,16 @@ describe('applyModelExtendParams', () => {
     expect(result.reasoning_effort).toBe('max');
   });
 
+  it('resolves GPT-6 xhigh reasoning effort', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ gpt6ReasoningEffort: 'xhigh' }),
+      extendParams: ['gpt6ReasoningEffort'],
+      model: 'gpt-6-astra',
+    });
+
+    expect(result.reasoning_effort).toBe('xhigh');
+  });
+
   it('resolves Kimi K3 reasoning effort', () => {
     const result = applyModelExtendParams({
       chatConfig: chatConfig({ kimiK3ReasoningEffort: 'high' }),

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -307,6 +307,10 @@ export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): Mode
     extendParams.reasoning_effort = chatConfig.gpt5_6ReasoningEffort;
   }
 
+  if (modelExtendParams.includes('gpt6ReasoningEffort') && chatConfig.gpt6ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.gpt6ReasoningEffort;
+  }
+
   if (modelExtendParams.includes('reasoningMode') && chatConfig.reasoningMode === 'pro') {
     extendParams.reasoning = { ...extendParams.reasoning, mode: 'pro' };
   }

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -94,6 +94,7 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig, AgentSelfIte
   gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   gpt5_6ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
+  gpt6ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   grok4_3ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   grok4_5ReasoningEffort?: 'low' | 'medium' | 'high';
   grok4_6ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
@@ -251,6 +252,7 @@ export const AgentChatConfigSchema = z
     gpt5_2ProReasoningEffort: z.enum(['medium', 'high', 'xhigh']).optional(),
     gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
     gpt5_6ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh', 'max']).optional(),
+    gpt6ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
     glm5_2ReasoningEffort: z.enum(['high', 'max']).optional(),
     glm5_3ReasoningEffort: z.enum(['low', 'high', 'max']).optional(),
     grok4_20ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -29,6 +29,7 @@ import EffortSlider from './EffortSlider';
 import GLM52ReasoningEffortSlider from './GLM52ReasoningEffortSlider';
 import GLM53ReasoningEffortSlider from './GLM53ReasoningEffortSlider';
 import GPT5ReasoningEffortSlider from './GPT5ReasoningEffortSlider';
+import { GPT6ReasoningEffortSlider } from './GPT6ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from './GPT51ReasoningEffortSlider';
 import GPT52ProReasoningEffortSlider from './GPT52ProReasoningEffortSlider';
 import GPT52ReasoningEffortSlider from './GPT52ReasoningEffortSlider';
@@ -350,6 +351,16 @@ const ControlsForm = memo<ControlsFormProps>(
         layout: 'vertical',
         minWidth: undefined,
         name: 'gpt5_6ReasoningEffort',
+        style: {
+          paddingBottom: 0,
+        },
+      },
+      {
+        children: <GPT6ReasoningEffortSlider />,
+        label: t('extendParams.reasoningEffort.title'),
+        layout: 'vertical',
+        minWidth: undefined,
+        name: 'gpt6ReasoningEffort',
         style: {
           paddingBottom: 0,
         },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/GPT6ReasoningEffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/GPT6ReasoningEffortSlider.tsx
@@ -1,0 +1,19 @@
+import type { CreatedLevelSliderProps } from './createLevelSlider';
+import { createLevelSliderComponent } from './createLevelSlider';
+
+/**
+ * GPT-6 Astra dropped `none` — its lowest reasoning effort is `low`.
+ *
+ * @see https://developers.openai.com/docs/models/gpt-6-astra
+ */
+const GPT6_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+type GPT6ReasoningEffort = (typeof GPT6_REASONING_EFFORT_LEVELS)[number];
+
+export type GPT6ReasoningEffortSliderProps = CreatedLevelSliderProps<GPT6ReasoningEffort>;
+
+export const GPT6ReasoningEffortSlider = createLevelSliderComponent<GPT6ReasoningEffort>({
+  configKey: 'gpt6ReasoningEffort',
+  defaultValue: 'medium',
+  levels: GPT6_REASONING_EFFORT_LEVELS,
+  style: { minWidth: 270 },
+});

--- a/src/features/ModelSwitchPanel/hooks/useBuildListItems.test.ts
+++ b/src/features/ModelSwitchPanel/hooks/useBuildListItems.test.ts
@@ -5,8 +5,12 @@ import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
 import { buildListItems } from './useBuildListItems';
 
-const model = (id: string, displayName = id) =>
-  ({ abilities: {}, displayName, id }) satisfies AiModelForSelect;
+const model = (id: string, displayName = id, releasedAt?: string) =>
+  ({ abilities: {}, displayName, id, releasedAt }) satisfies AiModelForSelect;
+
+/** `isNewReleaseDate` uses a 14-day window, so anchor fixtures relative to today. */
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
 
 const provider = (id: string, children: AiModelForSelect[]): EnabledProviderWithModels => ({
   children,
@@ -48,5 +52,62 @@ describe('buildListItems', () => {
           : [],
       ),
     ).toEqual(['mixed-pro', 'normal', 'lobehub-pro']);
+  });
+
+  it('should order the pinned new models newest-first instead of by catalog order', () => {
+    const items = buildListItems(
+      [
+        provider('lobehub', [
+          model('fable-5.1', 'Claude Fable 5.1', daysAgo(3)),
+          model('gpt-6-astra', 'GPT-6 Astra', daysAgo(1)),
+          model('glm-5.3-flash', 'GLM-5.3-Flash', daysAgo(9)),
+          model('deepseek-v4-pro', 'DeepSeek V4 Pro', daysAgo(200)),
+        ]),
+      ],
+      'byProvider',
+    );
+
+    expect(getProviderModelIds(items)).toEqual([
+      'gpt-6-astra',
+      'fable-5.1',
+      'glm-5.3-flash',
+      'deepseek-v4-pro',
+    ]);
+  });
+
+  it('should keep catalog order for new models released on the same day', () => {
+    const sameDay = daysAgo(2);
+    const items = buildListItems(
+      [
+        provider('lobehub', [
+          model('gemini-3.8-flash', 'Gemini 3.8 Flash', sameDay),
+          model('qwen3.8-max', 'Qwen3.8 Max', sameDay),
+          model('legacy', 'Legacy', daysAgo(400)),
+        ]),
+      ],
+      'byProvider',
+    );
+
+    expect(getProviderModelIds(items)).toEqual(['gemini-3.8-flash', 'qwen3.8-max', 'legacy']);
+  });
+
+  it('should order new models newest-first in byModel mode too', () => {
+    const items = buildListItems(
+      [
+        provider('lobehub', [
+          model('fable-5.1', 'Claude Fable 5.1', daysAgo(3)),
+          model('gpt-6-astra', 'GPT-6 Astra', daysAgo(1)),
+        ]),
+      ],
+      'byModel',
+    );
+
+    expect(
+      items.flatMap((item) =>
+        item.type === 'model-item-single' || item.type === 'model-item-multiple'
+          ? [item.data.model.id]
+          : [],
+      ),
+    ).toEqual(['gpt-6-astra', 'fable-5.1']);
   });
 });

--- a/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
+++ b/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { useMemo } from 'react';
 
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
@@ -11,6 +12,22 @@ import { type GroupMode, type ListItem, type ModelWithProviders } from '../types
  * jump ahead with no visible explanation.
  */
 const isNewModel = (releasedAt?: string): boolean => !!releasedAt && isNewReleaseDate(releasedAt);
+
+/**
+ * Pins new models to the top, then orders them newest-first. Ranking the pinned models by
+ * `displayOrder` instead would surface whichever vendor happens to sit earliest in the catalog,
+ * so a model released days earlier could outrank today's launch under the same "new" badge.
+ *
+ * Same-day releases fall through to 0 and keep `displayOrder` via stable sort.
+ */
+const compareNewness = (a?: string, b?: string): number => {
+  const aNew = isNewModel(a);
+  const bNew = isNewModel(b);
+  if (aNew !== bNew) return aNew ? -1 : 1;
+  if (!aNew) return 0;
+
+  return dayjs(b).valueOf() - dayjs(a).valueOf();
+};
 
 export const buildListItems = (
   enabledList: EnabledProviderWithModels[],
@@ -84,10 +101,7 @@ export const buildListItems = (
         const bLast = b.providers.every((provider) => sortModelLast(b.model.id, provider.id));
         if (aLast !== bLast) return Number(aLast) - Number(bLast);
       }
-      const aNew = isNewModel(a.model.releasedAt);
-      const bNew = isNewModel(b.model.releasedAt);
-      if (aNew !== bNew) return aNew ? -1 : 1;
-      return 0;
+      return compareNewness(a.model.releasedAt, b.model.releasedAt);
     });
 
     return sortedModels.map((data) => ({
@@ -112,10 +126,7 @@ export const buildListItems = (
             Number(sortModelLast(b.id, providerItem.id));
           if (diff !== 0) return diff;
         }
-        const aNew = isNewModel(a.releasedAt);
-        const bNew = isNewModel(b.releasedAt);
-        if (aNew !== bNew) return aNew ? -1 : 1;
-        return 0;
+        return compareNewness(a.releasedAt, b.releasedAt);
       });
 
       if (sortedModels.length > 0 || !searchKeyword.trim()) {

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -13,6 +13,7 @@ import EffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Ef
 import GLM52ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GLM52ReasoningEffortSlider';
 import GLM53ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GLM53ReasoningEffortSlider';
 import GPT5ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT5ReasoningEffortSlider';
+import { GPT6ReasoningEffortSlider } from '@/features/ModelSwitchPanel/components/ControlsForm/GPT6ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT51ReasoningEffortSlider';
 import GPT52ProReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT52ProReasoningEffortSlider';
 import GPT52ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT52ReasoningEffortSlider';
@@ -117,6 +118,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
   {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt5_6ReasoningEffort.hint',
     key: 'gpt5_6ReasoningEffort',
+  },
+  {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt6ReasoningEffort.hint',
+    key: 'gpt6ReasoningEffort',
   },
   {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt5_2ProReasoningEffort.hint',
@@ -227,6 +232,7 @@ const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   gpt5_2ProReasoningEffort: 'reasoningEffort',
   gpt5_2ReasoningEffort: 'reasoningEffort',
   gpt5_6ReasoningEffort: 'reasoningEffort',
+  gpt6ReasoningEffort: 'reasoningEffort',
   glm5_2ReasoningEffort: 'reasoningEffort',
   glm5_3ReasoningEffort: 'reasoningEffort',
   grok4_20ReasoningEffort: 'reasoningEffort',
@@ -287,6 +293,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   },
   gpt5_2ReasoningEffort: { labelSuffix: ' (GPT-5.2)', previewWidth: 300, tag: 'reasoning_effort' },
   gpt5_6ReasoningEffort: { labelSuffix: ' (GPT-5.6)', previewWidth: 340, tag: 'reasoning_effort' },
+  gpt6ReasoningEffort: { labelSuffix: ' (GPT-6)', previewWidth: 300, tag: 'reasoning_effort' },
   glm5_2ReasoningEffort: { labelSuffix: ' (GLM-5.2)', previewWidth: 240, tag: 'reasoning_effort' },
   glm5_3ReasoningEffort: { labelSuffix: ' (GLM-5.3)', previewWidth: 240, tag: 'reasoning_effort' },
   grok4_20ReasoningEffort: {
@@ -484,6 +491,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       gpt5_2ProReasoningEffort: <GPT52ProReasoningEffortSlider value="medium" />,
       gpt5_2ReasoningEffort: <GPT52ReasoningEffortSlider value="none" />,
       gpt5_6ReasoningEffort: <GPT56ReasoningEffortSlider value="medium" />,
+      gpt6ReasoningEffort: <GPT6ReasoningEffortSlider value="medium" />,
       glm5_2ReasoningEffort: <GLM52ReasoningEffortSlider value="max" />,
       glm5_3ReasoningEffort: <GLM53ReasoningEffortSlider value="max" />,
       grok4_20ReasoningEffort: <Grok420ReasoningEffortSlider value="medium" />,


### PR DESCRIPTION
Adds GPT-6 support to the OpenAI + Azure OpenAI runtimes and ships `gpt-6-astra` through the LobeHub provider. Two commits — the runtime work, plus a model-picker ordering fix the launch surfaced.

GPT-6 dropped the minor-version suffix (`gpt-6-astra`, not `gpt-6.0`), which broke every model-id helper in `providers/openai/modelId.ts` — they were all pinned to `majorVersion === 5`. Without this, GPT-6 silently falls back to chat.completions, keeps `temperature`/`top_p` in the payload, and loses the flex service tier.

#### 1. GPT-6 runtime support

- **`modelId.ts`** — replaced the GPT-5 gate with a reasoning-era gate (`majorVersion >= 5`), since GPT-5 was the generation that introduced the reasoning-model contract and every later major version inherits it. Helpers renamed accordingly (`isGPT5ResponsesModel` → `isGPTResponsesModel`, etc.). GPT-6+ is Responses-only.
- **`azureOpenai/index.ts`** — `isAzureReasoningModel` was a `model.includes('gpt-5')` substring check, so `gpt-6-astra` kept its sampling params and Azure rejected the request with `400 Unsupported parameter: 'temperature'`. Now matches GPT-5 through GPT-9 with a separator boundary.
- **`gpt6ReasoningEffort`** — new extend param. GPT-6 removed `reasoning.effort: 'none'` (lowest is `low`) and added `xhigh` / `max`, so it cannot reuse the GPT-5.6 slider.

#### 2. Order pinned new models by release date

Models inside the 14-day "new" window are pinned to the top of the model picker, but among themselves they were left in catalog order, so whichever vendor sits earliest in `displayOrder` won regardless of when the model shipped. On LobeHub that put Claude Fable 5.1 (`displayOrder` 25, released Sep 1) above GPT-6 Astra (`displayOrder` 145, released Sep 3) under an identical 新 badge.

`useBuildListItems.ts` hoisted new models and then `return 0`; `toSorted` is stable, so the zero fell through to `displayOrder`. The same four lines were duplicated across the `byModel` and `byProvider` branches — both now share a `compareNewness` comparator that keeps the hoist and adds a newest-first tiebreak. Same-day releases still return 0 and keep `displayOrder`.

| Before | After |
| ------ | ----- |
| Claude Fable 5.1 · GPT-6 Astra · GLM-5.3-Flash · Gemini 3.8 Flash · Qwen3.8 Max | GPT-6 Astra · Gemini 3.8 Flash · Qwen3.8 Max · Claude Fable 5.1 · GLM-5.3-Flash |

#### Key Decisions / Non-goals

- **`GPT_MODEL_PATTERN` major version narrowed to a single digit.** Azure's legacy GPT-3.5 deployment name drops the dot (`gpt-35-turbo-16k`), and the old `(\d+)` major read that as version **35** — which satisfies `>= 5` and would have routed a 2023 chat model to the Responses API. Two existing Azure tests caught this. Every real GPT id parses identically before and after; `gpt-35-turbo*` now simply doesn't parse as a modern GPT id, which is correct.
- **`supportsGPTResponsesReasoningEffortNone` is deliberately still GPT-5.x-only.** `none` was a GPT-5.x affordance: GPT-5 Pro never had it and GPT-6 removed it. It did not generalize with the rest.
- **Non-goal:** no static model card under `packages/model-bank/src/aiModels/openai.ts`. `gpt-6-astra` ships through the LobeHub online model config; the self-hosted OpenAI provider card follows its own cadence.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Verified end to end against a live Azure `gpt-6-astra` deployment through `LobeAzureOpenAI` — HTTP 200, streaming works, `reasoning.effort: xhigh` accepted, `temperature`/`top_p` correctly pruned. Also probed on the live deployment: web search tool, function calling, and `text.verbosity` all accepted; sending `temperature` returns 400 as expected.

Unit tests cover GPT-6 id parsing, Responses-only routing, chat/OpenRouter exclusions, `none` being unsupported, payload pruning on both the OpenAI and Azure paths, `xhigh` effort resolution, the `gpt-35-turbo` regression, and three ordering cases (newest-first, same-day fallback, `byModel` branch). Ordering fixtures are anchored to `Date.now()` so they don't rot out of the 14-day window. 260 tests pass across the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)