### PR TITLE
🐛 fix(task): keep recurring tasks free of delivery acceptance so a failed verify cannot disarm the schedule

### DIFF
--- a/apps/server/src/services/taskRunner/buildTaskPrompt.test.ts
+++ b/apps/server/src/services/taskRunner/buildTaskPrompt.test.ts
@@ -7,7 +7,15 @@ import { GoalModel } from '@/database/models/goal';
 import { GoalGraphModel } from '@/database/models/goalGraph';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
-import { goalEdges, goalEvents, goalNodes, goals, tasks, users } from '@/database/schemas';
+import {
+  acceptances,
+  goalEdges,
+  goalEvents,
+  goalNodes,
+  goals,
+  tasks,
+  users,
+} from '@/database/schemas';
 
 import { buildTaskPrompt } from './buildTaskPrompt';
 
@@ -19,6 +27,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  await db.delete(acceptances);
   await db.delete(goalEdges);
   await db.delete(goalEvents);
   await db.delete(goalNodes);
@@ -58,5 +67,45 @@ describe('buildTaskPrompt Goal loop context', () => {
 
     expect(result.prompt).toContain('Goal loop — round 2 of 2');
     expect(result.prompt).not.toContain('round 2 of 20');
+  });
+});
+
+describe('buildTaskPrompt delivery acceptance', () => {
+  const buildFor = async (taskId: string) => {
+    const taskModel = new TaskModel(db, userId);
+    const currentTask = await taskModel.findById(taskId);
+    return buildTaskPrompt(currentTask!, {
+      briefModel: new BriefModel(db, userId),
+      db,
+      taskModel,
+      taskTopicModel: new TaskTopicModel(db, userId),
+      userId,
+    });
+  };
+
+  it('renders the acceptance section for a plain task with a verify config', async () => {
+    const task = await new TaskModel(db, userId).create({
+      config: { verify: { enabled: true, requirement: 'The report is delivered as a document.' } },
+      instruction: 'Write the report.',
+    });
+
+    const result = await buildFor(task.id);
+
+    expect(result.prompt).toContain('Verify — delivery acceptance');
+  });
+
+  it('omits the acceptance section for a recurring task', async () => {
+    // A recurring task never gets a verify plan instantiated, so its per-tick
+    // prompt must not ask the builder to self-evidence acceptance criteria.
+    const task = await new TaskModel(db, userId).create({
+      automationMode: 'schedule',
+      config: { verify: { enabled: true, requirement: 'The report is delivered as a document.' } },
+      instruction: 'Send the daily report.',
+      schedulePattern: '0 9 * * *',
+    });
+
+    const result = await buildFor(task.id);
+
+    expect(result.prompt).not.toContain('Verify — delivery acceptance');
   });
 });

--- a/apps/server/src/services/taskRunner/buildTaskPrompt.ts
+++ b/apps/server/src/services/taskRunner/buildTaskPrompt.ts
@@ -231,9 +231,12 @@ export async function buildTaskPrompt(
   // what to self-evidence while it works. Run-time handles (verifyRunId /
   // checkItemId) don't exist yet at prompt-build time — the verify skill
   // resolves those at runtime from the builder's operationId.
-  const resolvedAcceptance = await resolveTaskAcceptance(db, userId, task.id, workspaceId).catch(
-    () => undefined,
-  );
+  // Recurring tasks (schedule / heartbeat) never get a verify plan (see
+  // instantiateVerifyPlanOnStart) — don't tell the builder to self-evidence
+  // acceptance criteria whose run-time plan will never exist.
+  const resolvedAcceptance = task.automationMode
+    ? undefined
+    : await resolveTaskAcceptance(db, userId, task.id, workspaceId).catch(() => undefined);
   const verifyConfig = resolvedAcceptance?.config;
   const verifyEnabled = !!resolvedAcceptance && verifyConfig?.enabled !== false;
   let verifyCriteria: Array<{

--- a/apps/server/src/services/verify/__tests__/acceptanceLifecycle.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceLifecycle.test.ts
@@ -99,6 +99,25 @@ describe('Verify acceptance lifecycle', () => {
     expect(mocks.acceptanceAttachPolicyRun).toHaveBeenCalledWith('run-1', 'acceptance-1');
   });
 
+  it('skips instantiation for a recurring task, even when an Acceptance policy exists', async () => {
+    // A failed acceptance pauses the task, and `paused` is permanently off the
+    // cron — so a recurring task must never get a verify plan in the first place.
+    mocks.taskFindById.mockResolvedValue({ automationMode: 'schedule', id: 'task-1' });
+    mocks.taskAcceptanceResolve.mockResolvedValue({
+      acceptance: { id: 'acceptance-1' },
+      config: { enabled: true, verifyRubricId: 'rubric-1' },
+    });
+
+    await instantiateVerifyPlanOnStart(db, 'user-1', {
+      operationId: 'operation-1',
+      taskId: 'task-1',
+    });
+
+    expect(mocks.taskAcceptanceResolve).not.toHaveBeenCalled();
+    expect(mocks.generateDraftPlan).not.toHaveBeenCalled();
+    expect(mocks.confirmPlan).not.toHaveBeenCalled();
+  });
+
   it('keeps an empty Acceptance opted out of verification', async () => {
     mocks.taskAcceptanceResolve.mockResolvedValue({
       acceptance: { id: 'acceptance-1' },

--- a/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
+++ b/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
@@ -169,6 +169,42 @@ describe('driveTaskFromVerify', () => {
     expect(statusRecompute.mock.calls).toEqual([['repair-op-1'], ['root-op']]);
   });
 
+  it('failed → keeps a recurring task scheduled instead of pausing (disarming) it', async () => {
+    runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'failed' });
+    taskFindById.mockResolvedValue({
+      assigneeAgentId: 'a1',
+      automationMode: 'schedule',
+      id: 'task-1',
+      identifier: 'T-1',
+      status: 'scheduled',
+    });
+
+    await driveTaskFromVerify(db, 'u1', 'op-1');
+
+    // Pausing would permanently disarm the cron — the schedule query never
+    // picks `paused` tasks up again. The verdict stays on the run.
+    expect(taskUpdateStatus).not.toHaveBeenCalled();
+    expect(serviceUpdateStatus).not.toHaveBeenCalled();
+    // The tick's rejection still reaches the creator callback.
+    expect(deliverMock.mock.calls[0][0]).toMatchObject({ reason: 'error', taskId: 'task-1' });
+  });
+
+  it('errored → keeps a recurring task scheduled', async () => {
+    runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'errored' });
+    taskFindById.mockResolvedValue({
+      assigneeAgentId: 'a1',
+      automationMode: 'heartbeat',
+      id: 'task-1',
+      identifier: 'T-1',
+      status: 'scheduled',
+    });
+
+    await driveTaskFromVerify(db, 'u1', 'op-1');
+
+    expect(taskUpdateStatus).not.toHaveBeenCalled();
+    expect(serviceUpdateStatus).not.toHaveBeenCalled();
+  });
+
   it('failed → pauses with the reason on the task row without creating an inbox brief', async () => {
     runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'failed' });
     await driveTaskFromVerify(db, 'u1', 'op-1');

--- a/apps/server/src/services/verify/planInstantiation.ts
+++ b/apps/server/src/services/verify/planInstantiation.ts
@@ -41,6 +41,14 @@ export const instantiateVerifyPlanOnStart = async (
   try {
     const taskModel = new TaskModel(db, userId, workspaceId);
 
+    const task = await taskModel.findById(params.taskId);
+    // A recurring task (schedule / heartbeat) is a loop of ticks, not a
+    // delivery: a single tick has no acceptance contract, and a failed
+    // acceptance would pause the task — permanently disarming its schedule,
+    // since the cron query never picks `paused` tasks up again. Verify stays
+    // off for automation tasks even when they inherit an Acceptance policy.
+    if (task?.automationMode) return;
+
     const resolvedAcceptance = await resolveTaskAcceptance(db, userId, params.taskId, workspaceId);
     if (!resolvedAcceptance) return;
     const { acceptance, config: verifyConfig, requirement } = resolvedAcceptance;
@@ -63,7 +71,6 @@ export const instantiateVerifyPlanOnStart = async (
     // Idempotent: a plan already exists for this run (re-fire, or agent/UI-built).
     if (existing?.plan?.length) return;
 
-    const task = await taskModel.findById(params.taskId);
     const goal = task?.instruction ?? task?.name ?? '';
 
     const planGenerator = new VerifyPlanGeneratorService(db, userId, workspaceId);

--- a/apps/server/src/services/verify/settle.ts
+++ b/apps/server/src/services/verify/settle.ts
@@ -130,13 +130,26 @@ export const driveTaskFromVerify = async (
       const pauseSummary = isErrored
         ? 'Verification could not run (internal error); the delivery was not evaluated.'
         : 'Delivery did not pass verification.';
-      // Verification outcomes belong to the task itself. Do not create an inbox
-      // brief here: a verifier rejection/error is not a separate user todo.
-      await taskModel.updateStatus(taskOperation.taskId, 'paused', { error: pauseSummary });
-      log(
-        isErrored ? 'verify errored → task %s paused' : 'verify failed → task %s paused',
-        taskOperation.taskId,
-      );
+      if (task.automationMode) {
+        // Mirror of the pass branch: verify judges THIS tick, not the lifetime
+        // schedule. Pausing here would permanently disarm the cron (the
+        // schedule query never picks `paused` tasks up again), so a recurring
+        // task keeps its schedule and the verdict stays on the run.
+        log(
+          isErrored
+            ? 'verify errored → recurring task %s remains scheduled'
+            : 'verify failed → recurring task %s remains scheduled',
+          taskOperation.taskId,
+        );
+      } else {
+        // Verification outcomes belong to the task itself. Do not create an inbox
+        // brief here: a verifier rejection/error is not a separate user todo.
+        await taskModel.updateStatus(taskOperation.taskId, 'paused', { error: pauseSummary });
+        log(
+          isErrored ? 'verify errored → task %s paused' : 'verify failed → task %s paused',
+          taskOperation.taskId,
+        );
+      }
     }
 
     // Deferred creator callback: verify-bound runs defer

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   openAcceptance: vi.fn(),
   openAcceptanceCheck: vi.fn(),
   subjectArgs: [] as unknown[],
+  taskDetailOverrides: {} as Record<string, unknown>,
   toggleTaskAgentPanel: vi.fn(),
   updateVerifyConfig: vi.fn(),
 }));
@@ -159,7 +160,9 @@ vi.mock('@/store/task', () => {
   const useTaskStore = (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       activeTaskId: 'T-231',
-      taskDetailMap: { 'T-231': { id: 'task-database-231', identifier: 'T-231' } },
+      taskDetailMap: {
+        'T-231': { id: 'task-database-231', identifier: 'T-231', ...mocks.taskDetailOverrides },
+      },
     });
   useTaskStore.getState = () => ({
     updateVerifyConfig: mocks.updateVerifyConfig,
@@ -178,6 +181,20 @@ describe('TaskAcceptance', () => {
     mocks.acceptanceSubject = null;
     mocks.bundle = undefined;
     mocks.currentPortalView = null;
+    mocks.taskDetailOverrides = {};
+  });
+
+  it('renders nothing for a recurring task — no Verifier config, no acceptance fetch', () => {
+    // Recurring tasks never get a verify plan on the server; the whole
+    // acceptance section (config editor included) must stay hidden.
+    mocks.taskDetailOverrides = { automationMode: 'schedule' };
+
+    const { container } = render(<TaskAcceptance />);
+
+    expect(screen.queryByTestId('task-acceptance-criteria')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+    // The acceptance subject fetch is skipped, not just its rendering.
+    expect(mocks.subjectArgs).toEqual(['task', null]);
   });
 
   it('renders the configured criteria in the same slot before an acceptance aggregate exists', () => {

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx
@@ -128,6 +128,7 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
   const { allowed: canEditTask } = usePermission('create_content');
   const taskId = useTaskStore(taskDetailSelectors.activeTaskId);
   const taskDatabaseId = useTaskStore(taskDetailSelectors.activeTaskDatabaseId);
+  const automationMode = useTaskStore(taskDetailSelectors.activeTaskAutomationMode);
   const verify = useTaskStore(taskDetailSelectors.activeTaskVerifyConfig);
   const [sectionExpanded, setSectionExpanded] = useState(true);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
@@ -138,7 +139,7 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
     error: subjectError,
     isLoading: subjectLoading,
     mutate: mutateSubject,
-  } = useAcceptanceBySubject('task', taskDatabaseId ?? null);
+  } = useAcceptanceBySubject('task', automationMode ? null : (taskDatabaseId ?? null));
   const {
     data: bundle,
     error: bundleError,
@@ -175,6 +176,11 @@ const TaskAcceptance = memo<TaskAcceptanceProps>(({ variant = 'default' }) => {
   const groupKeys = groups.map((group) => group.key);
   const allGroupsCollapsed =
     groupKeys.length > 0 && groupKeys.every((key) => collapsedGroups.has(key));
+  // A recurring task (schedule / heartbeat) never gets a verify plan on the
+  // server — its ticks are not deliveries. Offering the Verifier config or an
+  // acceptance section here would advertise a contract that never runs.
+  if (automationMode) return null;
+
   if (subjectLoading) return <NeuralNetworkLoading size={28} />;
   // Before the first Acceptance round exists, the configured criteria ARE the
   // delivery acceptance. Keep them in this single slot; once a round exists,

--- a/src/features/AgentTasks/AgentTaskDetail/TaskProperties.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskProperties.tsx
@@ -85,8 +85,9 @@ const TaskProperties = memo(() => {
       </TaskStatusTag>
 
       {/* The human layer: whether the delivery is accepted. Read-only here —
-          the decision itself is made on the acceptance page this links to. */}
-      <TaskAcceptanceStateRow />
+          the decision itself is made on the acceptance page this links to.
+          Recurring tasks have no delivery acceptance, so no state to show. */}
+      {!automationMode && <TaskAcceptanceStateRow />}
 
       <TaskPriorityTag priority={priority} taskIdentifier={taskId}>
         <Block


### PR DESCRIPTION
A recurring task (schedule / heartbeat) is a loop of ticks, not a delivery. Yet every tick's run got a verify plan instantiated unconditionally, and when the acceptance failed, `driveTaskFromVerify` set the task to `paused` — a status the cron eligibility query (`getScheduledTasks`) permanently excludes. One failed acceptance silently disarmed the schedule forever. The pass branch already special-cased `automationMode` (a passing verify keeps the task scheduled); the failed/errored branch missed it.

#### Changes

- **`verify/planInstantiation.ts`** — skip plan instantiation entirely for `automationMode` tasks. This is the single choke point for all run-start callers (`CompletionLifecycle`, `agentNotify`, `heterogeneousAgent`), so recurring tasks no longer spend the per-tick evidence sub-run and judge call either. Covers policies inherited from a parent task too.
- **`verify/settle.ts`** — defensive mirror of the pass branch: if a pre-existing verify run on a recurring task settles as `failed`/`errored`, record the verdict on the run and keep the task scheduled instead of pausing it.
- **`taskRunner/buildTaskPrompt.ts`** — drop the "Verify — delivery acceptance" section from recurring-task prompts, so the builder doesn't self-evidence against a plan that will never exist.

#### Test

Regression tests were verified to fail before the fix (stashed the three source changes → exactly the 4 new cases fail → restored → all green):

- `acceptanceLifecycle.test.ts`: plan instantiation is skipped for a recurring task even when an Acceptance policy exists
- `driveTaskFromVerify.test.ts`: `failed` / `errored` verdicts keep a recurring task scheduled instead of pausing it
- `buildTaskPrompt.test.ts`: the acceptance prompt section renders for a plain task and is omitted for a recurring one

Also ran the neighboring suites (verify lifecycle, evidenceSubmission, scheduleTick, heartbeatTick, CompletionLifecycle — 94 tests), lint, and the full type check.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#### UI follow-up (second commit)

The Verifier / acceptance UI is now hidden for recurring tasks to match the server behavior:

- `TaskAcceptance` returns `null` when the task has an `automationMode` — one gate that covers the task detail page, the agent-scoped page, and both portals (TaskDetail / TaskResult), including the `TaskVerifyConfig` editor it mounts. The acceptance-subject fetch is skipped as well, not just the rendering.
- `TaskProperties` no longer renders the read-only acceptance state row for recurring tasks.
- Regression test: a `schedule` task renders an empty acceptance section and skips the subject fetch (verified failing before the gate).
