### PR TITLE
✨ feat: add The Grid provider support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -324,6 +324,8 @@ ENV \
     STEPFUN_API_KEY="" STEPFUN_MODEL_LIST="" \
     # Taichu
     TAICHU_API_KEY="" TAICHU_MODEL_LIST="" \
+    # The Grid
+    THEGRID_API_KEY="" THEGRID_MODEL_LIST="" \
     # TogetherAI
     TOGETHERAI_API_KEY="" TOGETHERAI_MODEL_LIST="" \
     # Upstage

--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -68,6 +68,7 @@
   "supergrok.description": "Access Grok models with your SuperGrok or X Premium subscription, no API key required.",
   "taichu.description": "A next-generation multimodal model from CASIA and the Wuhan Institute of AI, supporting multi-turn QA, writing, image generation, 3D understanding, and signal analysis with stronger cognition and creativity.",
   "tencentcloud.description": "LLM Knowledge Engine Atomic Power provides end-to-end knowledge QA for enterprises and developers, with modular services like document parsing, chunking, embeddings, and multi-turn rewriting to assemble custom AI solutions.",
+  "thegrid.description": "The Grid is an inference marketplace that serves models from several labs behind one OpenAI-compatible API, addressing capability tiers rather than a specific model name.",
   "togetherai.description": "Together AI delivers leading performance with innovative models, broad customization, rapid scaling, and straightforward deployment for enterprise needs.",
   "upstage.description": "Upstage builds AI models for business needs, including Solar LLM and Document AI, with chat APIs that support function calling, translation, embeddings, and domain-specific use cases.",
   "v0.description": "v0 is a pair-programming assistant that turns natural-language ideas into code and UI for your project.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -68,6 +68,7 @@
   "supergrok.description": "通过您的 SuperGrok 或 X 高级订阅访问 Grok 模型，无需 API 密钥。",
   "taichu.description": "太初是中科院自动化所与武汉人工智能研究院联合研发的新一代多模态模型，支持多轮问答、写作、图像生成、3D 理解与信号分析，具备更强的认知与创造力。",
   "tencentcloud.description": "腾讯云大模型知识引擎原子能力为企业与开发者提供端到端知识问答服务，支持文档解析、切分、向量化、多轮重写等模块化服务，助力构建定制 AI 方案。",
+  "thegrid.description": "The Grid 是一个推理市场，通过统一的 OpenAI 兼容 API 提供来自多个实验室的模型，按能力等级而非具体模型名称进行调用。",
   "togetherai.description": "Together AI 提供领先性能的创新模型，支持广泛定制、快速扩展与简便部署，满足企业需求。",
   "upstage.description": "Upstage 构建面向商业需求的 AI 模型，包括 Solar LLM 与文档 AI，其聊天 API 支持函数调用、翻译、向量化与行业场景应用。",
   "v0.description": "v0 是一款配对编程助手，可将自然语言想法转化为项目中的代码与界面。",

--- a/packages/env/src/llm.ts
+++ b/packages/env/src/llm.ts
@@ -175,6 +175,9 @@ export const getLLMConfig = () => {
       ENABLED_SAMBANOVA: z.boolean(),
       SAMBANOVA_API_KEY: z.string().optional(),
 
+      ENABLED_THEGRID: z.boolean(),
+      THEGRID_API_KEY: z.string().optional(),
+
       ENABLED_PPIO: z.boolean(),
       PPIO_API_KEY: z.string().optional(),
 
@@ -425,6 +428,9 @@ export const getLLMConfig = () => {
 
       ENABLED_SAMBANOVA: !!process.env.SAMBANOVA_API_KEY,
       SAMBANOVA_API_KEY: process.env.SAMBANOVA_API_KEY,
+
+      ENABLED_THEGRID: !!process.env.THEGRID_API_KEY,
+      THEGRID_API_KEY: process.env.THEGRID_API_KEY,
 
       ENABLED_PPIO: !!process.env.PPIO_API_KEY,
       PPIO_API_KEY: process.env.PPIO_API_KEY,

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -78,6 +78,7 @@
     "./superGrok": "./src/aiModels/superGrok.ts",
     "./taichu": "./src/aiModels/taichu.ts",
     "./tencentcloud": "./src/aiModels/tencentcloud.ts",
+    "./thegrid": "./src/aiModels/thegrid.ts",
     "./togetherai": "./src/aiModels/togetherai.ts",
     "./upstage": "./src/aiModels/upstage.ts",
     "./v0": "./src/aiModels/v0.ts",

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -69,6 +69,7 @@ import { default as streamlake } from './streamlake';
 import { default as supergrok } from './superGrok';
 import { default as taichu } from './taichu';
 import { default as tencentcloud } from './tencentcloud';
+import { default as thegrid } from './thegrid';
 import { default as togetherai } from './togetherai';
 import { default as upstage } from './upstage';
 import { default as v0 } from './v0';
@@ -179,6 +180,7 @@ const staticModelMap: ModelsMap = {
   supergrok,
   taichu,
   tencentcloud,
+  thegrid,
   togetherai,
   upstage,
   v0,
@@ -295,6 +297,7 @@ export { default as streamlake } from './streamlake';
 export { default as supergrok } from './superGrok';
 export { default as taichu } from './taichu';
 export { default as tencentcloud } from './tencentcloud';
+export { default as thegrid } from './thegrid';
 export { default as togetherai } from './togetherai';
 export { default as upstage } from './upstage';
 export { default as v0 } from './v0';

--- a/packages/model-bank/src/aiModels/thegrid.ts
+++ b/packages/model-bank/src/aiModels/thegrid.ts
@@ -1,0 +1,189 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// The Grid addresses capability tiers rather than a specific lab's model name; a tier
+// routes to a current model for that tier. Lab-pinned instruments use the `*-latest` ids.
+// Catalog: https://api.thegrid.ai/v1/models
+// Specs:   https://thegrid.ai/docs/instrument-specifications/current-instruments
+//
+// No `pricing` block: The Grid is market-priced and the catalog currently publishes no
+// per-token rate, so any static figure here would be wrong. The model fetcher is enabled
+// on the provider so the live catalog stays authoritative.
+
+const thegridChatModels: AIChatModelCard[] = [
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 128_000,
+    description:
+      'Price-optimized, high-throughput text for high-volume, low-stakes work. An instrument where any qualifying model can fill orders, so you contract for the specification, not a model name.',
+    displayName: 'Text Standard',
+    enabled: true,
+    id: 'text-standard',
+    maxOutput: 65_536,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 196_608,
+    description:
+      'The production default for everyday text generation. Strong reasoning at a fraction of frontier cost, suited to RAG, content drafting, summarization, and customer-facing generation.',
+    displayName: 'Text Prime',
+    id: 'text-prime',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Frontier-tier text for high-stakes, long-context work. The 1M-token context window handles synthesis across many documents.',
+    displayName: 'Text Max',
+    id: 'text-max',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 128_000,
+    description:
+      'Price-optimized, high-throughput code for autocomplete, linting, and batch edits where latency and throughput dominate over reasoning depth.',
+    displayName: 'Code Standard',
+    id: 'code-standard',
+    maxOutput: 65_536,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 196_608,
+    description:
+      'The production default for daily coding work. Fast enough for interactive use and capable on non-trivial tasks.',
+    displayName: 'Code Prime',
+    enabled: true,
+    id: 'code-prime',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Frontier-tier code for changes that span a whole codebase. The 1M-token context window handles full-repo analysis and large multi-file refactors.',
+    displayName: 'Code Max',
+    id: 'code-max',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 128_000,
+    description:
+      'Price-optimized, high-throughput agents for orchestration glue, routing, tool selection, and high-volume single-purpose agents.',
+    displayName: 'Agent Standard',
+    id: 'agent-standard',
+    maxOutput: 65_536,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 196_608,
+    description:
+      'The production default for daily agent work, production agent loops, multi-step tool chains, and planning.',
+    displayName: 'Agent Prime',
+    id: 'agent-prime',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Frontier-tier agents for autonomous work, deep tool chains, long-horizon research, and high-stakes automation.',
+    displayName: 'Agent Max',
+    enabled: true,
+    id: 'agent-max',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Lab latest market for Claude Opus frontier supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'Claude Opus Latest',
+    id: 'claude-opus-latest',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Lab latest market for GPT frontier supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'GPT Sol Latest',
+    id: 'gpt-sol-latest',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Lab latest market for Gemini Pro frontier supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'Gemini Pro Latest',
+    id: 'gemini-pro-latest',
+    maxOutput: 65_536,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Lab latest market for DeepSeek Pro supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'DeepSeek Pro Latest',
+    id: 'deepseek-pro-latest',
+    maxOutput: 384_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Lab latest market for GLM supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'GLM Latest',
+    id: 'glm-latest',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_048_576,
+    description:
+      'Lab latest market for Kimi supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'Kimi Latest',
+    id: 'kimi-latest',
+    // maxOutput omitted: the catalog reports max_completion_tokens equal to the
+    // full context window (1_048_576), which cannot be an output ceiling.
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Lab latest market for MiniMax supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'MiniMax Latest',
+    id: 'minimax-latest',
+    maxOutput: 512_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 262_144,
+    description:
+      'Lab latest market for ByteDance Pro supply. You contract for the latest qualifying route, not a specific model.',
+    displayName: 'ByteDance Pro Latest',
+    id: 'bytedance-pro-latest',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+];
+
+export default thegridChatModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -68,6 +68,7 @@ export enum ModelProvider {
   SuperGrok = 'supergrok',
   Taichu = 'taichu',
   TencentCloud = 'tencentcloud',
+  TheGrid = 'thegrid',
   TogetherAI = 'togetherai',
   Upstage = 'upstage',
   V0 = 'v0',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -70,6 +70,7 @@ import StreamLakeProvider from './streamlake';
 import SuperGrokProvider from './superGrok';
 import TaichuProvider from './taichu';
 import TencentcloudProvider from './tencentcloud';
+import TheGridProvider from './thegrid';
 import TogetherAIProvider from './togetherai';
 import UpstageProvider from './upstage';
 import V0Provider from './v0';
@@ -107,6 +108,7 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   XinferenceProvider.chatModels,
   OpenRouterProvider.chatModels,
   TogetherAIProvider.chatModels,
+  TheGridProvider.chatModels,
   FireworksAIProvider.chatModels,
   PerplexityProvider.chatModels,
   AnthropicProvider.chatModels,
@@ -176,6 +178,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   Ai302Provider,
   NvidiaProvider,
   TogetherAIProvider,
+  TheGridProvider,
   FireworksAIProvider,
   GroqProvider,
   PerplexityProvider,
@@ -314,6 +317,7 @@ export { default as StreamLakeProviderCard } from './streamlake';
 export { default as SuperGrokProviderCard } from './superGrok';
 export { default as TaichuProviderCard } from './taichu';
 export { default as TencentCloudProviderCard } from './tencentcloud';
+export { default as TheGridProviderCard } from './thegrid';
 export { default as TogetherAIProviderCard } from './togetherai';
 export { default as UpstageProviderCard } from './upstage';
 export { default as V0ProviderCard } from './v0';

--- a/packages/model-bank/src/modelProviders/thegrid.ts
+++ b/packages/model-bank/src/modelProviders/thegrid.ts
@@ -1,0 +1,23 @@
+import type { ModelProviderCard } from '../types';
+
+// ref: https://thegrid.ai/docs/instrument-specifications/current-instruments
+const TheGrid: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'text-standard',
+  description:
+    'The Grid is an inference marketplace that serves models from several labs behind one OpenAI-compatible API, addressing capability tiers rather than a specific model name.',
+  id: 'thegrid',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://api.thegrid.ai/v1/models',
+  name: 'The Grid',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.thegrid.ai/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://thegrid.ai',
+};
+
+export default TheGrid;

--- a/packages/model-runtime/src/providers/thegrid/index.test.ts
+++ b/packages/model-runtime/src/providers/thegrid/index.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeTheGridAI } from './index';
+
+const provider = ModelProvider.TheGrid;
+const defaultBaseURL = 'https://api.thegrid.ai/v1';
+
+testProvider({
+  Runtime: LobeTheGridAI,
+  provider,
+  defaultBaseURL,
+  chatDebugEnv: 'DEBUG_THEGRID_CHAT_COMPLETION',
+  chatModel: 'text-standard',
+  test: {
+    skipAPICall: true,
+  },
+});

--- a/packages/model-runtime/src/providers/thegrid/index.ts
+++ b/packages/model-runtime/src/providers/thegrid/index.ts
@@ -1,0 +1,11 @@
+import { ModelProvider } from 'model-bank';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const LobeTheGridAI = createOpenAICompatibleRuntime({
+  baseURL: 'https://api.thegrid.ai/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_THEGRID_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.TheGrid,
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -67,6 +67,7 @@ import { LobeStreamLakeAI } from './providers/streamlake';
 import { LobeSuperGrokAI } from './providers/superGrok';
 import { LobeTaichuAI } from './providers/taichu';
 import { LobeTencentCloudAI } from './providers/tencentcloud';
+import { LobeTheGridAI } from './providers/thegrid';
 import { LobeTogetherAI } from './providers/togetherai';
 import { LobeUpstageAI } from './providers/upstage';
 import { LobeV0AI } from './providers/v0';
@@ -153,6 +154,7 @@ export const providerRuntimeMap = {
   supergrok: LobeSuperGrokAI,
   taichu: LobeTaichuAI,
   tencentcloud: LobeTencentCloudAI,
+  thegrid: LobeTheGridAI,
   togetherai: LobeTogetherAI,
   upstage: LobeUpstageAI,
   v0: LobeV0AI,


### PR DESCRIPTION
## What

Adds **The Grid** as a provider. The Grid is an inference marketplace that serves models from several labs behind one OpenAI-compatible API, addressing capability tiers (`text-standard`, `code-prime`, `agent-max`) rather than a specific lab's model name — so a session keeps working when the underlying model is swapped.

Uses `createOpenAICompatibleRuntime` with `sdkType: 'openai'`; no bespoke runtime logic. Modeled on the CometAPI and SambaNova entries.

Registration points (same set as SambaNova):

| File | Change |
| --- | --- |
| `packages/model-bank/src/const/modelProvider.ts` | `TheGrid = 'thegrid'` |
| `packages/model-bank/src/modelProviders/thegrid.ts` | provider card (new) |
| `packages/model-bank/src/modelProviders/index.ts` | import, chatModels, list, re-export |
| `packages/model-bank/src/aiModels/thegrid.ts` | 17 instruments (new) |
| `packages/model-bank/src/aiModels/index.ts` | import, map, re-export |
| `packages/model-bank/package.json` | `./thegrid` export |
| `packages/model-runtime/src/providers/thegrid/` | runtime + test (new) |
| `packages/model-runtime/src/runtimeMap.ts` | import + map entry |
| `packages/env/src/llm.ts` | `ENABLED_THEGRID` / `THEGRID_API_KEY` |
| `Dockerfile`, `locales/{en-US,zh-CN}/providers.json` | env vars, descriptions |

Only `en-US` and `zh-CN` locales are touched; the rest are generated by `auto-i18n`.

## Why there is no `pricing` block

The Grid is market-priced, and `GET /v1/models` currently returns `"pricing": null` for every instrument. Rather than hardcode figures that would be wrong — and stale immediately — I left `pricing` off and enabled `showModelFetcher` so the live catalog stays authoritative. This follows CometAPI, ai302 and akashchat, which also ship without static pricing.

## Model data

Generated from the live catalog rather than hand-written, so context windows, output ceilings and capability flags match the API exactly.

One deliberate omission: `kimi-latest` reports `max_completion_tokens` equal to its full context window (1,048,576), which can't be an output ceiling, so `maxOutput` is left off for that entry with a comment explaining why.

## Verification

- All 9 touched/added TS files parse clean
- `locales/*.json` and `package.json` re-serialize as valid JSON with no reformatting of surrounding keys (+1 line each)
- Live API checked with the OpenAI SDK: chat, streaming, and tool calls all work against `https://api.thegrid.ai/v1`; `GET /v1/models` returns a spec-shaped `{object: "list", data: [...]}` with 17 entries and no redirect

I couldn't run `pnpm lint` / `type-check` locally (monorepo install), so please let CI judge those.

## Not included

No `docs/usage/providers/thegrid.mdx` — the `add-provider-doc` skill asks for screenshots I can't produce meaningfully, and CometAPI ships without one. Happy to add it if you'd like.

A matching icon PR for `lobehub/lobe-icons` follows separately.

Disclosure: I work on The Grid.
