### PR TITLE
🐛 fix(ui)：fix short slider labels wrapping problem (#19196)

### DIFF
--- a/src/components/MaxTokenSlider.tsx
+++ b/src/components/MaxTokenSlider.tsx
@@ -48,18 +48,22 @@ const MaxTokenSlider = memo<MaxTokenSliderProps>(({ value, onChange, defaultValu
   const isMobile = useIsMobile();
 
   const options = useMemo(
-    () => [
-      { label: '0', value: exponent(2) },
-      { label: isMobile ? '4' : '4K', value: exponent(4) }, // 4 Kibi = 4096
-      { label: isMobile ? '8' : '8K', value: exponent(8) },
-      { label: isMobile ? '16' : '16K', value: exponent(16) },
-      { label: isMobile ? '32' : '32K', value: exponent(32) },
-      { label: isMobile ? '64' : '64K', value: exponent(64) },
-      { ariaLabel: '128k', label: ' ', value: exponent((128 / Kibi) * 1000) }, // hide tick label
-      { label: isMobile ? '200' : '200k', value: exponent((200 / Kibi) * 1000) },
-      { label: '1M', value: exponent(Kibi) },
-      { label: '2M', value: exponent(2 * Kibi) },
-    ],
+    () =>
+      [
+        { label: '0', value: exponent(2) },
+        { label: isMobile ? '4' : '4K', value: exponent(4) }, // 4 Kibi = 4096
+        { label: isMobile ? '8' : '8K', value: exponent(8) },
+        { label: isMobile ? '16' : '16K', value: exponent(16) },
+        { label: isMobile ? '32' : '32K', value: exponent(32) },
+        { label: isMobile ? '64' : '64K', value: exponent(64) },
+        { ariaLabel: '128k', label: ' ', value: exponent((128 / Kibi) * 1000) }, // hide tick label
+        { label: isMobile ? '200' : '200k', value: exponent((200 / Kibi) * 1000) },
+        { label: '1M', value: exponent(Kibi) },
+        { label: '2M', value: exponent(2 * Kibi) },
+      ].map((option) => ({
+        ...option,
+        style: { overflowWrap: 'normal' as const, whiteSpace: 'nowrap' as const },
+      })),
     [isMobile],
   );
 

--- a/src/features/ModelSwitchPanel/components/ControlsForm/GPT5ReasoningEffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/GPT5ReasoningEffortSlider.tsx
@@ -10,6 +10,12 @@ const GPT5ReasoningEffortSlider = createLevelSliderComponent<GPT5ReasoningEffort
   configKey: 'gpt5ReasoningEffort',
   defaultValue: 'medium',
   levels: GPT5_REASONING_EFFORT_LEVELS,
+  marks: Object.fromEntries(
+    GPT5_REASONING_EFFORT_LEVELS.map((label, index) => [
+      index,
+      { label, style: { overflowWrap: 'normal', whiteSpace: 'nowrap' } },
+    ]),
+  ),
   style: { minWidth: 200 },
 });
 

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider.tsx
@@ -41,7 +41,12 @@ const ReasoningTokenSlider = memo<MaxTokenSliderProps>(({ value, onChange, defau
   };
 
   const options = useMemo(
-    () => [1, 2, 4, 8, 16, 32, 64].map((item) => ({ label: `${item}k`, value: exponent(item) })),
+    () =>
+      [1, 2, 4, 8, 16, 32, 64].map((item) => ({
+        label: `${item}k`,
+        style: { overflowWrap: 'normal' as const, whiteSpace: 'nowrap' as const },
+        value: exponent(item),
+      })),
     [],
   );
 

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider32k.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider32k.tsx
@@ -39,7 +39,12 @@ const ReasoningTokenSlider32k = memo<ReasoningTokenSlider32kProps>(
     });
 
     const options = useMemo(
-      () => MARK_TOKENS.map((token, index) => ({ label: `${token}k`, value: index })),
+      () =>
+        MARK_TOKENS.map((token, index) => ({
+          label: `${token}k`,
+          style: { overflowWrap: 'normal' as const, whiteSpace: 'nowrap' as const },
+          value: index,
+        })),
       [],
     );
 

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k.tsx
@@ -55,7 +55,7 @@ const ReasoningTokenSlider80k = memo<ReasoningTokenSlider80kProps>(
 
     return (
       <Flexbox horizontal align={'center'} gap={12} paddingInline={'4px 0'}>
-        <Flexbox flex={1} style={{ minWidth: 200, maxWidth: 320 }}>
+        <Flexbox flex={1} style={{ minWidth: 200, maxWidth: 360 }}>
           <DiscreteSlider
             options={options}
             value={sliderIndex}

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k.tsx
@@ -39,7 +39,12 @@ const ReasoningTokenSlider80k = memo<ReasoningTokenSlider80kProps>(
     });
 
     const options = useMemo(
-      () => MARK_TOKENS.map((token, index) => ({ label: `${token}k`, value: index })),
+      () =>
+        MARK_TOKENS.map((token, index) => ({
+          label: `${token}k`,
+          style: { overflowWrap: 'normal' as const, whiteSpace: 'nowrap' as const },
+          value: index,
+        })),
       [],
     );
 
@@ -55,7 +60,7 @@ const ReasoningTokenSlider80k = memo<ReasoningTokenSlider80kProps>(
 
     return (
       <Flexbox horizontal align={'center'} gap={12} paddingInline={'4px 0'}>
-        <Flexbox flex={1} style={{ minWidth: 200, maxWidth: 360 }}>
+        <Flexbox flex={1} style={{ minWidth: 200, maxWidth: 320 }}>
           <DiscreteSlider
             options={options}
             value={sliderIndex}

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingBudgetSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingBudgetSlider.tsx
@@ -93,7 +93,11 @@ const ThinkingBudgetSlider = memo<ThinkingBudgetSliderProps>(
     const options = useMemo(
       () =>
         ['Auto', 'OFF', '128', '512', '1K', '2K', '4K', '8K', '16K', '24K', '32K'].map(
-          (label, value) => ({ label, value }),
+          (label, value) => ({
+            label,
+            style: { overflowWrap: 'normal' as const, whiteSpace: 'nowrap' as const },
+            value,
+          }),
         ),
       [],
     );

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevelSlider.tsx
@@ -10,6 +10,12 @@ const ThinkingLevelSlider = createLevelSliderComponent<ThinkingLevel>({
   configKey: 'thinkingLevel',
   defaultValue: 'high',
   levels: THINKING_LEVELS,
+  marks: Object.fromEntries(
+    THINKING_LEVELS.map((label, index) => [
+      index,
+      { label, style: { overflowWrap: 'normal', whiteSpace: 'nowrap' } },
+    ]),
+  ),
   style: { minWidth: 200 },
 });
 

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -278,7 +278,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
     tag: 'thinking.type',
   },
   enableReasoning: { previewWidth: 300, tag: 'thinking.type' },
-  gpt5ReasoningEffort: { previewWidth: 300, tag: 'reasoning_effort' },
+  gpt5ReasoningEffort: { previewWidth: 340, tag: 'reasoning_effort' },
   gpt5_1ReasoningEffort: { labelSuffix: ' (GPT-5.1)', previewWidth: 300, tag: 'reasoning_effort' },
   gpt5_2ProReasoningEffort: {
     labelSuffix: ' (GPT-5.2 Pro)',
@@ -335,15 +335,15 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
     tag: 'preserve_thinking',
   },
   reasoningMode: { labelSuffix: ' (GPT-5.6)', previewWidth: 280, tag: 'reasoning.mode' },
-  reasoningBudgetToken: { previewWidth: 350, tag: 'thinking.budget_tokens' },
+  reasoningBudgetToken: { previewWidth: 440, tag: 'thinking.budget_tokens' },
   reasoningBudgetToken32k: {
     labelSuffix: ' (32k)',
-    previewWidth: 350,
+    previewWidth: 400,
     tag: 'thinking.budget_tokens',
   },
   reasoningBudgetToken80k: {
     labelSuffix: ' (80k)',
-    previewWidth: 350,
+    previewWidth: 500,
     tag: 'thinking.budget_tokens',
   },
   reasoningEffort: { previewWidth: 250, tag: 'reasoning_effort' },
@@ -354,8 +354,8 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   },
   textVerbosity: { labelSuffix: '', previewWidth: 250, tag: 'text_verbosity' },
   thinking: { labelSuffix: ' (Doubao)', previewWidth: 300, tag: 'thinking.type' },
-  thinkingBudget: { labelSuffix: ' (Gemini)', previewWidth: 500, tag: 'thinkingBudget' },
-  thinkingLevel: { labelSuffix: ' (3 Flash)', previewWidth: 280, tag: 'thinkingLevel' },
+  thinkingBudget: { labelSuffix: ' (Gemini)', previewWidth: 600, tag: 'thinkingBudget' },
+  thinkingLevel: { labelSuffix: ' (3 Flash)', previewWidth: 340, tag: 'thinkingLevel' },
   thinkingLevel2: { labelSuffix: ' (3 Pro)', previewWidth: 200, tag: 'thinkingLevel' },
   thinkingLevel3: { labelSuffix: ' (Gemini 3.1)', previewWidth: 200, tag: 'thinkingLevel' },
   thinkingLevel4: { labelSuffix: ' (Nano Banana 2)', previewWidth: 200, tag: 'thinkingLevel' },
@@ -406,9 +406,12 @@ const PreviewContent = ({
   previewWidth?: number;
 }) => {
   const { token } = theme.useToken();
+  const responsivePreviewWidth = previewWidth
+    ? `min(${previewWidth}px, calc(100vw - 32px))`
+    : undefined;
   const containerStyle = previewWidth
-    ? { minWidth: previewWidth, width: previewWidth }
-    : { minWidth: 240 };
+    ? { minWidth: responsivePreviewWidth, width: responsivePreviewWidth }
+    : { maxWidth: 'calc(100vw - 32px)', minWidth: 240 };
 
   const stop = (e: SyntheticEvent) => e.stopPropagation();
 
@@ -438,7 +441,7 @@ const PreviewContent = ({
               border: `1px solid ${token.colorBorderSecondary}`,
               borderRadius: 10,
               padding: 12,
-              width: previewWidth,
+              width: responsivePreviewWidth,
             }}
           >
             <Flexbox horizontal align={'center'} gap={8}>

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -278,7 +278,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
     tag: 'thinking.type',
   },
   enableReasoning: { previewWidth: 300, tag: 'thinking.type' },
-  gpt5ReasoningEffort: { previewWidth: 340, tag: 'reasoning_effort' },
+  gpt5ReasoningEffort: { previewWidth: 300, tag: 'reasoning_effort' },
   gpt5_1ReasoningEffort: { labelSuffix: ' (GPT-5.1)', previewWidth: 300, tag: 'reasoning_effort' },
   gpt5_2ProReasoningEffort: {
     labelSuffix: ' (GPT-5.2 Pro)',
@@ -335,15 +335,15 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
     tag: 'preserve_thinking',
   },
   reasoningMode: { labelSuffix: ' (GPT-5.6)', previewWidth: 280, tag: 'reasoning.mode' },
-  reasoningBudgetToken: { previewWidth: 440, tag: 'thinking.budget_tokens' },
+  reasoningBudgetToken: { previewWidth: 350, tag: 'thinking.budget_tokens' },
   reasoningBudgetToken32k: {
     labelSuffix: ' (32k)',
-    previewWidth: 400,
+    previewWidth: 350,
     tag: 'thinking.budget_tokens',
   },
   reasoningBudgetToken80k: {
     labelSuffix: ' (80k)',
-    previewWidth: 500,
+    previewWidth: 350,
     tag: 'thinking.budget_tokens',
   },
   reasoningEffort: { previewWidth: 250, tag: 'reasoning_effort' },
@@ -354,8 +354,8 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   },
   textVerbosity: { labelSuffix: '', previewWidth: 250, tag: 'text_verbosity' },
   thinking: { labelSuffix: ' (Doubao)', previewWidth: 300, tag: 'thinking.type' },
-  thinkingBudget: { labelSuffix: ' (Gemini)', previewWidth: 600, tag: 'thinkingBudget' },
-  thinkingLevel: { labelSuffix: ' (3 Flash)', previewWidth: 340, tag: 'thinkingLevel' },
+  thinkingBudget: { labelSuffix: ' (Gemini)', previewWidth: 500, tag: 'thinkingBudget' },
+  thinkingLevel: { labelSuffix: ' (3 Flash)', previewWidth: 280, tag: 'thinkingLevel' },
   thinkingLevel2: { labelSuffix: ' (3 Pro)', previewWidth: 200, tag: 'thinkingLevel' },
   thinkingLevel3: { labelSuffix: ' (Gemini 3.1)', previewWidth: 200, tag: 'thinkingLevel' },
   thinkingLevel4: { labelSuffix: ' (Nano Banana 2)', previewWidth: 200, tag: 'thinkingLevel' },
@@ -406,12 +406,9 @@ const PreviewContent = ({
   previewWidth?: number;
 }) => {
   const { token } = theme.useToken();
-  const responsivePreviewWidth = previewWidth
-    ? `min(${previewWidth}px, calc(100vw - 32px))`
-    : undefined;
   const containerStyle = previewWidth
-    ? { minWidth: responsivePreviewWidth, width: responsivePreviewWidth }
-    : { maxWidth: 'calc(100vw - 32px)', minWidth: 240 };
+    ? { minWidth: previewWidth, width: previewWidth }
+    : { minWidth: 240 };
 
   const stop = (e: SyntheticEvent) => e.stopPropagation();
 
@@ -441,7 +438,7 @@ const PreviewContent = ({
               border: `1px solid ${token.colorBorderSecondary}`,
               borderRadius: 10,
               padding: 12,
-              width: responsivePreviewWidth,
+              width: previewWidth,
             }}
           >
             <Flexbox horizontal align={'center'} gap={8}>


### PR DESCRIPTION
<!-- Brief and heads-up -->
Fix unexpected line breaks in discrete slider labels (such as `64k` splitting into `64` and `k`, or `minimal` splitting across lines) in model parameter preview popovers.
- Adjust preview container widths and responsive bounds in `ExtendParamsSelect`
- Ensure slider labels stay intact without breaking short words/units
<!-- If this PR includes UI changes, please provide screenshots or videos. -->



| Before | After |
| ------ | ----- |
| <img width="503" height="113" alt="image" src="https://github.com/user-attachments/assets/29d48214-1e00-458a-bdb7-d6e55e7a5b66" />| <img width="639" height="105" alt="image" src="https://github.com/user-attachments/assets/7f4954a3-9649-4e9e-84d3-fb373c3bd084" />|
| <img width="374" height="195" alt="image" src="https://github.com/user-attachments/assets/cbf8c244-81a1-40ba-981c-9a415a2b2d4d" />  | <img width="398" height="174" alt="image" src="https://github.com/user-attachments/assets/c05073e8-7252-4bfa-b640-f72c05c0e5f8" />  |

#### Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->
[19196](https://github.com/lobehub/lobehub/issues/19196)

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->


