### PR TITLE
♻️ refactor(agent-testing): extract heterogeneous compatibility skill

### DIFF
--- a/.agents/acceptance/PROJECT.md
+++ b/.agents/acceptance/PROJECT.md
@@ -258,7 +258,9 @@ The live official-provider model matrix belongs to the
 `testing-heterogeneous-agents` project skill
 (`.agents/skills/testing-heterogeneous-agents/`). It extends Acceptance with the
 matrix semantics and harness while reusing the Electron environment, auth, and
-CDP commands above. Route periodic or release-time compatibility runs there.
+CDP commands above. It is manual-only: the user must explicitly invoke
+`/testing-heterogeneous-agents` in Claude Code or `$testing-heterogeneous-agents`
+in Codex. Do not automatically load or run it during other acceptance tasks.
 
 ### Bot channels (project skill)
 

--- a/.agents/acceptance/PROJECT.md
+++ b/.agents/acceptance/PROJECT.md
@@ -252,54 +252,13 @@ stale standalone install: a recently added workspace package fails to resolve â€
   `agent-browser --session s<port> --cdp <port>`. Pool design, the collision
   matrix, and the login-copy recipe: `.agents/acceptance/references/multi-instance.md`.
 
-#### Official heterogeneous-provider compatibility matrix
+### Heterogeneous-agent compatibility (project skill)
 
-Use `heterogeneous-agent-official-smoke.mjs` to exercise every model currently
-advertised by the server for Claude Code, Codex, Grok Build, Kimi Code, Pi, and TRAE.
-It tests only LobeHub's official `server-default` provider binding; user-defined
-providers and their API keys are outside this matrix.
-
-```bash
-HARNESS=.agents/acceptance/scripts/heterogeneous-agent-official-smoke.mjs
-
-# Read the live matrix and probe already-installed CLI versions. No model calls.
-node "$HARNESS" list --agent claude-code,codex --model MODEL_ID
-
-# Run selected cells sequentially through the real Desktop IPC + official relay.
-node "$HARNESS" run --confirm-live --topic-id TOPIC_ID --cdp 9222
-```
-
-The filters, topic id, and non-default CDP port are optional when the current
-Electron window already provides the intended scope.
-
-- Prerequisites: an already-running, signed-in Electron instance and either an
-  active personal topic or `--topic-id`. Use the Electron commands above to
-  start and authenticate the app.
-- The server's live `getServerDefaultHeterogeneousCapability` response is the
-  source of truth; model ids are not hard-coded in the harness.
-- The harness invokes no installer, updater command, or sign-in flow. Detection
-  does execute existing CLIs with version/help flags. To also suppress Claude
-  Code's own background update checks during detection, start or restart the
-  Electron instance with
-  `DISABLE_AUTOUPDATER=1 DISABLE_UPDATES=1 .agents/acceptance/scripts/electron-dev.sh start`.
-  Claude cells receive both variables independently as session environment.
-  Every model for a missing CLI is recorded as `blocked` without invoking an
-  installer/updater.
-- `run` makes real official-provider requests, consumes usage, and creates
-  server operation records. This is why `--confirm-live` is mandatory. It does
-  not persist chat messages because the harness listens to the direct IPC stream.
-  By default, CLIs run in an isolated workspace inside the report directory
-  rather than in the repository; use `--cwd` only when a specific project is
-  part of the compatibility claim.
-- Each cell starts idempotently inside the renderer and is observed with short
-  host-side polls. Do not collapse this into one long `agent-browser eval`:
-  long evaluations can be re-evaluated after roughly 30 seconds, duplicating
-  live requests and operation ids.
-- The local structured report lands under
-  `.records/reports/<timestamp>-heterogeneous-official-provider-smoke/` unless
-  `--report-dir` is supplied. It is not published automatically.
-- Exit codes: `0` all cells passed; `1` at least one failed; `2` no failures but
-  at least one blocked; `3` Electron/auth/capability preflight failed.
+The live official-provider model matrix belongs to the
+`testing-heterogeneous-agents` project skill
+(`.agents/skills/testing-heterogeneous-agents/`). It extends Acceptance with the
+matrix semantics and harness while reusing the Electron environment, auth, and
+CDP commands above. Route periodic or release-time compatibility runs there.
 
 ### Bot channels (project skill)
 

--- a/.agents/skills/heterogeneous-agent/SKILL.md
+++ b/.agents/skills/heterogeneous-agent/SKILL.md
@@ -85,3 +85,6 @@ Use this skill when the bug or feature lives in the external CLI agent pipeline,
 ## References
 
 - For commands, trace capture, invariants, and focused test commands, read [references/debug-workflow.md](./references/debug-workflow.md).
+- For periodic or release-time live compatibility checks across the official
+  model matrix, use the `testing-heterogeneous-agents` skill. Return here with
+  its failed-cell evidence when diagnosis or a code fix is needed.

--- a/.agents/skills/heterogeneous-agent/SKILL.md
+++ b/.agents/skills/heterogeneous-agent/SKILL.md
@@ -85,6 +85,8 @@ Use this skill when the bug or feature lives in the external CLI agent pipeline,
 ## References
 
 - For commands, trace capture, invariants, and focused test commands, read [references/debug-workflow.md](./references/debug-workflow.md).
-- For periodic or release-time live compatibility checks across the official
-  model matrix, use the `testing-heterogeneous-agents` skill. Return here with
-  its failed-cell evidence when diagnosis or a code fix is needed.
+- Live official-model compatibility checks are available only through explicit
+  user invocation of `/testing-heterogeneous-agents` in Claude Code or
+  `$testing-heterogeneous-agents` in Codex. Do not automatically load or run that
+  skill during diagnosis. Its failed-cell evidence can be used here for diagnosis
+  or a code fix.

--- a/.agents/skills/testing-heterogeneous-agents/SKILL.md
+++ b/.agents/skills/testing-heterogeneous-agents/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: testing-heterogeneous-agents
+description: 'Runs the live LobeHub official-provider compatibility matrix across Claude Code, Codex, Grok Build, Kimi Code, Pi, and TRAE. Use for periodic model checks, release smoke tests, new official model validation, or investigating which heterogeneous agent and model combinations currently pass.'
+---
+
+# Testing Heterogeneous Agents
+
+This project skill extends `acceptance` with one scenario: proving that every
+server-advertised official model completes through each supported external CLI
+agent and LobeHub's `server-default` provider binding.
+
+It does not replace Acceptance. Use Acceptance for the plan, approval gate,
+evidence contract, immutable rounds, publishing, and teardown. Use
+`.agents/acceptance/PROJECT.md` for LobeHub's Electron launch, auth, CDP, and
+multi-instance commands. This skill owns only the compatibility-matrix semantics
+and its executable harness.
+
+## Scope
+
+The matrix covers:
+
+- Claude Code, Codex, Grok Build, Kimi Code, Pi, and TRAE;
+- models returned by the live `getServerDefaultHeterogeneousCapability` response;
+- the real Desktop renderer → IPC → CLI → official relay path;
+- the ingress selected by each agent (`anthropic-messages` or
+  `openai-responses`);
+- a unique marker round trip plus authoritative relay, provider, and model
+  observations.
+
+It does not cover user-defined providers, user-managed API keys, general model
+quality, tool-use quality, or ordinary chat-agent execution. Add a separate
+scenario instead of silently widening this matrix.
+
+## Harness
+
+```bash
+HARNESS=.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs
+
+# Discover the live matrix and installed CLI versions. Makes no model calls.
+node "$HARNESS" list --json
+
+# Narrow discovery when validating one change.
+node "$HARNESS" list --agent claude-code,codex --model MODEL_ID --json
+
+# Execute selected or all cells through the real official provider.
+node "$HARNESS" run --confirm-live --topic-id TOPIC_ID --cdp 9222
+```
+
+Filters, topic id, and non-default CDP port are optional when the attached
+Electron window already supplies the intended scope.
+
+Exit codes:
+
+| Code | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| `0`  | Every selected cell passed                                      |
+| `1`  | At least one selected cell failed                               |
+| `2`  | No failures, but at least one cell was blocked                  |
+| `3`  | Electron, authentication, topic, or capability preflight failed |
+
+## Run Workflow
+
+### 1. Load the parent contract and project adapter
+
+Read the `acceptance` skill, `.agents/acceptance/PROCESS.md`, and
+`.agents/acceptance/PROJECT.md`. Follow their approval and teardown rules. This
+scenario makes billable requests and creates server operation records, so never
+infer permission to run it from a request to inspect or list the matrix.
+
+### 2. Discover before spending
+
+Run `list --json` first. It reads the live capability response and probes only
+already-installed CLI binaries with version/help flags. Use its exact cells as
+the plan; do not maintain a second hard-coded model list.
+
+Report missing CLIs as blocked. Do not install, update, or sign in to an external
+CLI during this workflow. To suppress Claude Code's background update paths even
+during detection, start or restart the Electron instance with:
+
+```bash
+DISABLE_AUTOUPDATER=1 DISABLE_UPDATES=1 \
+  .agents/acceptance/scripts/electron-dev.sh start
+```
+
+### 3. Establish the Electron surface
+
+Use the Electron section of `.agents/acceptance/PROJECT.md` to attach to an
+already-running signed-in instance or start one for this run. Confirm an active
+personal topic or pass `--topic-id`. Never trigger an interactive OAuth flow.
+
+### 4. Confirm scope, cost, and history
+
+For the first live run, present the discovered agents/models and obtain the
+Acceptance plan approval before passing `--confirm-live`. Run sequentially; do
+not parallelize cells because the CLIs share profiles and provider quota.
+
+For periodic runs, reuse one stable Acceptance subject so every execution becomes
+another immutable round in the same history. Put that subject and the authorized
+agent/model scope in the schedule prompt. A schedule owns when to run; this skill
+continues to own how each run is executed and evidenced.
+
+### 5. Execute once
+
+Run the selected matrix with `--confirm-live`. By default each CLI receives an
+isolated workspace inside the report directory. Pass `--cwd` only when a real
+project workspace is part of the compatibility claim.
+
+The harness starts each cell idempotently in the renderer and polls it with short
+host-side evaluations. Do not replace this with one long `agent-browser eval`:
+long evaluations can be retried by the driver and duplicate live requests.
+
+### 6. Inspect and publish the round
+
+The harness writes an Acceptance-compatible `result.json`, one text evidence
+artifact per cell, and a structured matrix table under:
+
+```text
+.records/reports/<timestamp>-heterogeneous-official-provider-smoke/
+```
+
+Unless `--report-dir` selects another location. Inspect the report and evidence;
+do not infer success from the process exit code alone. Publish it with the clean
+production `lh acceptance run ingest` environment required by
+`.agents/acceptance/PROCESS.md`. Confirm that every matrix cell has its required
+text evidence and return only the stable Acceptance URL.
+
+### 7. Diagnose failures at the owning layer
+
+Use each failed cell's evidence to identify the first broken boundary:
+
+1. CLI launch or authentication;
+2. request ingress and metadata normalization;
+3. official relay/provider/model selection;
+4. raw CLI output;
+5. heterogeneous adapter or terminal mapping.
+
+Load the `heterogeneous-agent` skill for raw trace, adapter, IPC, persistence, or
+terminal-event diagnosis. A model refusing one ingress but passing another is a
+request-compatibility signal, not proof of an adapter bug.
+
+## Safety Invariants
+
+- `run` requires `--confirm-live`; never bypass this gate.
+- Never invoke installers, updaters, or sign-in flows.
+- Never read custom provider credentials for this matrix.
+- Claude Code cells receive both update-disabling environment variables.
+- Missing binaries are blocked, not repaired automatically.
+- Cells run sequentially to limit quota and profile contention.
+- The harness listens to direct IPC and does not persist chat messages.
+- Stop only the Electron instance started by the current run.
+
+## Harness Self-Test
+
+The self-test uses a fully stubbed `agent-browser`; it launches no browser,
+external CLI, or model request:
+
+```bash
+bash .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
+```

--- a/.agents/skills/testing-heterogeneous-agents/SKILL.md
+++ b/.agents/skills/testing-heterogeneous-agents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: testing-heterogeneous-agents
-description: 'Runs the live LobeHub official-provider compatibility matrix across Claude Code, Codex, Grok Build, Kimi Code, Pi, and TRAE. Use for periodic model checks, release smoke tests, new official model validation, or investigating which heterogeneous agent and model combinations currently pass.'
+description: 'Manually runs the live LobeHub official-provider compatibility matrix across Claude Code, Codex, Grok Build, Kimi Code, Pi, and TRAE when explicitly invoked by the user.'
+disable-model-invocation: true
 ---
 
 # Testing Heterogeneous Agents
@@ -14,6 +15,14 @@ evidence contract, immutable rounds, publishing, and teardown. Use
 `.agents/acceptance/PROJECT.md` for LobeHub's Electron launch, auth, CDP, and
 multi-instance commands. This skill owns only the compatibility-matrix semantics
 and its executable harness.
+
+## Manual Invocation Only
+
+The user invokes this skill with `/testing-heterogeneous-agents` in Claude Code
+or `$testing-heterogeneous-agents` in Codex. Do not automatically load or execute
+it as part of development, debugging, acceptance, or release tasks, and do not
+schedule it. A reference from another skill is not permission to invoke it.
+Manual invocation still requires scope and cost approval before live requests.
 
 ## Scope
 
@@ -90,14 +99,13 @@ personal topic or pass `--topic-id`. Never trigger an interactive OAuth flow.
 
 ### 4. Confirm scope, cost, and history
 
-For the first live run, present the discovered agents/models and obtain the
+For each live run, present the discovered agents/models and obtain the
 Acceptance plan approval before passing `--confirm-live`. Run sequentially; do
 not parallelize cells because the CLIs share profiles and provider quota.
 
-For periodic runs, reuse one stable Acceptance subject so every execution becomes
-another immutable round in the same history. Put that subject and the authorized
-agent/model scope in the schedule prompt. A schedule owns when to run; this skill
-continues to own how each run is executed and evidenced.
+For repeated manual runs of the same compatibility scope, reuse one stable
+Acceptance subject so every execution becomes another immutable round in the
+same history. Previous runs do not authorize another live run.
 
 ### 5. Execute once
 

--- a/.agents/skills/testing-heterogeneous-agents/agents/openai.yaml
+++ b/.agents/skills/testing-heterogeneous-agents/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs
+++ b/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs
@@ -8,8 +8,8 @@
  * `--confirm-live` because every matrix cell makes a real model request.
  *
  * Usage:
- *   node .agents/acceptance/scripts/heterogeneous-agent-official-smoke.mjs list
- *   node .agents/acceptance/scripts/heterogeneous-agent-official-smoke.mjs run \
+ *   node .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs list
+ *   node .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs run \
  *     --confirm-live [--topic-id <id>] [--cdp 9222]
  */
 
@@ -40,8 +40,8 @@ const POLL_INTERVAL_MS = 500;
 const sleep = (durationMs) => new Promise((resolve) => setTimeout(resolve, durationMs));
 
 const usage = `Usage:
-  node .agents/acceptance/scripts/heterogeneous-agent-official-smoke.mjs list [options]
-  node .agents/acceptance/scripts/heterogeneous-agent-official-smoke.mjs run --confirm-live [options]
+  node .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs list [options]
+  node .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs run --confirm-live [options]
 
 Commands:
   list                 Read the server model matrix and detect existing CLIs. No model calls.
@@ -739,7 +739,7 @@ const writeReport = ({ cases, createdAt, dir, matrix, options, plan, preflight }
     cases: reportCases,
     commit: gitValue(['rev-parse', '--short=12', 'HEAD']),
     createdAt,
-    entry: `node .agents/acceptance/scripts/heterogeneous-agent-official-smoke.mjs run --confirm-live --cdp ${options.cdp}`,
+    entry: `node .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs run --confirm-live --cdp ${options.cdp}`,
     plan,
     scenario: 'coding',
     subject: options.subject ?? null,

--- a/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs
+++ b/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs
@@ -67,7 +67,7 @@ Safety:
 `;
 
 const fail = (message, exitCode = 1) => {
-  console.error(`heterogeneous-agent-official-smoke: ${message}`);
+  console.error(`official-smoke: ${message}`);
   process.exit(exitCode);
 };
 

--- a/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
+++ b/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
@@ -197,10 +197,12 @@ export HETERO_SMOKE_STUB_STATE="$TEST_TMP/cell-count"
 # The live confirmation gate must run before even the browser/CLI
 # preflight, so a mistyped run command has no side effects.
 set +e
-node "$HARNESS" run --browser "$TEST_TMP/fake-agent-browser.mjs" > /dev/null 2>&1
+unconfirmed_output="$(node "$HARNESS" run --browser "$TEST_TMP/fake-agent-browser.mjs" 2>&1)"
 unconfirmed_code=$?
 set -e
 [[ "$unconfirmed_code" -eq 2 ]] || fail "unconfirmed run exited $unconfirmed_code instead of 2"
+[[ "$unconfirmed_output" == "official-smoke: "* ]] ||
+  fail "unexpected diagnostic prefix: $unconfirmed_output"
 [[ ! -e "$HETERO_SMOKE_STUB_LOG" ]] || fail "unconfirmed run reached agent-browser preflight"
 
 # `list` must read the live-shaped matrix but never execute a cell or create a

--- a/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
+++ b/.agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS="$SCRIPT_DIR/heterogeneous-agent-official-smoke.mjs"
+HARNESS="$SCRIPT_DIR/official-smoke.mjs"
 TEST_TMP="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMP"' EXIT
 


### PR DESCRIPTION
## Brief and heads-up

Extract the official heterogeneous-agent model matrix from the generic LobeHub Acceptance adapter into a dedicated `testing-heterogeneous-agents` scenario skill.

The new skill:

- extends the existing Acceptance plan, evidence, immutable-round, and publishing contract;
- reuses the LobeHub Electron/auth/CDP project adapter instead of duplicating environment setup;
- owns live matrix discovery, cost confirmation, sequential execution, report inspection, manual-run history, and failure handoff;
- keeps the existing smoke harness behavior while moving the harness and its self-test next to the scenario instructions;
- links back to `heterogeneous-agent` when a failed matrix cell needs trace or adapter diagnosis.

This makes the dependency one-way: the scenario skill depends on Acceptance, while the generic Acceptance project adapter documents the explicit manual entry point without auto-routing.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bash .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
node .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs --help
bun run check .agents/acceptance/PROJECT.md .agents/skills/heterogeneous-agent/SKILL.md .agents/skills/testing-heterogeneous-agents/SKILL.md .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.mjs .agents/skills/testing-heterogeneous-agents/scripts/official-smoke.test.sh
```

The harness self-test uses a stubbed `agent-browser`; no browser, external CLI, model request, or billable provider call was made.

#### 🔗 Related Issue

None.

### Manual-only invocation

- Claude Code: `disable-model-invocation: true` in SKILL.md.
- Codex: `policy.allow_implicit_invocation: false` in agents/openai.yaml.
- No automatic invocation or scheduling; each live run requires scope and cost approval.
- Audited the five existing manual-only skills (version-release, cli, desktop, add-provider-doc, add-setting-env): all already have both configurations, so no duplicate edits were needed.
- Validation: changed-file check passed; parsed and checked all six manual-only skill configurations; stubbed smoke harness self-test passed. No live model calls or billable requests were made. Client runtime visibility was not exercised.