### PR TITLE
🐛 fix(desktop): preserve OIDC refresh error codes for re-authentication

### DIFF
--- a/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
@@ -480,9 +480,12 @@ export default class RemoteServerConfigCtr extends ControllerModule {
       if (!response.ok) {
         // Try to parse error response
         const errorData = await response.json().catch(() => ({}));
-        const errorMessage = `Token refresh failed: ${response.status} ${response.statusText} ${
-          errorData.error_description || errorData.error || ''
-        }`.trim();
+        // Keep the OIDC code so AuthCtr can distinguish revoked grants from transient failures.
+        const errorDetail = [errorData.error, errorData.error_description]
+          .filter(Boolean)
+          .join(' ');
+        const errorMessage =
+          `Token refresh failed: ${response.status} ${response.statusText} ${errorDetail}`.trim();
         logger.error(errorMessage, errorData);
         return { error: errorMessage, success: false };
       }

--- a/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
@@ -524,7 +524,11 @@ describe('RemoteServerConfigCtr', () => {
       );
     });
 
-    it('should handle refresh failure', async () => {
+    it.each([
+      { error: 'invalid_grant' },
+      { error: 'invalid_grant', error_description: 'grant request is invalid' },
+      { error: 'invalid_client', error_description: 'client authentication failed' },
+    ])('should classify refresh failure as non-retryable: %j', async (errorData) => {
       const { safeStorage } = await import('electron');
       vi.mocked(safeStorage.isEncryptionAvailable).mockReturnValue(true);
       vi.mocked(safeStorage.decryptString).mockImplementation((buffer: Buffer) =>
@@ -545,7 +549,7 @@ describe('RemoteServerConfigCtr', () => {
       await controller.saveTokens('old-access', 'old-refresh');
 
       mockFetch.mockResolvedValue({
-        json: () => Promise.resolve({ error: 'invalid_grant' }),
+        json: () => Promise.resolve(errorData),
         ok: false,
         status: 400,
         statusText: 'Bad Request',
@@ -555,6 +559,11 @@ describe('RemoteServerConfigCtr', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Token refresh failed');
+      expect(result.error).toContain(errorData.error);
+      if (errorData.error_description) {
+        expect(result.error).toContain(errorData.error_description);
+      }
+      expect(controller.isNonRetryableError(result.error)).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -665,6 +674,7 @@ describe('RemoteServerConfigCtr', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Network error');
+      expect(controller.isNonRetryableError(result.error)).toBe(false);
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
An expired desktop session can remain stuck loading when token refresh returns both `error: "invalid_grant"` and `error_description: "grant request is invalid"`. The refresh handler retained only the description, so `isNonRetryableError` never saw the OIDC code and treated the revoked grant as a transient failure.

Preserve the code alongside its description so the existing `AuthCtr` recovery path clears stale credentials and requests re-authentication.

| Before | After |
| ------ | ----- |
| The error description hides `invalid_grant`; refresh keeps retrying on later cycles. | Both fields reach the classifier; invalid credentials trigger the existing re-authentication path. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Regression tests cover code-only responses and code-plus-description responses for `invalid_grant` and `invalid_client`; both new description cases fail against the original implementation.
- Verify transient network failures remain retryable and refresh still makes only one request.
- `bun run check apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts` — lint clean, 79 tests passed.
- Independent light code review: no actionable findings. Packaged-app UI recovery has not been tested with a rebuilt binary.

#### 🔗 Related Issue

Related prior work: #14928 and #15604. Neither preserves the OIDC error code when an error description is present; no existing issue or PR matching this specific defect was found.
