### PR TITLE
🐛 fix(cli): keep persisted workspace scope out of server-dispatched runs

### DIFF
--- a/apps/cli/src/api/workspace.test.ts
+++ b/apps/cli/src/api/workspace.test.ts
@@ -68,6 +68,23 @@ describe('api/workspace scope resolution', () => {
     expect(resolveWorkspaceScope()).toEqual({ source: 'env', workspaceId: 'ws_env' });
   });
 
+  // A goal/task dispatch spawns `hetero exec` with an operation-scoped
+  // LOBEHUB_JWT and states its scope solely through LOBEHUB_WORKSPACE_ID. The
+  // machine's `workspace use` scope must not leak into that run: it FORBIDDENs
+  // every ingest call of a personal-scope topic.
+  it('ignores the persisted workspace when running under an injected LOBEHUB_JWT', () => {
+    process.env.LOBEHUB_JWT = 'jwt-from-dispatch';
+    mockLoadActiveWorkspace.mockReturnValue(stored());
+    try {
+      expect(resolveWorkspaceScope()).toEqual({ source: 'personal' });
+
+      process.env.LOBEHUB_WORKSPACE_ID = 'ws_env';
+      expect(resolveWorkspaceScope()).toEqual({ source: 'env', workspaceId: 'ws_env' });
+    } finally {
+      delete process.env.LOBEHUB_JWT;
+    }
+  });
+
   it('prefers an explicit argument over everything else', () => {
     process.env.LOBEHUB_WORKSPACE_ID = 'ws_env';
     mockLoadActiveWorkspace.mockReturnValue(stored());

--- a/apps/cli/src/api/workspace.ts
+++ b/apps/cli/src/api/workspace.ts
@@ -58,6 +58,15 @@ export function resolveWorkspaceScope(explicit?: string): WorkspaceScope {
   const fromEnv = process.env.LOBEHUB_WORKSPACE_ID;
   if (fromEnv && fromEnv.length > 0) return { source: 'env', workspaceId: fromEnv };
 
+  // A server-dispatched execution (operation-scoped `LOBEHUB_JWT`) carries its
+  // complete scope in env: `LOBEHUB_WORKSPACE_ID` when the run is
+  // workspace-scoped, nothing when personal. The persisted `workspace use`
+  // scope belongs to whoever sits at this machine's terminal; letting it leak
+  // into a dispatched run stamps every heteroIngest/heteroFinish call with a
+  // workspace the run's topic is not in, and the server rejects the entire
+  // event stream ("Topic is outside the caller scope").
+  if (process.env.LOBEHUB_JWT) return { source: 'personal' };
+
   return resolvePersistedScope() ?? { source: 'personal' };
 }
 


### PR DESCRIPTION
Every goal/task-dispatched hetero run on a machine with a persisted `lh workspace use` scope silently lost its entire event stream.

The dispatch contract states the run's scope through env alone: an operation-scoped `LOBEHUB_JWT`, plus `LOBEHUB_WORKSPACE_ID` when (and only when) the run is workspace-scoped. But `resolveWorkspaceScope` fell through to the persisted scope belonging to whoever sits at the machine's terminal, so the spawned `hetero exec` stamped `X-Workspace-Id` onto every `heteroIngest`/`heteroFinish` call. For a personal-scope topic the server rejects each call with `Topic is outside the caller scope`; `BatchIngester` exhausts its 5 retries on the first batch and drops everything after, with no log output until drain. Observable blast radius: the run's assistant message stays a `...` placeholder, the topic sticks in `running`, and the goal coordinator reclaims the perfectly healthy operation as abandoned after the 5-minute lease — burning the task's attempt budget on ghost retries.

Fix: when `LOBEHUB_JWT` is present (server-dispatched execution), ignore the persisted scope entirely; explicit arg and `LOBEHUB_WORKSPACE_ID` still take precedence as before.

#### Test

- `bun run check` — lint clean, 14 tests passed, including a new regression test: with `LOBEHUB_JWT` set and a persisted scope present, resolution is `personal`; `LOBEHUB_WORKSPACE_ID` still wins when provided.
- Root cause reproduced and fix path verified live: running the bundled desktop CLI (`ELECTRON_RUN_AS_NODE`) against a real operation failed with `Topic is outside the caller scope` while the stale scope file existed, and ingested cleanly once the scope no longer applied.

- [x] Tested locally
- [x] Added/updated tests

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)