### PR TITLE
🐛 fix: ensure agent status icons follow theme

### DIFF
--- a/src/features/Electron/HeterogeneousAgent/StatusGuide/GuideShell.tsx
+++ b/src/features/Electron/HeterogeneousAgent/StatusGuide/GuideShell.tsx
@@ -48,6 +48,7 @@ const GuideShell = ({
               background={cssVar.colorFillQuaternary}
               shape={'square'}
               size={compact ? 32 : 48}
+              style={{ color: cssVar.colorText }}
             />
             <Flexbox gap={2} style={{ minWidth: 0 }}>
               <Text ellipsis={compact} style={{ fontSize: compact ? 14 : 16, fontWeight: 600 }}>


### PR DESCRIPTION
## Summary

- apply the current theme text color to heterogeneous-agent status avatars
- keep monochrome provider icons visible on light avatar backgrounds
- preserve theme-aware contrast in dark mode

## Verification

- `bun run check src/features/Electron/HeterogeneousAgent/StatusGuide/GuideShell.tsx`
- Electron acceptance in light and dark themes
- Acceptance: https://app.lobehub.com/acceptance/d6a47690-5d47-4378-b7ec-12a02b7431ca