### PR TITLE
🐛 fix(chat): stop the doc-page chat panel from suspending forever

### DIFF
--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -1,13 +1,25 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import { SWRConfig } from 'swr';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { __resetFloatingChatPanelRegistry } from './guard';
 import FloatingChatPanel from './index';
 
-vi.mock('./ChatBody', () => ({
-  default: () => <div data-testid="chat-body">body</div>,
-}));
+vi.mock('./ChatBody', async () => {
+  const { useSWRConfig } = await import('swr');
+  // Probe the effective SWR config so the suspense opt-out is testable: the
+  // panel must shield its conversation subtree from suspense-mode hosts.
+  const ChatBodyProbe = () => {
+    const { suspense } = useSWRConfig();
+    return (
+      <div data-swr-suspense={String(suspense ?? false)} data-testid="chat-body">
+        body
+      </div>
+    );
+  };
+  return { default: ChatBodyProbe };
+});
 
 const sheetHandlers = vi.hoisted(() => ({
   current: {
@@ -310,6 +322,21 @@ describe('FloatingChatPanel', () => {
     expect(panel).toContainElement(getByTestId('chat-input'));
     expect(queryByTestId('floating-panel-shell')).toBeNull();
     expect(queryByTestId('floating-chat-panel-collapse-button')).toBeNull();
+  });
+
+  it('opts its subtree out of a suspense-mode SWRConfig host', () => {
+    // The agent-doc layout wraps its whole outlet in SWRConfig{suspense:true}.
+    // The panel's loading model is messagesInit gating, not suspense — without
+    // the opt-out any conversation hook whose fetcher resolves undefined
+    // (e.g. a missing model reasoning config) strands the panel on the host's
+    // Suspense fallback forever.
+    const { getByTestId } = render(
+      <SWRConfig value={{ suspense: true }}>
+        <FloatingChatPanel agentId="agent-1" mode="embedded" topicId="topic-1" />
+      </SWRConfig>,
+    );
+
+    expect(getByTestId('chat-body').dataset.swrSuspense).toBe('false');
   });
 
   it('binds the embedded toolbar topic selection to the conversation context', () => {

--- a/src/features/FloatingChatPanel/index.tsx
+++ b/src/features/FloatingChatPanel/index.tsx
@@ -7,6 +7,7 @@ import { ChevronDown } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { SWRConfig } from 'swr';
 
 import {
   type ActionsBarConfig,
@@ -130,7 +131,7 @@ export interface FloatingChatPanelProps {
  *
  * Single instance per page (see `./guard.ts`).
  */
-const FloatingChatPanel = memo<FloatingChatPanelProps>(
+const FloatingChatPanelInner = memo<FloatingChatPanelProps>(
   ({
     agentId,
     topicId,
@@ -304,6 +305,22 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
     );
   },
 );
+
+FloatingChatPanelInner.displayName = 'FloatingChatPanelInner';
+
+/**
+ * The panel's loading model is `messagesInit` gating inside ChatList — it was
+ * never designed for SWR suspense mode. Hosts that render under a
+ * `SWRConfig {suspense: true}` layout (e.g. the agent-doc page) would otherwise
+ * suspend the whole panel on any conversation-adjacent hook, and a fetcher that
+ * legitimately resolves `undefined` (SWR suspense never settles on undefined
+ * data) turns that into a permanent skeleton with an infinite refetch loop.
+ */
+const FloatingChatPanel = memo<FloatingChatPanelProps>((props) => (
+  <SWRConfig value={{ suspense: false }}>
+    <FloatingChatPanelInner {...props} />
+  </SWRConfig>
+));
 
 FloatingChatPanel.displayName = 'FloatingChatPanel';
 

--- a/src/store/aiInfra/slices/aiModel/action.test.ts
+++ b/src/store/aiInfra/slices/aiModel/action.test.ts
@@ -1050,4 +1050,25 @@ describe('AiModelAction', () => {
       });
     });
   });
+
+  describe('useFetchAiModelReasoningConfig', () => {
+    it('resolves a missing config as null so SWR data is never undefined', async () => {
+      // The server legitimately returns nothing when the user never customized
+      // this model's reasoning params. SWR suspense mode can only settle on
+      // defined data, so the fetcher must normalize that to null.
+      vi.spyOn(aiModelService, 'getAiModelReasoningConfig').mockResolvedValue(undefined);
+
+      const { result } = renderHook(
+        () => useStore.getState().useFetchAiModelReasoningConfig('test-model', 'test-provider'),
+        { wrapper: withSWR },
+      );
+
+      await waitFor(() => expect(result.current.data).toBeNull());
+      expect(aiModelService.getAiModelReasoningConfig).toHaveBeenCalledTimes(1);
+      // The store map keeps its `| undefined` contract — null never leaks in.
+      expect(
+        useStore.getState().modelReasoningConfigMap['test-provider/test-model'],
+      ).toBeUndefined();
+    });
+  });
 });

--- a/src/store/aiInfra/slices/aiModel/action.ts
+++ b/src/store/aiInfra/slices/aiModel/action.ts
@@ -289,21 +289,28 @@ export class AiModelActionImpl {
   useFetchAiModelReasoningConfig = (
     id: string | undefined,
     provider: string | undefined,
-  ): SWRResponse<AiModelReasoningConfig | undefined> => {
-    return useClientDataSWR<AiModelReasoningConfig | undefined>(
+  ): SWRResponse<AiModelReasoningConfig | null> => {
+    return useClientDataSWR<AiModelReasoningConfig | null>(
       id && provider ? aiModelKeys.reasoningConfig(provider, id) : null,
-      ([, provider, id]) =>
-        aiModelService.getAiModelReasoningConfig(id as string, provider as string),
+      // A model without a personalized config legitimately resolves to nothing.
+      // That MUST land as `null`, not `undefined`: SWR suspense mode treats
+      // undefined data as "not loaded yet" and refetches forever, so a
+      // suspense-wrapped host (e.g. the agent-doc layout) would hang on its
+      // Suspense fallback while hammering this endpoint.
+      async ([, provider, id]) =>
+        (await aiModelService.getAiModelReasoningConfig(id as string, provider as string)) ?? null,
       {
         onSuccess: (data) => {
           const key = modelReasoningConfigKey(provider!, id!);
           // Don't clobber an in-flight optimistic value with a stale response
           if (this.#get().modelReasoningConfigUpdatingKeys.includes(key)) return;
-          if (isEqual(data, this.#get().modelReasoningConfigMap[key])) return;
+          // The store map keeps its `| undefined` shape — only SWR needs null.
+          const value = data ?? undefined;
+          if (isEqual(value, this.#get().modelReasoningConfigMap[key])) return;
 
           this.#set(
             (state) => ({
-              modelReasoningConfigMap: { ...state.modelReasoningConfigMap, [key]: data },
+              modelReasoningConfigMap: { ...state.modelReasoningConfigMap, [key]: value },
             }),
             false,
             `useFetchAiModelReasoningConfig/${key}`,


### PR DESCRIPTION
## Problem

Opening `/agent/:aid/docs/:docId` leaves the right-hand chat panel on a permanent skeleton (the `RightPanel` Suspense fallback), while `aiModel.getAiModelReasoningConfig` is refetched in an infinite loop (20k+ requests observed in one session).

## Root cause

`9c81af8ad2` wrapped the agent-doc layout in `SWRConfig {suspense: true}`, which also covers the chat panel. Inside the panel, `ChatInputProvider → ReasoningConfigLoader → useFetchAiModelReasoningConfig` fires whenever the agent's model advertises reasoning extend params. When the user never customized that model's reasoning params, the server legitimately returns `undefined` — and SWR suspense mode treats `undefined` data as "not loaded yet": it throws again, refetches, and never settles. The panel stays on the Suspense fallback forever.

Verified end to end against a local full-stack env: the doc page reproduced the hang on pristine canary; manually feeding a value into the `aiModel:reasoningConfig` SWR key un-suspended the panel instantly.

## Fix (both layers)

- **`FloatingChatPanel`** wraps its subtree in `SWRConfig {suspense: false}` — the panel's loading model is `messagesInit` gating inside `ChatList`; it was never designed for suspense, and no host layout should be able to strand it.
- **`useFetchAiModelReasoningConfig`** normalizes a missing config to `null` so its SWR data contract is suspense-safe wherever it is mounted (the store map keeps its `| undefined` shape).

## Tests

- `FloatingChatPanel` regression test: rendering under a suspense-mode `SWRConfig` host asserts the subtree sees `suspense: false` (fails before the fix).
- `useFetchAiModelReasoningConfig` regression test: a missing config resolves as `null`, never `undefined`, with a single settled request (fails before the fix).
- Live-verified: the previously hanging doc page now renders the panel (welcome + toolbar + composer) on the same data.

Note: other layouts that got `suspense: true` in `9c81af8ad2` share the same hazard with any fetcher that can resolve `undefined`; this PR fixes the user-facing hang and the one offending fetcher, a broader sweep can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)