### PR TITLE
🐛 fix(connector): persist description, avatar and custom headers on save

### DIFF
--- a/src/features/Connectors/CustomConnectorModal/connectorMetadata.test.ts
+++ b/src/features/Connectors/CustomConnectorModal/connectorMetadata.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCustomConnectorMetadata, cleanRecord } from './connectorMetadata';
+
+describe('cleanRecord', () => {
+  it('drops pairs with empty keys or values and trims nothing else', () => {
+    expect(
+      cleanRecord({ '': 'x', 'X-MCP-Readonly': 'true', 'X-Whitespace': '   ', 'y': '' }),
+    ).toEqual({ 'X-MCP-Readonly': 'true' });
+  });
+
+  it('returns undefined for empty, missing, or non-record input', () => {
+    expect(cleanRecord()).toBeUndefined();
+    expect(cleanRecord({})).toBeUndefined();
+    expect(cleanRecord({ ' ': ' ' })).toBeUndefined();
+    expect(cleanRecord([] as unknown as Record<string, string>)).toBeUndefined();
+  });
+});
+
+describe('buildCustomConnectorMetadata', () => {
+  describe('create (no existing metadata)', () => {
+    it('persists description, avatar and custom headers together (#16070)', () => {
+      expect(
+        buildCustomConnectorMetadata({
+          avatar: 'https://plugin-avatar.com/a.png',
+          description: 'My MCP server',
+          headers: { 'X-MCP-Readonly': 'true' },
+        }),
+      ).toEqual({
+        avatar: 'https://plugin-avatar.com/a.png',
+        customHeaders: { 'X-MCP-Readonly': 'true' },
+        description: 'My MCP server',
+      });
+    });
+
+    it('omits keys for empty or whitespace-only form fields', () => {
+      expect(
+        buildCustomConnectorMetadata({ avatar: '   ', description: '', headers: { ' ': '' } }),
+      ).toEqual({});
+    });
+
+    it('trims description and avatar', () => {
+      expect(buildCustomConnectorMetadata({ avatar: ' a.png ', description: ' hi ' })).toEqual({
+        avatar: 'a.png',
+        description: 'hi',
+      });
+    });
+  });
+
+  describe('edit (merging into existing metadata)', () => {
+    it('preserves sibling keys the form does not own', () => {
+      const existing = {
+        composio: { connectedAccountId: 'ca_1' },
+        customHeaders: { 'X-Old': '1' },
+        description: 'old',
+        mountedByAgentId: 'agt_1',
+      };
+      expect(
+        buildCustomConnectorMetadata({ description: 'new', headers: { 'X-New': '2' } }, existing),
+      ).toEqual({
+        composio: { connectedAccountId: 'ca_1' },
+        customHeaders: { 'X-New': '2' },
+        description: 'new',
+        mountedByAgentId: 'agt_1',
+      });
+    });
+
+    it('deletes form-owned keys the user cleared', () => {
+      const existing = {
+        avatar: 'a.png',
+        customHeaders: { 'X-Old': '1' },
+        description: 'old',
+        other: true,
+      };
+      expect(buildCustomConnectorMetadata({}, existing)).toEqual({ other: true });
+    });
+
+    it('does not mutate the existing metadata object', () => {
+      const existing = { description: 'old' };
+      buildCustomConnectorMetadata({ description: 'new' }, existing);
+      expect(existing).toEqual({ description: 'old' });
+    });
+
+    it('handles null/undefined existing metadata', () => {
+      expect(buildCustomConnectorMetadata({ description: 'd' }, null)).toEqual({
+        description: 'd',
+      });
+      expect(buildCustomConnectorMetadata({ avatar: 'a' }, undefined)).toEqual({ avatar: 'a' });
+    });
+  });
+});

--- a/src/features/Connectors/CustomConnectorModal/connectorMetadata.ts
+++ b/src/features/Connectors/CustomConnectorModal/connectorMetadata.ts
@@ -1,0 +1,44 @@
+/** Drop empty key/value pairs a user may have left behind in an editor. */
+export const cleanRecord = (
+  record?: Record<string, string>,
+): Record<string, string> | undefined => {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return undefined;
+  const cleaned = Object.fromEntries(
+    Object.entries(record).filter(([k, v]) => k.trim() && (v ?? '').trim()),
+  );
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+};
+
+/**
+ * Build the connector `metadata` jsonb payload from the DevModal form state.
+ *
+ * Description, avatar and custom headers all persist in the metadata column —
+ * the encrypted `credentials` column only holds the single auth credential
+ * (#16070: earlier save paths only wrote `customHeaders`, silently dropping
+ * description and avatar on both create and edit).
+ *
+ * A jsonb update replaces the whole column, so edit mode must pass `existing`
+ * to carry over sibling keys the form does not own (e.g. composio identity,
+ * `mountedByAgentId`). Form-owned keys are re-derived from the form on every
+ * save: a cleared field deletes its key.
+ */
+export const buildCustomConnectorMetadata = (
+  form: { avatar?: string; description?: string; headers?: Record<string, string> },
+  existing?: Record<string, unknown> | null,
+): Record<string, unknown> => {
+  const metadata: Record<string, unknown> = { ...existing };
+
+  const description = form.description?.trim();
+  if (description) metadata.description = description;
+  else delete metadata.description;
+
+  const avatar = form.avatar?.trim();
+  if (avatar) metadata.avatar = avatar;
+  else delete metadata.avatar;
+
+  const headers = cleanRecord(form.headers);
+  if (headers) metadata.customHeaders = headers;
+  else delete metadata.customHeaders;
+
+  return metadata;
+};

--- a/src/features/Connectors/CustomConnectorModal/index.tsx
+++ b/src/features/Connectors/CustomConnectorModal/index.tsx
@@ -7,6 +7,7 @@ import DevModal from '@/features/PluginDevModal';
 import { useToolStore } from '@/store/tool';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 
+import { buildCustomConnectorMetadata, cleanRecord } from './connectorMetadata';
 import { executeLegacyMigrationSave } from './legacyPluginMigration';
 
 interface CustomConnectorModalProps {
@@ -69,15 +70,6 @@ const waitForOAuthPopup = (popup: Window, connectorId: string): Promise<OAuthPop
       }
     }, 800);
   });
-
-/** Drop empty key/value pairs a user may have left behind in an editor. */
-const cleanRecord = (record?: Record<string, string>): Record<string, string> | undefined => {
-  if (!record) return undefined;
-  const cleaned = Object.fromEntries(
-    Object.entries(record).filter(([k, v]) => k.trim() && (v ?? '').trim()),
-  );
-  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
-};
 
 /**
  * "Add / Edit custom connector" entry. Reuses the rich PluginDevModal MCP form,
@@ -181,6 +173,7 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
 
       return {
         customParams: {
+          avatar: connector.metadata?.avatar as string | undefined,
           description: connector.metadata?.description as string | undefined,
           mcp: {
             args: mcpStdioConfig?.args,
@@ -268,22 +261,26 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
 
         if (newUrl !== undefined) patch.mcpServerUrl = newUrl;
 
-        // Custom headers live in metadata (independent of the auth credential and
-        // of the server URL), so always re-sync them from the form. Merge into the
-        // existing metadata — a jsonb update replaces the whole column, so other
-        // keys (e.g. description) must be carried over. Also migrates legacy rows
-        // that stored headers as a 'header' credential (cleared below).
+        // Description, avatar and custom headers live in metadata (independent of
+        // the auth credential and of the server URL), so always re-sync them from
+        // the form. Merge into the existing metadata — a jsonb update replaces the
+        // whole column, so keys the form doesn't own (e.g. composio identity) must
+        // be carried over. Also migrates legacy rows that stored headers as a
+        // 'header' credential (cleared below).
         //
         // Guard on `connector`: only rewrite metadata once the connector record is
-        // loaded, so we never overwrite a populated column with `{}` (which would
-        // drop sibling keys like description). In practice the form can't be
-        // submitted before `connector` resolves, but this keeps it safe.
-        const headers = cleanRecord(mcp.headers);
+        // loaded, so we never overwrite a populated column with form-only values
+        // (which would drop sibling keys). In practice the form can't be submitted
+        // before `connector` resolves, but this keeps it safe.
         if (connector) {
-          const nextMetadata: Record<string, unknown> = { ...connector.metadata };
-          if (headers) nextMetadata.customHeaders = headers;
-          else delete nextMetadata.customHeaders;
-          patch.metadata = nextMetadata;
+          patch.metadata = buildCustomConnectorMetadata(
+            {
+              avatar: value.customParams?.avatar,
+              description: value.customParams?.description,
+              headers: mcp.headers,
+            },
+            connector.metadata,
+          );
         }
 
         if (urlChanged) {
@@ -330,8 +327,18 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
       }
 
       // ── Create mode ───────────────────────────────────────────────────────
+      // Description, avatar and custom headers all persist in `metadata` (the
+      // credentials column only holds the single auth credential, see below).
+      // Built into `base` so the OAuth create path keeps them too.
+      const formMetadata = buildCustomConnectorMetadata({
+        avatar: value.customParams?.avatar,
+        description: value.customParams?.description,
+        headers: mcp.headers,
+      });
+
       const base = {
         identifier,
+        metadata: Object.keys(formMetadata).length > 0 ? formMetadata : undefined,
         mcpConnectionType: (mcp.type ?? 'http') as 'http' | 'stdio',
         mcpServerUrl: isHttp ? mcp.url?.trim() : undefined,
         mcpStdioConfig: isHttp
@@ -379,16 +386,14 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         return;
       }
 
-      // The auth credential (bearer token) and custom headers are stored
-      // separately: the credential goes in the encrypted single-kind
-      // `credentials` column, while custom headers live in
-      // `metadata.customHeaders` so they can coexist with no-auth OR bearer
+      // The auth credential (bearer token) goes in the encrypted single-kind
+      // `credentials` column — custom headers live in `metadata.customHeaders`
+      // (already inside `base`) so they can coexist with no-auth OR bearer
       // (the credentials column can only hold one credential kind at a time).
       const credentials =
         authType === 'bearer' && mcp.auth?.token?.trim()
           ? ({ token: mcp.auth.token.trim(), type: 'bearer' } as const)
           : undefined;
-      const headers = cleanRecord(mcp.headers);
 
       // `connector.create` is an idempotent upsert on (user, identifier);
       // `isNew` is the server's verdict on whether this row was freshly
@@ -399,7 +404,6 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
       const { id: newConnectorId, isNew } = await createConnector({
         ...base,
         credentials,
-        metadata: headers ? { customHeaders: headers } : undefined,
       });
       try {
         await syncConnectorTools(newConnectorId);


### PR DESCRIPTION
Custom Connector's create/edit save paths only ever wrote `metadata.customHeaders` — the **description** and **avatar** entered in the form were silently dropped on both create and edit, and the edit form never pre-filled the avatar. The OAuth create path passed no `metadata` at all, so it lost custom headers too. #15909 fixed the credentials wipe but did not cover these display fields.

**Changes** (all in `src/features/Connectors/CustomConnectorModal/`):

- New `buildCustomConnectorMetadata` helper — derives `description` / `avatar` / `customHeaders` from the DevModal form state. On edit it merges into the connector's existing metadata (a jsonb update replaces the whole column), preserving keys the form doesn't own (`composio` identity, `mountedByAgentId`) while a cleared field deletes its key.
- Edit save: patch metadata via the helper instead of syncing only `customHeaders`.
- Create save: metadata is built into the shared `base` payload, so the OAuth create branch now persists description/avatar/headers as well.
- `editValue` now pre-fills `customParams.avatar` (description was already pre-filled but, since it was never saved, always came back empty).

#### Test

- `bunx vitest run src/features/Connectors/CustomConnectorModal/` — 42 passed (9 new in `connectorMetadata.test.ts`, covering create-mode field persistence, whitespace trimming/omission, edit-mode sibling-key preservation, clear-field deletion, and input immutability)
- `bun run type-check` — no new errors introduced (identical error count with the change stashed)

- [x] Added/updated tests

#### 🔗 Related Issue

Fixes #16070

🤖 Generated with [Claude Code](https://claude.com/claude-code)