### PR TITLE
fix(topic): generate titles for voice-first conversations

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -56,6 +56,7 @@ function createMockStore() {
     internal_toggleToolCallingStreaming: vi.fn(),
     markTopicUnread: vi.fn(),
     messagesMap: {} as Record<string, any>,
+    topicDataMap: {},
     operations: {
       'op-1': {
         context: { agentId: 'agent-1', scope: 'session', topicId: 'topic-1' },

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -249,6 +249,7 @@ function createMockStore(overrides: Record<string, any> = {}) {
     internal_dispatchMessage: vi.fn(),
     internal_toggleToolCallingStreaming: vi.fn(),
     markTopicUnread: vi.fn(),
+    messagesMap: {},
     operations: {
       'op-1': {
         context: { agentId: 'agent-1', scope: 'main', topicId: 'topic-1' },
@@ -266,6 +267,7 @@ function createMockStore(overrides: Record<string, any> = {}) {
         operationId: `sub-op-${subOpCounter}`,
       };
     }),
+    topicDataMap: {},
     updateTopicMetadata: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as any;
@@ -6139,6 +6141,45 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
 
       expect(mockShowNotification).not.toHaveBeenCalled();
       expect(mockSetBadgeCount).not.toHaveBeenCalled();
+    });
+
+    it('summarizes an audio-first topic after heterogeneous completion', async () => {
+      const messages = [
+        {
+          audioList: [{ alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' }],
+          content: '',
+          id: 'user-1',
+          role: 'user',
+        },
+        {
+          children: [
+            {
+              content: 'Analyzing the recording.',
+              id: 'assistant-tool',
+              tools: [{ apiName: 'analyzeMedia', id: 'tool-1' }],
+            },
+            { content: 'The recording asks how to list files.', id: 'assistant-answer' },
+          ],
+          content: '',
+          id: 'assistant-group',
+          role: 'assistantGroup',
+        },
+      ];
+      const summaryTopicTitle = vi.fn().mockResolvedValue(undefined);
+      const store = createMockStore({
+        messagesMap: { 'main_agent-1_topic-1': messages },
+        summaryTopicTitle,
+        topicDataMap: {
+          'agent-1__main': {
+            items: [{ id: 'topic-1', title: 'defaultTitle' }],
+            total: 1,
+          },
+        },
+      });
+
+      await runToComplete(store, [ccInit(), ccText('msg_01', 'done'), ccResult()]);
+
+      expect(summaryTopicTitle).toHaveBeenCalledWith('topic-1', messages);
     });
 
     // ── 2. metadata-save failure isolation (guarded) ──

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatStore } from '@/store/chat/store';
 
 import { messageMapKey } from '../../../../utils/messageMapKey';
+import { topicMapKey } from '../../../../utils/topicMapKey';
 import type { AgentRuntimeType } from '../dispatch/agentDispatcher';
 import { buildRunLifecycle } from './buildRunLifecycle';
 import type { RunCompleteEvent, RunTerminalStatus, UserMessagePersistedEvent } from './types';
@@ -59,7 +60,8 @@ const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
       },
     },
     refreshTopic: vi.fn(async () => {}),
-    summaryTopicTitle: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    summaryTopicTitle: vi.fn().mockResolvedValue(undefined),
     // topicDataMap / messagesMap reads default to empty (no topic, no messages).
     topicDataMap: {},
     updateTopicStatus: vi.fn(async () => {}),
@@ -114,6 +116,34 @@ describe('buildRunLifecycle.completeRun — transport-driven disposition', () =>
         sourceType: 'client.runtime.complete',
       }),
     );
+  });
+
+  it('summarizes an audio-first topic before returning a queued follow-up', async () => {
+    const { get, store } = makeStore();
+    const messages = [
+      {
+        audioList: [{ alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' }],
+        content: '',
+        id: 'u1',
+        role: 'user',
+      },
+      { content: 'The recording asks how to list files.', id: 'a1', role: 'assistant' },
+    ];
+    store.drainQueuedMessages = vi.fn(() => [{ content: 'follow up', id: 'q1' } as any]);
+    store.messagesMap = { [messageMapKey(CONTEXT)]: messages } as any;
+    store.topicDataMap = {
+      [topicMapKey({ agentId: 'a1' })]: {
+        items: [{ id: 't1', title: 'defaultTitle' }],
+        total: 1,
+      },
+    } as any;
+
+    const { requeued } = await lifecycle('client', get).completeRun(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(requeued).toBe(true);
+    expect(store.summaryTopicTitle).toHaveBeenCalledWith('t1', messages);
   });
 
   it.each<[RunTerminalStatus, 'completeOperation' | 'failOperation']>([
@@ -370,6 +400,117 @@ describe('buildRunLifecycle.afterRunComplete — client desktop notification bod
     );
 
     expect(desktopNotificationMock.notifyDesktopAgentCompleted).not.toHaveBeenCalled();
+  });
+
+  it('summarizes an untitled topic after its audio-only first message receives a reply', async () => {
+    const { get, store } = makeStore();
+    const voiceMessage = {
+      audioList: [{ alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' }],
+      content: '',
+      id: 'u1',
+      role: 'user',
+    } as any;
+    const messages = [voiceMessage, thisTurnAssistant];
+    store.messagesMap = { [KEY]: messages } as any;
+    store.topicDataMap = {
+      [topicMapKey({ agentId: 'a1' })]: {
+        items: [{ id: 't1', title: 'defaultTitle' }],
+        total: 1,
+      },
+    } as any;
+
+    await lifecycle('client', get).afterRunComplete(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(store.summaryTopicTitle).toHaveBeenCalledWith('t1', messages);
+  });
+
+  it('summarizes an audio-first topic when the reply is grouped around a media tool call', async () => {
+    const { get, store } = makeStore();
+    const messages = [
+      {
+        audioList: [{ alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' }],
+        content: '',
+        id: 'u1',
+        role: 'user',
+      },
+      {
+        children: [
+          {
+            content: 'Analyzing the recording.',
+            id: 'assistant-tool',
+            tools: [{ apiName: 'analyzeMedia', id: 'tool-1' }],
+          },
+          { content: 'The recording asks how to list files.', id: 'assistant-answer' },
+        ],
+        content: '',
+        id: 'assistant-group',
+        role: 'assistantGroup',
+      },
+    ];
+    store.messagesMap = { [KEY]: messages } as any;
+    store.topicDataMap = {
+      [topicMapKey({ agentId: 'a1' })]: {
+        items: [{ id: 't1', title: 'defaultTitle' }],
+        total: 1,
+      },
+    } as any;
+
+    await lifecycle('client', get).afterRunComplete(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(store.summaryTopicTitle).toHaveBeenCalledWith('t1', messages);
+  });
+
+  it.each(['error', 'interrupted'] as const)(
+    'does not summarize partial audio replies when the client run ends as %s',
+    async (runtimeStatus) => {
+      const { get, store } = makeStore();
+      store.messagesMap = {
+        [KEY]: [
+          {
+            audioList: [
+              { alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' },
+            ],
+            content: '',
+            id: 'u1',
+            role: 'user',
+          },
+          { ...thisTurnAssistant, content: 'Partial reply' },
+        ],
+      } as any;
+      store.topicDataMap = {
+        [topicMapKey({ agentId: 'a1' })]: {
+          items: [{ id: 't1', title: 'defaultTitle' }],
+          total: 1,
+        },
+      } as any;
+
+      await lifecycle('client', get).afterRunComplete(completeEvent('client', { runtimeStatus }));
+
+      expect(store.summaryTopicTitle).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not re-summarize a text-first topic after the reply completes', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = {
+      [KEY]: [{ content: 'hello', id: 'u1', role: 'user' }, thisTurnAssistant],
+    } as any;
+    store.topicDataMap = {
+      [topicMapKey({ agentId: 'a1' })]: {
+        items: [{ id: 't1', title: 'defaultTitle' }],
+        total: 1,
+      },
+    } as any;
+
+    await lifecycle('client', get).afterRunComplete(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(store.summaryTopicTitle).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -2,12 +2,18 @@ import type { AgentState } from '@lobechat/agent-runtime';
 import { isDesktop } from '@lobechat/const';
 import type { ConversationContext, UIChatMessage } from '@lobechat/types';
 import debug from 'debug';
+import { t } from 'i18next';
 
+import { LOADING_FLAT } from '@/const/message';
 import type { AgentRuntimeType } from '@/store/chat/slices/agentRun/actions/dispatch/agentDispatcher';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge';
 import { snapshotTopicWorkingDirGit } from '@/store/chat/slices/agentRun/actions/lifecycle/snapshotWorkingDirGit';
 import type { ChatStore } from '@/store/chat/store';
 import { notifyDesktopAgentCompleted } from '@/store/chat/utils/desktopNotification';
+import {
+  hasCompletedAssistantText,
+  isAudioOnlyFirstUserMessage,
+} from '@/store/chat/utils/topicTitle';
 import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { messageMapKey } from '../../../../utils/messageMapKey';
@@ -144,6 +150,33 @@ export const buildRunLifecycle = (
   const { agentId, topicId, threadId, groupId, workspaceSlug } = context;
   const messageKey = messageMapKey(context);
   const contextKey = messageKey;
+  let voiceTopicTitleSummaryRequested = false;
+
+  const summarizeVoiceTopicTitleAfterCompletion = () => {
+    if (voiceTopicTitleSummaryRequested || adapter.runScope === 'sub_agent' || !topicId) return;
+
+    const topic = topicSelectors.getTopicById(topicId)(get());
+    const messages = displayMessageSelectors.getDisplayMessagesByKey(messageKey)(get());
+    const isUntitled =
+      !topic?.title ||
+      topic.title === LOADING_FLAT ||
+      topic.title === t('defaultTitle', { ns: 'topic' });
+
+    if (
+      topic &&
+      isUntitled &&
+      isAudioOnlyFirstUserMessage(messages) &&
+      hasCompletedAssistantText(messages)
+    ) {
+      voiceTopicTitleSummaryRequested = true;
+      void get()
+        .summaryTopicTitle(topicId, messages)
+        .catch((error) => {
+          voiceTopicTitleSummaryRequested = false;
+          log('Failed to summarize voice topic title: %O', error);
+        });
+    }
+  };
 
   const emitComplete = (operationId: string, runtimeStatus: AgentState['status'] | undefined) => {
     // `client.runtime.complete` is a CLIENT-only source event (browser → server
@@ -250,6 +283,17 @@ export const buildRunLifecycle = (
       }
     },
     afterRunComplete: async (event: RunCompleteEvent) => {
+      if (adapter.runScope === 'sub_agent') return;
+
+      // A voice-only first message cannot be summarized at the post-persist seam:
+      // its content is empty and the assistant row is still a loading placeholder.
+      // Once the reply completes, use the now-textual conversation to generate a
+      // meaningful title. This also leaves the visible default title intact if the
+      // title request fails instead of turning the sidebar row blank.
+      if (resolveTerminalDisposition(event) === 'success') {
+        summarizeVoiceTopicTitleAfterCompletion();
+      }
+
       // Desktop notification + dock badge. Single home for all runtimes'
       // completion notification — every transport funnels through the shared
       // `notifyDesktopAgentCompleted` helper, so title (topic/agent name), body
@@ -257,7 +301,6 @@ export const buildRunLifecycle = (
       // Top-level-only: a nested sub-agent finishing is not a user-facing run
       // completion — the parent run is still going, so it must not fire a
       // "generation finished" notification / badge. See RunScope.
-      if (adapter.runScope === 'sub_agent') return;
       if (!isDesktop) return;
 
       const notificationContext = { agentId, groupId, topicId, workspaceSlug };
@@ -314,6 +357,11 @@ export const buildRunLifecycle = (
       // OR the normalized `status` gateway/hetero pass — so the same side effects
       // fire regardless of which transport reached this boundary.
       const disposition = resolveTerminalDisposition(event);
+
+      // Title recovery is a successful-completion side effect, not a notification
+      // side effect. Run it before the queued-message early return so a follow-up
+      // cannot strand an audio-first topic without a title.
+      if (disposition === 'success') summarizeVoiceTopicTitleAfterCompletion();
 
       const completeSuccess = () => {
         get().completeOperation(operationId);

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -2370,6 +2370,7 @@ export const executeHeterogeneousAgent = async (
               runId: operationId,
               runScope,
               runtimeType: 'hetero',
+              status: 'completed',
             });
 
             // Shell Work scan for this LOCAL run: no server operation exists, so

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -2556,6 +2556,188 @@ describe('topic action', () => {
     });
   });
   describe('summaryTopicTitle', () => {
+    it('should wait for assistant text before summarizing an audio-only conversation', async () => {
+      const topicId = 'topic-1';
+      const messages = [
+        {
+          audioList: [{ alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' }],
+          content: '',
+          id: 'message-1',
+          role: 'user',
+        },
+        { content: LOADING_FLAT, id: 'message-2', role: 'assistant' },
+      ] as UIChatMessage[];
+      const topics = [{ id: topicId, title: '' }] as ChatTopic[];
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        useChatStore.setState({
+          activeAgentId: 'test',
+          topicDataMap: {
+            [topicMapKey({ agentId: 'test' })]: {
+              currentPage: 0,
+              hasMore: false,
+              items: topics,
+              pageSize: 20,
+              total: topics.length,
+            },
+          },
+        });
+      });
+
+      const updateTitleSpy = vi.spyOn(result.current, 'internal_updateTopicTitleInSummary');
+      const generateSpy = vi.spyOn(aiChatService, 'generateJSON');
+
+      await act(async () => {
+        await result.current.summaryTopicTitle(topicId, messages);
+      });
+
+      expect(updateTitleSpy).not.toHaveBeenCalled();
+      expect(generateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should preserve the existing summary behavior for a non-audio attachment-only conversation', async () => {
+      const topicId = 'topic-1';
+      const messages = [
+        {
+          content: '',
+          id: 'message-1',
+          imageList: [{ alt: 'photo.png', id: 'image-1', url: 'https://example.com/photo.png' }],
+          role: 'user',
+        },
+        { content: LOADING_FLAT, id: 'message-2', role: 'assistant' },
+      ] as UIChatMessage[];
+      const topics = [{ id: topicId, title: '' }] as ChatTopic[];
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        useChatStore.setState({
+          activeAgentId: 'test',
+          topicDataMap: {
+            [topicMapKey({ agentId: 'test' })]: {
+              currentPage: 0,
+              hasMore: false,
+              items: topics,
+              pageSize: 20,
+              total: topics.length,
+            },
+          },
+        });
+      });
+
+      const updateTitleSpy = vi.spyOn(result.current, 'internal_updateTopicTitleInSummary');
+      const generateSpy = vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+        data: { title: 'Shared Image' },
+        tracingId: 'tracing-1',
+      } as any);
+
+      await act(async () => {
+        await result.current.summaryTopicTitle(topicId, messages);
+      });
+
+      expect(updateTitleSpy).toHaveBeenCalledWith(topicId, LOADING_FLAT);
+      expect(generateSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should summarize the final answer inside an assistant group for an audio-only conversation', async () => {
+      const topicId = 'topic-1';
+      const finalAnswer = 'The recording asks how to list files in the current directory.';
+      const messages = [
+        {
+          audioList: [{ alt: 'voice.webm', id: 'audio-1', url: 'https://example.com/voice.webm' }],
+          content: '',
+          id: 'message-1',
+          role: 'user',
+        },
+        {
+          children: [
+            {
+              content: 'Analyzing the recording.',
+              id: 'message-2-tool',
+              tools: [{ apiName: 'analyzeMedia', id: 'tool-1' }],
+            },
+            { content: finalAnswer, id: 'message-2-answer' },
+          ],
+          content: '',
+          id: 'message-2',
+          role: 'assistantGroup',
+        },
+      ] as UIChatMessage[];
+      const topics = [{ id: topicId, title: '' }] as ChatTopic[];
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        useChatStore.setState({
+          activeAgentId: 'test',
+          topicDataMap: {
+            [topicMapKey({ agentId: 'test' })]: {
+              currentPage: 0,
+              hasMore: false,
+              items: topics,
+              pageSize: 20,
+              total: topics.length,
+            },
+          },
+        });
+      });
+
+      const generateSpy = vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+        data: { title: 'List Current Directory Files' },
+        tracingId: 'tracing-1',
+      } as any);
+
+      await act(async () => {
+        await result.current.summaryTopicTitle(topicId, messages);
+      });
+
+      const promptMessages = generateSpy.mock.calls[0][0].messages;
+      expect(promptMessages.at(-1)?.content).toContain(finalAnswer);
+    });
+
+    it('should deduplicate concurrent title requests for the same topic', async () => {
+      const topicId = 'topic-1';
+      const messages = [{ content: 'Hello', id: 'message-1', role: 'user' }] as UIChatMessage[];
+      const topics = [{ id: topicId, title: 'Default Topic' }] as ChatTopic[];
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        useChatStore.setState({
+          activeAgentId: 'test',
+          topicDataMap: {
+            [topicMapKey({ agentId: 'test' })]: {
+              currentPage: 0,
+              hasMore: false,
+              items: topics,
+              pageSize: 20,
+              total: topics.length,
+            },
+          },
+        });
+      });
+
+      let resolveGeneration!: (value: unknown) => void;
+      const generation = new Promise((resolve) => {
+        resolveGeneration = resolve;
+      });
+      const generateSpy = vi
+        .spyOn(aiChatService, 'generateJSON')
+        .mockReturnValue(generation as any);
+
+      let firstRequest!: Promise<void>;
+      let secondRequest!: Promise<void>;
+      act(() => {
+        firstRequest = result.current.summaryTopicTitle(topicId, messages);
+        secondRequest = result.current.summaryTopicTitle(topicId, messages);
+      });
+
+      expect(generateSpy).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        resolveGeneration({ data: { title: '  ' }, tracingId: 'tracing-1' });
+        await Promise.all([firstRequest, secondRequest]);
+      });
+    });
+
     it('should show a loading placeholder when auto-summarizing a topic without a title', async () => {
       const topicId = 'topic-1';
       const messages = [{ id: 'message-1', content: 'Hello' }] as UIChatMessage[];

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -26,6 +26,10 @@ import { evictMessageCache } from '@/store/chat/utils/evictMessageCache';
 import { snapshotAgentModel } from '@/store/chat/utils/snapshotAgentModel';
 import { topicMapKey, type TopicMapScope } from '@/store/chat/utils/topicMapKey';
 import {
+  isAudioOnlyFirstUserMessage,
+  normalizeTopicTitleMessages,
+} from '@/store/chat/utils/topicTitle';
+import {
   canReadTopicGitTransport,
   getTopicLinkedPullRequestBase,
   isSuccessfulLinkedPullRequestLookup,
@@ -137,6 +141,8 @@ export class ChatTopicActionImpl {
   #switchTopicEpoch = 0;
 
   #staleRunningTopicCleanupInFlight = false;
+
+  #summarizingTopicTitleIds = new Set<string>();
 
   constructor(set: Setter, get: () => ChatStore, _api?: unknown) {
     void _api;
@@ -290,6 +296,20 @@ export class ChatTopicActionImpl {
     const topic = topicSelectors.getTopicById(topicId)(this.#get());
     if (!topic) return;
 
+    const messagesForTitle = normalizeTopicTitleMessages(messages);
+
+    // A voice-only first message has no text until the assistant responds. Do not
+    // replace the visible default title with a loading placeholder for an empty
+    // summary request; the run lifecycle retries with the completed reply.
+    const hasTextContent = messagesForTitle.some((message) => {
+      const content = message.content?.trim();
+      return !!content && !(message.role === 'assistant' && content === LOADING_FLAT);
+    });
+    if (!hasTextContent && isAudioOnlyFirstUserMessage(messagesForTitle)) return;
+    if (this.#summarizingTopicTitleIds.has(topicId)) return;
+
+    this.#summarizingTopicTitleIds.add(topicId);
+
     // Keep an optimistic title like "阅读下面..." stable while AI rename runs;
     // otherwise the sidebar flickers `title -> ... -> final title`.
     const shouldShowPlaceholder = !topic.title || topic.title === LOADING_FLAT;
@@ -311,7 +331,7 @@ export class ChatTopicActionImpl {
       const { data } = await aiChatService.generateJSON(
         {
           ...chainSummaryTitle(
-            messages,
+            messagesForTitle,
             userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),
           ),
           model,
@@ -336,6 +356,8 @@ export class ChatTopicActionImpl {
     } catch (error) {
       console.error('[summaryTopicTitle] failed to generate a title:', error);
       restorePreviousTitle();
+    } finally {
+      this.#summarizingTopicTitleIds.delete(topicId);
     }
   };
 

--- a/src/store/chat/utils/topicTitle.ts
+++ b/src/store/chat/utils/topicTitle.ts
@@ -1,0 +1,30 @@
+import { resolveAssistantGroupFinalContent } from '@lobechat/conversation-flow';
+import type { UIChatMessage } from '@lobechat/types';
+
+export const isAudioOnlyFirstUserMessage = (messages: UIChatMessage[]) => {
+  const firstUserMessage = messages.find((message) => message.role === 'user');
+
+  return Boolean(
+    firstUserMessage && !firstUserMessage.content?.trim() && firstUserMessage.audioList?.length,
+  );
+};
+
+export const normalizeTopicTitleMessages = (messages: UIChatMessage[]) =>
+  messages.map((message) => {
+    if (message.role !== 'assistantGroup' && message.role !== 'supervisor') return message;
+
+    const content = resolveAssistantGroupFinalContent(message);
+    return content ? { ...message, content, role: 'assistant' as const } : message;
+  });
+
+export const hasCompletedAssistantText = (messages: UIChatMessage[]) =>
+  messages.some((message) => {
+    if (
+      message.role !== 'assistant' &&
+      message.role !== 'assistantGroup' &&
+      message.role !== 'supervisor'
+    )
+      return false;
+
+    return !!resolveAssistantGroupFinalContent(message);
+  });


### PR DESCRIPTION
## Summary

- defer topic-title generation when a new conversation starts with an audio-only user message
- recover the title after a successful assistant completion across client, gateway, and heterogeneous runtimes
- normalize assistant-group and supervisor replies, suppress duplicate requests, and preserve text-first behavior
- keep title recovery active when completion immediately drains a queued follow-up

| Before | After |
| ------ | ----- |
| An audio-only first message could leave a blank topic row in the sidebar. | The topic receives a non-empty generated title after the assistant reply completes. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Repository check: 7 files lint clean, 248 related tests passed, full types clean
- Independent light review: no remaining findings
- Web Acceptance: https://app.lobehub.com/acceptance/2b763ac5-384a-4bbe-9da9-a616e14887e1?r=1 (1/1 passed, screenshot + DOM snapshot)

#### 🔗 Related Issue

No linked issue.
