### PR TITLE
✨ feat(chat): inject the agent's name and title into the system context

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -656,6 +656,9 @@ export const buildServerCallLlmContext = async ({
   const contextEngineInput = {
     additionalContexts: llmPayload.additionalContexts,
     agentDocuments,
+    // Identity lives on the agent row, not in the prompt text — inject it so
+    // the model introduces itself by the user-given name.
+    agentIdentity: { name: agentConfig.name ?? undefined, title: agentConfig.title ?? undefined },
     ...(agentBuilderContext && { agentBuilderContext }),
     agentGroup: state.metadata?.agentGroup as AgentGroupConfig | undefined,
     agentManagementContext: (state as any).initialContext?.initialContext?.mentionedAgents?.length

--- a/apps/server/src/modules/Mecha/ContextEngineering/index.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/index.ts
@@ -122,6 +122,7 @@ export const serverMessagesEngine = async ({
   modelKnowledgeCutoff,
   provider,
   systemRole,
+  agentIdentity,
   inputTemplate,
   enableAgentMode,
   enableExpertise,
@@ -203,6 +204,7 @@ export const serverMessagesEngine = async ({
     provider,
     planTodo,
     systemRole,
+    agentIdentity,
 
     // Timezone for system date provider
     timezone: userTimezone,

--- a/apps/server/src/modules/Mecha/ContextEngineering/types.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/types.ts
@@ -18,7 +18,7 @@ import type {
   TopicReferenceItem,
   UserMemoryData,
 } from '@lobechat/context-engine';
-import type { PageContentContext } from '@lobechat/prompts';
+import type { AgentIdentityContext, PageContentContext } from '@lobechat/prompts';
 import type {
   ExpertiseContextSnapshot,
   RuntimeAdditionalContextFragment,
@@ -163,6 +163,9 @@ export interface ServerMessagesEngineParams {
 
   /** System role */
   systemRole?: string;
+
+  /** The agent's identity (personal name + role title) for self-introduction */
+  agentIdentity?: AgentIdentityContext;
 
   // ========== Skills ==========
   /** Skills configuration for <available_skills> injection */

--- a/apps/server/src/services/aiAgent/pipeline/resolveRunAgentConfig.ts
+++ b/apps/server/src/services/aiAgent/pipeline/resolveRunAgentConfig.ts
@@ -280,6 +280,10 @@ export const resolveRunAgentConfig = async (
     }
 
     const runtimeConfig = getAgentRuntimeConfig(agentSlug, {
+      // The renameable default assistant must introduce itself by the name the
+      // user gave it, not the hardcoded product default.
+      agentName: agentConfig.name ?? undefined,
+      agentTitle: agentConfig.title ?? undefined,
       model: agentConfig.model,
       plugins: activePluginIds,
       userLocale,

--- a/packages/builtin-agents/src/agents/inbox/index.ts
+++ b/packages/builtin-agents/src/agents/inbox/index.ts
@@ -14,7 +14,7 @@ export const INBOX: BuiltinAgentDefinition = {
   avatar: '/avatars/lobe-ai.png',
   runtime: (ctx) => ({
     plugins: [AgentDocumentsIdentifier, UserInteractionIdentifier, ...(ctx.plugins || [])],
-    systemRole: createSystemRole(ctx.userLocale),
+    systemRole: createSystemRole(ctx.userLocale, { name: ctx.agentName, title: ctx.agentTitle }),
   }),
 
   slug: BUILTIN_AGENT_SLUGS.inbox,

--- a/packages/builtin-agents/src/agents/inbox/systemRole.test.ts
+++ b/packages/builtin-agents/src/agents/inbox/systemRole.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSystemRole } from './systemRole';
+
+describe('inbox createSystemRole', () => {
+  it('defaults to Lobe when the assistant has no custom name', () => {
+    expect(createSystemRole()).toContain('You are Lobe, an AI Agent');
+  });
+
+  it('introduces the user-given name instead of the product default', () => {
+    const result = createSystemRole(undefined, { name: '芙莉莲' });
+
+    expect(result).toContain('You are 芙莉莲, an AI Agent');
+    expect(result).not.toContain('You are Lobe');
+  });
+
+  it('carries the role title alongside the name', () => {
+    expect(createSystemRole(undefined, { name: '芙莉莲', title: '魔法使' })).toContain(
+      'You are 芙莉莲 (魔法使), an AI Agent',
+    );
+  });
+
+  it('uses the title as identity when there is no name', () => {
+    expect(createSystemRole(undefined, { title: 'Health Assistant' })).toContain(
+      'You are Lobe (Health Assistant), an AI Agent',
+    );
+  });
+
+  it('treats blank identity values as absent', () => {
+    expect(createSystemRole(undefined, { name: '  ', title: '' })).toContain(
+      'You are Lobe, an AI Agent',
+    );
+  });
+
+  it('keeps the preferred-language suffix', () => {
+    expect(createSystemRole('zh-CN', { name: '芙莉莲' })).toContain(
+      'Preferred reply language: zh-CN',
+    );
+  });
+});

--- a/packages/builtin-agents/src/agents/inbox/systemRole.ts
+++ b/packages/builtin-agents/src/agents/inbox/systemRole.ts
@@ -3,7 +3,26 @@
  *
  * This is the default assistant agent for general conversations.
  */
-const systemRoleTemplate = `You are Lobe, an AI Agent will help users.
+
+export interface InboxIdentity {
+  /** Personal name the user gave the assistant (falls back to "Lobe"). */
+  name?: string;
+  /** Role title shown alongside the name. */
+  title?: string;
+}
+
+/**
+ * The default assistant is renameable — when the user gives it a name (and
+ * optionally a role title), the prompt must introduce that identity instead of
+ * the hardcoded "Lobe", or the assistant answers "who are you?" with the
+ * product default no matter what it is called.
+ */
+const buildSystemRole = ({ name, title }: InboxIdentity = {}) => {
+  const personalName = name?.trim() || 'Lobe';
+  const role = title?.trim();
+  const identity = role ? `${personalName} (${role})` : personalName;
+
+  return `You are ${identity}, an AI Agent will help users.
 
 Today's date: {{date}}
 
@@ -14,10 +33,11 @@ Your role is to:
 - Be friendly and professional in your responses
 
 Respond in the same language the user is using.`;
+};
 
-export const createSystemRole = (userLocale?: string) =>
+export const createSystemRole = (userLocale?: string, identity?: InboxIdentity) =>
   [
-    systemRoleTemplate,
+    buildSystemRole(identity),
     userLocale
       ? `Preferred reply language: ${userLocale}. Use this language unless the user explicitly asks to switch.`
       : '',

--- a/packages/builtin-agents/src/types.ts
+++ b/packages/builtin-agents/src/types.ts
@@ -57,6 +57,16 @@ export interface BuiltinAgentRuntimeResult {
  * Runtime Context - context passed to runtime function
  */
 export interface RuntimeContext {
+  /**
+   * The agent's personal name as the user sees it (e.g. a renamed default
+   * assistant). Builtin system roles should introduce themselves by this name
+   * instead of the hardcoded product default.
+   */
+  agentName?: string;
+
+  /** The agent's role title ("Health Assistant"), shown alongside the name. */
+  agentTitle?: string;
+
   /** Document content for PageAgent */
   documentContent?: string;
 

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -34,6 +34,7 @@ import {
   AgentDocumentMessageInjector,
   AgentDocumentSystemAppendInjector,
   AgentDocumentSystemReplaceInjector,
+  AgentIdentityInjector,
   AgentManagementContextInjector,
   BotPlatformContextInjector,
   ContextSelectionsInjector,
@@ -150,6 +151,7 @@ export class MessagesEngine {
       modelKnowledgeCutoff,
       provider,
       systemRole,
+      agentIdentity,
       inputTemplate,
       enableAgentMode,
       enableHistoryCount,
@@ -277,6 +279,13 @@ export class MessagesEngine {
       new AgentDocumentBeforeSystemInjector(agentDocConfig),
       // Agent's system role (creates the initial system message)
       new SystemRoleInjector({ systemRole }),
+      // Agent identity (name/title) — lets the model answer "who are you?"
+      // with the user-given name. Group chat establishes identity through
+      // GroupContextInjector instead, so it is suppressed there.
+      new AgentIdentityInjector({
+        enabled: !isGroupContextEnabled,
+        identity: agentIdentity,
+      }),
       // Eval context (appends envPrompt)
       new EvalContextSystemInjector({ enabled: !!evalContext?.envPrompt, evalContext }),
       // Bot platform context (formatting instructions for non-Markdown platforms)

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -72,6 +72,46 @@ describe('MessagesEngine', () => {
   });
 
   describe('process', () => {
+    describe('agent identity', () => {
+      it('appends the agent identity after the system role', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({
+            agentIdentity: { name: '芙莉莲', title: '魔法使' },
+            systemRole: 'You are a helpful assistant.',
+          }),
+        ).process();
+
+        const system = result.messages[0];
+        expect(system.role).toBe('system');
+        expect(system.content).toContain('You are a helpful assistant.');
+        expect(system.content).toContain('<name>芙莉莲</name>');
+        expect(system.content).toContain('<title>魔法使</title>');
+      });
+
+      it('injects identity even without a system role', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({ agentIdentity: { name: '芙莉莲' } }),
+        ).process();
+
+        const system = result.messages[0];
+        expect(system.role).toBe('system');
+        expect(system.content).toContain('<name>芙莉莲</name>');
+      });
+
+      it('suppresses identity in group chat — GroupContextInjector owns it there', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({
+            agentGroup: { currentAgentId: 'agent-1' },
+            agentIdentity: { name: '芙莉莲' },
+            systemRole: 'You are a helpful assistant.',
+          }),
+        ).process();
+
+        const system = result.messages.find((m) => m.role === 'system');
+        expect(system?.content).not.toContain('<agent_identity>');
+      });
+    });
+
     describe('TODO context priority', () => {
       const messageTodos = {
         items: [{ status: 'processing' as const, text: 'Message task' }],

--- a/packages/context-engine/src/engine/messages/types.ts
+++ b/packages/context-engine/src/engine/messages/types.ts
@@ -1,5 +1,10 @@
 /* eslint-disable perfectionist/sort-interfaces */
-import type { FileContent, KnowledgeBaseInfo, PageContentContext } from '@lobechat/prompts';
+import type {
+  AgentIdentityContext,
+  FileContent,
+  KnowledgeBaseInfo,
+  PageContentContext,
+} from '@lobechat/prompts';
 import type {
   ExpertiseContextSnapshot,
   RuntimeAdditionalContextFragment,
@@ -254,6 +259,12 @@ export interface MessagesEngineParams {
   inputTemplate?: string;
   /** System role */
   systemRole?: string;
+  /**
+   * The agent's identity (personal `name` + role `title`), appended to the
+   * system message so the model can introduce itself by the name the user gave
+   * it. Ignored in group chat, where GroupContextInjector owns identity.
+   */
+  agentIdentity?: AgentIdentityContext;
   /** Agent-materialized presentation contexts for this LLM call */
   additionalContexts?: readonly RuntimeAdditionalContextFragment[];
   /** Immutable expertise captured when the operation started. */

--- a/packages/context-engine/src/providers/AgentIdentityInjector.ts
+++ b/packages/context-engine/src/providers/AgentIdentityInjector.ts
@@ -1,0 +1,63 @@
+import { type AgentIdentityContext, agentIdentityPrompt } from '@lobechat/prompts';
+import debug from 'debug';
+
+import { BaseSystemRoleProvider } from '../base/BaseSystemRoleProvider';
+import type { PipelineContext, ProcessorOptions } from '../types';
+
+declare module '../types' {
+  interface PipelineContextMetadataOverrides {
+    agentIdentityInjected?: boolean;
+  }
+}
+
+const log = debug('context-engine:provider:AgentIdentityInjector');
+
+export interface AgentIdentityInjectorConfig {
+  /** Whether identity injection is enabled */
+  enabled?: boolean;
+  /** The agent's identity (personal name + role title) */
+  identity?: AgentIdentityContext;
+}
+
+/**
+ * Agent Identity Injector
+ *
+ * Appends the agent's identity (name / title) to the system message so the
+ * model can answer "who are you?" with the name the user gave it. The identity
+ * lives outside the prompt text (`agents.name` / `agents.title`), so an agent
+ * with a custom persona but no self-introduction in its systemRole would
+ * otherwise fall back to the product or model name.
+ *
+ * Group chat is expected to disable this — GroupContextInjector already
+ * establishes the speaking agent's identity there.
+ */
+export class AgentIdentityInjector extends BaseSystemRoleProvider {
+  readonly name = 'AgentIdentityInjector';
+
+  constructor(
+    private config: AgentIdentityInjectorConfig,
+    options: ProcessorOptions = {},
+  ) {
+    super(options);
+  }
+
+  protected buildSystemRoleContent(_context: PipelineContext): string | null {
+    if (this.config.enabled === false) {
+      log('Disabled, skipping identity injection');
+      return null;
+    }
+
+    const content = agentIdentityPrompt(this.config.identity ?? {});
+    if (!content) {
+      log('No agent identity configured, skipping injection');
+      return null;
+    }
+
+    return content;
+  }
+
+  protected onInjected(context: PipelineContext, content: string): void {
+    context.metadata.agentIdentityInjected = true;
+    log(`Agent identity injected: "${content.slice(0, 80)}..."`);
+  }
+}

--- a/packages/context-engine/src/providers/__tests__/AgentIdentityInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentIdentityInjector.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentIdentityInjector } from '../AgentIdentityInjector';
+
+const createContext = (messages: any[]) => ({
+  initialState: {
+    messages: [],
+    model: 'gpt-4',
+    provider: 'openai',
+    systemRole: '',
+    tools: [],
+  },
+  isAborted: false,
+  messages,
+  metadata: {
+    maxTokens: 4096,
+    model: 'gpt-4',
+  },
+});
+
+const systemMessage = {
+  content: 'You are a helpful assistant.',
+  createdAt: Date.now(),
+  id: 'system-1',
+  role: 'system',
+  updatedAt: Date.now(),
+};
+
+const userMessage = {
+  content: '你是谁?',
+  createdAt: Date.now(),
+  id: '1',
+  role: 'user',
+  updatedAt: Date.now(),
+};
+
+describe('AgentIdentityInjector', () => {
+  it('appends the agent name and title to the existing system message', async () => {
+    const provider = new AgentIdentityInjector({
+      identity: { name: '芙莉莲', title: '魔法使' },
+    });
+
+    const result = await provider.process(createContext([systemMessage, userMessage]) as any);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].role).toBe('system');
+    expect(result.messages[0].content).toContain('You are a helpful assistant.');
+    expect(result.messages[0].content).toContain('<agent_identity>');
+    expect(result.messages[0].content).toContain('<name>芙莉莲</name>');
+    expect(result.messages[0].content).toContain('<title>魔法使</title>');
+    expect(result.metadata.agentIdentityInjected).toBe(true);
+  });
+
+  it('creates a system message when none exists', async () => {
+    const provider = new AgentIdentityInjector({ identity: { name: '芙莉莲' } });
+
+    const result = await provider.process(createContext([userMessage]) as any);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].role).toBe('system');
+    expect(result.messages[0].content).toContain('<name>芙莉莲</name>');
+    expect(result.messages[0].content).not.toContain('<title>');
+  });
+
+  it('skips when the agent has neither name nor title', async () => {
+    const provider = new AgentIdentityInjector({ identity: { name: '  ', title: undefined } });
+
+    const result = await provider.process(createContext([systemMessage, userMessage]) as any);
+
+    expect(result.messages[0].content).toBe('You are a helpful assistant.');
+    expect(result.metadata.agentIdentityInjected).toBeUndefined();
+  });
+
+  it('skips when disabled (group chat owns identity there)', async () => {
+    const provider = new AgentIdentityInjector({
+      enabled: false,
+      identity: { name: '芙莉莲', title: '魔法使' },
+    });
+
+    const result = await provider.process(createContext([systemMessage, userMessage]) as any);
+
+    expect(result.messages[0].content).toBe('You are a helpful assistant.');
+    expect(result.metadata.agentIdentityInjected).toBeUndefined();
+  });
+});

--- a/packages/context-engine/src/providers/index.ts
+++ b/packages/context-engine/src/providers/index.ts
@@ -9,6 +9,7 @@ export {
   AgentDocumentSystemAppendInjector,
   AgentDocumentSystemReplaceInjector,
 } from './AgentDocumentInjector';
+export { AgentIdentityInjector } from './AgentIdentityInjector';
 export { AgentManagementContextInjector } from './AgentManagementContextInjector';
 export { BotPlatformContextInjector } from './BotPlatformContextInjector';
 export { ContextSelectionsInjector } from './ContextSelectionsInjector';
@@ -72,6 +73,7 @@ export type {
   AgentDocumentSystemAppendInjectorConfig,
   AgentDocumentSystemReplaceInjectorConfig,
 } from './AgentDocumentInjector';
+export type { AgentIdentityInjectorConfig } from './AgentIdentityInjector';
 export type {
   AgentManagementContext,
   AgentManagementContextInjectorConfig,

--- a/packages/prompts/src/prompts/agentIdentity/index.test.ts
+++ b/packages/prompts/src/prompts/agentIdentity/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentIdentityPrompt } from './index';
+
+describe('agentIdentityPrompt', () => {
+  it('renders name and title with the name as the primary label', () => {
+    const result = agentIdentityPrompt({ name: '芙莉莲', title: '魔法使' });
+
+    expect(result).toContain('<name>芙莉莲</name>');
+    expect(result).toContain('<title>魔法使</title>');
+    expect(result).toContain('The user knows you as "芙莉莲"');
+  });
+
+  it('falls back to the title as label when there is no name', () => {
+    const result = agentIdentityPrompt({ title: 'Health Assistant' });
+
+    expect(result).not.toContain('<name>');
+    expect(result).toContain('<title>Health Assistant</title>');
+    expect(result).toContain('The user knows you as "Health Assistant"');
+  });
+
+  it('treats blank values as absent', () => {
+    expect(agentIdentityPrompt({ name: '  ', title: '' })).toBe('');
+    expect(agentIdentityPrompt({})).toBe('');
+  });
+
+  it('escapes XML-sensitive characters', () => {
+    const result = agentIdentityPrompt({ name: 'A <&> B' });
+
+    expect(result).toContain('<name>A &lt;&amp;&gt; B</name>');
+    expect(result).not.toContain('<name>A <&> B</name>');
+  });
+});

--- a/packages/prompts/src/prompts/agentIdentity/index.ts
+++ b/packages/prompts/src/prompts/agentIdentity/index.ts
@@ -1,0 +1,38 @@
+import { escapeXmlContent } from '../search/xmlEscape';
+
+export interface AgentIdentityContext {
+  /** Personal name the user addresses the agent by ("Alice", "小艾"). */
+  name?: string | null;
+  /** The role the agent plays ("Health Assistant"). */
+  title?: string | null;
+}
+
+/**
+ * The agent's own identity, injected into the system message so the model can
+ * answer "who are you?" with the name the user actually gave it — instead of
+ * falling back to the product or model name. `name` is the personal name and
+ * wins as the primary label; `title` is the role (mirrors `agentDisplayName`).
+ *
+ * Deliberately does NOT constrain persona beyond the label: a custom
+ * `systemRole` still owns tone and behavior, this only pins the identity facts
+ * that live outside the prompt text.
+ */
+export const agentIdentityPrompt = ({ name, title }: AgentIdentityContext): string => {
+  const personalName = name?.trim();
+  const role = title?.trim();
+  if (!personalName && !role) return '';
+
+  const label = personalName ?? role!;
+
+  const fields = [
+    personalName && `  <name>${escapeXmlContent(personalName)}</name>`,
+    role && `  <title>${escapeXmlContent(role)}</title>`,
+  ].filter(Boolean);
+
+  return [
+    '<agent_identity>',
+    ...fields,
+    `  <instruction>The user knows you as "${escapeXmlContent(label)}". When asked who you are, identify yourself by this identity rather than a platform or model name.</instruction>`,
+    '</agent_identity>',
+  ].join('\n');
+};

--- a/packages/prompts/src/prompts/index.ts
+++ b/packages/prompts/src/prompts/index.ts
@@ -2,6 +2,7 @@ export * from './agentArtwork';
 export * from './agentBuilder';
 export * from './agentDocuments';
 export * from './agentGroup';
+export * from './agentIdentity';
 export * from './agentSignal';
 export * from './agentSkillManager';
 export * from './botPlatformContext';

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -447,6 +447,10 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
   // Use basePlugins as fallback when ctx.plugins is not provided
   // This ensures builtin agents (e.g., INBOX) receive user-configured plugins for merging
   const runtimeConfig = getAgentRuntimeConfig(slug, {
+    // The renameable default assistant must introduce itself by the name the
+    // user gave it, not the hardcoded product default.
+    agentName: agent?.name ?? undefined,
+    agentTitle: agent?.title ?? undefined,
     documentContent,
     groupSupervisorContext,
     isDev,

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -705,10 +705,18 @@ export const contextEngineering = async ({
     }
   }
 
+  // The agent's identity lives on the agent row (name/title), not in the
+  // prompt text — inject it so the model can answer "who are you?" with the
+  // name the user gave it instead of the product/model name.
+  const agentIdentityMeta = agentId
+    ? agentSelectors.getAgentMetaById(agentId)(agentStoreState)
+    : undefined;
+
   // Create MessagesEngine with injected dependencies
   const engine = new MessagesEngine({
     additionalContexts,
     // Agent configuration
+    agentIdentity: { name: agentIdentityMeta?.name, title: agentIdentityMeta?.title },
     enableHistoryCount,
     formatHistorySummary: historySummaryPrompt,
     historyCount,


### PR DESCRIPTION
## Problem

Renaming the default assistant (e.g. to 芙莉莲) changes every UI surface except the model's own self-concept: the inbox system role hardcodes **"You are Lobe, an AI Agent will help users."**, so the assistant keeps answering "你是谁?" as Lobe no matter what the user calls it.

## Fix 1 — the LobeAI prompt itself (root cause)

The inbox system role is now parametrized with the agent's identity. `RuntimeContext` gains `agentName` / `agentTitle`, wired from the agent row at both runtime-config call sites (client `agentConfigResolver`, server `resolveRunAgentConfig`):

- renamed to 芙莉莲 + 魔法使 → `You are 芙莉莲 (魔法使), an AI Agent will help users.`
- never renamed → unchanged `You are Lobe, an AI Agent will help users.`

## Fix 2 — generic identity injection (covers custom agents)

Custom agents have the same failure mode one layer up: their identity lives on the agent row, and a persona systemRole without a self-introduction leaves the model guessing. A new `AgentIdentityInjector` appends an `<agent_identity>` block (name / title + a one-line instruction) right after the system role, in both the client and server context pipelines. Group chat is excluded — `GroupContextInjector` already owns identity there.

```xml
<agent_identity>
  <name>芙莉莲</name>
  <title>魔法使</title>
  <instruction>The user knows you as "芙莉莲". When asked who you are, identify yourself by this identity rather than a platform or model name.</instruction>
</agent_identity>
```

## Verification

- Unit tests: inbox systemRole identity handling (name / title / fallback / blanks), prompt builder (labels, escaping), injector (append / create / skip / disabled), engine-level placement + group suppression.
- Live-verified in a local full-stack env: renamed the inbox assistant to 芙莉莲/魔法使, sent "你是谁？", and captured the real `/webapi/chat/*` payload — the system prompt opens with `You are 芙莉莲 (魔法使), an AI Agent will help users.`, contains the `<agent_identity>` block, and no longer contains `You are Lobe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)