### PR TITLE
✨ feat(fts-search): sync writes to every live index generation

### DIFF
--- a/apps/server/src/services/ftsSearch/elasticsearch.test.ts
+++ b/apps/server/src/services/ftsSearch/elasticsearch.test.ts
@@ -357,7 +357,7 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
     );
   });
 
-  it('sends bulk payloads to the alias-only endpoint', async () => {
+  it('sends bulk payloads addressed to physical generation indexes', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ errors: false, items: [{ index: { status: 201 } }] }), {
         headers: { 'Content-Type': 'application/json' },
@@ -377,7 +377,7 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
       items: [{ index: { status: 201 } }],
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      new URL('https://search.example.com/_bulk?require_alias=true'),
+      new URL('https://search.example.com/_bulk'),
       expect.objectContaining({
         body,
         headers: {
@@ -386,6 +386,65 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
         },
         method: 'POST',
       }),
+    );
+  });
+
+  it('lists every live generation behind each alias, including the writable index', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          'lobehub-agents-v2': { aliases: { 'lobehub-agents': { is_write_index: true } } },
+          'lobehub-agents-v1': { aliases: { 'lobehub-agents': { is_write_index: false } } },
+          'custom-topics': { aliases: { 'lobehub-topics': {} } },
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          'lobehub-agents-v1': { aliases: { 'lobehub-agents': { is_write_index: false } } },
+          'lobehub-agents-v2': { aliases: { 'lobehub-agents': { is_write_index: true } } },
+          'lobehub-agents-v3': { aliases: {} },
+          'lobehub-agents-v3-backup': { aliases: {} },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new ElasticsearchFtsSearchHttpClient({
+      apiKey: 'test-api-key',
+      url: 'https://search.example.com',
+    });
+
+    await expect(
+      client.getFtsSearchSyncGenerationTargets(['lobehub-topics', 'lobehub-agents']),
+    ).resolves.toEqual({
+      'lobehub-agents': ['lobehub-agents-v1', 'lobehub-agents-v2', 'lobehub-agents-v3'],
+      'lobehub-topics': ['custom-topics'],
+    });
+    expect(fetchMock.mock.calls.map(([url]) => url.toString())).toEqual([
+      'https://search.example.com/_alias/lobehub-topics,lobehub-agents',
+      'https://search.example.com/lobehub-topics-v*,lobehub-agents-v*/_alias?expand_wildcards=open&allow_no_indices=true',
+    ]);
+  });
+
+  it('refuses generation targets for an alias without a unique writable index', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          Response.json({
+            'lobehub-agents-v1': { aliases: { 'lobehub-agents': {} } },
+            'lobehub-agents-v2': { aliases: { 'lobehub-agents': {} } },
+          }),
+        )
+        .mockResolvedValueOnce(Response.json({})),
+    );
+    const client = new ElasticsearchFtsSearchHttpClient({
+      apiKey: 'test-api-key',
+      url: 'https://search.example.com',
+    });
+
+    await expect(client.getFtsSearchSyncGenerationTargets(['lobehub-agents'])).rejects.toThrow(
+      'is not a writable alias: lobehub-agents',
     );
   });
 

--- a/apps/server/src/services/ftsSearch/elasticsearch.ts
+++ b/apps/server/src/services/ftsSearch/elasticsearch.ts
@@ -41,14 +41,17 @@ const searchResponseSchema = z.object({
   took: z.number().nonnegative().optional(),
 });
 
+const bulkItemErrorSchema = z.object({ type: z.string().optional() }).passthrough();
 const bulkResponseSchema = z.object({
   errors: z.boolean().optional(),
   items: z.array(
     z.object({
-      index: z.object({ error: z.unknown().optional(), status: z.number() }),
+      index: z.object({ error: bulkItemErrorSchema.optional(), status: z.number() }),
     }),
   ),
 });
+
+const escapeRegExp = (value: string) => value.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
 
 const aliasResponseSchema = z.record(
   z.string(),
@@ -99,9 +102,13 @@ const indexIdentityResponseSchema = z.record(
   }),
 );
 
+export interface ElasticsearchFtsSearchBulkItem {
+  index: { error?: { type?: string }; status: number };
+}
+
 export interface ElasticsearchFtsSearchBulkResponse {
   errors?: boolean;
-  items: Array<{ index: { error?: unknown; status: number } }>;
+  items: ElasticsearchFtsSearchBulkItem[];
 }
 
 export interface ElasticsearchFtsSearchHttpClientOptions {
@@ -301,9 +308,9 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
     return resolved;
   }
 
-  private async getFtsSearchSyncWriteTargetMap(aliases: string[]) {
-    const aliasPath = aliases.map(encodeURIComponent).join(',');
-    const aliasResponse = await fetch(new URL(`/_alias/${aliasPath}`, this.url), {
+  /** Fetches `GET /_alias/...` or `GET /<indices>/_alias` and validates the shared response shape. */
+  private async fetchAliasTable(path: string): Promise<z.infer<typeof aliasResponseSchema>> {
+    const aliasResponse = await fetch(new URL(path, this.url), {
       headers: this.headers(),
       method: 'GET',
       signal: AbortSignal.timeout(this.requestTimeoutMs),
@@ -331,30 +338,74 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
         aliasResponse.status,
       );
     }
+    return aliasPayload.data;
+  }
+
+  /** Picks the unique writable physical index behind `alias`, failing closed on ambiguity. */
+  private selectWriteTarget(
+    aliasTable: z.infer<typeof aliasResponseSchema>,
+    alias: string,
+  ): string {
+    const targets = Object.entries(aliasTable).filter(([, value]) =>
+      Object.hasOwn(value.aliases, alias),
+    );
+    const explicitWriteTargets = targets.filter(
+      ([, value]) => value.aliases[alias].is_write_index === true,
+    );
+    const writeTarget =
+      explicitWriteTargets.length === 1
+        ? explicitWriteTargets[0]
+        : targets.length === 1 && targets[0][1].aliases[alias].is_write_index !== false
+          ? targets[0]
+          : undefined;
+    if (!writeTarget) {
+      throw new ElasticsearchFtsSearchRequestError(
+        `Elasticsearch full-text search sync destination is not a writable alias: ${alias}`,
+      );
+    }
+    return writeTarget[0];
+  }
+
+  private async getFtsSearchSyncWriteTargetMap(aliases: string[]) {
+    const aliasPath = aliases.map(encodeURIComponent).join(',');
+    const aliasTable = await this.fetchAliasTable(`/_alias/${aliasPath}`);
 
     const writeTargets = new Map<string, string>();
-    for (const alias of aliases) {
-      const targets = Object.entries(aliasPayload.data).filter(([, value]) =>
-        Object.hasOwn(value.aliases, alias),
-      );
-      const explicitWriteTargets = targets.filter(
-        ([, value]) => value.aliases[alias].is_write_index === true,
-      );
-      const writeTarget =
-        explicitWriteTargets.length === 1
-          ? explicitWriteTargets[0]
-          : targets.length === 1 && targets[0][1].aliases[alias].is_write_index !== false
-            ? targets[0]
-            : undefined;
-      if (!writeTarget) {
-        throw new ElasticsearchFtsSearchRequestError(
-          `Elasticsearch full-text search sync destination is not a writable alias: ${alias}`,
-        );
-      }
-      writeTargets.set(alias, writeTarget[0]);
-    }
-
+    for (const alias of aliases) writeTargets.set(alias, this.selectWriteTarget(aliasTable, alias));
     return writeTargets;
+  }
+
+  /**
+   * Lists every live physical generation of each alias so incremental sync can write to all of
+   * them. Generations follow `<alias>-v<n>`; the alias's writable index is always included even if
+   * it was named differently by an operator. Only open indexes count: a generation being retired
+   * is closed first, which drops it from this list before it is deleted.
+   *
+   * Resolved on every drain rather than cached so a generation created by a running rebuild starts
+   * receiving writes on the next batch, and a retired one stops without a restart.
+   */
+  async getFtsSearchSyncGenerationTargets(aliases: string[]): Promise<Record<string, string[]>> {
+    if (aliases.length === 0) return {};
+
+    const patternPath = aliases.map((alias) => encodeURIComponent(`${alias}-v*`)).join(',');
+    // Wildcard patterns only expand to physical indexes, so the alias table still has to be fetched
+    // by alias name to learn which generation currently serves reads and writes.
+    const [aliasTable, generationTable] = await Promise.all([
+      this.fetchAliasTable(`/_alias/${aliases.map(encodeURIComponent).join(',')}`),
+      this.fetchAliasTable(`/${patternPath}/_alias?expand_wildcards=open&allow_no_indices=true`),
+    ]);
+
+    const targets: Record<string, string[]> = {};
+    for (const alias of [...aliases].sort()) {
+      const writeIndex = this.selectWriteTarget(aliasTable, alias);
+      const generationPattern = new RegExp(`^${escapeRegExp(alias)}-v\\d+$`);
+      const generations = new Set(
+        Object.keys(generationTable).filter((index) => generationPattern.test(index)),
+      );
+      generations.add(writeIndex);
+      targets[alias] = [...generations].sort();
+    }
+    return targets;
   }
 
   /** Returns each alias's unique writable physical index after validating tombstone support. */
@@ -501,8 +552,13 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
     );
   }
 
+  /**
+   * Actions name physical generation indexes (see `getFtsSearchSyncGenerationTargets`), so
+   * `require_alias` cannot be used. The live generation is never deleted while aliased, and retired
+   * generations leave the target list before deletion, so no action can auto-create an index.
+   */
   async bulk(body: string): Promise<ElasticsearchFtsSearchBulkResponse> {
-    const endpoint = new URL('/_bulk?require_alias=true', this.url);
+    const endpoint = new URL('/_bulk', this.url);
     const response = await fetch(endpoint, {
       body,
       headers: this.headers({ 'Content-Type': 'application/x-ndjson' }),

--- a/apps/server/src/services/ftsSearchSync/service.test.ts
+++ b/apps/server/src/services/ftsSearchSync/service.test.ts
@@ -39,10 +39,23 @@ const createHarness = (
     ),
     releaseMany: vi.fn(async (_items: FtsSearchSyncWork[]) => undefined),
   };
-  const client = { bulk: vi.fn() };
+  const client = {
+    bulk: vi.fn(),
+    getFtsSearchSyncGenerationTargets: vi.fn(async (aliases: string[]) =>
+      Object.fromEntries(aliases.map((alias) => [alias, [`${alias}-v1`]])),
+    ),
+  };
 
   return { builder, client, outbox };
 };
+
+/** Bulk action metadata lines of the first bulk request, in order. */
+const bulkActions = (client: { bulk: { mock: { calls: unknown[][] } } }, call = 0) =>
+  (client.bulk.mock.calls[call][0] as string)
+    .trim()
+    .split('\n')
+    .filter((_, index) => index % 2 === 0)
+    .map((line) => JSON.parse(line).index as { _id: string; _index: string; version: number });
 
 describe('FtsSearchSyncService', () => {
   beforeEach(() => {
@@ -145,6 +158,139 @@ describe('FtsSearchSyncService', () => {
         result: 'response_error',
       }),
     ]);
+  });
+
+  it('writes every change to each live generation and settles it only when all of them hold it', async () => {
+    const works = [work('a', 3), work('b', 4)];
+    const harness = createHarness(
+      works,
+      new Map(works.map((item) => [item.documentId, { id: item.documentId, title: 'title' }])),
+    );
+    harness.client.getFtsSearchSyncGenerationTargets.mockResolvedValue({
+      'lobehub-test-agents': ['lobehub-test-agents-v1', 'lobehub-test-agents-v2'],
+    });
+    harness.client.bulk.mockResolvedValue({
+      errors: true,
+      items: [201, 409, 201, 429].map((status) => ({ index: { status } })),
+    });
+    const service = new FtsSearchSyncService(
+      harness.builder as never,
+      harness.outbox as never,
+      harness.client,
+      'lobehub-test',
+    );
+
+    const result = await service.drainOnce();
+
+    expect(harness.client.getFtsSearchSyncGenerationTargets).toHaveBeenCalledWith([
+      'lobehub-test-agents',
+    ]);
+    expect(bulkActions(harness.client)).toEqual([
+      { _id: 'a', _index: 'lobehub-test-agents-v1', version: 3, version_type: 'external' },
+      { _id: 'a', _index: 'lobehub-test-agents-v2', version: 3, version_type: 'external' },
+      { _id: 'b', _index: 'lobehub-test-agents-v1', version: 4, version_type: 'external' },
+      { _id: 'b', _index: 'lobehub-test-agents-v2', version: 4, version_type: 'external' },
+    ]);
+    expect(harness.outbox.acknowledgeMany).toHaveBeenCalledWith([works[0]]);
+    expect(harness.outbox.markFailures).toHaveBeenCalledWith([
+      expect.objectContaining({ documentId: 'b', permanent: false }),
+    ]);
+    expect(result).toMatchObject({ acknowledged: 1, bulkItems: 4, failed: 1 });
+    expect(result.bulkRequestSamples[0].entities).toEqual({
+      agents: { bytes: expect.any(Number), items: 4, result: 'mixed' },
+    });
+  });
+
+  it('ignores a generation retired mid-drain once another generation accepted the write', async () => {
+    const works = [work('kept'), work('lost')];
+    const harness = createHarness(
+      works,
+      new Map(works.map((item) => [item.documentId, { id: item.documentId, title: 'title' }])),
+    );
+    harness.client.getFtsSearchSyncGenerationTargets.mockResolvedValue({
+      'lobehub-test-agents': ['lobehub-test-agents-v1', 'lobehub-test-agents-v2'],
+    });
+    const notFound = { error: { type: 'index_not_found_exception' }, status: 404 };
+    harness.client.bulk.mockResolvedValue({
+      errors: true,
+      items: [
+        { index: notFound },
+        { index: { status: 201 } },
+        { index: notFound },
+        { index: notFound },
+      ],
+    });
+    const service = new FtsSearchSyncService(
+      harness.builder as never,
+      harness.outbox as never,
+      harness.client,
+      'lobehub-test',
+    );
+
+    const result = await service.drainOnce();
+
+    expect(harness.outbox.acknowledgeMany).toHaveBeenCalledWith([works[0]]);
+    // Every generation vanished: the change must stay durable instead of being silently dropped.
+    expect(harness.outbox.markFailures).toHaveBeenCalledWith([
+      expect.objectContaining({ documentId: 'lost', permanent: true }),
+    ]);
+    expect(result).toMatchObject({ acknowledged: 1, dead: 1, failed: 1 });
+  });
+
+  it('durably retries every claimed change when generation targets cannot be resolved', async () => {
+    const works = [work('a'), work('b')];
+    const harness = createHarness(
+      works,
+      new Map(works.map((item) => [item.documentId, { id: item.documentId, title: 'title' }])),
+    );
+    harness.client.getFtsSearchSyncGenerationTargets.mockRejectedValueOnce(
+      new ElasticsearchFtsSearchRequestError('alias check failed', 503),
+    );
+    const service = new FtsSearchSyncService(
+      harness.builder as never,
+      harness.outbox as never,
+      harness.client,
+      'lobehub-test',
+    );
+
+    const result = await service.drainOnce();
+
+    expect(harness.client.bulk).not.toHaveBeenCalled();
+    expect(harness.outbox.markFailures).toHaveBeenCalledWith([
+      expect.not.objectContaining({ permanent: true }),
+      expect.not.objectContaining({ permanent: true }),
+    ]);
+    expect(result).toMatchObject({ dead: 0, failed: 2, released: 0 });
+  });
+
+  it('splits bulk requests by the expanded multi-generation payload size', async () => {
+    const works = [work('a'), work('b')];
+    const harness = createHarness(
+      works,
+      new Map(works.map((item) => [item.documentId, { id: item.documentId, title: 'x' }])),
+    );
+    harness.client.getFtsSearchSyncGenerationTargets.mockResolvedValue({
+      'lobehub-test-agents': ['lobehub-test-agents-v1', 'lobehub-test-agents-v2'],
+    });
+    harness.client.bulk.mockResolvedValue({
+      errors: false,
+      items: [{ index: { status: 201 } }, { index: { status: 201 } }],
+    });
+    const service = new FtsSearchSyncService(
+      harness.builder as never,
+      harness.outbox as never,
+      harness.client,
+      'lobehub-test',
+      // Fits one two-generation change (~270 bytes) but not two of them.
+      { bulkMaxBytes: 400 },
+    );
+
+    const result = await service.drainOnce();
+
+    expect(harness.client.bulk).toHaveBeenCalledTimes(2);
+    expect(bulkActions(harness.client, 0).map(({ _id }) => _id)).toEqual(['a', 'a']);
+    expect(bulkActions(harness.client, 1).map(({ _id }) => _id)).toEqual(['b', 'b']);
+    expect(result).toMatchObject({ acknowledged: 2, bulkItems: 4, bulkRequests: 2 });
   });
 
   it('writes a soft tombstone when the PostgreSQL row no longer exists', async () => {
@@ -276,13 +422,10 @@ describe('FtsSearchSyncService', () => {
 
     const result = await service.drainOnce();
 
-    const body = harness.client.bulk.mock.calls[0][0] as string;
-    const documentIds = body
-      .trim()
-      .split('\n')
-      .filter((_, index) => index % 2 === 0)
-      .map((line) => JSON.parse(line).index._id);
-    expect(documentIds).toEqual(['urgent-message', 'ordinary-agent']);
+    expect(bulkActions(harness.client)).toEqual([
+      expect.objectContaining({ _id: 'urgent-message', _index: 'lobehub-test-messages-v1' }),
+      expect.objectContaining({ _id: 'ordinary-agent', _index: 'lobehub-test-agents-v1' }),
+    ]);
     expect(result.bulkRequestSamples[0].entities).toEqual({
       agents: { bytes: expect.any(Number), items: 1, result: 'success' },
       messages: { bytes: expect.any(Number), items: 1, result: 'success' },

--- a/apps/server/src/services/ftsSearchSync/service.ts
+++ b/apps/server/src/services/ftsSearchSync/service.ts
@@ -11,7 +11,10 @@ import type {
   FtsSearchSyncWork,
 } from '@/database/repositories/ftsSearchSyncOutbox';
 
-import type { ElasticsearchFtsSearchBulkResponse } from '../ftsSearch/elasticsearch';
+import type {
+  ElasticsearchFtsSearchBulkItem,
+  ElasticsearchFtsSearchBulkResponse,
+} from '../ftsSearch/elasticsearch';
 
 export const FTS_SEARCH_SYNC_BULK_MAX_BYTES = 50 * 1024 * 1024;
 export const FTS_SEARCH_SYNC_CLAIM_LIMIT = 100;
@@ -20,11 +23,16 @@ export const FTS_SEARCH_SYNC_PROJECTION_BATCH_SIZE = FTS_SEARCH_SYNC_CLAIM_LIMIT
 
 interface FtsSearchSyncElasticsearchClient {
   bulk: (body: string) => Promise<ElasticsearchFtsSearchBulkResponse>;
+  /** Live physical generations per alias; every change is written to all of them. */
+  getFtsSearchSyncGenerationTargets: (aliases: string[]) => Promise<Record<string, string[]>>;
 }
 
+/** One Outbox change expanded into one bulk action per live generation of its entity. */
 interface FtsSearchSyncOperation {
   body: string;
   bytes: number;
+  /** Number of bulk actions (= generation targets) this change expands to. */
+  items: number;
   work: FtsSearchSyncWork;
 }
 
@@ -82,20 +90,36 @@ const chunks = <Item>(items: Item[], size: number): Item[][] => {
 
 const buildOperation = (
   work: FtsSearchSyncWork,
-  indexNamespace: string,
+  targets: string[],
   source: Record<string, unknown>,
 ): FtsSearchSyncOperation => {
-  const metadata = {
-    index: {
-      _id: work.documentId,
-      _index: getFtsSearchIndexAlias(indexNamespace, work.entity),
-      version: work.revision,
-      version_type: 'external',
-    },
-  };
-  const body = `${JSON.stringify(metadata)}\n${JSON.stringify(source)}\n`;
-  return { body, bytes: Buffer.byteLength(body), work };
+  const sourceLine = JSON.stringify(source);
+  /**
+   * The same revision goes to every generation with `version_type: external`, so a generation that
+   * a concurrent rebuild already filled with a newer revision answers 409 and is settled as done.
+   */
+  const body = targets
+    .map((target) => {
+      const metadata = {
+        index: {
+          _id: work.documentId,
+          _index: target,
+          version: work.revision,
+          version_type: 'external',
+        },
+      };
+      return `${JSON.stringify(metadata)}\n${sourceLine}\n`;
+    })
+    .join('');
+  return { body, bytes: Buffer.byteLength(body), items: targets.length, work };
 };
+
+const isAcceptedBulkItem = ({ index: item }: ElasticsearchFtsSearchBulkItem) =>
+  (item.status >= 200 && item.status < 300) || item.status === 409;
+
+/** A generation retired between target resolution and the write; the next drain re-resolves. */
+const isRetiredGenerationBulkItem = ({ index: item }: ElasticsearchFtsSearchBulkItem) =>
+  item.error?.type === 'index_not_found_exception' || item.error?.type === 'index_closed_exception';
 
 const summarizeBulkEntities = (
   operations: FtsSearchSyncOperation[],
@@ -104,14 +128,15 @@ const summarizeBulkEntities = (
 ): FtsSearchSyncBulkRequestSample['entities'] => {
   const summaries = new Map<
     FtsSearchSyncWork['entity'],
-    { bytes: number; failed: number; items: number }
+    { bytes: number; failed: number; items: number; works: number }
   >();
 
   for (const operation of operations) {
     const entity = operation.work.entity;
-    const current = summaries.get(entity) ?? { bytes: 0, failed: 0, items: 0 };
+    const current = summaries.get(entity) ?? { bytes: 0, failed: 0, items: 0, works: 0 };
     current.bytes += operation.bytes;
-    current.items += 1;
+    current.items += operation.items;
+    current.works += 1;
     if (failedWorkKeys?.has(workKey(operation.work))) current.failed += 1;
     summaries.set(entity, current);
   }
@@ -123,7 +148,7 @@ const summarizeBulkEntities = (
         ? result
         : summary.failed === 0
           ? 'success'
-          : summary.failed === summary.items
+          : summary.failed === summary.works
             ? 'item_error'
             : 'mixed';
     entitySamples[entity] = {
@@ -216,10 +241,11 @@ export class FtsSearchSyncService {
       const operations = bulk;
       const requestBody = operations.map((operation) => operation.body).join('');
       const requestBytes = bulkBytes;
+      const requestItems = operations.reduce((total, operation) => total + operation.items, 0);
       bulk = [];
       bulkBytes = 0;
       result.bulkBytes += requestBytes;
-      result.bulkItems += operations.length;
+      result.bulkItems += requestItems;
       result.bulkRequests += 1;
 
       let response: ElasticsearchFtsSearchBulkResponse;
@@ -231,7 +257,7 @@ export class FtsSearchSyncService {
           bytes: requestBytes,
           durationMs: Date.now() - startedAt,
           entities: summarizeBulkEntities(operations, 'request_error'),
-          items: operations.length,
+          items: requestItems,
           result: 'request_error',
         });
         /** Request-level failures can be deployment or proxy faults; retry every item durably. */
@@ -239,19 +265,19 @@ export class FtsSearchSyncService {
         return;
       }
 
-      if (response.items.length !== operations.length) {
+      if (response.items.length !== requestItems) {
         result.bulkRequestSamples.push({
           bytes: requestBytes,
           durationMs: Date.now() - startedAt,
           entities: summarizeBulkEntities(operations, 'response_error'),
-          items: operations.length,
+          items: requestItems,
           result: 'response_error',
         });
         await fail(
           operations.map(({ work }) => ({
             ...work,
             error: new Error(
-              `Elasticsearch bulk returned ${response.items.length} items for ${operations.length} operations`,
+              `Elasticsearch bulk returned ${response.items.length} items for ${requestItems} operations`,
             ),
           })),
         );
@@ -260,23 +286,35 @@ export class FtsSearchSyncService {
 
       const acknowledged: FtsSearchSyncWork[] = [];
       const failures: FtsSearchSyncFailure[] = [];
-      for (const [index, operation] of operations.entries()) {
-        const item = response.items[index].index;
-        if ((item.status >= 200 && item.status < 300) || item.status === 409) {
-          /**
-           * A version conflict is safe to settle because two database fences preserve source order:
-           * fresh reindexes reserve their base revision before capture activation, and same-document
-           * Outbox upserts allocate a revision only after locking the unique Outbox row. Settlement
-           * is also revision-and-lease fenced, so a concurrent refresh remains queued.
-           */
+      let offset = 0;
+      for (const operation of operations) {
+        const items = response.items.slice(offset, offset + operation.items);
+        offset += operation.items;
+        /**
+         * A version conflict is safe to settle because two database fences preserve source order:
+         * fresh reindexes reserve their base revision before capture activation, and same-document
+         * Outbox upserts allocate a revision only after locking the unique Outbox row. Settlement
+         * is also revision-and-lease fenced, so a concurrent refresh remains queued.
+         */
+        const accepted = items.filter(isAcceptedBulkItem).length;
+        const rejected = items.filter(
+          (item) => !isAcceptedBulkItem(item) && !isRetiredGenerationBulkItem(item),
+        );
+        /**
+         * A change is done once every generation that still exists holds it. Retired generations
+         * are ignored only when another generation accepted the write; if none did, the alias
+         * itself is gone and the change must not be lost.
+         */
+        if (rejected.length === 0 && accepted > 0) {
           acknowledged.push(operation.work);
-        } else {
-          failures.push({
-            ...operation.work,
-            error: new Error(`Elasticsearch bulk item failed (${item.status})`),
-            permanent: isPermanentElasticsearchStatus(item.status),
-          });
+          continue;
         }
+        const failedItem = (rejected[0] ?? items[0]).index;
+        failures.push({
+          ...operation.work,
+          error: new Error(`Elasticsearch bulk item failed (${failedItem.status})`),
+          permanent: isPermanentElasticsearchStatus(failedItem.status),
+        });
       }
 
       const bulkResult =
@@ -285,7 +323,7 @@ export class FtsSearchSyncService {
         bytes: requestBytes,
         durationMs: Date.now() - startedAt,
         entities: summarizeBulkEntities(operations, bulkResult, new Set(failures.map(workKey))),
-        items: operations.length,
+        items: requestItems,
         result: bulkResult,
       });
 
@@ -340,6 +378,42 @@ export class FtsSearchSyncService {
         }
       }
 
+      /**
+       * Resolve the live generations of every entity in this batch once per drain. Resolution
+       * failures are retried durably like a failed bulk request: the alias table is an
+       * Elasticsearch read that can fail for the same transient reasons.
+       */
+      const targetsByEntity = new Map<FtsSearchSyncWork['entity'], string[]>();
+      const pendingEntities = [
+        ...new Set(works.filter((work) => unsettled.has(workKey(work))).map((work) => work.entity)),
+      ];
+      if (!stoppedForDeadLetter && pendingEntities.length > 0) {
+        const aliasEntities = new Map(
+          pendingEntities.map(
+            (entity) => [getFtsSearchIndexAlias(this.indexNamespace, entity), entity] as const,
+          ),
+        );
+        try {
+          const targets = await this.client.getFtsSearchSyncGenerationTargets([
+            ...aliasEntities.keys(),
+          ]);
+          for (const [alias, entity] of aliasEntities) {
+            const entityTargets = targets[alias];
+            if (!entityTargets || entityTargets.length === 0) {
+              throw new Error(`Elasticsearch returned no generation targets for alias ${alias}`);
+            }
+            targetsByEntity.set(entity, entityTargets);
+          }
+        } catch (error) {
+          await fail(
+            works
+              .filter((work) => unsettled.has(workKey(work)))
+              .map((work) => ({ ...work, error })),
+          );
+          if (result.dead > 0) stoppedForDeadLetter = true;
+        }
+      }
+
       let exhaustedBulkBudget = false;
       operations: for (const work of works) {
         if (stoppedForDeadLetter) break;
@@ -348,14 +422,14 @@ export class FtsSearchSyncService {
         const source =
           projectedSources.get(sourceKey(work.entity, work.documentId)) ??
           ({ id: work.documentId, fts_search_sync_deleted: true } as Record<string, unknown>);
-        const operation = buildOperation(work, this.indexNamespace, source);
+        const operation = buildOperation(work, targetsByEntity.get(work.entity)!, source);
 
         if (operation.bytes > this.options.bulkMaxBytes) {
           await fail([
             {
               ...work,
               error: new Error(
-                `Full-text search document is ${operation.bytes} bytes and exceeds the ${this.options.bulkMaxBytes}-byte bulk limit`,
+                `Full-text search document is ${operation.bytes} bytes across ${operation.items} generation(s) and exceeds the ${this.options.bulkMaxBytes}-byte bulk limit`,
               ),
               permanent: true,
             },

--- a/scripts/elasticsearchReindex/runtime/elasticsearchClient.ts
+++ b/scripts/elasticsearchReindex/runtime/elasticsearchClient.ts
@@ -283,10 +283,10 @@ export class FtsSearchReindexHttpClient implements FtsSearchReindexElasticsearch
       }
 
       /**
-       * Incremental sync writes only through the stable alias. Moving that alias while a resumable
-       * backfill is running could acknowledge a change in the old index without replaying it into
-       * the new one. Online schema upgrades therefore require a separate durable dual-write
-       * protocol; this initial migration fails closed instead of pretending the cutover is safe.
+       * Incremental sync writes every change to all live generations of an entity, so a newer
+       * generation can be backfilled while the alias keeps serving the old one. Promotion is still
+       * a separate explicit step gated on the backfill and the Outbox catching up; this command
+       * never moves an existing alias and fails closed instead.
        */
       throw new FtsSearchReindexRequestError(
         `Elasticsearch alias ${alias} already points to a different index`,


### PR DESCRIPTION
> **Stacked on #19186.** Base is `feat/fts-search-mapping-migration`; once that PR merges to `canary`, this PR's base should be retargeted to `canary` (GitHub usually does this automatically; please confirm before merging).

Second step of the Elasticsearch mapping migration work. Incremental sync used to address one alias per entity with `require_alias=true`, which made it impossible to backfill a new mapping generation while the old one kept serving traffic. This PR turns the sync into a multi-generation writer so a rebuild can run alongside it.

#### What changed

- `ElasticsearchFtsSearchHttpClient.getFtsSearchSyncGenerationTargets(aliases)` — resolves, per alias, every live physical generation named `<alias>-v<n>` plus the alias's writable index (kept even if an operator named it differently). Uses `GET /<alias>-v*/_alias?expand_wildcards=open`, so a generation that has been closed no longer counts as a target. The alias table fetch and write-target selection were extracted into shared helpers.
- `FtsSearchSyncService.drainOnce` — resolves generation targets once per drain for the entities in the claimed batch and expands every Outbox change into one bulk action per generation, all carrying the same external revision. A change is acknowledged only when every generation that still exists accepted it (2xx or 409). Items failing with `index_not_found_exception` / `index_closed_exception` are ignored when at least one other generation accepted the write; if none did, the change fails as before so nothing is silently dropped. Target-resolution failures are retried durably like a failed bulk request.
- Bulk byte and item accounting now reflect the expanded payload, so the byte-budget split and the telemetry samples count real Elasticsearch actions.
- `bulk()` drops `require_alias=true` because actions now name physical indexes. The live generation is never deleted while aliased, and retired generations leave the target list before deletion, so no action can auto-create an index.

#### Key Decisions / Non-goals

- **Physical names for all generations, including the live one.** Writing the live generation through its alias would lose the write for the old generation if the alias moved mid-drain; naming both physical indexes keeps rollback targets consistent.
- **No caching of targets.** One extra `_alias` round trip per drain is cheap next to the bulk request and guarantees a freshly created generation starts receiving writes on the very next batch.
- **Retirement contract for the follow-up `--retire` command:** close the index first, let at least one drain cycle pass so it drops out of the target list, then delete. The sync side already tolerates both states.
- Physical index names and aliases are unchanged for existing deployments: with a single generation per entity the request body is identical to before except for the `_index` value.
- `--status` classification, upgrade backfill, `--promote`, and `--retire` are follow-ups under the same Linear issue.

#### Test

- [x] Added/updated tests (multi-generation fan-out and settlement, retired-generation tolerance, resolution-failure retry, byte-budget split on expanded payloads, generation-target discovery)
- [x] `bun run check` (lint + related tests: 62 passed) and `bun run check --type` clean

#### 🔗 Related Issue

Part of [LOBE-13835](https://linear.app/lobehub/issue/LOBE-13835)