### PR TITLE
💄 style(chat-input): never truncate the reasoning effort on the model chip

### DIFF
--- a/src/features/ChatInput/ActionBar/Model/index.tsx
+++ b/src/features/ChatInput/ActionBar/Model/index.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Tooltip } from '@lobehub/ui';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -69,7 +68,6 @@ const ModelSwitch = memo(() => {
     <SelectorTrigger
       aria-disabled={!interactive}
       ariaLabel={triggerText}
-      icon={<ModelIcon model={model} size={14} />}
       secondaryText={effortLabel}
       text={displayName}
       {...(interactive ? {} : { style: { cursor: 'default' } })}

--- a/src/features/ChatInput/ActionBar/Model/index.tsx
+++ b/src/features/ChatInput/ActionBar/Model/index.tsx
@@ -1,3 +1,4 @@
+import { ModelIcon } from '@lobehub/icons';
 import { Tooltip } from '@lobehub/ui';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -56,8 +57,9 @@ const ModelSwitch = memo(() => {
     [activeTopicId, canSelectModel, selectModel, updateTopicModel],
   );
 
-  // Both current values in one label, the way the heterogeneous selector reads:
-  // "GPT-5.6 Sol 中". The effort half is dropped for models without one.
+  // Both current values on one chip, the way the heterogeneous selector reads:
+  // "GPT-5.6 Sol 中". The effort half is dropped for models without one; the
+  // chip keeps the two halves apart so the effort is never ellipsised away.
   const effortLabel = effort.effortValue
     ? t(`reasoningEffort.levels.${effort.effortValue}`)
     : undefined;
@@ -67,7 +69,9 @@ const ModelSwitch = memo(() => {
     <SelectorTrigger
       aria-disabled={!interactive}
       ariaLabel={triggerText}
-      text={triggerText}
+      icon={<ModelIcon model={model} size={14} />}
+      secondaryText={effortLabel}
+      text={displayName}
       {...(interactive ? {} : { style: { cursor: 'default' } })}
     />
   );

--- a/src/features/ChatInput/ControlBar/HeteroModel/SelectorMenu.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/SelectorMenu.tsx
@@ -73,7 +73,12 @@ const SelectorMenu = memo<SelectorMenuProps>(
     return (
       <DropdownMenuRoot>
         <DropdownMenuTrigger nativeButton={false}>
-          <Trigger ariaLabel={view.ariaLabel} fast={view.isFastSpeed} text={view.triggerText} />
+          <Trigger
+            ariaLabel={view.ariaLabel}
+            fast={view.isFastSpeed}
+            secondaryText={view.triggerLabel.secondaryText}
+            text={view.triggerLabel.text}
+          />
         </DropdownMenuTrigger>
         <DropdownMenuPortal>
           {/* The trigger label changes width as selections change, and it sits in the

--- a/src/features/ChatInput/ControlBar/HeteroModel/labels.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/labels.ts
@@ -54,7 +54,17 @@ export const getModelLabel = (model: string, defaultLabel: string) => {
   return `${family[0].toUpperCase()}${family.slice(1)} ${major}.${minor}`;
 };
 
-export const getTriggerText = ({
+/**
+ * The two halves of the composer chip: the model (ellipsised when long) and
+ * the reasoning effort (never truncated). Collapses to a single "Default
+ * config" label when nothing is overridden.
+ */
+export interface TriggerLabel {
+  secondaryText?: string;
+  text: string;
+}
+
+export const getTriggerLabel = ({
   defaultConfigLabel,
   defaultModelLabel,
   defaultReasoningLabel,
@@ -70,16 +80,17 @@ export const getTriggerText = ({
   effortLabel?: string;
   model: string;
   modelLabel: string;
-}) => {
+}): TriggerLabel => {
   const isDefaultModel = model === HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
   const resolvedModelLabel = isDefaultModel ? defaultModelLabel : modelLabel;
 
-  if (!effort) return isDefaultModel ? defaultConfigLabel : resolvedModelLabel;
+  if (!effort) return { text: isDefaultModel ? defaultConfigLabel : resolvedModelLabel };
 
   const isDefaultEffort = effort === HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
-  if (isDefaultModel && isDefaultEffort) return defaultConfigLabel;
+  if (isDefaultModel && isDefaultEffort) return { text: defaultConfigLabel };
 
-  const resolvedEffortLabel = isDefaultEffort ? defaultReasoningLabel : effortLabel;
-
-  return `${resolvedModelLabel} ${resolvedEffortLabel}`;
+  return {
+    secondaryText: isDefaultEffort ? defaultReasoningLabel : effortLabel,
+    text: resolvedModelLabel,
+  };
 };

--- a/src/features/ChatInput/ControlBar/HeteroModel/selectorView.test.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/selectorView.test.ts
@@ -132,11 +132,13 @@ describe('current value surfaced on each dimension', () => {
     expect(view.dimensions[0].current).toBe('ultra');
     expect(view.dimensions[0].valueLabel).toBe('heteroAgent.modelSelector.mode.ultra');
     expect(view.ariaLabel).toBe('heteroAgent.modelSelector.mode.ariaLabel');
-    expect(view.triggerText).toBe('heteroAgent.modelSelector.mode.ultra');
+    expect(view.triggerLabel).toEqual({ text: 'heteroAgent.modelSelector.mode.ultra' });
   });
 
   it('shows Default config when Amp does not override its native mode', () => {
-    expect(viewOf({ type: 'amp' }).triggerText).toBe('heteroAgent.modelSelector.defaultConfig');
+    expect(viewOf({ type: 'amp' }).triggerLabel).toEqual({
+      text: 'heteroAgent.modelSelector.defaultConfig',
+    });
   });
 
   it('shows the resolved model and effort labels', () => {
@@ -176,15 +178,23 @@ describe('current value surfaced on each dimension', () => {
   });
 
   it('collapses the trigger to one label when nothing is overridden', () => {
-    expect(viewOf({ type: 'claude-code' }).triggerText).toBe(
-      'heteroAgent.modelSelector.defaultConfig',
-    );
+    expect(viewOf({ type: 'claude-code' }).triggerLabel).toEqual({
+      text: 'heteroAgent.modelSelector.defaultConfig',
+    });
   });
 
   it('names both halves in the trigger once either is overridden', () => {
-    expect(viewOf({ model: 'opus', type: 'claude-code' }).triggerText).toBe(
-      'Opus 4.8 heteroAgent.modelSelector.defaultReasoning',
-    );
+    expect(viewOf({ model: 'opus', type: 'claude-code' }).triggerLabel).toEqual({
+      secondaryText: 'heteroAgent.modelSelector.defaultReasoning',
+      text: 'Opus 4.8',
+    });
+  });
+
+  it('keeps the effort in its own half so a long model name cannot truncate it', () => {
+    expect(viewOf({ effort: 'xhigh', model: 'gpt-5.6-sol', type: 'codex' }).triggerLabel).toEqual({
+      secondaryText: 'heteroAgent.modelSelector.reasoning.xhigh',
+      text: 'GPT-5.6 Sol',
+    });
   });
 });
 

--- a/src/features/ChatInput/ControlBar/HeteroModel/selectorView.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/selectorView.ts
@@ -11,7 +11,8 @@ import {
 } from '@lobechat/types';
 import type { TFunction } from 'i18next';
 
-import { getEffortLabelKeys, getModeLabelKey, getModelLabel, getTriggerText } from './labels';
+import type { TriggerLabel } from './labels';
+import { getEffortLabelKeys, getModeLabelKey, getModelLabel, getTriggerLabel } from './labels';
 import { getStaticModelOptions } from './modelOptions';
 
 type Translate = TFunction<'chat'>;
@@ -39,7 +40,7 @@ export interface SelectorView {
   isCatalogModel: boolean;
   isFastSpeed: boolean;
   model: string;
-  triggerText: string;
+  triggerLabel: TriggerLabel;
 }
 
 export type SelectorShape =
@@ -214,11 +215,14 @@ export const buildSelectorView = ({
     isCatalogModel,
     isFastSpeed,
     model,
-    triggerText: isModeOnly
-      ? mode === HETEROGENEOUS_AGENT_DEFAULT_SELECTION
-        ? t('heteroAgent.modelSelector.defaultConfig')
-        : (modeLabel ?? defaultLabel)
-      : getTriggerText({
+    triggerLabel: isModeOnly
+      ? {
+          text:
+            mode === HETEROGENEOUS_AGENT_DEFAULT_SELECTION
+              ? t('heteroAgent.modelSelector.defaultConfig')
+              : (modeLabel ?? defaultLabel),
+        }
+      : getTriggerLabel({
           defaultConfigLabel: t('heteroAgent.modelSelector.defaultConfig'),
           defaultModelLabel: t('heteroAgent.modelSelector.defaultModel'),
           defaultReasoningLabel: t('heteroAgent.modelSelector.defaultReasoning'),

--- a/src/features/ChatInput/SendArea/index.tsx
+++ b/src/features/ChatInput/SendArea/index.tsx
@@ -45,7 +45,8 @@ const SendArea = memo<SendAreaProps>(({ hideContextWindow = true }) => {
   );
 
   return (
-    <Flexbox horizontal align={'center'} flex={'none'} gap={12}>
+    /** The model label must yield space before the footer clips Send on narrow panels. */
+    <Flexbox horizontal align={'center'} flex={'0 1 auto'} gap={12} style={{ minWidth: 0 }}>
       {items}
       {!audioInputActive && <SendButton />}
     </Flexbox>

--- a/src/features/ChatInput/components/SelectorTrigger.tsx
+++ b/src/features/ChatInput/components/SelectorTrigger.tsx
@@ -1,15 +1,25 @@
 import { Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDownIcon, ZapIcon } from 'lucide-react';
-import type { ComponentPropsWithRef } from 'react';
+import type { ComponentPropsWithRef, ReactNode } from 'react';
 import { memo } from 'react';
 
 const styles = createStaticStyles(({ css }) => ({
   label: css`
     overflow: hidden;
-    max-width: 150px;
+    max-width: 200px;
     text-overflow: ellipsis;
     white-space: nowrap;
+  `,
+  icon: css`
+    display: flex;
+    flex: none;
+    align-items: center;
+  `,
+  secondary: css`
+    flex: none;
+    color: ${cssVar.colorTextTertiary};
+    transition: color 0.2s;
   `,
   trigger: css`
     cursor: pointer;
@@ -32,14 +42,25 @@ const styles = createStaticStyles(({ css }) => ({
     &:hover {
       color: ${cssVar.colorText};
       background: ${cssVar.colorFillSecondary};
+
+      [data-secondary] {
+        color: ${cssVar.colorTextSecondary};
+      }
     }
   `,
 }));
 
 /**
- * The text chip both composer model selectors open from — the heterogeneous
- * one and the standard model + reasoning-effort one. Text only by design: the
- * label already names the model, so an icon would only add noise next to Send.
+ * The chip both composer model selectors open from — the heterogeneous one and
+ * the standard model + reasoning-effort one. An optional leading `icon` lets a
+ * selector badge the model (see LOBE-13826); it stays out of the truncation so
+ * the model is still recognisable once its name is ellipsised.
+ *
+ * The chip reads as two halves, the way the Codex composer does ("5.6 Sol 极高"):
+ * `text` is the model, `secondaryText` the reasoning effort. Only the model half
+ * may be ellipsised; the effort half never shrinks, so a long model name can
+ * no longer push the effort out of view, and it renders a step dimmer so the
+ * two values scan as name + qualifier instead of one run-on label.
  *
  * `DropdownMenuTrigger` clones its child to inject the open handler, ref and
  * `aria-haspopup`/`aria-expanded`. Swallowing the rest props here leaves a
@@ -48,16 +69,26 @@ const styles = createStaticStyles(({ css }) => ({
 interface TriggerProps extends ComponentPropsWithRef<'div'> {
   ariaLabel: string;
   fast?: boolean;
+  icon?: ReactNode;
+  secondaryText?: string;
   text: string;
 }
 
-const SelectorTrigger = memo<TriggerProps>(({ ariaLabel, className, fast, text, ...rest }) => (
-  <div {...rest} aria-label={ariaLabel} className={cx(styles.trigger, className)}>
-    {fast && <Icon icon={ZapIcon} size={12} />}
-    <span className={styles.label}>{text}</span>
-    <Icon icon={ChevronDownIcon} size={12} />
-  </div>
-));
+const SelectorTrigger = memo<TriggerProps>(
+  ({ ariaLabel, className, fast, icon, secondaryText, text, ...rest }) => (
+    <div {...rest} aria-label={ariaLabel} className={cx(styles.trigger, className)}>
+      {icon && <span className={styles.icon}>{icon}</span>}
+      {fast && <Icon icon={ZapIcon} size={12} />}
+      <span className={styles.label}>{text}</span>
+      {secondaryText && (
+        <span data-secondary className={styles.secondary}>
+          {secondaryText}
+        </span>
+      )}
+      <Icon icon={ChevronDownIcon} size={12} />
+    </div>
+  ),
+);
 
 SelectorTrigger.displayName = 'SelectorTrigger';
 

--- a/src/features/ChatInput/components/SelectorTrigger.tsx
+++ b/src/features/ChatInput/components/SelectorTrigger.tsx
@@ -7,7 +7,10 @@ import { memo } from 'react';
 const styles = createStaticStyles(({ css }) => ({
   label: css`
     overflow: hidden;
+
+    min-width: 0;
     max-width: 200px;
+
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
@@ -20,10 +23,12 @@ const styles = createStaticStyles(({ css }) => ({
     cursor: pointer;
 
     display: flex;
-    flex: none;
+    flex: 0 1 auto;
     gap: 6px;
     align-items: center;
 
+    min-width: 0;
+    max-width: 100%;
     height: 28px;
     padding-inline: 8px;
     border-radius: 6px;
@@ -55,6 +60,8 @@ const styles = createStaticStyles(({ css }) => ({
  * may be ellipsised; the effort half never shrinks, so a long model name can
  * no longer push the effort out of view, and it renders a step dimmer so the
  * two values scan as name + qualifier instead of one run-on label.
+ * The trigger can shrink with its send area on narrow panels; only the model
+ * label gives up width so the effort and adjacent Send control remain visible.
  *
  * `DropdownMenuTrigger` clones its child to inject the open handler, ref and
  * `aria-haspopup`/`aria-expanded`. Swallowing the rest props here leaves a

--- a/src/features/ChatInput/components/SelectorTrigger.tsx
+++ b/src/features/ChatInput/components/SelectorTrigger.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDownIcon, ZapIcon } from 'lucide-react';
-import type { ComponentPropsWithRef, ReactNode } from 'react';
+import type { ComponentPropsWithRef } from 'react';
 import { memo } from 'react';
 
 const styles = createStaticStyles(({ css }) => ({
@@ -10,11 +10,6 @@ const styles = createStaticStyles(({ css }) => ({
     max-width: 200px;
     text-overflow: ellipsis;
     white-space: nowrap;
-  `,
-  icon: css`
-    display: flex;
-    flex: none;
-    align-items: center;
   `,
   secondary: css`
     flex: none;
@@ -52,9 +47,8 @@ const styles = createStaticStyles(({ css }) => ({
 
 /**
  * The chip both composer model selectors open from — the heterogeneous one and
- * the standard model + reasoning-effort one. An optional leading `icon` lets a
- * selector badge the model (see LOBE-13826); it stays out of the truncation so
- * the model is still recognisable once its name is ellipsised.
+ * the standard model + reasoning-effort one. Text only by design: the label
+ * already names the model, so an icon would only add noise next to Send.
  *
  * The chip reads as two halves, the way the Codex composer does ("5.6 Sol 极高"):
  * `text` is the model, `secondaryText` the reasoning effort. Only the model half
@@ -69,15 +63,13 @@ const styles = createStaticStyles(({ css }) => ({
 interface TriggerProps extends ComponentPropsWithRef<'div'> {
   ariaLabel: string;
   fast?: boolean;
-  icon?: ReactNode;
   secondaryText?: string;
   text: string;
 }
 
 const SelectorTrigger = memo<TriggerProps>(
-  ({ ariaLabel, className, fast, icon, secondaryText, text, ...rest }) => (
+  ({ ariaLabel, className, fast, secondaryText, text, ...rest }) => (
     <div {...rest} aria-label={ariaLabel} className={cx(styles.trigger, className)}>
-      {icon && <span className={styles.icon}>{icon}</span>}
       {fast && <Icon icon={ZapIcon} size={12} />}
       <span className={styles.label}>{text}</span>
       {secondaryText && (


### PR DESCRIPTION
The composer's model chip rendered the model name and the reasoning effort as a **single string** clipped at `max-width: 150px`. Any moderately long display name ellipsised the effort away completely, so the user could no longer tell which reasoning level was active without opening the menu.

This splits the chip into two independent halves:

- **Model name** — its own span, max-width widened `150px → 200px`, still ellipsises when too long.
- **Reasoning effort** — its own span with `flex: none`, so it can never shrink or be truncated. Rendered in `colorTextTertiary`, one tone dimmer than the name, and brightened together with the name on hover.

The chip stays text-only; the model icon removed in the recent redesign is not coming back here.

The heterogeneous selector (Claude Code / Codex) goes through the same trigger, so `getTriggerText` there was replaced by `getTriggerLabel`, which returns `{ text, secondaryText }` instead of a pre-joined string.

| Before | After |
| ------ | ----- |
| `DeepSeek V4 Flash Visio…` — one 150px-clipped string, the effort is invisible | `DeepSeek V4 Flash Vision Exp` + dimmer `高` — effort always fully visible |

#### Test

[Latest acceptance, round 4](https://app.lobehub.com/acceptance/28da250d-67ff-45d0-bd37-b199808755e8?r=4) covers the narrow-panel repair at `2d2603be94`.

- A real 600px-wide page reproduced Send clipping by 15.89px. After allowing both the send area and trigger to shrink, the model label yields width while effort and Send remain inside the footer. The same browser geometry assertion fails before and passes after.
- The 1440px layout still displays the full model name and effort.
- 35 focused tests and the full type check pass. Lint passes with one unrelated existing warning.
- The five standard-selector checks from round 3 cover text-only appearance, long names, effort switching, and hover tone. Mobile-specific re-verification is blocked at local authentication; the external-agent selector remains unverified because the isolated runtime has no connected device.

The send area and trigger now shrink with their container; only the model-name span gives up width, while reasoning effort and Send retain their size. The unrelated OIDC CI fixture fix from upstream `e7fcb63685f` was included by rebase.

- [x] Tested locally
- [x] Added/updated tests in the original change

#### 🔗 Related Issue

Fixes LOBE-13826