### PR TITLE
💄 style(task): mount the live Acceptance checklist in the task result panel

### DIFF
--- a/src/features/Acceptance/Run/RunResult.tsx
+++ b/src/features/Acceptance/Run/RunResult.tsx
@@ -1,6 +1,6 @@
 import { Flexbox, Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { Check, Info, RefreshCw, Shield, ShieldCheck, X } from 'lucide-react';
+import { Info, Shield, ShieldAlert, ShieldCheck, ShieldX } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -8,19 +8,6 @@ import { useVerifyResults, useVerifyState } from '../hooks';
 import { countResults, type DockPhase, phaseFromStatus } from '../utils';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  badge: css`
-    display: inline-flex;
-    flex: none;
-    gap: 5px;
-    align-items: center;
-
-    padding-block: 4px;
-    padding-inline: 10px;
-    border-radius: 999px;
-
-    font-size: 12px;
-    font-weight: 600;
-  `,
   body: css`
     padding-block: 12px;
     padding-inline: 16px;
@@ -54,11 +41,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     display: flex;
     gap: 14px;
     align-items: flex-start;
-    justify-content: space-between;
 
     padding-block: 14px;
     padding-inline: 16px;
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  status: css`
+    font-size: 13px;
+    font-weight: 600;
   `,
   sub: css`
     margin-block-start: 4px;
@@ -75,7 +65,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 interface BadgeMeta {
   color: 'default' | 'success' | 'error' | 'warning';
-  icon: typeof Check;
+  /** Shield family only: the glyph is the block's identity AND its verdict. */
+  icon: typeof Shield;
   key: 'pending' | 'failed' | 'errored' | 'repairing' | 'passed';
 }
 
@@ -87,11 +78,11 @@ const phaseToResult: Record<DockPhase, { badge: BadgeMeta; subKey: string } | nu
   errored: {
     // Warning, not error: the verifier couldn't run, so the delivery was never
     // judged — never render it as a failed check.
-    badge: { color: 'warning', icon: Info, key: 'errored' },
+    badge: { color: 'warning', icon: ShieldAlert, key: 'errored' },
     subKey: 'result.errored.sub',
   },
   failed: {
-    badge: { color: 'error', icon: X, key: 'failed' },
+    badge: { color: 'error', icon: ShieldX, key: 'failed' },
     subKey: 'result.failed.sub',
   },
   idle: {
@@ -99,11 +90,11 @@ const phaseToResult: Record<DockPhase, { badge: BadgeMeta; subKey: string } | nu
     subKey: 'result.pending.sub',
   },
   passed: {
-    badge: { color: 'success', icon: Check, key: 'passed' },
+    badge: { color: 'success', icon: ShieldCheck, key: 'passed' },
     subKey: 'result.passed.sub',
   },
   repairing: {
-    badge: { color: 'warning', icon: RefreshCw, key: 'repairing' },
+    badge: { color: 'warning', icon: ShieldAlert, key: 'repairing' },
     subKey: 'result.repairing.sub',
   },
   verifying: {
@@ -149,27 +140,28 @@ const RunResult = memo<RunResultProps>(({ operationId, round = 1, embedded }) =>
     warning: cssVar.colorWarningTextActive,
   } as const;
 
+  // The verdict lives IN the title: the shield changes form and colour with the
+  // phase and the status text sits right after the round number, so the reader
+  // never has to travel to the far edge of the card — a pill there read as a
+  // separate control and left the title looking neutral on a failed round.
   const header = (
     <div className={styles.head}>
       <Flexbox>
         <Flexbox horizontal align="center" gap={7}>
-          <Icon icon={ShieldCheck} size={16} />
+          <Icon
+            color={meta.badge.color === 'default' ? undefined : badgeColorMap[meta.badge.color]}
+            icon={meta.badge.icon}
+            size={16}
+          />
           <span className={styles.title}>{t('result.title', { round })}</span>
+          <span className={styles.status} style={{ color: badgeTextMap[meta.badge.color] }}>
+            {t(`badge.${meta.badge.key}` as any)}
+          </span>
         </Flexbox>
         <div className={styles.sub}>
           {t(meta.subKey as any, { passed: counts.passed, total: counts.total } as any)}
         </div>
       </Flexbox>
-      <span
-        className={styles.badge}
-        style={{
-          background: `color-mix(in srgb, ${badgeColorMap[meta.badge.color]} 12%, transparent)`,
-          color: badgeTextMap[meta.badge.color],
-        }}
-      >
-        <Icon icon={meta.badge.icon} size={14} />
-        {t(`badge.${meta.badge.key}` as any)}
-      </span>
     </div>
   );
 

--- a/src/features/AgentGoals/ProcessControl/goalGraphViewModel.test.ts
+++ b/src/features/AgentGoals/ProcessControl/goalGraphViewModel.test.ts
@@ -8,7 +8,7 @@ import type {
 } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
-import { buildGoalGraphView, isTroubledTaskNode } from './goalGraphViewModel';
+import { buildGoalGraphView, hasReviewableResult, isTroubledTaskNode } from './goalGraphViewModel';
 
 const T0 = new Date('2026-08-01T00:00:00Z');
 const at = (minutes: number) => new Date(T0.getTime() + minutes * 60_000);
@@ -565,5 +565,78 @@ describe('isTroubledTaskNode', () => {
     );
 
     expect(isTroubledTaskNode(view.byId.p1)).toBe(false);
+  });
+});
+
+describe('hasReviewableResult', () => {
+  // The graph drill-down routes on this: only a Task with a delivery to read
+  // opens the result surface; everything else opens the original Task detail.
+  it('keeps a healthy running task on the detail surface — its result panel would be empty', () => {
+    const view = buildGoalGraphView(
+      snapshot({
+        events: [event('w1', 'activated', 110)],
+        nodes: [node('w1', { status: 'active', taskId: 'task-1', updatedAt: at(115) })],
+      }),
+      NOW,
+    );
+
+    expect(view.byId.w1.isStale).toBe(false);
+    expect(hasReviewableResult(view.byId.w1)).toBe(false);
+  });
+
+  it('keeps an undispatched task on the detail surface', () => {
+    const view = buildGoalGraphView(
+      snapshot({ nodes: [node('w1', { status: 'proposed', taskId: 'task-1' })] }),
+      NOW,
+    );
+
+    expect(hasReviewableResult(view.byId.w1)).toBe(false);
+  });
+
+  it('opens the result surface once the task settled', () => {
+    const view = buildGoalGraphView(
+      snapshot({
+        events: [event('w1', 'activated', 100), event('w1', 'resolved', 110)],
+        nodes: [
+          node('w1', {
+            resolvedAt: at(110),
+            status: 'resolved',
+            taskId: 'task-1',
+            updatedAt: at(110),
+          }),
+        ],
+      }),
+      NOW,
+    );
+
+    expect(hasReviewableResult(view.byId.w1)).toBe(true);
+  });
+
+  it('opens the result surface while a delivery is being judged — the acceptance lives there', () => {
+    const view = buildGoalGraphView(
+      snapshot({
+        acceptances: { w1: { id: 'acc-1', status: 'verifying' } },
+        deliveredAt: { w1: at(30) },
+        events: [event('w1', 'activated', 30)],
+        nodes: [node('w1', { status: 'active', taskId: 'task-1', updatedAt: at(30) })],
+      }),
+      NOW,
+    );
+
+    expect(view.byId.w1.isVerifying).toBe(true);
+    expect(hasReviewableResult(view.byId.w1)).toBe(true);
+  });
+
+  it('never opens the result surface on a troubled task, even a stale delivered one', () => {
+    const view = buildGoalGraphView(
+      snapshot({
+        events: [event('w1', 'activated', 30)],
+        nodes: [node('w1', { status: 'active', taskId: 'task-1', updatedAt: at(0) })],
+      }),
+      NOW,
+    );
+
+    expect(view.byId.w1.isStale).toBe(true);
+    expect(hasReviewableResult(view.byId.w1)).toBe(false);
   });
 });

--- a/src/features/AgentGoals/ProcessControl/goalGraphViewModel.ts
+++ b/src/features/AgentGoals/ProcessControl/goalGraphViewModel.ts
@@ -118,6 +118,19 @@ export const isTroubledTaskNode = (view: GoalNodeView): boolean => {
   return view.attempts.at(-1)?.outcome === 'failed';
 };
 
+/**
+ * Whether a Task node has a delivery worth opening the result surface on: it
+ * settled successfully, or it delivered and its Acceptance is being judged.
+ * A Task that is still running (or was never dispatched) has no result yet —
+ * opening the result panel there shows an empty shell, so those open the
+ * original Task detail, where progress and configuration live.
+ */
+export const hasReviewableResult = (view: GoalNodeView): boolean => {
+  if (view.node.kind !== 'task') return false;
+  if (isTroubledTaskNode(view)) return false;
+  return view.node.status === 'resolved' || view.isVerifying;
+};
+
 export type FrontierItemKind = 'gate' | 'stale' | 'verifying' | 'running' | 'ready' | 'done';
 
 export interface FrontierItem {

--- a/src/features/AgentGoals/ProcessControl/index.tsx
+++ b/src/features/AgentGoals/ProcessControl/index.tsx
@@ -16,7 +16,7 @@ import Activity from './Activity';
 import Deliverables from './Deliverables';
 import Findings from './Findings';
 import Frontier, { type FrontierActions } from './Frontier';
-import { buildGoalGraphView, isTroubledTaskNode } from './goalGraphViewModel';
+import { buildGoalGraphView, hasReviewableResult } from './goalGraphViewModel';
 import Graph from './Graph';
 
 /**
@@ -70,12 +70,11 @@ const ProcessControl = memo<ProcessControlProps>(
     );
 
     // Every click funnels here: keep the map highlight (spatial continuity) and
-    // open the drill-down — a dispatched Task lands on its result-focused
-    // review surface. The original editable Task remains one explicit step
-    // deeper, so Goal inspection does not begin with implementation metadata.
-    //
-    // A lost or failed Task inverts that: it has no result worth reviewing, and
-    // the question is what the run did, so it opens the original Task directly.
+    // open the drill-down. Only a Task with a delivery to read — settled, or
+    // delivered and under Acceptance judgment — lands on its result-focused
+    // review surface; a Task still running, waiting, or in trouble opens the
+    // original Task detail, because its result panel would be an empty shell
+    // and the question is what the run is doing, not what it produced.
     const select = useCallback(
       (nodeId: string) => {
         setSelectedId(nodeId);
@@ -85,8 +84,8 @@ const ProcessControl = memo<ProcessControlProps>(
           openGoalNode(goalId, nodeId);
           return;
         }
-        if (view && isTroubledTaskNode(view)) openTaskDetail(taskId);
-        else openTaskResult(taskId);
+        if (view && hasReviewableResult(view)) openTaskResult(taskId);
+        else openTaskDetail(taskId);
       },
       [goalId, graph, openGoalNode, openTaskDetail, openTaskResult],
     );

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
@@ -65,11 +65,6 @@ vi.mock('@/components/NeuralNetworkLoading', () => ({ default: () => <div>loadin
 vi.mock('@/features/Acceptance', async () => ({
   // The real row/list primitives: the assertions cover the shared grammar.
   ...(await vi.importActual('@/features/Acceptance/CriterionList')),
-  AcceptanceCheckRow: ({ check, onToggle }: { check: { title: string }; onToggle: () => void }) => (
-    <button data-testid="acceptance-check-item" type="button" onClick={onToggle}>
-      item: {check.title}
-    </button>
-  ),
   CheckRow: ({ check }: { check: { title: string } }) => (
     <div data-testid="acceptance-check-detail">detail: {check.title}</div>
   ),
@@ -97,6 +92,39 @@ vi.mock('@/features/Acceptance', async () => ({
       mutate: mocks.mutateSubject,
     };
   },
+}));
+
+// The result panel mounts the real Acceptance atoms; the assertions only care
+// that the right atoms land in the right scope, not their internals.
+vi.mock('@/features/Acceptance/Viewer/AcceptanceScope', () => ({
+  AcceptanceBundleGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AcceptanceScope: ({
+    acceptanceId,
+    children,
+    embedded,
+  }: {
+    acceptanceId: string;
+    children: ReactNode;
+    embedded?: boolean;
+  }) => (
+    <div
+      data-acceptance-id={acceptanceId}
+      data-embedded={embedded ? '' : undefined}
+      data-testid="acceptance-scope"
+    >
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/features/Acceptance/Viewer/AcceptanceCheckInventory', () => ({
+  default: ({ toolbar }: { toolbar?: ReactNode }) => (
+    <div data-testid="acceptance-check-inventory">{toolbar}</div>
+  ),
+}));
+
+vi.mock('@/features/Acceptance/Viewer/AcceptanceDecision', () => ({
+  default: () => <div data-testid="acceptance-decision" />,
 }));
 
 vi.mock('@/services/verify', () => ({
@@ -237,7 +265,7 @@ describe('TaskAcceptance', () => {
     expect(mocks.openAcceptance).toHaveBeenCalledWith('acceptance-1');
   });
 
-  it('renders the canonical Acceptance check item in the task result panel', () => {
+  it('mounts the live Acceptance checklist and decision bar in the task result panel', () => {
     mocks.acceptanceSubject = { id: 'acceptance-1' };
     mocks.bundle = {
       acceptance: { id: 'acceptance-1', requirement: 'Everything is verifiable.' },
@@ -247,9 +275,35 @@ describe('TaskAcceptance', () => {
 
     render(<TaskAcceptance variant={'result'} />);
 
-    expect(screen.getByTestId('acceptance-check-item')).toHaveTextContent('item: Create task');
-    fireEvent.click(screen.getByTestId('acceptance-check-item'));
-    expect(mocks.openAcceptanceCheck).toHaveBeenCalledWith('acceptance-1', 'c1');
+    const scope = screen.getByTestId('acceptance-scope');
+    expect(scope).toHaveAttribute('data-acceptance-id', 'acceptance-1');
+    expect(scope).toHaveAttribute('data-embedded');
+    expect(screen.getByTestId('acceptance-check-inventory')).toBeInTheDocument();
+    expect(screen.getByTestId('acceptance-decision')).toBeInTheDocument();
+    // No collapsible 交付验收 section header — the inventory brings its own.
+    expect(screen.queryByText('taskDetail.acceptance.title')).not.toBeInTheDocument();
+  });
+
+  it('keeps the report link reachable from the inventory toolbar in the result panel', () => {
+    mocks.acceptanceSubject = { id: 'acceptance-1' };
+    mocks.bundle = {
+      acceptance: { id: 'acceptance-1', requirement: 'Everything is verifiable.' },
+      checks: [{ category: 'Setup', id: 'c1', seq: 1, title: 'Create task' }],
+      isOwner: true,
+    };
+
+    render(<TaskAcceptance variant={'result'} />);
+
+    fireEvent.click(screen.getByText('taskDetail.acceptance.openReport'));
+    expect(mocks.toggleTaskAgentPanel).toHaveBeenCalledWith(true);
+    expect(mocks.openAcceptance).toHaveBeenCalledWith('acceptance-1');
+  });
+
+  it('falls back to the configured criteria in the result panel before an acceptance exists', () => {
+    render(<TaskAcceptance variant={'result'} />);
+
+    expect(screen.getByTestId('task-acceptance-criteria')).toBeInTheDocument();
+    expect(screen.queryByTestId('acceptance-scope')).not.toBeInTheDocument();
   });
 
   it('groups a checklist with more than 10 checks', () => {

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx
@@ -17,7 +17,6 @@ import { useTranslation } from 'react-i18next';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import {
   type AcceptanceCheck,
-  AcceptanceCheckRow,
   checkDisplayTitle,
   checkHeadMeta,
   CriterionList,
@@ -27,6 +26,12 @@ import {
   useAcceptanceBundle,
   useAcceptanceBySubject,
 } from '@/features/Acceptance';
+import AcceptanceCheckInventory from '@/features/Acceptance/Viewer/AcceptanceCheckInventory';
+import AcceptanceDecision from '@/features/Acceptance/Viewer/AcceptanceDecision';
+import {
+  AcceptanceBundleGate,
+  AcceptanceScope,
+} from '@/features/Acceptance/Viewer/AcceptanceScope';
 import { usePermission } from '@/hooks/usePermission';
 import { verifyService } from '@/services/verify';
 import { useChatStore } from '@/store/chat';
@@ -60,8 +65,6 @@ const styles = createStaticStyles(({ css }) => ({
     padding-inline: 12px;
   `,
 }));
-
-const readOnlyReview = async () => false;
 
 interface AcceptanceErrorProps {
   onRetry: () => void;
@@ -109,10 +112,10 @@ CompactCheckRow.displayName = 'TaskAcceptanceCompactCheckRow';
 interface TaskAcceptanceProps {
   /**
    * `result` — the task result panel. The reader there has just read the
-   * delivery and wants one thing from this block: the checklist and how each
-   * check came out. The round timeline and the 验收目标 contract answer "how
-   * was this judged", which the full report keeps; leading with them buried
-   * the verdicts they came for.
+   * delivery and wants to judge it on the spot, so this mounts the real
+   * Acceptance checklist and decision bar (the same atoms the acceptance page
+   * assembles) instead of a compact preview that only links out. The round
+   * timeline and the 验收目标 contract stay behind the report link.
    */
   variant?: 'default' | 'result';
 }
@@ -208,35 +211,52 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
   // `acceptance.remove` only authorizes the acceptance creator (or a workspace
   // owner, cloud-side), not everyone who can edit the task — so the affordance
   // follows the bundle's isOwner rather than dead-ending in FORBIDDEN.
+  const reportButton = acceptanceSubject && (
+    <Flexbox horizontal align={'center'} gap={4}>
+      <Button
+        icon={<Icon icon={ExternalLink} />}
+        size={'small'}
+        type={'text'}
+        onClick={() => openReport(acceptanceSubject.id)}
+      >
+        {t('taskDetail.acceptance.openReport')}
+      </Button>
+      {canEditTask && bundle?.isOwner && (
+        <ActionIcon
+          icon={Trash}
+          size={'small'}
+          title={t('taskDetail.acceptance.remove')}
+          onClick={handleRemoveAcceptance}
+        />
+      )}
+    </Flexbox>
+  );
+
+  // The result panel mounts the live checklist itself — rows expand in place,
+  // reviews land here, and the decision bar closes the loop without a detour
+  // through the acceptance page. Its own 验收检查清单 header replaces the
+  // section header; the report link rides in the inventory toolbar.
+  if (variant === 'result' && acceptanceSubject && !subjectError) {
+    return (
+      <AcceptanceScope embedded acceptanceId={acceptanceSubject.id}>
+        <AcceptanceBundleGate height={160}>
+          <Flexbox gap={16}>
+            <AcceptanceCheckInventory toolbar={reportButton} />
+            <AcceptanceDecision />
+          </Flexbox>
+        </AcceptanceBundleGate>
+      </AcceptanceScope>
+    );
+  }
+
   const header = (
     <TaskAcceptanceHeader
       count={checks.length}
       // The section shows the rounds and the checklist; the report is the full
       // record behind them — reachable from the block it belongs to, instead
       // of only from the status row at the top of the page.
+      extra={reportButton}
       isOpen={sectionExpanded}
-      extra={
-        acceptanceSubject && (
-          <Flexbox horizontal align={'center'} gap={4}>
-            <Button
-              icon={<Icon icon={ExternalLink} />}
-              size={'small'}
-              type={'text'}
-              onClick={() => openReport(acceptanceSubject.id)}
-            >
-              {t('taskDetail.acceptance.openReport')}
-            </Button>
-            {canEditTask && bundle?.isOwner && (
-              <ActionIcon
-                icon={Trash}
-                size={'small'}
-                title={t('taskDetail.acceptance.remove')}
-                onClick={handleRemoveAcceptance}
-              />
-            )}
-          </Flexbox>
-        )
-      }
       onToggle={() => setSectionExpanded((expanded) => !expanded)}
     />
   );
@@ -261,8 +281,8 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
           {bundleError && <AcceptanceError onRetry={() => void mutateBundle()} />}
           {bundle && (
             <>
-              {variant !== 'result' && <GoalRoundTimeline rounds={bundle.rounds} />}
-              {variant !== 'result' && requirement && (
+              <GoalRoundTimeline rounds={bundle.rounds} />
+              {requirement && (
                 <Flexbox gap={6}>
                   <Text fontSize={12} type={'secondary'}>
                     {t('taskDetail.acceptance.goal')}
@@ -282,28 +302,26 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
                 </Flexbox>
               )}
               <Flexbox gap={7}>
-                {(variant !== 'result' || (grouped && groupKeys.length > 0)) && (
-                  <Flexbox horizontal align={'center'} gap={8}>
-                    <Text fontSize={12} type={'secondary'}>
-                      {t('taskDetail.acceptance.checklist')}
-                    </Text>
-                    <Flexbox flex={1} />
-                    {grouped && groupKeys.length > 0 && (
-                      <ActionIcon
-                        icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
-                        size={'small'}
-                        title={
-                          allGroupsCollapsed
-                            ? t('taskDetail.acceptance.expandAll')
-                            : t('taskDetail.acceptance.collapseAll')
-                        }
-                        onClick={() =>
-                          setCollapsedGroups(allGroupsCollapsed ? new Set() : new Set(groupKeys))
-                        }
-                      />
-                    )}
-                  </Flexbox>
-                )}
+                <Flexbox horizontal align={'center'} gap={8}>
+                  <Text fontSize={12} type={'secondary'}>
+                    {t('taskDetail.acceptance.checklist')}
+                  </Text>
+                  <Flexbox flex={1} />
+                  {grouped && groupKeys.length > 0 && (
+                    <ActionIcon
+                      icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
+                      size={'small'}
+                      title={
+                        allGroupsCollapsed
+                          ? t('taskDetail.acceptance.expandAll')
+                          : t('taskDetail.acceptance.collapseAll')
+                      }
+                      onClick={() =>
+                        setCollapsedGroups(allGroupsCollapsed ? new Set() : new Set(groupKeys))
+                      }
+                    />
+                  )}
+                </Flexbox>
                 <CriterionList>
                   {grouped
                     ? groups.map((group) => {
@@ -341,47 +359,23 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
                               />
                             </Flexbox>
                             {!collapsed &&
-                              group.checks.map((check) =>
-                                variant === 'result' ? (
-                                  <AcceptanceCheckRow
-                                    canReview={false}
-                                    check={check}
-                                    expanded={false}
-                                    key={check.id}
-                                    reviewPending={false}
-                                    onReview={readOnlyReview}
-                                    onToggle={() => openCheck(bundle.acceptance.id, check.id)}
-                                  />
-                                ) : (
-                                  <CompactCheckRow
-                                    check={check}
-                                    key={check.id}
-                                    onOpen={() => openCheck(bundle.acceptance.id, check.id)}
-                                  />
-                                ),
-                              )}
+                              group.checks.map((check) => (
+                                <CompactCheckRow
+                                  check={check}
+                                  key={check.id}
+                                  onOpen={() => openCheck(bundle.acceptance.id, check.id)}
+                                />
+                              ))}
                           </Flexbox>
                         );
                       })
-                    : checks.map((check) =>
-                        variant === 'result' ? (
-                          <AcceptanceCheckRow
-                            canReview={false}
-                            check={check}
-                            expanded={false}
-                            key={check.id}
-                            reviewPending={false}
-                            onReview={readOnlyReview}
-                            onToggle={() => openCheck(bundle.acceptance.id, check.id)}
-                          />
-                        ) : (
-                          <CompactCheckRow
-                            check={check}
-                            key={check.id}
-                            onOpen={() => openCheck(bundle.acceptance.id, check.id)}
-                          />
-                        ),
-                      )}
+                    : checks.map((check) => (
+                        <CompactCheckRow
+                          check={check}
+                          key={check.id}
+                          onOpen={() => openCheck(bundle.acceptance.id, check.id)}
+                        />
+                      ))}
                 </CriterionList>
               </Flexbox>
             </>


### PR DESCRIPTION
#### Brief

The task result panel used to render the delivery acceptance as a compact, read-only preview: collapsed check rows that only linked out to the acceptance page, with the checklist header, filters, and decision actions all missing. Reviewing a delivery from the result panel always required a detour.

This PR mounts the real Acceptance atoms inline instead (`AcceptanceScope` + `AcceptanceCheckInventory` + `AcceptanceDecision` — the same components the acceptance page assembles), so the result panel becomes a first-class review surface:

- Full 验收检查清单 header with count badge, state filter (待验收/待修复/已验收/已忽略), round filter, and grouping controls.
- Checks expand in place with their evidence (screenshots render inline) and verifier reasoning; per-row accept / ignore / reject lands directly from the panel.
- The sticky decision bar (progress ring, 评论并打回 / 接受交付) closes the loop without leaving the panel.
- The 验收报告 link and the remove-acceptance action move into the inventory toolbar slot.
- Before the first acceptance round exists, the panel still falls back to the configured-criteria view (`TaskVerifyConfig`).

The `variant='result'` compact rendering path (`AcceptanceCheckRow` in read-only mode) is deleted; the default task-detail variant is unchanged.

| Before | After |
| ------ | ----- |
| Compact read-only rows, click-through only | Live inline checklist with filters, in-place review, and decision bar |

#### Test

Verified end-to-end on a local full stack with a 2-round / 6-check mixed-state fixture acceptance (pass / fail-then-repaired / blocked, with screenshot evidence). Visual evidence and per-check verdicts: https://app.lobehub.com/acceptance/65585a14-d6f5-4483-a903-0a33cf6d344e

- In-place accept confirmed against the database (`verify_check_results.user_decision = accepted`) with the decision bar updating to 1/6.
- Report link opens the full acceptance page in the same panel; a task with no acceptance falls back to the config view.
- Note: the raw `goalDetail.taskResult` / `goalDetail.viewOriginalTask` keys visible in the panel header screenshots are a pre-existing canary defect (missing locale keys, also flagged by type-check) unrelated to this change.

- [x] Tested locally
- [x] Added/updated tests

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)