### PR TITLE
feat: add Mizumi provider

### DIFF
--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -41,6 +41,7 @@ export enum ModelProvider {
   Minimax = 'minimax',
   MinimaxCodingPlan = 'minimaxcodingplan',
   Mistral = 'mistral',
+  Mizumi = 'mizumi',
   ModelScope = 'modelscope',
   Moonshot = 'moonshot',
   Nebius = 'nebius',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -43,6 +43,7 @@ import MetaProvider from './meta';
 import MinimaxProvider from './minimax';
 import MinimaxCodingPlanProvider from './minimaxCodingPlan';
 import MistralProvider from './mistral';
+import MizumiProvider from './mizumi';
 import ModelScopeProvider from './modelscope';
 import MoonshotProvider from './moonshot';
 import NebiusProvider from './nebius';
@@ -101,6 +102,7 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   GithubProvider.chatModels,
   MinimaxProvider.chatModels,
   MistralProvider.chatModels,
+  MizumiProvider.chatModels,
   ModelScopeProvider.chatModels,
   MoonshotProvider.chatModels,
   OllamaProvider.chatModels,
@@ -165,6 +167,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   ZhiPuProvider,
   MinimaxProvider,
   MistralProvider,
+  MizumiProvider,
   XiaomiMiMoProvider,
   AiHubMixProvider,
   OpenRouterProvider,

--- a/packages/model-bank/src/modelProviders/mizumi.ts
+++ b/packages/model-bank/src/modelProviders/mizumi.ts
@@ -1,0 +1,25 @@
+import type { ModelProviderCard } from '../types';
+
+// ref: https://mizumi.co/docs
+const Mizumi: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'gpt-4.1-mini',
+  description:
+    'Mizumi is an OpenAI-compatible LLM API gateway offering frontier models at 15–28% below official list pricing with spend-based tiers, zero prompt retention, and a $2 free trial credit.',
+  disableBrowserRequest: true,
+  id: 'mizumi',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://mizumi.co/docs',
+  name: 'Mizumi',
+  settings: {
+    disableBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'https://api.mizumi.co/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://mizumi.co',
+};
+
+export default Mizumi;

--- a/packages/model-runtime/src/providers/mizumi/index.ts
+++ b/packages/model-runtime/src/providers/mizumi/index.ts
@@ -1,0 +1,11 @@
+import { ModelProvider } from 'model-bank';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const LobeMizumi = createOpenAICompatibleRuntime({
+  baseURL: 'https://api.mizumi.co/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_MIZUMI_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.Mizumi,
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -40,6 +40,7 @@ import { LobeMetaAI } from './providers/meta';
 import { LobeMinimaxAI } from './providers/minimax';
 import { LobeMinimaxCodingPlanAI } from './providers/minimaxCodingPlan';
 import { LobeMistralAI } from './providers/mistral';
+import { LobeMizumi } from './providers/mizumi';
 import { LobeModelScopeAI } from './providers/modelscope';
 import { LobeMoonshotAI } from './providers/moonshot';
 import { LobeNebiusAI } from './providers/nebius';
@@ -126,6 +127,7 @@ export const providerRuntimeMap = {
   minimax: LobeMinimaxAI,
   minimaxcodingplan: LobeMinimaxCodingPlanAI,
   mistral: LobeMistralAI,
+  mizumi: LobeMizumi,
   modelscope: LobeModelScopeAI,
   moonshot: LobeMoonshotAI,
   nebius: LobeNebiusAI,


### PR DESCRIPTION
## What

Adds **Mizumi** as a built-in model provider (OpenAI-compatible, same pattern as Novita/SambaNova).

Mizumi (https://mizumi.co) is an OpenAI-compatible LLM API gateway:

- Base URL: `https://api.mizumi.co/v1`, auth via `Authorization: Bearer sk-mizumi-...`
- Models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-4.1-mini`
- Streaming supported
- 15–28% below official list pricing (spend-based tiers), zero prompt retention, $2 free trial credit
- Docs: https://mizumi.co/docs

## Changes (5 files)

- `packages/model-bank/src/const/modelProvider.ts` — `Mizumi = 'mizumi'`
- `packages/model-bank/src/modelProviders/mizumi.ts` (new) — provider card: `sdkType: 'openai'`, `showModelFetcher: true` (models are pulled live from Mizumi's `/v1/models`, so no static `chatModels` needed), `disableBrowserRequest` to route via server
- `packages/model-bank/src/modelProviders/index.ts` — import + register in `DEFAULT_MODEL_PROVIDER_LIST` and the deprecated default list (matching novita)
- `packages/model-runtime/src/providers/mizumi/index.ts` (new) — minimal `createOpenAICompatibleRuntime` (mirrors `sambanova`)
- `packages/model-runtime/src/runtimeMap.ts` — `mizumi: LobeMizumi`

## Verification

- New files syntax-checked with `tsc` (isolated); the code mirrors existing providers verbatim in structure.
- Not run: full monorepo `pnpm install` / vitest — the monorepo install exceeded what my environment could complete; happy to address any CI findings.

Contact: laurence.fok@synercoint.com
