### PR TITLE
💄 style(model-bank): complete provider and subscription models

### DIFF
--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -290,3 +290,39 @@ describe('vendor provider cards', () => {
     expect(glm53Flash?.settings?.searchImpl).toBe('params');
   });
 });
+
+describe('recent direct-provider models', () => {
+  it.each([
+    ['openai', 'gpt-6-astra', 'gpt6ReasoningEffort'],
+    ['google', 'gemini-3.8-flash', 'thinkingLevel3'],
+    ['vertexai', 'gemini-3.8-flash', 'thinkingLevel3'],
+    ['xai', 'grok-4.6', 'grok4_6ReasoningEffort'],
+    ['qwen', 'qwen3.8-max', 'reasoningBudgetToken'],
+    ['qwen', 'qwen3.8-max-0902', 'reasoningBudgetToken'],
+  ])('exposes %s/%s with its reasoning controls', (providerId, id, reasoningParam) => {
+    const model = LOBE_DEFAULT_MODEL_LIST.find(
+      (entry) => entry.providerId === providerId && entry.id === id,
+    );
+
+    expect(model).toMatchObject({
+      abilities: { functionCall: true, reasoning: true, vision: true },
+      enabled: true,
+      type: 'chat',
+    });
+    expect(model?.settings?.extendParams).toContain(reasoningParam);
+  });
+});
+
+describe('Gemini 3.8 introductory pricing', () => {
+  it.each(['google', 'vertexai'])('uses the published output rate for %s', (providerId) => {
+    const model = LOBE_DEFAULT_MODEL_LIST.find(
+      (entry) => entry.providerId === providerId && entry.id === 'gemini-3.8-flash',
+    );
+    expect(model?.pricing?.units).toContainEqual({
+      name: 'textOutput',
+      rate: 3.75,
+      strategy: 'fixed',
+      unit: 'millionTokens',
+    });
+  });
+});

--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -106,7 +106,7 @@ describe('ChatGPT subscription models', () => {
       (model) => model.providerId === ModelProvider.ChatGPT,
     );
 
-    expect(models).toHaveLength(4);
+    expect(models).toHaveLength(5);
     expect(
       models.every((model) => model.settings?.extendParams?.includes('preserveThinking')),
     ).toBe(true);
@@ -324,5 +324,27 @@ describe('Gemini 3.8 introductory pricing', () => {
       strategy: 'fixed',
       unit: 'millionTokens',
     });
+  });
+});
+
+describe('subscription model catalogs', () => {
+  it.each([
+    ['chatgpt', 'gpt-6-astra', 'gpt6ReasoningEffort'],
+    ['supergrok', 'grok-4.6', 'grok4_6ReasoningEffort'],
+  ])('exposes %s/%s without usage-based pricing', (providerId, id, reasoningParam) => {
+    const model = LOBE_DEFAULT_MODEL_LIST.find(
+      (entry) => entry.providerId === providerId && entry.id === id,
+    );
+    expect(model).toMatchObject({ enabled: true, type: 'chat' });
+    expect(model?.pricing).toBeUndefined();
+    expect(model?.settings?.extendParams).toContain(reasoningParam);
+  });
+
+  it('keeps the ChatGPT context cap and thinking preservation', () => {
+    const model = LOBE_DEFAULT_MODEL_LIST.find(
+      (entry) => entry.providerId === 'chatgpt' && entry.id === 'gpt-6-astra',
+    );
+    expect(model?.contextWindowTokens).toBe(272_000);
+    expect(model?.settings?.extendParams).toContain('preserveThinking');
   });
 });

--- a/packages/model-bank/src/aiModels/chatGPT.ts
+++ b/packages/model-bank/src/aiModels/chatGPT.ts
@@ -1,7 +1,13 @@
 import type { AIChatModelCard } from '../types/aiModel';
 import { openaiChatModels } from './openai';
 
-const CHATGPT_MODEL_IDS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5']);
+const CHATGPT_MODEL_IDS = new Set([
+  'gpt-6-astra',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  'gpt-5.5',
+]);
 
 /**
  * Models available through ChatGPT subscription authentication use the Codex

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -162,6 +162,53 @@ const googleChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
+      'Gemini 3.8 Flash improves long-horizon software engineering, autonomous agents, and complex multi-step reasoning.',
+    displayName: 'Gemini 3.8 Flash',
+    enabled: true,
+    family: 'gemini',
+    generation: 'gemini-3.8',
+    id: 'gemini-3.8-flash',
+    maxOutput: 65_536,
+    /** Introductory rates through 2026-12-31; standard token rates double afterward.
+     * @see https://ai.google.dev/gemini-api/docs/pricing
+     */
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3.75, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 0.5 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-09-02',
+    settings: {
+      disabledParams: ['temperature', 'top_p'],
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      audio: true,
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
       'Gemini 3.7 Flash is the next iteration in the Gemini 3 series of highly-capable, natively multimodal, reasoning models, with support for computer use and file search.',
     displayName: 'Gemini 3.7 Flash',
     enabled: true,

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -13,6 +13,72 @@ export const openaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
+    description:
+      'OpenAI’s most capable model for complex reasoning, coding, computer use, research, and document creation.',
+    displayName: 'GPT-6 Astra',
+    enabled: true,
+    id: 'gpt-6-astra',
+    maxOutput: 128_000,
+    /** @see https://developers.openai.com/api/docs/models/gpt-6-astra */
+    pricing: {
+      units: [
+        {
+          name: 'textInput',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 10, upTo: 272_000 },
+            { rate: 20, upTo: 'infinity' },
+          ],
+        },
+        {
+          name: 'textInput_cacheRead',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 1, upTo: 272_000 },
+            { rate: 2, upTo: 'infinity' },
+          ],
+        },
+        {
+          name: 'textInput_cacheWrite',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 12.5, upTo: 272_000 },
+            { rate: 25, upTo: 'infinity' },
+          ],
+        },
+        {
+          name: 'textOutput',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 50, upTo: 272_000 },
+            { rate: 75, upTo: 'infinity' },
+          ],
+        },
+      ],
+    },
+    releasedAt: '2026-09-03',
+    settings: {
+      extendParams: ['gpt6ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+    family: 'gpt',
+    generation: 'gpt-6',
+    knowledgeCutoff: '2026-04',
+  },
+  {
+    abilities: {
+      functionCall: true,
       search: true,
       structuredOutput: true,
       vision: true,

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -11,6 +11,76 @@ const qwenChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+      video: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'The September update to Qwen3.8 Max improves coding, multi-tool orchestration, and visual understanding.',
+    displayName: 'Qwen3.8 Max 0902',
+    enabled: true,
+    family: 'qwen',
+    generation: 'qwen3.8',
+    id: 'qwen3.8-max-0902',
+    maxOutput: 131_072,
+    /** @see https://help.aliyun.com/zh/model-studio/qwen3-8-max */
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 36, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-09-02',
+    settings: {
+      extendParams: ['reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+      video: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Qwen3.8 Max supports complex coding, multimodal understanding, and long-horizon agentic workflows with a 1M context window.',
+    displayName: 'Qwen3.8 Max',
+    enabled: true,
+    family: 'qwen',
+    generation: 'qwen3.8',
+    id: 'qwen3.8-max',
+    maxOutput: 131_072,
+    /** @see https://help.aliyun.com/zh/model-studio/qwen3-8-max */
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 36, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-08-02',
+    settings: {
+      extendParams: ['reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
       vision: true,
     },
     contextWindowTokens: 262_144,

--- a/packages/model-bank/src/aiModels/superGrok.ts
+++ b/packages/model-bank/src/aiModels/superGrok.ts
@@ -3,10 +3,34 @@ import type { AIChatModelCard } from '../types/aiModel';
 // Grok models available through the SuperGrok / X Premium subscription.
 // Same model ids as the `xai` provider, but without pricing: usage is
 // covered by the flat-rate subscription, so per-token cost would mislead.
-// Only the latest generation is listed by default — older models can still
+// Recent generations are listed by default — older models can still
 // be pulled in via the remote model list.
 // ref: https://docs.x.ai/docs/models
 const superGrokChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 500_000,
+    description:
+      "SpaceXAI's flagship model for coding, agentic tasks, and knowledge work — configurable reasoning (low/medium/high/xhigh).",
+    displayName: 'Grok 4.6',
+    enabled: true,
+    family: 'grok',
+    generation: 'grok-4.6',
+    id: 'grok-4.6',
+    knowledgeCutoff: '2026-02',
+    releasedAt: '2026-08-12',
+    settings: {
+      extendParams: ['grok4_6ReasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -16,6 +16,47 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
+      'Gemini 3.8 Flash improves long-horizon software engineering, autonomous agents, and complex multi-step reasoning.',
+    displayName: 'Gemini 3.8 Flash',
+    enabled: true,
+    family: 'gemini',
+    generation: 'gemini-3.8',
+    id: 'gemini-3.8-flash',
+    maxOutput: 65_536,
+    /** Introductory rates through 2026-12-31; standard token rates double afterward.
+     * @see https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+     */
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-09-02',
+    settings: {
+      disabledParams: ['temperature', 'top_p'],
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      audio: true,
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
       'Gemini 3.7 Flash is the next iteration in the Gemini 3 series of highly-capable, natively multimodal, reasoning models, with support for computer use and file search.',
     displayName: 'Gemini 3.7 Flash',
     enabled: true,

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -7,6 +7,62 @@ const xaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      vision: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 500_000,
+    description:
+      'Grok 4.6 is a frontier model for coding, long-running agents, and knowledge work with a 500K context window.',
+    displayName: 'Grok 4.6',
+    enabled: true,
+    id: 'grok-4.6',
+    /** @see https://docs.x.ai/developers/models/grok-4.6 */
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.5, upTo: 199_999 },
+            { rate: 1, upTo: 'infinity' },
+          ],
+        },
+        {
+          name: 'textInput',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 199_999 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+        },
+        {
+          name: 'textOutput',
+          unit: 'millionTokens',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 6, upTo: 199_999 },
+            { rate: 12, upTo: 'infinity' },
+          ],
+        },
+      ],
+    },
+    releasedAt: '2026-08-12',
+    settings: {
+      extendParams: ['grok4_6ReasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+    family: 'grok',
+    generation: 'grok-4.6',
+    knowledgeCutoff: '2026-02',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       structuredOutput: true,
       vision: true,
     },


### PR DESCRIPTION
Add missing direct-provider and subscription model cards so users can select GPT-6 Astra, Grok 4.6, Qwen3.8 Max / 0902, and Gemini 3.8 Flash (Google and Vertex AI) with the appropriate capabilities, reasoning controls, and pricing.

- Include GPT-6 Astra in ChatGPT and Grok 4.6 in SuperGrok without usage-based pricing. Retain the existing ChatGPT context cap and thinking-preservation setting.
- Reuse existing runtime support; retain existing model cards.
- Use native CNY pricing for Qwen and document Gemini introductory pricing through December 31, 2026.
- Vertex cache-storage pricing is omitted because the official table does not explicitly list this model; token and cache-read prices are included.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- Targeted model-bank suite: 26 tests passed, including model visibility, reasoning controls, and Gemini output pricing.
- Lint passed for all changed files.
- Full workspace type-check failed with generated route module errors and incompatible database dependency types; full type validation remains incomplete.
- Live provider requests were not tested.

#### 🔗 References

- [OpenAI GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra)
- [Gemini pricing](https://ai.google.dev/gemini-api/docs/pricing)
- [Vertex pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing)
- [Grok 4.6](https://docs.x.ai/developers/models/grok-4.6)
- [Qwen3.8 Max](https://help.aliyun.com/zh/model-studio/qwen3-8-max)
