### PR TITLE
🐛 fix(model-switch): order pinned new models by release date

### DIFF
--- a/src/features/ModelSwitchPanel/hooks/useBuildListItems.test.ts
+++ b/src/features/ModelSwitchPanel/hooks/useBuildListItems.test.ts
@@ -5,8 +5,12 @@ import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
 import { buildListItems } from './useBuildListItems';
 
-const model = (id: string, displayName = id) =>
-  ({ abilities: {}, displayName, id }) satisfies AiModelForSelect;
+const model = (id: string, displayName = id, releasedAt?: string) =>
+  ({ abilities: {}, displayName, id, releasedAt }) satisfies AiModelForSelect;
+
+/** `isNewReleaseDate` uses a 14-day window, so anchor fixtures relative to today. */
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
 
 const provider = (id: string, children: AiModelForSelect[]): EnabledProviderWithModels => ({
   children,
@@ -48,5 +52,62 @@ describe('buildListItems', () => {
           : [],
       ),
     ).toEqual(['mixed-pro', 'normal', 'lobehub-pro']);
+  });
+
+  it('should order the pinned new models newest-first instead of by catalog order', () => {
+    const items = buildListItems(
+      [
+        provider('lobehub', [
+          model('fable-5.1', 'Claude Fable 5.1', daysAgo(3)),
+          model('gpt-6-astra', 'GPT-6 Astra', daysAgo(1)),
+          model('glm-5.3-flash', 'GLM-5.3-Flash', daysAgo(9)),
+          model('deepseek-v4-pro', 'DeepSeek V4 Pro', daysAgo(200)),
+        ]),
+      ],
+      'byProvider',
+    );
+
+    expect(getProviderModelIds(items)).toEqual([
+      'gpt-6-astra',
+      'fable-5.1',
+      'glm-5.3-flash',
+      'deepseek-v4-pro',
+    ]);
+  });
+
+  it('should keep catalog order for new models released on the same day', () => {
+    const sameDay = daysAgo(2);
+    const items = buildListItems(
+      [
+        provider('lobehub', [
+          model('gemini-3.8-flash', 'Gemini 3.8 Flash', sameDay),
+          model('qwen3.8-max', 'Qwen3.8 Max', sameDay),
+          model('legacy', 'Legacy', daysAgo(400)),
+        ]),
+      ],
+      'byProvider',
+    );
+
+    expect(getProviderModelIds(items)).toEqual(['gemini-3.8-flash', 'qwen3.8-max', 'legacy']);
+  });
+
+  it('should order new models newest-first in byModel mode too', () => {
+    const items = buildListItems(
+      [
+        provider('lobehub', [
+          model('fable-5.1', 'Claude Fable 5.1', daysAgo(3)),
+          model('gpt-6-astra', 'GPT-6 Astra', daysAgo(1)),
+        ]),
+      ],
+      'byModel',
+    );
+
+    expect(
+      items.flatMap((item) =>
+        item.type === 'model-item-single' || item.type === 'model-item-multiple'
+          ? [item.data.model.id]
+          : [],
+      ),
+    ).toEqual(['gpt-6-astra', 'fable-5.1']);
   });
 });

--- a/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
+++ b/src/features/ModelSwitchPanel/hooks/useBuildListItems.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { useMemo } from 'react';
 
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
@@ -11,6 +12,22 @@ import { type GroupMode, type ListItem, type ModelWithProviders } from '../types
  * jump ahead with no visible explanation.
  */
 const isNewModel = (releasedAt?: string): boolean => !!releasedAt && isNewReleaseDate(releasedAt);
+
+/**
+ * Pins new models to the top, then orders them newest-first. Ranking the pinned models by
+ * `displayOrder` instead would surface whichever vendor happens to sit earliest in the catalog,
+ * so a model released days earlier could outrank today's launch under the same "new" badge.
+ *
+ * Same-day releases fall through to 0 and keep `displayOrder` via stable sort.
+ */
+const compareNewness = (a?: string, b?: string): number => {
+  const aNew = isNewModel(a);
+  const bNew = isNewModel(b);
+  if (aNew !== bNew) return aNew ? -1 : 1;
+  if (!aNew) return 0;
+
+  return dayjs(b).valueOf() - dayjs(a).valueOf();
+};
 
 export const buildListItems = (
   enabledList: EnabledProviderWithModels[],
@@ -84,10 +101,7 @@ export const buildListItems = (
         const bLast = b.providers.every((provider) => sortModelLast(b.model.id, provider.id));
         if (aLast !== bLast) return Number(aLast) - Number(bLast);
       }
-      const aNew = isNewModel(a.model.releasedAt);
-      const bNew = isNewModel(b.model.releasedAt);
-      if (aNew !== bNew) return aNew ? -1 : 1;
-      return 0;
+      return compareNewness(a.model.releasedAt, b.model.releasedAt);
     });
 
     return sortedModels.map((data) => ({
@@ -112,10 +126,7 @@ export const buildListItems = (
             Number(sortModelLast(b.id, providerItem.id));
           if (diff !== 0) return diff;
         }
-        const aNew = isNewModel(a.releasedAt);
-        const bNew = isNewModel(b.releasedAt);
-        if (aNew !== bNew) return aNew ? -1 : 1;
-        return 0;
+        return compareNewness(a.releasedAt, b.releasedAt);
       });
 
       if (sortedModels.length > 0 || !searchKeyword.trim()) {


### PR DESCRIPTION
Models still inside the 14-day "new" window are pinned to the top of the model picker, but among themselves they were left in catalog order — so whichever vendor sits earliest in `displayOrder` won, regardless of when the model actually shipped.

Concretely, on LobeHub today: Claude Fable 5.1 (`displayOrder` 25, released Sep 1) rendered above GPT-6 Astra (`displayOrder` 145, released Sep 3). Both wear the same 新 badge, so the ordering reads as arbitrary — the newest model is not the one on top.

| Before | After |
| ------ | ----- |
| Claude Fable 5.1 · GPT-6 Astra · GLM-5.3-Flash · Gemini 3.8 Flash · Qwen3.8 Max | GPT-6 Astra · Gemini 3.8 Flash · Qwen3.8 Max · Claude Fable 5.1 · GLM-5.3-Flash |

#### Cause

`useBuildListItems.ts` hoisted new models with `if (aNew !== bNew) return aNew ? -1 : 1;` and then `return 0`. `toSorted` is stable, so the zero fell through to the incoming `displayOrder` sequence. The same four lines were duplicated across the `byModel` and `byProvider` branches.

Replaced both with a shared `compareNewness` comparator that keeps the existing hoist and adds a newest-first tiebreak.

- Same-day releases still return 0, so `displayOrder` remains the tiebreak (Gemini 3.8 Flash and Qwen3.8 Max, both Sep 2, keep their relative order).
- Uses `dayjs` to match `isNewReleaseDate`, which already parses these strings.
- Non-new models are untouched.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Three new cases in `useBuildListItems.test.ts`: newest-first among pinned models, same-day releases falling back to catalog order, and the `byModel` branch getting the same treatment. Fixtures are anchored relative to `Date.now()` so they don't rot out of the 14-day window. 5 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)