### PR TITLE
chore: clean up LOBE-13787 markers from code comments

### DIFF
--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -1073,7 +1073,8 @@ export class CompletionLifecycle {
       //    provenance `call_llm` stamps on every assistant row it creates or
       //    reuses (`metadata.operationId`). Unlike "the latest assistant row in
       //    the topic", this is bound to THIS operation, so a topic that also
-      //    holds a concurrent run's rows cannot supply the answer (LOBE-13787).
+      //    holds a concurrent run's rows cannot supply the answer (root cause of
+      //    the Discord thread bug where the bot kept repeating the same reply).
       if (!extractTextFromMessage(row)?.trim() && topicId) {
         const byOperation = await messageModel.findLatestAssistantByOperationId({
           operationId,

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -1219,8 +1219,9 @@ describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery
     );
   });
 
-  // LOBE-13787: the named row can be an empty placeholder while the run's real
-  // reply sits on another row. Resolve it by the run's own provenance
+  // The named row can be an empty placeholder while the run's real reply sits
+  // on another row (the Discord thread bug where the bot kept repeating the
+  // same message). Resolve it by the run's own provenance
   // (`metadata.operationId`), never by "the latest assistant row in the topic" —
   // a topic can hold a concurrent run's rows.
   it('falls back to operation provenance when the named row is empty', async () => {

--- a/apps/server/src/services/bot/__tests__/renderThrownError.test.ts
+++ b/apps/server/src/services/bot/__tests__/renderThrownError.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { renderThrownAgentError } from '../renderThrownError';
 
-// LOBE-13787: the bot's startup / catch-all failure paths posted a bare
+// The bot's startup / catch-all failure paths posted a bare
 // "**Agent Execution Failed**" — with no operation id, that carried no
-// information at all. Classifying the thrown value first lets the tiered
-// renderer pick curated copy, WITHOUT ever emitting the raw message.
+// information at all (reported from a Discord thread). Classifying the thrown
+// value first lets the tiered renderer pick curated copy, WITHOUT ever
+// emitting the raw message.
 describe('renderThrownAgentError', () => {
   it('gives a plain thrown Error the harness-tier copy instead of a bare header', () => {
     const out = renderThrownAgentError(new Error('Topic not found'), 'op-1');

--- a/apps/server/src/services/bot/renderThrownError.ts
+++ b/apps/server/src/services/bot/renderThrownError.ts
@@ -9,8 +9,8 @@ import { renderAgentError } from './replyTemplate';
  * The bot's failure paths that catch a raw `Error` (bridge startup, the
  * handleMention / router catch-alls) used to render `renderError(operationId)`,
  * which produces a bare "**Agent Execution Failed**" — and, when the operation
- * never got far enough to have an id, not even that (LOBE-13787: the user saw
- * two consecutive failures carrying no information at all).
+ * never got far enough to have an id, not even that (a Discord thread report
+ * showed two consecutive failures carrying no information at all).
  *
  * Running the value through the runtime's own error normalizer first gives
  * those paths the same `errorType` + `attribution` the completion path already


### PR DESCRIPTION
## Summary

Automated daily scan found 4 `LOBE-XXX` markers left in code comments. This PR removes them and, per project convention for open-source hygiene, replaces each internal ticket reference with an inline description of the actual scenario instead of leaving a bare `LOBE-13787` pointer.

## Context

`LOBE-13787` (Discord Thread execution issue) reported that the bot kept returning the same reply, and surfaced a bare "Agent Execution Failed" with no information when the run died before it had an operation id.

## Changes

- `apps/server/src/services/agentRuntime/CompletionLifecycle.ts`
  - Reworded the operation-provenance fallback comment to state the root cause (the Discord thread bot repeating the same reply) instead of `(LOBE-13787)`.
- `apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts`
  - Rewrote the test description comment to describe the repeated-reply scenario instead of `LOBE-13787:`.
- `apps/server/src/services/bot/renderThrownError.ts`
  - Reworded the JSDoc to describe the failure scenario instead of `(LOBE-13787: ...)`.
- `apps/server/src/services/bot/__tests__/renderThrownError.test.ts`
  - Rewrote the describe-block comment to state the scenario instead of `LOBE-13787:`.

No code semantics changed — comment-only edits.

Generated on 2026-09-05.