### PR TITLE
📝 docs: streamline acceptance delegation and evidence review

### DIFF
--- a/.agents/acceptance/PROCESS.md
+++ b/.agents/acceptance/PROCESS.md
@@ -13,6 +13,14 @@ file wins; about _what may be published_, the skill wins.
 PLAN (0–2)  →  EXECUTE (3–5)  →  FINISH (6)
 ```
 
+Follow the skill's [delegation workflow](../skills/acceptance/references/delegation.md).
+The steps below define project mechanics. Keep environment ownership with the
+delegated run through this project's teardown step.
+For delegated runs, Step 1 is only a tentative scope outline: the worker checks
+the environment in Step 2 before drafting the executable plan for discussion.
+The primary handles the approval gate. An already agreed plan can be reused
+unless new evidence invalidates it.
+
 Do not enter Execute until Plan has confirmed both the environment state and the
 plan. Loading skills and reading logs is silent preparation — never narrate it.
 The first user-visible message of a session is about the user's test, not setup.
@@ -226,6 +234,9 @@ made in a real LobeHub round. The generic set is in the skill's SKILL.md.
 | "The fix is in and the tests are green"                                   | Reproduce the failure's precondition first (here: the empty→non-empty task-list transition swaps the composer instance). A run that cannot fail proves nothing; when the mocked seam is the suspect, drop the mock and drive the real kernel. (was L-S18, now generic M31)                                                     |
 
 ### Step 5 — Report and publish
+
+Apply the skill's [final review and publication contract](../skills/acceptance/references/delegation.md#4-primary-reviews-the-completed-round)
+before the repository-specific publishing steps below.
 
 The report schema, the language rule, visual/dual-text/structured-visualization
 evidence rules, and the immutable-round rules are the skill's

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: acceptance
-version: 0.3.0
+version: 0.5.1
 description: >
-  End-to-end verification and self-evidence for a delivery in any repository,
+  Delegated end-to-end verification with primary-agent evidence review for a delivery in any repository,
   with or without a preconfigured verify plan. Discover an existing plan when
   one was handed to this run; otherwise author checks and publish a standalone
   acceptance. Pick the proving surface (CLI / web / desktop / iOS Simulator),
@@ -14,16 +14,43 @@ description: >
   ambient ids, and never depends on running inside a LobeHub conversation.
 ---
 
-# Acceptance (Builder Self-Evidence)
+# Acceptance (Delegated Execution, Primary Review)
 
-You are the **builder** for a delivery. A separate review step judges it against
-a **plan** — checks you author, or a verify plan handed to this run. A check that
+The primary agent owns the delivery judgment. Use one execution worker for
+environment inspection, plan drafting, and case execution. Settle the plan with
+the primary before execution; the primary reviews all evidence at the end. A check that
 declares `requiredEvidence` **cannot pass on your text alone**: a missing artifact
 marks it `uncertain` and holds the delivery.
 
 ```
-author (or discover) the plan  →  pick the surface  →  capture evidence  →  publish the round  →  self-check coverage
+one worker: environment → select surface + plan ↔ primary discussion → execute agreed cases
+primary: review completed evidence → resolve findings → publish → verify uploaded coverage
 ```
+
+## Delegate work, retain judgment
+
+Before dispatch, explicitly select a suitable lower-cost model through the current
+host's supported controls, or verify an explicitly configured worker default.
+An absent setting may inherit the primary model; never assume it means cheap.
+If a lower-cost selection cannot be established, follow the selection/fallback
+rules in [delegation.md](references/delegation.md#select-the-worker-without-assuming-cheap-defaults).
+Do not change user configuration. Reuse one worker across stages and cases.
+After plan agreement, routine cases proceed without primary approval between
+cases. Escalate requirement ambiguity, failures, or blockers; otherwise notify
+the primary when the complete report is ready. Wait for these notifications
+rather than reading files to infer progress. The primary then inspects every
+case's original evidence; worker pass labels are insufficient. Do not create a
+separate final audit agent.
+
+If a case fails, the implementer repairs it, the acceptance worker reruns it,
+and the primary reviews the new evidence. Missing evidence goes back to the
+executor. A repairer's self-check never replaces this re-verification.
+
+Read [delegation.md](references/delegation.md) before dispatch. It defines the
+handoffs, plan discussion, autonomous execution, final review, repair, and fallback
+when lower-cost selection or delegation is unavailable. These are the responsibilities throughout
+the surface guides; references to "you" do not require the primary to perform
+every tool call. Existing user authorization and host restrictions still apply.
 
 ## Read the project layer first
 
@@ -186,10 +213,11 @@ Coverage: 2/2 criteria, all required evidence uploaded
 
 - **Engine-level capture over OS capture.** `agent-browser screenshot` / `dom` /
   `eval` run headless; `screencapture` / osascript are macOS-only. iOS: `xcrun
-simctl io` over host-window capture. Rounds land under `.acceptances/`, which
-  the CLI keeps out of git.
-- **Upload as you go.** Evidence keyed to its check mid-run survives a crash near
-  the end.
+simctl io` over host-window capture. Use the project report root or the ignored
+  `.acceptances/` fallback defined in [evidence.md](references/evidence.md#capture-first-publish-after-review).
+- **Save evidence as you go; publish after review.** Preserve local artifacts and
+  the attempt ledger during execution. For plan-driven rounds, defer `result submit`
+  until the primary reviews the completed round; see [plan-format.md](references/plan-format.md).
 - **Don't invent evidence.** Capture only the types a check declares.
 
 ## Reference map

--- a/packages/builtin-skills/src/acceptance/index.ts
+++ b/packages/builtin-skills/src/acceptance/index.ts
@@ -5,6 +5,7 @@ import agentBrowser from './references/agent-browser.md';
 import authWeb from './references/auth-web.md';
 import commonMistakes from './references/common-mistakes.md';
 import computerUse from './references/computer-use.md';
+import delegation from './references/delegation.md';
 import evidence from './references/evidence.md';
 import interactionCost from './references/interaction-cost.md';
 import planFormat from './references/plan-format.md';
@@ -24,13 +25,14 @@ import web from './surfaces/web.md';
 export const AcceptanceIdentifier = 'acceptance';
 
 /**
- * The single builder-side acceptance skill: discover or author the plan → pick a
- * surface → capture evidence per criterion → publish a round → self-check
- * coverage. It runs from any task's working directory, with or without a LobeHub
- * operation/topic, and depends on no repository-local script. Surface-specific
- * tools stay explicit: agent-browser for Web/Electron, shell-level native
- * automation for macOS, and an installed Simulator HID/Accessibility CLI plus
- * Xcode/simctl for iOS.
+ * The delegated acceptance skill: the primary agent owns the delivery judgment;
+ * one worker inspects the environment, drafts and executes the agreed plan,
+ * and the primary reviews the completed evidence. It runs from any task's working
+ * directory, with or without a LobeHub operation/topic, and depends on no
+ * repository-local script.
+ * Surface-specific tools stay explicit: agent-browser for Web/Electron,
+ * shell-level native automation for macOS, and an installed Simulator
+ * HID/Accessibility CLI plus Xcode/simctl for iOS.
  *
  * Everything a specific repository needs on top — its start/stop commands, its
  * approval gate and teardown, its own living logs and probe scripts — lives in
@@ -49,7 +51,7 @@ export const AcceptanceIdentifier = 'acceptance';
  *
  * `version` is read from SKILL.md's own frontmatter rather than declared here,
  * so there is one place to bump and an installed copy on disk always states the
- * version it carries. Bump it whenever a change alters what a builder must DO —
+ * version it carries. Bump it whenever a change alters what an acceptance agent must DO —
  * a new required step, a changed contract or vocabulary, a moved reference —
  * not for a typo or a reworded sentence.
  */
@@ -57,7 +59,7 @@ export const AcceptanceSkill: BuiltinSkill = {
   avatar: '✅',
   content,
   description:
-    'End-to-end verification and self-evidence for a delivery in any repository, with or without a LobeHub operation or verify plan — discover or author checks, drive CLI, web, desktop, or iOS Simulator on the correct surface, capture visually confirmed evidence, and publish a standalone or subject-linked acceptance round. Reads the repository’s own `.agents/acceptance/` project layer when one exists.',
+    'Delegated end-to-end verification with primary-agent evidence review for a delivery in any repository, with or without a LobeHub operation or verify plan — discover or author checks, drive CLI, web, desktop, or iOS Simulator on the correct surface, capture visually confirmed evidence, and publish a standalone or subject-linked acceptance round. Reads the repository’s own `.agents/acceptance/` project layer when one exists.',
   identifier: AcceptanceIdentifier,
   name: 'acceptance',
   resources: toResourceMeta({
@@ -65,6 +67,7 @@ export const AcceptanceSkill: BuiltinSkill = {
     'references/common-mistakes.md': commonMistakes,
     'references/auth-web.md': authWeb,
     'references/computer-use.md': computerUse,
+    'references/delegation.md': delegation,
     'references/evidence.md': evidence,
     'references/interaction-cost.md': interactionCost,
     'references/plan-format.md': planFormat,

--- a/packages/builtin-skills/src/acceptance/references/agent-browser.md
+++ b/packages/builtin-skills/src/acceptance/references/agent-browser.md
@@ -221,7 +221,8 @@ Providers: `agentcore`, `browserbase`, `browserless`, `browseruse`, `kernel`.
 - **`snapshot -i` doesn't find contenteditable** — use `snapshot -i -C` for rich
   text editors; `fill` doesn't work on contenteditable, use `type`.
 - **Screenshots written to a path are easiest** — `agent-browser screenshot
-./proof/x.png` then upload that path; with no path they land in
+"$EVIDENCE_DIR/x.png"` saves an artifact for the primary to review and publish
+  after the complete round; with no path screenshots land in
   `~/.agent-browser/tmp/screenshots/`.
 - **Dialogs block all commands** — if commands time out, check
   `agent-browser dialog status`.

--- a/packages/builtin-skills/src/acceptance/references/delegation.md
+++ b/packages/builtin-skills/src/acceptance/references/delegation.md
@@ -1,0 +1,153 @@
+# Acceptance delegation
+
+Default to **one primary agent and one execution worker**. The worker checks the
+environment, drafts the plan, executes it, and prepares evidence. The primary
+challenges the plan before execution and reviews the complete evidence at the
+end. Do not require primary approval after every case or create a separate final
+audit worker. Reuse the execution worker across stages and repairs.
+
+## Select the worker without assuming cheap defaults
+
+Read the current host's tool schema or instructions and explicitly select the
+least expensive available model capable of the task. Pass the supported value,
+which may be an enum alias rather than a full model ID; do not invent `cheap` as
+a model name. Claude Code and Codex use their own native controls. Do not copy
+one host's API into another or guess CLI flags. Per-dispatch selection avoids
+the need to inspect user defaults.
+
+An explicitly configured worker default is usable when its effective selection
+is known and suitable. Missing settings, `inherit`, or unknown models do not
+establish a lower-cost worker. Do not read secrets or change user settings to
+resolve this. If lower-cost selection is unavailable, retain at most the single
+execution worker when independent execution is needed; otherwise the primary
+may execute directly and disclose builder self-verification. Honor explicit user
+requirements for independent execution. Never add a reviewer as a fallback.
+
+Record the selected model and selection mechanism, plus the reported model when
+available. Leave unknown values unknown. Lower per-token cost does not prove
+lower total cost; claim savings only with comparable usage evidence. Escalate
+only for a concrete capability gap within host/user limits. Send bounded briefs
+and artifact paths instead of the full parent history; do not delegate individual
+clicks or commands or spawn recursively from the worker.
+
+## 1. Check the environment
+
+Give the worker the original requirement, changed behavior, target revision,
+authorized surface, this skill, relevant project-adapter paths, and both the generic
+and project living-log paths. The worker loads the common-mistakes checklists and
+probe-pattern indexes before planning, and rereads both checklists before marking
+any case `pass`, following the skill's living-log retrieval rules. It inventories existing
+instances and checks dependencies, authentication, and available probes before
+drafting executable cases. It may prepare the environment within existing
+authority; environment mechanics do not create new permissions.
+
+Maintain a run ledger with process/session identities, owner, stop commands,
+fixtures and restoration steps. The worker owns cleanup; keep the review
+environment available until the primary releases it after final review, following
+the project's teardown order. The primary collects its terminal result before
+final handoff. If the host cannot resume the worker, hand its replacement
+the ledger and artifacts. Verify ownership and liveness before replacing it so
+an existing task is not accidentally started twice.
+
+## 2. Settle the plan before execution
+
+The primary supplies requirements and implementation facts separately from
+hypotheses. The worker drafts the plan using the existing report schema:
+
+- Each case's user-visible outcome and connection to the requirement.
+- Preconditions, actions, expected behavior, and explicit failure conditions.
+- Required evidence types, capture strategy, and relevant dependencies.
+
+Preserve supplied checks and stable IDs. The primary challenges omissions,
+ambiguous expectations, and probes that cannot distinguish success from failure.
+Discuss until material concerns are resolved; additional discussion needs a new
+substantive question, not agreement for its own sake. Record the settled plan
+before execution. Apply project approval gates within existing user authority;
+internal agreement is not user authorization.
+
+Agree up front on which failures stop dependent cases, which cases can continue
+independently, and what requires renewed requirement discussion. The worker must
+not silently weaken criteria to obtain a pass. Reopen the affected part of the
+plan only when new evidence invalidates it or material ambiguity is discovered.
+
+## 3. Execute autonomously; escalate exceptions
+
+The worker executes the agreed cases, records observations and evidence, and
+proceeds without waiting for primary approval after each case. It may use an
+earlier case's observed result to run an agreed dependent case when that case's
+precondition is satisfied. The primary does not monitor every artifact or repeat
+successful execution. Shared fixtures and fault injections remain serialized.
+
+Notify the primary when requirement ambiguity, a product failure, an environment
+blocker, or an evidence problem prevents credible verification. Include affected
+case IDs, expected versus observed behavior, tested revision, decisive evidence
+paths, and the decision needed. Pause affected dependent cases; independent cases
+may continue. Routine successful cases need no individual approval message.
+
+Product repair belongs to the implementation owner: the primary or the existing
+implementation agent. Keep the acceptance executor separate from the repairer;
+the primary retains the final judgment even when it makes the repair itself.
+After a repair, identify which earlier evidence the change invalidates and rerun
+affected cases on the changed revision. Preserve unaffected evidence only with
+its original revision and reuse clearly labeled; an earlier pass does not carry
+across a relevant change. Missing evidence belongs to the executor, without implying
+a product change. If probe repair repeats without new evidence or a credible next
+step, escalate the concrete failure instead of continuing blind attempts.
+
+Give each execution an attempt ID and preserve its evidence. Snapshot relevant
+live-log excerpts rather than citing a growing log. Supplemental evidence from
+the same execution may use new files; a rerun uses a new attempt ID. Record the
+current attempt and exact evidence paths per case in the ledger, marking replaced
+attempts so the final review does not confuse discarded and current results.
+
+## Communicate completion; do not poll files
+
+At dispatch, specify a parent-visible message/completion channel and a bounded
+checkpoint for long work. Worker-local commentary may not reach the primary.
+Use notifications for exceptions, an agreed long-work checkpoint, report readiness,
+and cleanup completion. Writing files alone is not a handoff. If the host only
+delivers terminal results, return at the agreed checkpoint and continue the same
+worker role using native resume or the ledger; do not force one dispatch per case.
+
+The primary waits for notifications and reads cited files to make decisions, not
+to infer progress. Do not repeatedly list directories, check modification times,
+or reopen unfinished drafts. On an overdue checkpoint, ask the running worker
+once for its operation/session and blocker if the host supports that channel.
+Otherwise, or if delivery fails, inspect the ledger and recorded process. Silence
+alone does not establish that a worker died; verify before interrupting it.
+
+## 4. Primary reviews the completed round
+
+The worker sends a report-ready handoff after checking plan/case mapping and
+evidence references. Every planned case must have an explicit outcome, including
+blocked or unexecuted cases. Supply completed report paths, the attempt ledger,
+tested revisions, evidence reuse, and cleanup state. Keep submitted evidence and
+the report stable while the primary reviews them.
+
+The primary reviews the whole requirement, plan, and original evidence at this
+point. Open the screenshots, inspect temporal evidence for flicker or transitions,
+and check request/output records for behavioral claims. A worker's pass label is
+not proof. Check missing required evidence, contradictions, stale revisions, and
+ineffective injection. Apply the skill's living-log checklists and record case
+decisions in the report; a final review still covers every case.
+
+Route findings to the implementer or executor as above. Review corrected evidence
+and affected conclusions without rerunning unrelated passing cases or restarting
+the entire review. The primary executes publication and owns the final handoff
+for both authored and plan-driven rounds. Publish only after its final review is complete,
+with remaining failures or uncertainty reported explicitly. Follow the project's
+cleanup sequence and collect cleanup completion before the final user handoff.
+Published rounds remain immutable; repairs after publication create a new round.
+For a plan-driven round, the worker stages evidence locally and the primary submits
+only reviewed attempts after the complete review, following
+[plan-format.md](plan-format.md#review-before-submission). Server result IDs are not
+attempt IDs; the local ledger preserves execution history.
+
+## Reporting
+
+Keep the existing plan/case/evidence schema. The narrative tail records who
+implemented, executed, and performed the final review, worker/run/model provenance,
+tested revisions, reused evidence, and limitations. Distinguish independent
+execution from builder self-verification. Do not create a separate final audit
+agent or claim that one reviewed this round. If delegation is unavailable or prohibited, the primary
+may execute within authority and disclose the missing independent execution.

--- a/packages/builtin-skills/src/acceptance/references/evidence.md
+++ b/packages/builtin-skills/src/acceptance/references/evidence.md
@@ -4,6 +4,31 @@ This reference defines the artifact contract shared by every surface. Capture
 commands belong to the selected surface guide; do not load another surface's
 instructions merely to learn how to submit an artifact.
 
+## Capture first, publish after review
+
+During execution, save artifacts and the attempt ledger locally. All upload and
+`result submit` examples in surface guides and this reference are publication
+commands for the primary **after reviewing the complete round**, not capture
+steps for the worker. Never rerun a command inside `--content`; submit the saved
+output that was actually reviewed. Follow [plan-format.md](plan-format.md) for
+plan-driven submission or [report.md](report.md) for authored ingestion.
+
+Use the project adapter's report root when specified; otherwise create a unique
+round directory under `.acceptances/` and ensure Git ignores it before writing
+artifacts. Set `EVIDENCE_DIR` to an absolute attempt directory within that round.
+Examples using `./proof` or `./out` are placeholders for this directory, not
+instructions to write in the repository root. Save an `attempt-ledger.json` in
+the round directory with case/attempt IDs, revisions, evidence paths and current
+status. Record the round path in the handoff so a resumed worker can find it.
+Before publishing, the primary reads the reviewed attempt's absolute artifact
+paths, attempt ID and tested revision from this ledger and sets any example
+variables in its own shell. Worker shell variables are not shared with the primary.
+Persist artifacts as they are captured and update the ledger after each attempt.
+Keep the directory across worker exits, review and upload retries until publication
+and uploaded coverage are confirmed. Do not rely on shell variables or terminal
+output as the only copy. Local storage survives process exits, not disk loss or
+external temporary-file cleanup; lost evidence requires recapture, never a pass.
+
 ## Evidence media
 
 | Type           | Use when                                                                                          |
@@ -27,7 +52,7 @@ a file exists. Upload the clip itself with `--type audio` and the acceptance
 page gives the reviewer a player.
 
 ```bash
-# The generated file is the evidence — attach the artifact the feature produced,
+# Publication only, after primary review. Attach the artifact the feature produced,
 # not a re-encode and not a screenshot of the player.
 lh acceptance run result submit --operation "$OPERATION_ID" --item "$CHECK_ITEM_ID" \
   --type audio --file ./out/tts-zh-female.mp3 --by program \

--- a/packages/builtin-skills/src/acceptance/references/plan-format.md
+++ b/packages/builtin-skills/src/acceptance/references/plan-format.md
@@ -94,15 +94,14 @@ the primary's evidence review does not replace that verifier. Add
 `--verdict` only when the task explicitly asks you to self-assert. Keep the
 printed run URL internal.
 
-The primary also records the reviewed role/run/model provenance and limitations
-in this round's narrative with `lh acceptance run report upsert --run "$VERIFY_RUN_ID" --content "$REVIEWED_NARRATIVE"`.
-After submission, read `lh acceptance run result list --operation "$OP" --json`
-and set `VERIFY_RUN_ID` from the returned rows' `verifyRunId`, not their `id` or
-the operation ID. Confirm the rows belong to the intended single round; if no
-rows exist or the run is ambiguous, resolve that before writing the narrative.
-Omit `--verdict` unless self-assertion was explicitly
-requested. This is part of initial publication, not permission to rewrite a
-published round after a repair.
+For this path, save the reviewed role/run/model provenance and limitations in a
+local narrative file, and submit it as supplementary `markdown` evidence on an
+existing planned item using the same `result submit` command without `--verdict`.
+Identify it as round-level provenance in the description; it does not replace any
+required evidence. This is the plan-driven equivalent of the authored narrative
+tail. Do not use `report upsert` merely to add this text: omitted report fields
+are overwritten with null, which can erase the configured verifier's verdict,
+summary and counts. Leave that verifier's report intact.
 
 ## Self-check coverage (do not skip)
 
@@ -114,7 +113,7 @@ Once you've submitted, the result rows exist. Map each `checkItemId` to its
 [
   {
     "id": "vcr_x9y8z7", // checkResultId (created by submit)
-    "verifyRunId": "vrn_a1b2c3", // report upsert --run uses this value
+    "verifyRunId": "vrn_a1b2c3", // verification round, distinct from the operation
     "checkItemId": "vci_a1b2c3", // joins back to verifyPlan[].id
     "status": "running",
   },

--- a/packages/builtin-skills/src/acceptance/references/plan-format.md
+++ b/packages/builtin-skills/src/acceptance/references/plan-format.md
@@ -47,10 +47,32 @@ Only items with a non-empty `requiredEvidence` need an artifact; the rest are
 judged on the deliverable text — don't fabricate evidence for them. The `hint`
 usually implies the surface (SKILL.md, Pick the surface).
 
-## Your worklist → submit by checkItemId
+## Review before submission
 
-For each `verifyPlan[]` item with non-empty `requiredEvidence`, capture each
-`type` with the selected surface guide and submit **one artifact per call** by
+The execution worker captures evidence locally for the complete agreed plan. Use
+the [storage and retention contract](evidence.md#capture-first-publish-after-review)
+for the round directory, attempt artifacts, and `attempt-ledger.json`. Use
+the attempt ledger from [delegation.md](delegation.md): each rerun has a new attempt
+ID and separate artifacts. Do not call `result submit` during case execution.
+The primary reviews the completed evidence before submitting any results, without
+intermediate approval per case or a separate audit agent.
+
+Submit only the reviewed current attempt for each item. Include its attempt ID
+and tested revision in the evidence description so it maps back to the ledger.
+`checkItemId` identifies the criterion, not an execution attempt; server row reuse
+does not preserve or supersede local attempts. Keep discarded attempts locally
+and do not upload them as current evidence.
+
+If a repair invalidates evidence already submitted to this run, use a new
+plan-driven run through the caller's or project's supported workflow. Do not
+overwrite the old round or mix repair attempts into it. If no supported way to
+obtain that run is available, report the publication blocker while retaining the
+new evidence; do not invent flags or silently switch to authored ingestion.
+
+## Reviewed worklist → submit by checkItemId
+
+After the primary's review, for each `verifyPlan[]` item with non-empty
+`requiredEvidence`, submit the reviewed artifacts **one artifact per call** by
 `checkItemId` (the same `--item` reuses the row):
 
 | checkItemId  | title                            | requiredEvidence |
@@ -67,9 +89,20 @@ lh acceptance run result submit --operation "$OP" --item vci_a1b2c3 --type scree
 check-result row for you** (idempotent on `checkItemId`), then attaches the
 evidence — there is no `checkResultId` to look up first. `--by` records
 provenance (`agent-browser` | `cdp` | `cli` | `program`); `--file` for binaries,
-`--content` for text, exactly one. Leave the verdict to the review step — add
+`--content` for text, exactly one. Leave the verdict to the plan's configured verifier;
+the primary's evidence review does not replace that verifier. Add
 `--verdict` only when the task explicitly asks you to self-assert. Keep the
 printed run URL internal.
+
+The primary also records the reviewed role/run/model provenance and limitations
+in this round's narrative with `lh acceptance run report upsert --run "$VERIFY_RUN_ID" --content "$REVIEWED_NARRATIVE"`.
+After submission, read `lh acceptance run result list --operation "$OP" --json`
+and set `VERIFY_RUN_ID` from the returned rows' `verifyRunId`, not their `id` or
+the operation ID. Confirm the rows belong to the intended single round; if no
+rows exist or the run is ambiguous, resolve that before writing the narrative.
+Omit `--verdict` unless self-assertion was explicitly
+requested. This is part of initial publication, not permission to rewrite a
+published round after a repair.
 
 ## Self-check coverage (do not skip)
 
@@ -81,6 +114,7 @@ Once you've submitted, the result rows exist. Map each `checkItemId` to its
 [
   {
     "id": "vcr_x9y8z7", // checkResultId (created by submit)
+    "verifyRunId": "vrn_a1b2c3", // report upsert --run uses this value
     "checkItemId": "vci_a1b2c3", // joins back to verifyPlan[].id
     "status": "running",
   },
@@ -92,5 +126,8 @@ lh acceptance run evidence list "$CHECK_RESULT_ID" --json # confirm each require
 ```
 
 Coverage rule: for each required criterion, **every** `requiredEvidence[].type`
-appears at least once in its evidence list. A missing type → capture and submit
-again; then hand off per SKILL.md (acceptance URL + `coverage: n/n`).
+appears at least once in its evidence list. A missing upload → retry with the
+same reviewed artifact. Missing captured evidence → return to the executor and
+have the primary review the supplement before submission; a rerun must follow
+the attempt and round rules above. Then hand off per SKILL.md
+(acceptance URL + `coverage: n/n`).

--- a/packages/builtin-skills/src/acceptance/references/recording-cdp.md
+++ b/packages/builtin-skills/src/acceptance/references/recording-cdp.md
@@ -64,5 +64,6 @@ published; it is useful when a reviewer asks about a one-frame defect.
   assembled media artifact.
 - `agent-browser` and `ffmpeg`/`ffprobe` are required. Probe them before the run.
 
-Choose `gif` versus `video` and submit the artifact using the shared contract in
+Choose `gif` versus `video` and save the artifact locally. The primary publishes
+it after reviewing the complete round, using the shared contract in
 [evidence.md](./evidence.md).

--- a/packages/builtin-skills/src/acceptance/references/recording-native-macos.md
+++ b/packages/builtin-skills/src/acceptance/references/recording-native-macos.md
@@ -36,5 +36,6 @@ notification, or secret entered the host-screen capture. Tag direct
 `screencapture` output as `--by cli` and FFmpeg-derived media as `--by program`.
 
 For input and Accessibility commands, use
-[computer-use.md](./computer-use.md). Choose `gif` versus `video` and submit using
-the shared contract in [evidence.md](./evidence.md).
+[computer-use.md](./computer-use.md). Choose `gif` versus `video` and save locally;
+the primary publishes after reviewing the complete round, using the shared
+contract in [evidence.md](./evidence.md).

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -130,7 +130,12 @@ supersedes? }`.
 5. **`report.md` is the narrative tail only** — this-round notes, follow-ups,
    score. Do NOT repeat the scope block or a case table; those double up on the
    page. Write it in the language the user is conversing in.
-6. **Publish:**
+6. **Review, then publish:** the worker hands off the complete round, then the
+   primary reviews all original evidence as defined in [delegation.md](delegation.md).
+   Do not require intermediate approval per case or create a separate audit agent.
+   Record role/run/model provenance, any missing independent execution, and
+   unresolved findings in the narrative tail.
+   The primary owns the final publication decision.
 
    ```bash
    lh acceptance run ingest "$REPORT_DIR" --source agent-testing --json

--- a/packages/builtin-skills/src/acceptance/surfaces/cli.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/cli.md
@@ -13,25 +13,26 @@ about rendered UI.
 
 1. Run the command, test, or query that exercises the change. Prefer a machine
    output mode (`--json`, a structured dump) so the proof is assertable, not prose.
-2. Capture the output and upload it as `text` evidence — inline with `--content`
-   for short output, or `--file` for a larger dump.
+2. Save the output as `text` evidence in the current attempt directory, using the
+   storage contract in [evidence.md](../references/evidence.md#capture-first-publish-after-review).
+3. After the primary reviews the complete round, the primary publishes the saved
+   artifact. The commands below separate capture from plan-driven publication;
+   authored rounds instead include the artifact in their report.
 
 ```bash
+# Worker: capture the actual product command's output, not a test-suite verdict.
+your-cli command --json > "$EVIDENCE_DIR/result.json"
+
+# Primary: publication only, after reviewing the completed round.
+# First read the current reviewed attempt from attempt-ledger.json. Replace these
+# placeholders with that record's values in the primary's own shell.
+ARTIFACT_PATH='/absolute/path/from/ledger/result.json'
+ATTEMPT_ID='reviewed-attempt-id-from-ledger'
+TESTED_REVISION='tested-revision-from-ledger'
 # CHECK_ITEM_ID is the criterion's plan item id (from `lh verify plan state`).
-# short result → inline
 lh acceptance run result submit --operation "$OPERATION_ID" --item "$CHECK_ITEM_ID" --type text \
-  --content "$(your-cli command --json)" \
-  --by cli --desc "command reports the new field after the change"
-
-# larger output (test log, full dump) → file
-your-cli command --json > ./proof/result.json
-lh acceptance run result submit --operation "$OPERATION_ID" --item "$CHECK_ITEM_ID" --type text \
-  --file ./proof/result.json --by cli --desc "full result set"
-
-# a test run is itself proof
-your-test-runner path/to/spec > ./proof/test.log 2>&1
-lh acceptance run result submit --operation "$OPERATION_ID" --item "$CHECK_ITEM_ID" --type text \
-  --file ./proof/test.log --by program --desc "regression spec passes"
+  --file "$ARTIFACT_PATH" --by cli \
+  --desc "Attempt $ATTEMPT_ID at $TESTED_REVISION: command reports the new field"
 ```
 
 Provenance: `cli` for command stdout, `program` for a script/test you ran. See

--- a/packages/builtin-skills/src/acceptance/surfaces/ios-simulator.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/ios-simulator.md
@@ -241,7 +241,8 @@ CLI interactions may mutate live data. Use a test fixture when possible. If an
 exploratory command appends a reaction, message, or other irreversible record,
 disclose the exact side effect in the report.
 
-Publish the artifacts with the plan-driven submit flow or place them under the
-structured report's `assets/` directory and ingest the whole round. Tag direct
+Stage artifacts locally under the [storage contract](../references/evidence.md#capture-first-publish-after-review).
+After reviewing the complete round, the primary publishes with the plan-driven
+submit flow or ingests the authored report and its `assets/` directory. Tag direct
 AXe/`simctl` captures as `--by cli`, deterministic UI-test/media-transform output
 as `--by program`, and preserve the device identity in every artifact description.

--- a/packages/builtin-skills/src/acceptance/surfaces/native.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/native.md
@@ -30,7 +30,10 @@ sleep 2 # let the result settle
 screencapture -l "$(osascript -e "tell application \"System Events\" to tell process \"$APP\" to get id of window 1")" ./proof/native-result.png
 ```
 
-Upload as evidence (provenance `cli`, since osascript/screencapture are
+Save under the current attempt directory using the
+[storage contract](../references/evidence.md#capture-first-publish-after-review);
+`./proof` above is a placeholder. After reviewing the complete round, the primary
+uploads the saved evidence (provenance `cli`, since osascript/screencapture are
 shell-driven):
 
 ```bash


### PR DESCRIPTION
Acceptance verification now uses one execution worker for environment inspection, plan drafting, and autonomous case execution. The primary settles the plan before execution, reviews original evidence once the round is complete, and publishes it. Routine cases no longer require intermediate approval, and the workflow prohibits a separate final audit agent.

### Key Decisions / Non-goals

- Select a suitable lower-cost worker explicitly through the host's supported controls. Missing defaults do not prove a cheaper model; Claude Code and Codex use their own controls and supported fallbacks.
- Reuse the worker and communicate exceptions/completion through notifications instead of polling draft files. Implementation owners repair product failures; the executor reruns affected cases.
- Keep attempt-specific evidence and provenance locally until final primary review, for both authored and plan-driven rounds. Preserve the plan's configured verifier and immutable published rounds.
- Keep generic rules in the builtin skill and project mechanics in the project adapter. Update surface guides consistently.
- This updates the packaged builtin skill as well as the repository skill linked to it. It contains no home-cache or authentication implementation changes.

#### Test

- [x] Tested locally
- Changed-file lint passed; the builtin skill resource tests passed (6 cases).
- Independent Claude Code review and follow-up review informed the final instructions. The final small run-ID and shell-handoff clarifications passed lint.
- No claim of an end-to-end run of this exact simplified workflow or measured total token savings.

#### Related PR

Split from https://github.com/lobehub/lobehub/pull/19219 so the skill workflow and home bootstrap fixes can be reviewed independently.
