### PR TITLE
💄 style(spa): unify boot shell brand mark and loading hint color

### DIFF
--- a/src/spa/BootShell/AppShellSkeleton.tsx
+++ b/src/spa/BootShell/AppShellSkeleton.tsx
@@ -55,11 +55,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     color: ${cssVar.colorTextQuaternary};
   `,
-  // The mark carries the fade, not the whole stack: multiplying it into the
-  // caption too leaves quaternary text at ~0.2 alpha, which is unreadable.
-  mark: css`
-    opacity: 0.48;
-  `,
   // Floated rather than stacked in flow: a caption that joins the column would
   // push the brand mark off the center it shares with the app that replaces it.
   hint: css`
@@ -68,7 +63,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     inset-inline-start: 50%;
 
     font-size: 13px;
-    color: ${cssVar.colorTextTertiary};
     white-space: nowrap;
 
     animation: ${slideUp} 0.42s ${cssVar.motionEaseOut} both;
@@ -157,9 +151,7 @@ const AppShellSkeleton = memo<AppShellSkeletonProps>(({ id }) => {
           >
             <div className={styles.contentBrand}>
               <div className={styles.brand}>
-                <div className={styles.mark}>
-                  <LobeHub size={40} type={'text'} />
-                </div>
+                <LobeHub size={40} type={'text'} />
                 {waiting && <LoadingHint />}
               </div>
             </div>


### PR DESCRIPTION
The boot shell's brand text and the "Still loading…" hint rendered in two different greys: the logo sat inside a wrapper with `opacity: 0.48` (tuned for the old mono icon mark, ~0.12 alpha with the text logo) while the hint used `colorTextTertiary`. Both now inherit `colorTextQuaternary` from the container.

| Before | After |
| ------ | ----- |
| Logo much lighter than hint text | Logo and hint share one tone |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed (pure style change)

#### 🔗 Related Issue

Follow-up to #19086

https://claude.ai/code/session_01AcWQvvVZjrDMhe3YcNKndi