### PR TITLE
🐛 fix(hetero-agent): add Astra selection and refresh Claude alias labels

### DIFF
--- a/packages/types/src/agent/heteroSelectorCapabilities.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.ts
@@ -78,7 +78,7 @@ const CODEX_MAX_REASONING_EFFORT_LEVELS = [
 ] as const satisfies readonly CodexReasoningEffort[];
 
 const CODEX_ULTRA_REASONING_MODELS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra'] as const;
-const CODEX_MAX_REASONING_MODELS = ['gpt-5.6-luna'] as const;
+const CODEX_MAX_REASONING_MODELS = ['gpt-6-astra', 'gpt-5.6-luna'] as const;
 
 /**
  * Qoder reasoning-effort levels, mirrored 1:1 with the CLI's

--- a/src/features/ChatInput/ControlBar/HeteroModel/modelOptions.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/modelOptions.ts
@@ -4,13 +4,15 @@ export interface StaticModelOption {
 }
 
 const CLAUDE_CODE_MODEL_OPTIONS: StaticModelOption[] = [
-  { label: 'Fable 5', value: 'fable' },
-  { label: 'Opus 4.8', value: 'opus' },
-  { label: 'Sonnet 4.6', value: 'sonnet' },
-  { label: 'Haiku 4.5', value: 'haiku' },
+  // Aliases resolve by CLI version and provider, so do not promise a fixed version.
+  { label: 'Fable', value: 'fable' },
+  { label: 'Opus', value: 'opus' },
+  { label: 'Sonnet', value: 'sonnet' },
+  { label: 'Haiku', value: 'haiku' },
 ];
 
 const CODEX_MODEL_OPTIONS: StaticModelOption[] = [
+  { label: 'GPT-6 Astra', value: 'gpt-6-astra' },
   { label: 'GPT-5.6 Sol', value: 'gpt-5.6-sol' },
   { label: 'GPT-5.6 Terra', value: 'gpt-5.6-terra' },
   { label: 'GPT-5.6 Luna', value: 'gpt-5.6-luna' },

--- a/src/features/ChatInput/ControlBar/HeteroModel/selectorView.test.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/selectorView.test.ts
@@ -62,6 +62,35 @@ describe('resolveSelectorShape', () => {
 });
 
 describe('dimensions per provider', () => {
+  it('offers Astra before older Codex models with five reasoning levels through max', () => {
+    const options = viewOf({ type: 'codex' }).dimensions[0].options;
+    expect(options[1]).toEqual({ label: 'GPT-6 Astra', value: 'gpt-6-astra' });
+
+    const view = viewOf({ effort: 'max', model: 'gpt-6-astra', type: 'codex' });
+    expect(view.dimensions[1].options.map((option) => option.value)).toEqual([
+      'default',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+    ]);
+    expect(view.triggerLabel).toEqual({
+      secondaryText: 'heteroAgent.modelSelector.reasoning.max',
+      text: 'GPT-6 Astra',
+    });
+  });
+
+  it('labels Claude aliases without claiming a fixed model version', () => {
+    const options = viewOf({ type: 'claude-code' }).dimensions[0].options;
+    expect(options.slice(1)).toEqual([
+      { label: 'Fable', value: 'fable' },
+      { label: 'Opus', value: 'opus' },
+      { label: 'Sonnet', value: 'sonnet' },
+      { label: 'Haiku', value: 'haiku' },
+    ]);
+  });
+
   it('offers Amp mode without inventing a model dimension', () => {
     const dimensions = viewOf({ type: 'amp' }).dimensions;
 
@@ -144,14 +173,14 @@ describe('current value surfaced on each dimension', () => {
   it('shows the resolved model and effort labels', () => {
     const view = viewOf({ effort: 'high', model: 'opus', type: 'claude-code' });
 
-    expect(view.dimensions[0].valueLabel).toBe('Opus 4.8');
+    expect(view.dimensions[0].valueLabel).toBe('Opus');
     expect(view.dimensions[1].valueLabel).toBe('heteroAgent.modelSelector.reasoning.high');
   });
 
   it('prefers a contradicting arg over the persisted field, matching spawn behaviour', () => {
     const view = viewOf({ args: ['--model', 'haiku'], model: 'opus', type: 'claude-code' });
 
-    expect(view.dimensions[0].valueLabel).toBe('Haiku 4.5');
+    expect(view.dimensions[0].valueLabel).toBe('Haiku');
   });
 
   it('renames codex low effort to Light', () => {
@@ -186,7 +215,7 @@ describe('current value surfaced on each dimension', () => {
   it('names both halves in the trigger once either is overridden', () => {
     expect(viewOf({ model: 'opus', type: 'claude-code' }).triggerLabel).toEqual({
       secondaryText: 'heteroAgent.modelSelector.defaultReasoning',
-      text: 'Opus 4.8',
+      text: 'Opus',
     });
   });
 
@@ -199,6 +228,19 @@ describe('current value surfaced on each dimension', () => {
 });
 
 describe('resolveModelSwitchSelection', () => {
+  it.each(['max', 'ultra'] as const)('handles %s when switching to Astra', (effort) => {
+    expect(
+      resolveModelSwitchSelection({
+        capability: capabilityOf('codex'),
+        effort,
+        isFastSpeed: false,
+        value: 'gpt-6-astra',
+      }),
+    ).toEqual(
+      effort === 'max' ? { model: 'gpt-6-astra' } : { effort: 'default', model: 'gpt-6-astra' },
+    );
+  });
+
   it('resets a fast speed the newly picked codex model cannot serve', () => {
     expect(
       resolveModelSwitchSelection({


### PR DESCRIPTION
Add GPT-6 Astra to the heterogeneous Codex selector and stop displaying fixed versions for Claude Code aliases.

- Add `gpt-6-astra` before the older Codex models, without changing the default selection.
- Expose Astra reasoning levels `low`, `medium`, `high`, `xhigh`, and `max`. Switching to Astra preserves `max` and resets unsupported `ultra` to default.
- Display `Fable`, `Opus`, `Sonnet`, and `Haiku` while preserving their CLI alias values. Their resolved versions depend on the CLI version and provider.
- Leave Fast support, CLI encoding, and runtime adapters unchanged.

#### Test

- [x] Tested locally (automated checks only)
- [x] Added/updated tests
- [ ] No tests needed

`bun run check`: lint clean, 56 tests passed. Regression coverage includes the Astra menu entry, exact effort options, selected label, model-switch effort handling, and versionless Claude alias labels.

`bun run check --type` was also run but failed on unrelated errors in unchanged files: missing `Skeleton` exports from `@lobehub/ui/base-ui` and invalid i18n keys. No changed-file errors were reported.

Visual verification was attempted with the local dev server, but the test-account sign-in returned HTTP 401. No screenshots or live CLI/model compatibility results are claimed.

Oracle performed a read-only review of the diff and selector/config/spawn consumers and found no blockers.

#### 🔗 Related Issue

No matching issue found for this narrow selector update. Follow-up to the model support in #19163 and #19027; does not duplicate their runtime or model-bank changes.