### PR TITLE
💄 style: simplify home greeting and announcement layout

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -48,7 +48,6 @@
   "dashboard.chat.recents": "Recent topics",
   "dashboard.chat.running": "Running topics",
   "dashboard.customize.decrease": "Decrease {{label}}",
-  "dashboard.customize.entry": "Customize",
   "dashboard.customize.group.agent": "Agent",
   "dashboard.customize.group.listSize": "List size",
   "dashboard.customize.group.rail": "Sidebar",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -48,7 +48,6 @@
   "dashboard.chat.recents": "最近话题",
   "dashboard.chat.running": "正在运行",
   "dashboard.customize.decrease": "减少{{label}}",
-  "dashboard.customize.entry": "自定义",
   "dashboard.customize.group.agent": "Agent",
   "dashboard.customize.group.listSize": "列表条数",
   "dashboard.customize.group.rail": "侧边栏",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -53,7 +53,6 @@ export default {
   'dashboard.chat.recents': 'Recent topics',
   'dashboard.chat.running': 'Running topics',
   'dashboard.customize.decrease': 'Decrease {{label}}',
-  'dashboard.customize.entry': 'Customize',
   'dashboard.customize.group.listSize': 'List size',
   'dashboard.customize.group.agent': 'Agent',
   'dashboard.customize.group.rail': 'Sidebar',

--- a/src/features/Home/CustomizeButton.tsx
+++ b/src/features/Home/CustomizeButton.tsx
@@ -1,42 +1,23 @@
-import { Icon } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
-import { createStaticStyles } from 'antd-style';
+import { ActionIcon } from '@lobehub/ui/base-ui';
 import { SlidersHorizontal } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { openHomeCustomizeModal } from './CustomizeModal';
 
-const styles = createStaticStyles(({ css }) => ({
-  // Floats in the page corner where the portrait can stand behind it — frost
-  // what shows through, like the rail cards do.
-  glass: css`
-    backdrop-filter: saturate(150%) blur(12px);
-  `,
-  label: css`
-    @media (width <= 1100px) {
-      display: none;
-    }
-  `,
-}));
-
 const CustomizeButton = memo(() => {
   const { t } = useTranslation('home');
-  const label = t('dashboard.customize.entry');
+  const label = t('dashboard.customize.title');
 
   return (
-    <Button
+    <ActionIcon
       aria-label={label}
-      className={styles.glass}
-      icon={<Icon icon={SlidersHorizontal} size={14} />}
-      shape={'round'}
+      icon={SlidersHorizontal}
       size={'small'}
       title={label}
-      type={'fill'}
+      variant={'borderless'}
       onClick={() => openHomeCustomizeModal()}
-    >
-      <span className={styles.label}>{label}</span>
-    </Button>
+    />
   );
 });
 

--- a/src/features/Home/HomeHeader.tsx
+++ b/src/features/Home/HomeHeader.tsx
@@ -10,17 +10,12 @@ import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/se
 import AgentSelect from './AgentSelect';
 
 const styles = createStaticStyles(({ css }) => ({
-  // The measure comes from the layout (`--home-greeting-measure`), which derives
-  // it from the container width: it has to clear the portrait's bubble, and it
-  // must not depend on the rail, or collapsing would re-wrap the headline and
-  // shove the composer and the whole task list down by a line.
   greeting: css`
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
 
-    max-width: var(--home-greeting-measure, none);
     margin: 0;
 
     font-size: 22px;

--- a/src/features/Home/HomeHeader.tsx
+++ b/src/features/Home/HomeHeader.tsx
@@ -10,6 +10,10 @@ import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/se
 import AgentSelect from './AgentSelect';
 
 const styles = createStaticStyles(({ css }) => ({
+  root: css`
+    /* Unbroken names must stay inside the start-aligned header's text lane. */
+    max-width: 100%;
+  `,
   greeting: css`
     overflow: hidden;
     display: -webkit-box;
@@ -54,7 +58,7 @@ const HomeHeader = memo<HomeHeaderProps>(({ centered }) => {
     // who speaks, the greeting answers below — but drops the toolbar chrome and
     // its 48px lane, so the pair reads as one compact block flush with the
     // composer. The layout's lift math (MINIMAL_LIFT) counts on these heights.
-    <Flexbox gap={centered ? 8 : 16} justify={'center'}>
+    <Flexbox className={styles.root} gap={centered ? 8 : 16} justify={'center'}>
       {centered ? (
         <AgentSelect />
       ) : (

--- a/src/features/Home/HomePortrait.tsx
+++ b/src/features/Home/HomePortrait.tsx
@@ -20,17 +20,19 @@ const styles = createStaticStyles(({ css }) => ({
    * character above the card (see ./portraitFraming), which clears the catalog
    * mascot's head — it is half its own height — and reaches the hem on a
    * standing figure, where 57% cut both at the collar and the waist. Change one
-   * and the studio's preview frame stops matching what home shows.
+   * and the studio's preview frame stops matching what home shows. The compact
+   * speech layout scales the image and recalculates overlap to retain that
+   * same visible ratio, including the gap above the supporting card.
    */
   image: css`
     pointer-events: none;
 
     position: absolute;
-    inset-block-end: -94px;
+    inset-block-end: var(--home-portrait-overlap, -94px);
     inset-inline-end: ${HOME_PORTRAIT_INSET}px;
 
-    width: ${HOME_PORTRAIT_WIDTH}px;
-    height: 200px;
+    width: var(--home-portrait-width, ${HOME_PORTRAIT_WIDTH}px);
+    height: var(--home-portrait-height, 200px);
 
     object-fit: contain;
     object-position: bottom;

--- a/src/features/Home/HomePortrait.tsx
+++ b/src/features/Home/HomePortrait.tsx
@@ -7,6 +7,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { useResolvedHomeAgentId } from './AgentSelect/useResolvedHomeAgentId';
+import { HOME_PORTRAIT_INSET, HOME_PORTRAIT_WIDTH } from './portraitFraming';
 
 const styles = createStaticStyles(({ css }) => ({
   /**
@@ -26,9 +27,9 @@ const styles = createStaticStyles(({ css }) => ({
 
     position: absolute;
     inset-block-end: -94px;
-    inset-inline-end: 12px;
+    inset-inline-end: ${HOME_PORTRAIT_INSET}px;
 
-    width: 176px;
+    width: ${HOME_PORTRAIT_WIDTH}px;
     height: 200px;
 
     object-fit: contain;

--- a/src/features/Home/HomePortrait.tsx
+++ b/src/features/Home/HomePortrait.tsx
@@ -7,32 +7,23 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { useResolvedHomeAgentId } from './AgentSelect/useResolvedHomeAgentId';
-import { HOME_PORTRAIT_INSET, HOME_PORTRAIT_WIDTH } from './portraitFraming';
+import { HOME_PORTRAIT_INSET } from './portraitFraming';
 
 const styles = createStaticStyles(({ css }) => ({
   /**
-   * One frame for every character. Generated artwork arrives cropped to the
-   * subject, and the built-in catalog draws its character across the frame with
-   * a few percent of margin, so sizing by height lands both at the same stature.
-   * Anchored deep enough that the lower body passes behind the first card — the
-   * character leans on the surface instead of standing on it. The offset is what
-   * sets how much shows: 94px leaves `HOME_PORTRAIT_VISIBLE_RATIO` of the
-   * character above the card (see ./portraitFraming), which clears the catalog
-   * mascot's head — it is half its own height — and reaches the hem on a
-   * standing figure, where 57% cut both at the collar and the waist. Change one
-   * and the studio's preview frame stops matching what home shows. The compact
-   * speech layout scales the image and recalculates overlap to retain that
-   * same visible ratio, including the gap above the supporting card.
+   * The speech layout owns image dimensions and overlap. Both sizes reveal
+   * the same fraction used by the artwork studio preview, with the lower
+   * body passing behind the supporting card.
    */
   image: css`
     pointer-events: none;
 
     position: absolute;
-    inset-block-end: var(--home-portrait-overlap, -94px);
+    inset-block-end: var(--home-portrait-overlap);
     inset-inline-end: ${HOME_PORTRAIT_INSET}px;
 
-    width: var(--home-portrait-width, ${HOME_PORTRAIT_WIDTH}px);
-    height: var(--home-portrait-height, 200px);
+    width: var(--home-portrait-width);
+    height: var(--home-portrait-height);
 
     object-fit: contain;
     object-position: bottom;

--- a/src/features/Home/PortraitBubble/index.tsx
+++ b/src/features/Home/PortraitBubble/index.tsx
@@ -12,8 +12,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   // Prose, not a row of chips: a flex container would make the brief's entity
   // links their own flex items and break the sentence into side-by-side columns.
   bubble: css`
-    position: relative;
-
     overflow: hidden;
     display: block;
 
@@ -29,7 +27,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorBgContainer};
   `,
-  /** Keep the optional daily brief secondary to the greeting and composer. */
+  /**
+   * Match the 24px action row when a brief replaces an announcement. Limit
+   * prose to two lines so optional content cannot push the composer far down.
+   */
   line: css`
     overflow: hidden;
     display: -webkit-box;

--- a/src/features/Home/PortraitBubble/index.tsx
+++ b/src/features/Home/PortraitBubble/index.tsx
@@ -18,7 +18,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     display: block;
 
     max-width: 100%;
-    padding-block: 8px;
+    padding-block: 6px;
     padding-inline: 12px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 14px;
@@ -28,41 +28,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextSecondary};
 
     background: ${cssVar.colorBgContainer};
-    box-shadow: ${cssVar.boxShadowTertiary};
-
-    /* The tail is what makes this read as the agent's line rather than one more
-       toolbar chip, so the layout switches it off via --home-bubble-tail wherever
-       it parks the bubble below the greeting instead of beside him. */
-    &::after {
-      content: '';
-
-      position: absolute;
-      inset-block-start: 50%;
-      inset-inline-end: -5px;
-      transform: translateY(-50%) rotate(45deg);
-
-      display: var(--home-bubble-tail, none);
-
-      width: 9px;
-      height: 9px;
-      border-block-start: 1px solid ${cssVar.colorBorderSecondary};
-      border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
-
-      background: ${cssVar.colorBgContainer};
-    }
-
-    &:dir(rtl)::after {
-      inset-inline: -5px auto;
-      transform: translateY(-50%) rotate(225deg);
-    }
   `,
-  // The bubble is anchored by its bottom edge, so an unbounded line grows
-  // upward into the toolbar row.
+  /** Keep the optional daily brief secondary to the greeting and composer. */
   line: css`
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+
+    min-height: 24px;
   `,
 }));
 

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -23,7 +23,11 @@ import HomeModeContent from './HomeModeContent';
 import HomePortrait from './HomePortrait';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
-import { HOME_PORTRAIT_INSET, HOME_PORTRAIT_WIDTH } from './portraitFraming';
+import {
+  HOME_PORTRAIT_INSET,
+  HOME_PORTRAIT_VISIBLE_RATIO,
+  HOME_PORTRAIT_WIDTH,
+} from './portraitFraming';
 import { RAIL_INBOX_PROPS, resolveRailVisibility } from './railVisibility';
 import type { HomeMode } from './types';
 
@@ -68,6 +72,17 @@ const PORTRAIT_LANE = HOME_PORTRAIT_WIDTH + HOME_PORTRAIT_INSET + 16;
 /** Reclaim the artwork's full lane so collapsing never narrows the text above. */
 const COLLAPSED_CONTENT_GAIN = PORTRAIT_LANE;
 const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
+const SPEECH_BUBBLE_MAX = 320;
+const SPEECH_GREETING_GAP = 24;
+const SPEECH_GREETING_MIN = 320;
+const SPEECH_RESERVED_WIDTH =
+  COLLAPSED_CONTENT_OFFSET * 2 + SPEECH_GREETING_GAP + SPEECH_BUBBLE_MAX + PORTRAIT_LANE;
+/** Use the tighter rail state so its animation cannot switch rows or rewrap text. */
+const SPEECH_INLINE_MIN = SPEECH_RESERVED_WIDTH + SPEECH_GREETING_MIN;
+const COMPACT_PORTRAIT_HEIGHT = 150;
+const COMPACT_PORTRAIT_WIDTH = HOME_PORTRAIT_WIDTH * (COMPACT_PORTRAIT_HEIGHT / 200);
+/** Include the 24px grid gap so the composer reveals the same artwork fraction. */
+const COMPACT_PORTRAIT_OVERLAP = COMPACT_PORTRAIT_HEIGHT * (1 - HOME_PORTRAIT_VISIBLE_RATIO) + 24;
 const MINIMAL_STACK_GAP = 24;
 /**
  * The minimal header stacks the agent switcher (24px avatar + 2px paddings,
@@ -128,25 +143,93 @@ const styles = createStaticStyles(({ css }) => ({
       }
     }
   `,
-  header: css`
-    display: flex;
-    grid-area: 1 / 1;
-    flex-direction: column;
+  hero: css`
+    display: grid;
+    grid-area: 1 / 1 / 2 / -1;
+    grid-template-columns: minmax(0, 1fr);
     gap: 16px;
-    align-items: flex-start;
+    align-items: end;
 
+    width: 100%;
     min-width: 0;
 
-    /* Keep the expanded text measure while the composer widens underneath.
-       Rail toggles then only move text horizontally, preserving line breaks
-       and the composer's vertical position even for long names and prose.
-       Keep this measure when artwork is off as well; stability takes priority
-       over filling the extra space above the wider composer. */
+    transition:
+      transform ${RAIL_TRANSITION_DURATION}ms ease-out,
+      width ${RAIL_TRANSITION_DURATION}ms ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  `,
+  heroCollapsed: css`
+    @media (width > 1100px) {
+      transform: translateX(${COLLAPSED_CONTENT_OFFSET}px);
+      width: calc(100% - ${COLLAPSED_CONTENT_OFFSET * 2}px);
+
+      &:dir(rtl) {
+        transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
+      }
+    }
+  `,
+  heroWithSpeech: css`
+    @container home (width >= ${SPEECH_INLINE_MIN}px) {
+      /* The middle track absorbs rail motion. Neither the greeting nor the
+         speech unit changes its text measure during the transition. */
+      grid-template-columns:
+        minmax(0, calc(100cqw - ${SPEECH_RESERVED_WIDTH}px))
+        minmax(${SPEECH_GREETING_GAP}px, 1fr)
+        max-content;
+      gap: 0;
+    }
+  `,
+  header: css`
+    min-width: 0;
+
+    @media (width > 1100px) {
+      /* Preserve the same readable measure in the stacked and portrait-off
+         modes, even while the enclosing hero changes width. */
+      max-width: calc(100cqw - ${RAIL_RECLAIMED_WIDTH}px);
+    }
+  `,
+  speech: css`
+    --home-portrait-width: ${COMPACT_PORTRAIT_WIDTH}px;
+    --home-portrait-height: ${COMPACT_PORTRAIT_HEIGHT}px;
+    --home-portrait-overlap: -${COMPACT_PORTRAIT_OVERLAP}px;
+
+    display: flex;
+    gap: 16px;
+    align-items: flex-end;
+    justify-self: end;
+
+    width: max-content;
     max-width: 100%;
+    min-height: ${COMPACT_PORTRAIT_HEIGHT - COMPACT_PORTRAIT_OVERLAP}px;
+
+    @media (width > 1100px) {
+      max-width: calc(100cqw - ${COLLAPSED_CONTENT_OFFSET * 2}px);
+    }
+
+    @container home (width >= ${SPEECH_INLINE_MIN}px) {
+      --home-portrait-width: ${HOME_PORTRAIT_WIDTH}px;
+      --home-portrait-height: 200px;
+      --home-portrait-overlap: -94px;
+
+      grid-area: 1 / 3;
+      align-self: stretch;
+      min-height: 0;
+    }
   `,
   bubbleSlot: css`
     width: max-content;
-    max-width: 100%;
+    min-width: 0;
+    max-width: ${SPEECH_BUBBLE_MAX}px;
+    margin-block-end: 4px;
+  `,
+  portrait: css`
+    pointer-events: none;
+    flex: none;
+    align-self: stretch;
+    width: calc(var(--home-portrait-width) + ${HOME_PORTRAIT_INSET}px);
   `,
   inputArea: css`
     position: relative;
@@ -170,31 +253,6 @@ const styles = createStaticStyles(({ css }) => ({
     max-inline-size: 760px;
     margin-inline: auto;
     padding-block-end: ${MINIMAL_LIFT}px;
-  `,
-  portrait: css`
-    pointer-events: none;
-    grid-area: 1 / 2;
-    transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
-
-    @media (width <= 1100px) {
-      display: none;
-    }
-  `,
-  // With the rail gone the agent has nothing to lean into, so it slides over the
-  // composer instead of disappearing with the cards — keeping the same dip, so
-  // the same half of it stays behind the surface it leans on.
-  portraitCollapsed: css`
-    @media (width > 1100px) {
-      transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
-
-      &:dir(rtl) {
-        transform: translateX(${COLLAPSED_CONTENT_OFFSET}px);
-      }
-    }
   `,
   railSurface: css`
     transform: translateX(0);
@@ -318,22 +376,28 @@ const Home = memo(() => {
 
   return (
     <Flexbox className={styles.grid}>
-      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
-        <HomeHeader />
-        {/* The portrait has one voice: a live campaign temporarily speaks in
-            place of the daily brief, which returns when the campaign leaves. */}
+      <div
+        className={cx(
+          styles.hero,
+          portraitVisible && styles.heroWithSpeech,
+          railCollapsed && styles.heroCollapsed,
+        )}
+      >
+        <div className={styles.header}>
+          <HomeHeader />
+        </div>
         {portraitVisible && (
-          <div className={styles.bubbleSlot}>
-            <PortraitBubble promo={promo} />
+          <div className={styles.speech}>
+            {/* Keep the agent's line and artwork together in both header layouts. */}
+            <div className={styles.bubbleSlot}>
+              <PortraitBubble promo={promo} />
+            </div>
+            <div className={styles.portrait}>
+              <HomePortrait />
+            </div>
           </div>
         )}
       </div>
-
-      {portraitVisible && (
-        <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
-          <HomePortrait />
-        </div>
-      )}
 
       <Flexbox
         className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -63,13 +63,11 @@ const RAIL_COLUMN_GAP = 28;
 const RAIL_EXIT_OFFSET = 24;
 const RAIL_TRANSITION_DURATION = 220;
 const RAIL_RECLAIMED_WIDTH = RAIL_CARD_WIDTH + RAIL_GUTTER + RAIL_COLUMN_GAP;
-/** Share of the vacated rail track the content keeps; the rest is split as margin. */
-const COLLAPSED_CONTENT_GAIN = 140;
-const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
-/** Portrait width plus its inline inset and the gap the bubble keeps from it. */
+/** Portrait width plus its inline inset and the gap it keeps from the text. */
 const PORTRAIT_LANE = HOME_PORTRAIT_WIDTH + HOME_PORTRAIT_INSET + 16;
-/** Keep at least 400px for text before retaining decorative artwork in the main column. */
-const COLLAPSED_PORTRAIT_MIN = COLLAPSED_CONTENT_OFFSET * 2 + PORTRAIT_LANE + 400;
+/** Reclaim the artwork's full lane so collapsing never narrows the text above. */
+const COLLAPSED_CONTENT_GAIN = PORTRAIT_LANE;
+const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
 const MINIMAL_STACK_GAP = 24;
 /**
  * The minimal header stacks the agent switcher (24px avatar + 2px paddings,
@@ -131,8 +129,6 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   header: css`
-    position: relative;
-
     display: flex;
     grid-area: 1 / 1;
     flex-direction: column;
@@ -140,24 +136,15 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: flex-start;
 
     min-width: 0;
-  `,
-  headerWithPortrait: css`
-    /* Only the collapsed rail puts the artwork inside the content column.
-       Keep the greeting and announcement in a stable vertical flow, with
-       decorative artwork yielding first when the text lane gets narrow. */
-    @media (width > 1100px) {
-      @container home (width >= ${COLLAPSED_PORTRAIT_MIN}px) {
-        padding-inline-end: ${PORTRAIT_LANE}px;
-      }
-    }
-  `,
-  identity: css`
-    flex: 0 1 auto;
-    min-width: 0;
+
+    /* Keep the expanded text measure while the composer widens underneath.
+       Rail toggles then only move text horizontally, preserving line breaks
+       and the composer's vertical position even for long names and prose.
+       Keep this measure when artwork is off as well; stability takes priority
+       over filling the extra space above the wider composer. */
     max-width: 100%;
   `,
   bubbleSlot: css`
-    flex: 0 1 auto;
     width: max-content;
     max-width: 100%;
   `,
@@ -201,10 +188,6 @@ const styles = createStaticStyles(({ css }) => ({
   // composer instead of disappearing with the cards — keeping the same dip, so
   // the same half of it stays behind the surface it leans on.
   portraitCollapsed: css`
-    @container home (width < ${COLLAPSED_PORTRAIT_MIN}px) {
-      display: none;
-    }
-
     @media (width > 1100px) {
       transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
 
@@ -335,17 +318,8 @@ const Home = memo(() => {
 
   return (
     <Flexbox className={styles.grid}>
-      <div
-        className={cx(
-          styles.header,
-          styles.content,
-          railCollapsed && styles.contentCollapsed,
-          portraitVisible && railCollapsed && styles.headerWithPortrait,
-        )}
-      >
-        <div className={styles.identity}>
-          <HomeHeader />
-        </div>
+      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
+        <HomeHeader />
         {/* The portrait has one voice: a live campaign temporarily speaks in
             place of the daily brief, which returns when the campaign leaves. */}
         {portraitVisible && (

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -72,11 +72,11 @@ const PORTRAIT_LANE = HOME_PORTRAIT_WIDTH + HOME_PORTRAIT_INSET + 16;
 /** Reclaim the artwork's full lane so collapsing never narrows the text above. */
 const COLLAPSED_CONTENT_GAIN = PORTRAIT_LANE;
 const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
-const SPEECH_BUBBLE_MAX = 320;
+const SPEECH_BUBBLE_MIN = 320;
 const SPEECH_GREETING_GAP = 24;
 const SPEECH_GREETING_MIN = 320;
 const SPEECH_RESERVED_WIDTH =
-  COLLAPSED_CONTENT_OFFSET * 2 + SPEECH_GREETING_GAP + SPEECH_BUBBLE_MAX + PORTRAIT_LANE;
+  COLLAPSED_CONTENT_OFFSET * 2 + SPEECH_GREETING_GAP + SPEECH_BUBBLE_MIN + PORTRAIT_LANE;
 /** Use the tighter rail state so its animation cannot switch rows or rewrap text. */
 const SPEECH_INLINE_MIN = SPEECH_RESERVED_WIDTH + SPEECH_GREETING_MIN;
 const COMPACT_PORTRAIT_HEIGHT = 150;
@@ -157,6 +157,10 @@ const styles = createStaticStyles(({ css }) => ({
       transform ${RAIL_TRANSITION_DURATION}ms ease-out,
       width ${RAIL_TRANSITION_DURATION}ms ease-out;
 
+    @media (width > 1100px) {
+      width: calc(100% - ${COLLAPSED_CONTENT_OFFSET * 2}px);
+    }
+
     @media (prefers-reduced-motion: reduce) {
       transition: none;
     }
@@ -173,11 +177,11 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   heroWithSpeech: css`
     @container home (width >= ${SPEECH_INLINE_MIN}px) {
-      /* The middle track absorbs rail motion. Neither the greeting nor the
-         speech unit changes its text measure during the transition. */
+      /* Size both text columns in a stable frame; only artwork placement
+         moves when the rail toggles. Short speech leaves room for the name. */
       grid-template-columns:
-        minmax(0, calc(100cqw - ${SPEECH_RESERVED_WIDTH}px))
-        minmax(${SPEECH_GREETING_GAP}px, 1fr)
+        minmax(0, 1fr)
+        ${SPEECH_GREETING_GAP}px
         max-content;
       gap: 0;
     }
@@ -205,8 +209,18 @@ const styles = createStaticStyles(({ css }) => ({
     max-width: 100%;
     min-height: ${COMPACT_PORTRAIT_HEIGHT - COMPACT_PORTRAIT_OVERLAP}px;
 
+    transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
+
     @media (width > 1100px) {
-      max-width: calc(100cqw - ${COLLAPSED_CONTENT_OFFSET * 2}px);
+      transform: translateX(${COLLAPSED_CONTENT_OFFSET * 2}px);
+
+      &:dir(rtl) {
+        transform: translateX(-${COLLAPSED_CONTENT_OFFSET * 2}px);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
     }
 
     @container home (width >= ${SPEECH_INLINE_MIN}px) {
@@ -216,13 +230,25 @@ const styles = createStaticStyles(({ css }) => ({
 
       grid-area: 1 / 3;
       align-self: stretch;
+
+      /* Use all room left by the greeting in the tighter rail state. */
+      max-width: calc(
+        100cqw - ${COLLAPSED_CONTENT_OFFSET * 2 + SPEECH_GREETING_MIN + SPEECH_GREETING_GAP}px
+      );
       min-height: 0;
+    }
+  `,
+  speechCollapsed: css`
+    @media (width > 1100px) {
+      && {
+        transform: none;
+      }
     }
   `,
   bubbleSlot: css`
     width: max-content;
     min-width: 0;
-    max-width: ${SPEECH_BUBBLE_MAX}px;
+    max-width: 100%;
     margin-block-end: 4px;
   `,
   portrait: css`
@@ -387,7 +413,7 @@ const Home = memo(() => {
           <HomeHeader />
         </div>
         {portraitVisible && (
-          <div className={styles.speech}>
+          <div className={cx(styles.speech, railCollapsed && styles.speechCollapsed)}>
             {/* Keep the agent's line and artwork together in both header layouts. */}
             <div className={styles.bubbleSlot}>
               <PortraitBubble promo={promo} />

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -23,6 +23,7 @@ import HomeModeContent from './HomeModeContent';
 import HomePortrait from './HomePortrait';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
+import { HOME_PORTRAIT_INSET, HOME_PORTRAIT_WIDTH } from './portraitFraming';
 import { RAIL_INBOX_PROPS, resolveRailVisibility } from './railVisibility';
 import type { HomeMode } from './types';
 
@@ -66,20 +67,9 @@ const RAIL_RECLAIMED_WIDTH = RAIL_CARD_WIDTH + RAIL_GUTTER + RAIL_COLUMN_GAP;
 const COLLAPSED_CONTENT_GAIN = 140;
 const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
 /** Portrait width plus its inline inset and the gap the bubble keeps from it. */
-const PORTRAIT_LANE = 152 + 12 + 16;
-const BUBBLE_MAX_WIDTH = 360;
-const BUBBLE_GAP = 16;
-/**
- * What the greeting must leave alone so the bubble never lands on it, measured
- * in the tighter of the two states: the collapsed content is inset by
- * COLLAPSED_CONTENT_OFFSET on both sides, and the bubble occupies the portrait's
- * lane plus its own width. Subtracted from the *container* width, because the
- * bubble tracks the container's trailing edge while the greeting starts at its
- * leading edge — a fixed measure only happens to clear it at full width.
- */
-const GREETING_LANE = COLLAPSED_CONTENT_OFFSET * 2 + PORTRAIT_LANE + BUBBLE_MAX_WIDTH + BUBBLE_GAP;
-/** Under this the greeting, the bubble and the portrait cannot share a line. */
-const BUBBLE_INLINE_MIN = 1080;
+const PORTRAIT_LANE = HOME_PORTRAIT_WIDTH + HOME_PORTRAIT_INSET + 16;
+/** Keep at least 400px for text before retaining decorative artwork in the main column. */
+const COLLAPSED_PORTRAIT_MIN = COLLAPSED_CONTENT_OFFSET * 2 + PORTRAIT_LANE + 400;
 const MINIMAL_STACK_GAP = 24;
 /**
  * The minimal header stacks the agent switcher (24px avatar + 2px paddings,
@@ -141,55 +131,35 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   header: css`
-    --home-greeting-measure: none;
-
     position: relative;
+
+    display: flex;
     grid-area: 1 / 1;
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
 
-    @container home (width >= ${BUBBLE_INLINE_MIN}px) {
-      --home-greeting-measure: calc(100cqw - ${GREETING_LANE}px);
-    }
+    min-width: 0;
   `,
-  // Parks beside the portrait when the row is wide enough for the three of them;
-  // otherwise it drops below the greeting, where it is just another line and
-  // needs no anchoring.
-  bubbleSlot: css`
-    --home-bubble-tail: none;
-
-    margin-block-start: 16px;
-
-    @container home (width >= ${BUBBLE_INLINE_MIN}px) {
-      --home-bubble-tail: block;
-
-      position: absolute;
-      inset-block-end: 4px;
-
-      /* Anchored to the header's trailing edge, which itself widens and slides
-         on collapse — so the slot only has to make up the difference, and it
-         makes it up with a transform, in step with the portrait it belongs to. */
-      inset-inline-end: ${PORTRAIT_LANE - RAIL_RECLAIMED_WIDTH}px;
-
-      display: flex;
-      justify-content: flex-end;
-
-      max-width: ${BUBBLE_MAX_WIDTH}px;
-      margin-block-start: 0;
-
-      transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
-  `,
-  bubbleSlotCollapsed: css`
-    @container home (width >= ${BUBBLE_INLINE_MIN}px) {
-      transform: translateX(-${RAIL_RECLAIMED_WIDTH}px);
-
-      &:dir(rtl) {
-        transform: translateX(${RAIL_RECLAIMED_WIDTH}px);
+  headerWithPortrait: css`
+    /* Only the collapsed rail puts the artwork inside the content column.
+       Keep the greeting and announcement in a stable vertical flow, with
+       decorative artwork yielding first when the text lane gets narrow. */
+    @media (width > 1100px) {
+      @container home (width >= ${COLLAPSED_PORTRAIT_MIN}px) {
+        padding-inline-end: ${PORTRAIT_LANE}px;
       }
     }
+  `,
+  identity: css`
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 100%;
+  `,
+  bubbleSlot: css`
+    flex: 0 1 auto;
+    width: max-content;
+    max-width: 100%;
   `,
   inputArea: css`
     position: relative;
@@ -231,6 +201,10 @@ const styles = createStaticStyles(({ css }) => ({
   // composer instead of disappearing with the cards — keeping the same dip, so
   // the same half of it stays behind the surface it leans on.
   portraitCollapsed: css`
+    @container home (width < ${COLLAPSED_PORTRAIT_MIN}px) {
+      display: none;
+    }
+
     @media (width > 1100px) {
       transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
 
@@ -361,12 +335,21 @@ const Home = memo(() => {
 
   return (
     <Flexbox className={styles.grid}>
-      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
-        <HomeHeader />
+      <div
+        className={cx(
+          styles.header,
+          styles.content,
+          railCollapsed && styles.contentCollapsed,
+          portraitVisible && railCollapsed && styles.headerWithPortrait,
+        )}
+      >
+        <div className={styles.identity}>
+          <HomeHeader />
+        </div>
         {/* The portrait has one voice: a live campaign temporarily speaks in
             place of the daily brief, which returns when the campaign leaves. */}
         {portraitVisible && (
-          <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
+          <div className={styles.bubbleSlot}>
             <PortraitBubble promo={promo} />
           </div>
         )}

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -24,8 +24,10 @@ import HomePortrait from './HomePortrait';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
 import {
+  getHomePortraitOverlap,
+  HOME_PORTRAIT_CARD_GAP,
+  HOME_PORTRAIT_HEIGHT,
   HOME_PORTRAIT_INSET,
-  HOME_PORTRAIT_VISIBLE_RATIO,
   HOME_PORTRAIT_WIDTH,
 } from './portraitFraming';
 import { RAIL_INBOX_PROPS, resolveRailVisibility } from './railVisibility';
@@ -80,9 +82,9 @@ const SPEECH_RESERVED_WIDTH =
 /** Use the tighter rail state so its animation cannot switch rows or rewrap text. */
 const SPEECH_INLINE_MIN = SPEECH_RESERVED_WIDTH + SPEECH_GREETING_MIN;
 const COMPACT_PORTRAIT_HEIGHT = 150;
-const COMPACT_PORTRAIT_WIDTH = HOME_PORTRAIT_WIDTH * (COMPACT_PORTRAIT_HEIGHT / 200);
-/** Include the 24px grid gap so the composer reveals the same artwork fraction. */
-const COMPACT_PORTRAIT_OVERLAP = COMPACT_PORTRAIT_HEIGHT * (1 - HOME_PORTRAIT_VISIBLE_RATIO) + 24;
+const COMPACT_PORTRAIT_WIDTH =
+  HOME_PORTRAIT_WIDTH * (COMPACT_PORTRAIT_HEIGHT / HOME_PORTRAIT_HEIGHT);
+const COMPACT_PORTRAIT_OVERLAP = getHomePortraitOverlap(COMPACT_PORTRAIT_HEIGHT);
 const MINIMAL_STACK_GAP = 24;
 /**
  * The minimal header stacks the agent switcher (24px avatar + 2px paddings,
@@ -109,7 +111,7 @@ const styles = createStaticStyles(({ css }) => ({
     display: grid;
     grid-template-columns: minmax(0, 1fr) ${RAIL_CARD_WIDTH + RAIL_GUTTER}px;
     grid-template-rows: auto auto;
-    gap: 24px ${RAIL_COLUMN_GAP}px;
+    gap: ${HOME_PORTRAIT_CARD_GAP}px ${RAIL_COLUMN_GAP}px;
 
     width: 100%;
 
@@ -153,9 +155,7 @@ const styles = createStaticStyles(({ css }) => ({
     width: 100%;
     min-width: 0;
 
-    transition:
-      transform ${RAIL_TRANSITION_DURATION}ms ease-out,
-      width ${RAIL_TRANSITION_DURATION}ms ease-out;
+    transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
 
     @media (width > 1100px) {
       width: calc(100% - ${COLLAPSED_CONTENT_OFFSET * 2}px);
@@ -168,7 +168,6 @@ const styles = createStaticStyles(({ css }) => ({
   heroCollapsed: css`
     @media (width > 1100px) {
       transform: translateX(${COLLAPSED_CONTENT_OFFSET}px);
-      width: calc(100% - ${COLLAPSED_CONTENT_OFFSET * 2}px);
 
       &:dir(rtl) {
         transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
@@ -179,21 +178,12 @@ const styles = createStaticStyles(({ css }) => ({
     @container home (width >= ${SPEECH_INLINE_MIN}px) {
       /* Size both text columns in a stable frame; only artwork placement
          moves when the rail toggles. Short speech leaves room for the name. */
-      grid-template-columns:
-        minmax(0, 1fr)
-        ${SPEECH_GREETING_GAP}px
-        max-content;
-      gap: 0;
+      grid-template-columns: minmax(0, 1fr) max-content;
+      column-gap: ${SPEECH_GREETING_GAP}px;
     }
   `,
   header: css`
     min-width: 0;
-
-    @media (width > 1100px) {
-      /* Preserve the same readable measure in the stacked and portrait-off
-         modes, even while the enclosing hero changes width. */
-      max-width: calc(100cqw - ${RAIL_RECLAIMED_WIDTH}px);
-    }
   `,
   speech: css`
     --home-portrait-width: ${COMPACT_PORTRAIT_WIDTH}px;
@@ -217,6 +207,10 @@ const styles = createStaticStyles(({ css }) => ({
       &:dir(rtl) {
         transform: translateX(-${COLLAPSED_CONTENT_OFFSET * 2}px);
       }
+
+      &[data-collapsed='true'] {
+        transform: none;
+      }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -225,10 +219,10 @@ const styles = createStaticStyles(({ css }) => ({
 
     @container home (width >= ${SPEECH_INLINE_MIN}px) {
       --home-portrait-width: ${HOME_PORTRAIT_WIDTH}px;
-      --home-portrait-height: 200px;
-      --home-portrait-overlap: -94px;
+      --home-portrait-height: ${HOME_PORTRAIT_HEIGHT}px;
+      --home-portrait-overlap: -${getHomePortraitOverlap(HOME_PORTRAIT_HEIGHT)}px;
 
-      grid-area: 1 / 3;
+      grid-area: 1 / 2;
       align-self: stretch;
 
       /* Use all room left by the greeting in the tighter rail state. */
@@ -236,13 +230,6 @@ const styles = createStaticStyles(({ css }) => ({
         100cqw - ${COLLAPSED_CONTENT_OFFSET * 2 + SPEECH_GREETING_MIN + SPEECH_GREETING_GAP}px
       );
       min-height: 0;
-    }
-  `,
-  speechCollapsed: css`
-    @media (width > 1100px) {
-      && {
-        transform: none;
-      }
     }
   `,
   bubbleSlot: css`
@@ -413,7 +400,7 @@ const Home = memo(() => {
           <HomeHeader />
         </div>
         {portraitVisible && (
-          <div className={cx(styles.speech, railCollapsed && styles.speechCollapsed)}>
+          <div className={styles.speech} data-collapsed={railCollapsed}>
             {/* Keep the agent's line and artwork together in both header layouts. */}
             <div className={styles.bubbleSlot}>
               <PortraitBubble promo={promo} />

--- a/src/features/Home/portraitFraming.ts
+++ b/src/features/Home/portraitFraming.ts
@@ -11,3 +11,7 @@
  * preview is lying about where home will cut.
  */
 export const HOME_PORTRAIT_VISIBLE_RATIO = 0.65;
+
+/** Shared with the greeting layout so text never enters the artwork's box. */
+export const HOME_PORTRAIT_WIDTH = 176;
+export const HOME_PORTRAIT_INSET = 12;

--- a/src/features/Home/portraitFraming.ts
+++ b/src/features/Home/portraitFraming.ts
@@ -3,8 +3,7 @@
  *
  * The home portrait hangs below its container so the lower body passes behind
  * the first card; what survives that overlap is this fraction of the character's
- * height, measured against the real layout (image box 200px tall, card top
- * 130px below the image's top edge).
+ * height, measured from the image's top edge to the supporting card.
  *
  * It lives here rather than inside the stylesheet because the artwork studio
  * draws the same fraction as a preview frame — if the two ever disagree, the
@@ -15,3 +14,11 @@ export const HOME_PORTRAIT_VISIBLE_RATIO = 0.65;
 /** Shared with the greeting layout so text never enters the artwork's box. */
 export const HOME_PORTRAIT_WIDTH = 176;
 export const HOME_PORTRAIT_INSET = 12;
+
+export const HOME_PORTRAIT_HEIGHT = 200;
+/** Space between the hero row and the card that masks the portrait. */
+export const HOME_PORTRAIT_CARD_GAP = 24;
+
+/** Keep the visible fraction consistent with the artwork studio at every size. */
+export const getHomePortraitOverlap = (height: number) =>
+  height * (1 - HOME_PORTRAIT_VISIBLE_RATIO) + HOME_PORTRAIT_CARD_GAP;


### PR DESCRIPTION
Home announcements now sit next to the agent artwork as one speech group. Wide layouts place the group beside the greeting; narrower layouts move the whole group below it and scale the portrait proportionally. Short announcements size to their content, while long content wraps with a single-line action. The Customize entry is an icon with a localized tooltip and accessible label.

The layout uses the tighter rail state to choose its row arrangement. Both text columns share a stable layout frame, and rail animation changes their positions while preserving their widths and the composer's vertical position. Portrait visibility continues to follow the existing customization behavior.

Validation: unified quality check passed with 46 related tests. Real browser inspection covered three presets, portrait toggles, short/long content, long user names, light/dark themes, and 1000–1640px viewports. At four desktop widths, rail toggles kept the composer top unchanged; 182 animation samples at 1280/1440px confirmed the same. Wide layouts recover 54px vertically; stacked layouts use additional height to preserve the speaker relationship. CSS geometry was checked in the browser rather than through stylesheet-string tests.

Packaged Electron, mobile, other languages, and the full range of generated portrait poses were not tested.

Announcements have no fixed 320px cap: they grow to their intrinsic width within the available space. Short announcements leave room for the greeting. The three reported 1280px cases (image announcement, card promotion, and long model name) now render on one line; narrower layouts still wrap as needed.

The layout cleanup removes the obsolete stacked-header width cap, redundant width animation, empty spacing column, and specificity override. Portrait dimensions and overlap share one source. Browser checks confirm the long greeting uses 724px at a 1280px viewport and rail geometry remains stable.
