### PR TITLE
🐛 fix: retry Codex capacity errors and refine Acceptance UI

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -2438,3 +2438,19 @@ stub's answer-mode off the NAME of the last `function_call` instead.
   `Detailed references` — never after the closing sections, or the taxonomy drifts.
 - Give it the next `P<nn>` id in its heading, an `**applies-to:**` line right under the
   heading, and one row in the `## Index` table. Ids are stable — never renumber.
+
+#### Acceptance evidence rendering in Electron uses the Portal
+
+The standalone `/acceptance/:id` route is Web-only. Adding that URL as an
+Electron tab can fall back to Home without exercising the Acceptance viewer.
+For desktop verification, open a real conversation and use the existing
+`chat.openAcceptance(id)` action to mount the canonical Acceptance Portal.
+When reusing a reviewed fixture, select the inventory's All filter before
+expanding its evidence; the default pending filter can legitimately be empty.
+
+When checking media or error-card spacing, inspect the complete rendered
+ancestor chain. `@lobehub/ui` Image has its own rounded root inside
+ScreenshotTiles, and Highlighter's `styles.content` styles a container whose
+`pre` has separate padding. An outer wrapper or `img` override alone does not
+prove the visible edge or total inset changed. Measure the settled DOM, then
+inspect a screenshot before declaring the styling verified.

--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -211,6 +211,38 @@ describe('CodexAdapter', () => {
     });
   });
 
+  it.each(['error', 'turn.failed'])(
+    'classifies capacity failures from %s for auto-retry',
+    (type) => {
+      const adapter = new CodexAdapter();
+      const message = 'Selected model is at capacity. Please try a different model.';
+      adapter.adapt({ type: 'turn.started' });
+
+      const events = adapter.adapt(
+        type === 'error' ? { message, type } : { error: { message }, type },
+      );
+
+      expect(events.at(-1)).toMatchObject({
+        data: {
+          agentType: 'codex',
+          clearEchoedContent: true,
+          code: 'overloaded',
+          details: { kind: 'server_overloaded' },
+          message,
+          stderr: message,
+        },
+        type: 'error',
+      });
+      expect(adapter.adapt({ error: { message }, type: 'turn.failed' })).toEqual([]);
+    },
+  );
+
+  it('does not auto-retry unrelated model errors', () => {
+    const adapter = new CodexAdapter();
+    const events = adapter.adapt({ message: 'Selected model is unavailable.', type: 'error' });
+    expect(events.at(-1)?.data).not.toHaveProperty('code');
+  });
+
   it('classifies Codex usage-limit errors with retry metadata', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 5, 13, 3, 9, 27));

--- a/packages/heterogeneous-agents/src/adapters/codex.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.ts
@@ -14,6 +14,7 @@ import {
   CODEX_COMMAND_OUTPUT_MAX_LENGTH,
   truncateCodexCommandOutput,
 } from '../utils/codexCommandOutput';
+import { isCodexCapacityError } from '../utils/codexErrors';
 import { toCodexUsageData, toTurnUsageFromCumulative } from '../utils/codexUsage';
 
 const CODEX_IDENTIFIER = 'codex';
@@ -903,7 +904,9 @@ export class CodexAdapter implements AgentEventAdapter {
             docsUrl: CODEX_USAGE_SETTINGS_URL,
             rateLimitInfo,
           }
-        : {}),
+        : isCodexCapacityError(message)
+          ? { code: 'overloaded', details: { kind: 'server_overloaded' } }
+          : {}),
       message,
       stderr,
     };

--- a/packages/heterogeneous-agents/src/adapters/codexAppServer.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codexAppServer.test.ts
@@ -260,6 +260,47 @@ describe('CodexAppServerAdapter', () => {
     });
   });
 
+  it.each([null, 'other'])('classifies capacity errors with info %s for auto-retry', (info) => {
+    const adapter = new CodexAppServerAdapter();
+    const message = 'Selected model is at capacity. Please try a different model.';
+    const error = { additionalDetails: null, codexErrorInfo: info, message };
+    const events = adapter.adapt('error', {
+      error,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      willRetry: false,
+    });
+    expect(events.at(-1)).toMatchObject({
+      data: {
+        agentType: 'codex',
+        clearEchoedContent: true,
+        code: 'overloaded',
+        details: { kind: 'server_overloaded' },
+        message,
+      },
+      type: 'error',
+    });
+    expect(
+      adapter.adapt('turn/completed', {
+        threadId: 'thread-1',
+        turn: { error, id: 'turn-1', items: [], status: 'failed' },
+      }),
+    ).toEqual([]);
+  });
+
+  it('preserves native retry notifications for capacity failures', () => {
+    const adapter = new CodexAppServerAdapter();
+    const message = 'Selected model is at capacity. Please try a different model.';
+    expect(
+      adapter.adapt('error', {
+        error: { additionalDetails: null, codexErrorInfo: null, message },
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        willRetry: true,
+      }),
+    ).toMatchObject([{ data: { message }, type: 'stream_retry' }]);
+  });
+
   it('keeps native and exec adapters semantically aligned during migration', async () => {
     const fixture = await loadParityFixture();
     const nativeAdapter = new CodexAppServerAdapter();

--- a/packages/heterogeneous-agents/src/adapters/codexAppServer.ts
+++ b/packages/heterogeneous-agents/src/adapters/codexAppServer.ts
@@ -35,6 +35,7 @@ import {
   CODEX_COMMAND_OUTPUT_MAX_LENGTH,
   truncateCodexCommandOutput,
 } from '../utils/codexCommandOutput';
+import { isCodexCapacityError } from '../utils/codexErrors';
 import { toTurnUsageFromCumulative } from '../utils/codexUsage';
 
 const CODEX_IDENTIFIER = 'codex';
@@ -323,7 +324,10 @@ const toUsage = (usage: TokenUsageBreakdown): UsageData | undefined => {
   };
 };
 
-const classifyCodexError = (info: CodexErrorInfo | null): CodexErrorClassification => {
+const classifyCodexError = (
+  info: CodexErrorInfo | null,
+  message: string,
+): CodexErrorClassification => {
   if (typeof info === 'object' && info) {
     if ('activeTurnNotSteerable' in info) return { kind: 'agent_failed' };
     const connection =
@@ -359,6 +363,9 @@ const classifyCodexError = (info: CodexErrorInfo | null): CodexErrorClassificati
       return { kind: 'invalid_request' };
     }
     default: {
+      if (isCodexCapacityError(message)) {
+        return { code: 'overloaded', kind: 'server_overloaded' };
+      }
       return { kind: 'agent_failed' };
     }
   }
@@ -744,7 +751,7 @@ export class CodexAppServerAdapter {
   private terminalError(error: TurnError): HeterogeneousAgentEvent[] {
     if (this.terminal) return [];
     this.terminal = true;
-    const classification = classifyCodexError(error.codexErrorInfo);
+    const classification = classifyCodexError(error.codexErrorInfo, error.message);
     const details = {
       ...(error.additionalDetails ? { additionalDetails: error.additionalDetails } : {}),
       ...(error.codexErrorInfo ? { codexErrorInfo: error.codexErrorInfo } : {}),

--- a/packages/heterogeneous-agents/src/utils/codexErrors.ts
+++ b/packages/heterogeneous-agents/src/utils/codexErrors.ts
@@ -1,0 +1,3 @@
+/** Capacity failures are transient and use the same retry policy as CC overloads. */
+export const isCodexCapacityError = (message: string): boolean =>
+  /\bselected model is at capacity\b/i.test(message);

--- a/src/features/Acceptance/Report/EvidenceComparisonCard.tsx
+++ b/src/features/Acceptance/Report/EvidenceComparisonCard.tsx
@@ -3,12 +3,11 @@
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 
 /** The `metadata.comparison` an evidence artifact may carry (authored at ingest). */
 export interface EvidenceComparisonMeta {
   id: string;
-  /** Optional per-side caption shown next to the role. */
+  /** Optional authored caption shown in the tinted band. */
   label?: string;
   /**
    * How the pair is arranged. Side by side reads best for tall, narrow captures
@@ -105,10 +104,6 @@ const styles = createStaticStyles(({ css }) => ({
     color: ${cssVar.colorSuccessText};
     background: ${cssVar.colorSuccessBg};
   `,
-  role: css`
-    flex: none;
-    font-weight: 600;
-  `,
   /* The two captions are themselves a before/after contrast, so they must stay
      readable side by side — wrap rather than ellipsize. */
   caption: css`
@@ -132,7 +127,7 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 export interface EvidenceComparisonSide {
-  /** Caption next to the role band — the comparison label, or the evidence description. */
+  /** Caption in the tinted band — the comparison label, or the evidence description. */
   caption?: string;
   content: ReactNode;
 }
@@ -149,8 +144,6 @@ interface EvidenceComparisonCardProps {
  */
 export const EvidenceComparisonCard = memo<EvidenceComparisonCardProps>(
   ({ after, before, layout = 'horizontal' }) => {
-    const { t } = useTranslation('verify');
-
     return (
       <div className={cx(styles.card, layout === 'vertical' && styles.cardVertical)}>
         {(
@@ -160,15 +153,16 @@ export const EvidenceComparisonCard = memo<EvidenceComparisonCardProps>(
           ] as const
         ).map(([role, side]) => (
           <div className={styles.side} key={role}>
-            <div
-              className={cx(
-                styles.label,
-                role === 'before' ? styles.labelBefore : styles.labelAfter,
-              )}
-            >
-              <span className={styles.role}>{t(`report.evidence.comparison.${role}`)}</span>
-              {side.caption && <span className={styles.caption}>{side.caption}</span>}
-            </div>
+            {side.caption && (
+              <div
+                className={cx(
+                  styles.label,
+                  role === 'before' ? styles.labelBefore : styles.labelAfter,
+                )}
+              >
+                <span className={styles.caption}>{side.caption}</span>
+              </div>
+            )}
             <div className={styles.content}>{side.content}</div>
           </div>
         ))}

--- a/src/features/Acceptance/Viewer/AcceptanceLedgerRail.tsx
+++ b/src/features/Acceptance/Viewer/AcceptanceLedgerRail.tsx
@@ -122,10 +122,11 @@ const AcceptanceLedgerRail = () => {
   const topic =
     topicProps && TopicPanel ? (
       <TopicPanel
+        agentAvatar={topicProps.agentAvatar}
+        agentBackgroundColor={topicProps.agentBackgroundColor}
         agentId={topicProps.agentId}
         title={topicProps.title}
         topicId={topicProps.topicId}
-        onBack={() => originConversation?.closeTopicDrawer()}
         onCollapse={() => setExpand(false)}
       />
     ) : null;

--- a/src/features/Acceptance/Viewer/AcceptanceLedgerRail.tsx
+++ b/src/features/Acceptance/Viewer/AcceptanceLedgerRail.tsx
@@ -4,7 +4,6 @@ import { DraggablePanel, Flexbox, Icon } from '@lobehub/ui';
 import { Drawer, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
 import { PanelRightOpen } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
 
@@ -13,8 +12,9 @@ import { resolveRoundParam } from '../utils';
 import { useAcceptanceScope } from './AcceptanceScope';
 import { checkFilterState } from './CheckList';
 import LedgerPanel, { type AcceptanceRound } from './LedgerPanel';
-import { originTopicPanelProps, useOriginConversation } from './originConversation';
+import { originTopicPanelProps } from './originConversation';
 import { useAcceptanceBundle } from './useAcceptanceBundle';
+import { useAcceptanceRailState } from './useAcceptanceRailState';
 import { canViewAcceptanceHistory } from './visibility';
 
 const styles = createStaticStyles(({ css }) => ({
@@ -60,27 +60,13 @@ const AcceptanceLedgerRail = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { acceptanceId, embedded } = useAcceptanceScope();
   const { data } = useAcceptanceBundle(acceptanceId);
-  const originConversation = useOriginConversation();
-  const originTopicOpen = Boolean(originConversation?.isOpen);
-  /**
-   * Collapsed by default. The rounds are provenance — worth reaching for when
-   * a verdict is in question, not worth a permanent column beside every read.
-   */
-  const [expand, setExpand] = useState(false);
-  const highlightRound = null;
   const focused = Boolean(params.checkId);
-
-  useEffect(() => {
-    if (isNarrowViewport) setExpand(false);
-  }, [isNarrowViewport]);
-
-  useEffect(() => {
-    if (focused) setExpand(false);
-  }, [focused]);
-
-  useEffect(() => {
-    if (originTopicOpen && !focused) setExpand(true);
-  }, [focused, originTopicOpen]);
+  const { expand, onExpandChange, originConversation } = useAcceptanceRailState({
+    focused,
+    isNarrowViewport,
+  });
+  const originTopicOpen = Boolean(originConversation?.isOpen);
+  const highlightRound = null;
 
   if (!data || !canViewAcceptanceHistory(data.isOwner)) return null;
 
@@ -127,7 +113,7 @@ const AcceptanceLedgerRail = () => {
         agentId={topicProps.agentId}
         title={topicProps.title}
         topicId={topicProps.topicId}
-        onCollapse={() => setExpand(false)}
+        onCollapse={() => onExpandChange(false)}
       />
     ) : null;
 
@@ -136,7 +122,7 @@ const AcceptanceLedgerRail = () => {
       highlight={highlightRound}
       reviewByRound={reviewByRound}
       rounds={data.rounds}
-      onCollapse={() => setExpand(false)}
+      onCollapse={() => onExpandChange(false)}
       onOpenReport={openReport}
     />
   );
@@ -149,7 +135,7 @@ const AcceptanceLedgerRail = () => {
           className={styles.toggle}
           gap={5}
           title={t('acceptance.ledger.expand')}
-          onClick={() => setExpand(true)}
+          onClick={() => onExpandChange(true)}
         >
           <Icon icon={PanelRightOpen} size={14} />
           <Text className={styles.chipCount}>{data.rounds.length}</Text>
@@ -164,7 +150,7 @@ const AcceptanceLedgerRail = () => {
           placement={'right'}
           styles={{ bodyContent: { padding: 0 } }}
           width={'min(340px, 88vw)'}
-          onClose={() => setExpand(false)}
+          onClose={() => onExpandChange(false)}
         >
           {topic ?? ledger}
         </Drawer>
@@ -176,7 +162,7 @@ const AcceptanceLedgerRail = () => {
           minWidth={300}
           placement={'right'}
           style={{ flex: 'none', height: '100%' }}
-          onExpandChange={setExpand}
+          onExpandChange={onExpandChange}
         >
           <Flexbox style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
             {topic ?? <Flexbox style={{ height: '100%', overflow: 'auto' }}>{ledger}</Flexbox>}

--- a/src/features/Acceptance/Viewer/CheckList.tsx
+++ b/src/features/Acceptance/Viewer/CheckList.tsx
@@ -422,6 +422,7 @@ const comparisonContent = (item: AcceptanceEvidence) => {
   if (item.type === 'screenshot' && item.fileUrl)
     return (
       <ScreenshotTiles
+        flat
         alt={item.description ?? item.fileName ?? item.type}
         fileHeight={item.fileHeight}
         fileWidth={item.fileWidth}

--- a/src/features/Acceptance/Viewer/ScreenshotTiles.tsx
+++ b/src/features/Acceptance/Viewer/ScreenshotTiles.tsx
@@ -2,7 +2,7 @@
 
 import type { AcceptanceReviewAnnotation } from '@lobechat/types';
 import { Flexbox, Image } from '@lobehub/ui';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { memo, type ReactNode, useState } from 'react';
 
 import {
@@ -46,6 +46,10 @@ const styles = createStaticStyles(({ css }) => ({
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadiusLG};
   `,
+  frameFlat: css`
+    border: none;
+    border-radius: 0;
+  `,
   rect: css`
     pointer-events: none;
 
@@ -64,11 +68,13 @@ interface ScreenshotTilesProps {
   caption?: ReactNode;
   fileHeight?: number | null;
   fileWidth?: number | null;
+  /** The surrounding comparison card already frames the screenshot. */
+  flat?: boolean;
   src: string;
 }
 
 export const ScreenshotTiles = memo<ScreenshotTilesProps>(
-  ({ alt, annotations, caption, fileHeight, fileWidth, src }) => {
+  ({ alt, annotations, caption, fileHeight, fileWidth, flat = false, src }) => {
     const [natural, setNatural] = useState(
       fileWidth && fileHeight ? { height: fileHeight, width: fileWidth } : undefined,
     );
@@ -95,11 +101,15 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
     if (!natural) {
       return shell(
         '100%',
-        <div className={styles.frame} style={{ maxWidth: '100%', width: '100%' }}>
+        <div
+          className={cx(styles.frame, flat && styles.frameFlat)}
+          style={{ maxWidth: '100%', width: '100%' }}
+        >
           <Image
             alt={alt}
             loading={'lazy'}
             src={src}
+            style={flat ? { borderRadius: 0 } : undefined}
             variant={'borderless'}
             width={'100%'}
             onLoad={rememberSize}
@@ -123,7 +133,7 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
 
             return (
               <div
-                className={styles.frame}
+                className={cx(styles.frame, flat && styles.frameFlat)}
                 key={slice.index}
                 style={{
                   aspectRatio: `${natural.width} / ${slice.height}`,
@@ -138,7 +148,7 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
                   maxWidth={'none'}
                   objectFit={'cover'}
                   src={src}
-                  style={{ height: '100%', width: '100%' }}
+                  style={{ borderRadius: flat ? 0 : undefined, height: '100%', width: '100%' }}
                   variant={'borderless'}
                   width={'100%'}
                   styles={{
@@ -180,7 +190,7 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
     return shell(
       portrait ? screenshotTileWidth(natural.width) : '100%',
       <div
-        className={styles.frame}
+        className={cx(styles.frame, flat && styles.frameFlat)}
         style={{
           aspectRatio: `${natural.width} / ${natural.height}`,
           maxWidth: '100%',
@@ -194,7 +204,7 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
           maxWidth={'none'}
           objectFit={'contain'}
           src={src}
-          style={{ width: '100%' }}
+          style={{ borderRadius: flat ? 0 : undefined, width: '100%' }}
           variant={'borderless'}
           width={'100%'}
         />

--- a/src/features/Acceptance/Viewer/TopicPanel.test.ts
+++ b/src/features/Acceptance/Viewer/TopicPanel.test.ts
@@ -39,13 +39,12 @@ vi.mock('@/features/AgentTasks/AgentTaskDetail/TopicChatDrawer', () => ({
 }));
 
 describe('TopicPanel', () => {
-  it('renders the topic conversation in the right rail and returns to runs', () => {
-    const onBack = vi.fn();
+  it('shows the agent avatar and only a collapse action in the conversation rail', () => {
     const onCollapse = vi.fn();
-    const { getByTestId, getByText, getByTitle } = render(
+    const { getByAltText, getByTestId, getByText, getByTitle, queryByTitle } = render(
       createElement(TopicPanel, {
+        agentAvatar: '🤖',
         agentId: 'agent-1',
-        onBack,
         onCollapse,
         title: 'Origin topic',
         topicId: 'topic-1',
@@ -63,8 +62,8 @@ describe('TopicPanel', () => {
     );
     expect(getByTestId('topic-conversation').textContent).toBe('agent-1:topic-1');
 
-    fireEvent.click(getByTitle('acceptance.origin.backToRuns'));
-    expect(onBack).toHaveBeenCalledOnce();
+    expect(getByAltText('🤖')).toBeTruthy();
+    expect(queryByTitle('acceptance.origin.backToRuns')).toBeNull();
 
     fireEvent.click(getByTitle('acceptance.ledger.collapse'));
     expect(onCollapse).toHaveBeenCalledOnce();

--- a/src/features/Acceptance/Viewer/TopicPanel.tsx
+++ b/src/features/Acceptance/Viewer/TopicPanel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Flexbox, Icon } from '@lobehub/ui';
-import { ActionIcon, Text } from '@lobehub/ui/base-ui';
+import { Flexbox } from '@lobehub/ui';
+import { ActionIcon, Avatar, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
-import { ArrowLeft, MessagesSquare, PanelRightClose } from 'lucide-react';
+import { PanelRightClose } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -17,11 +17,14 @@ import type { OriginTopicPanelProps } from './originConversation';
  * mounting the floating drawer chrome.
  */
 const TopicPanel = memo<OriginTopicPanelProps>(
-  ({ agentId, onBack, onCollapse, title, topicId }) => {
+  ({ agentAvatar, agentBackgroundColor, agentId, onCollapse, title, topicId }) => {
     const { t } = useTranslation('verify');
 
     return (
-      <Flexbox height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }}>
+      <Flexbox
+        height={'100%'}
+        style={{ background: cssVar.colorBgContainer, minHeight: 0, overflow: 'hidden' }}
+      >
         <Flexbox
           horizontal
           align={'center'}
@@ -30,13 +33,11 @@ const TopicPanel = memo<OriginTopicPanelProps>(
           paddingInline={12}
           style={{ borderBlockEnd: `1px solid ${cssVar.colorBorderSecondary}`, flexShrink: 0 }}
         >
-          <ActionIcon
-            icon={ArrowLeft}
-            size={'small'}
-            title={t('acceptance.origin.backToRuns')}
-            onClick={onBack}
+          <Avatar
+            avatar={agentAvatar ?? undefined}
+            background={agentBackgroundColor ?? undefined}
+            size={20}
           />
-          <Icon color={cssVar.colorTextSecondary} icon={MessagesSquare} size={16} />
           <Text ellipsis strong style={{ flex: 1, minWidth: 0, fontSize: 13 }}>
             {title}
           </Text>

--- a/src/features/Acceptance/Viewer/originConversation.test.ts
+++ b/src/features/Acceptance/Viewer/originConversation.test.ts
@@ -20,7 +20,7 @@ const wrapper = ({ children }: { children?: ReactNode }) =>
 
 describe('originTopicPanelProps', () => {
   const origin = {
-    agent: { id: 'agent-1' },
+    agent: { avatar: '🤖', backgroundColor: '#abcdef', id: 'agent-1' },
     topic: { id: 'topic-1', title: 'Origin topic' },
   };
 
@@ -42,6 +42,8 @@ describe('originTopicPanelProps', () => {
         subjectTitle: 'Subject',
       }),
     ).toEqual({
+      agentAvatar: '🤖',
+      agentBackgroundColor: '#abcdef',
       agentId: 'agent-1',
       title: 'Origin topic',
       topicId: 'topic-1',

--- a/src/features/Acceptance/Viewer/originConversation.tsx
+++ b/src/features/Acceptance/Viewer/originConversation.tsx
@@ -7,8 +7,9 @@ import { createContext, use, useMemo, useState } from 'react';
 // provider so origin-conversation affordances stay hidden. Open state lives
 // here — not the task-store topic drawer, which is unmounted on this page.
 export interface OriginTopicPanelProps {
+  agentAvatar?: string | null;
+  agentBackgroundColor?: string | null;
   agentId: string;
-  onBack: () => void;
   onCollapse: () => void;
   title: string;
   topicId: string;
@@ -28,13 +29,15 @@ export const originTopicPanelProps = ({
 }: {
   isOpen: boolean;
   origin?: {
-    agent?: { id: string } | null;
+    agent?: { avatar?: string | null; backgroundColor?: string | null; id: string } | null;
     topic?: { id: string; title?: string | null } | null;
   } | null;
   subjectTitle?: string | null;
-}): Omit<OriginTopicPanelProps, 'onBack' | 'onCollapse'> | null => {
+}): Omit<OriginTopicPanelProps, 'onCollapse'> | null => {
   if (!isOpen || !origin?.agent?.id || !origin.topic) return null;
   return {
+    agentAvatar: origin.agent.avatar,
+    agentBackgroundColor: origin.agent.backgroundColor,
     agentId: origin.agent.id,
     title: origin.topic.title ?? subjectTitle ?? origin.topic.id,
     topicId: origin.topic.id,

--- a/src/features/Acceptance/Viewer/useAcceptanceRailState.test.ts
+++ b/src/features/Acceptance/Viewer/useAcceptanceRailState.test.ts
@@ -1,0 +1,29 @@
+/** @vitest-environment happy-dom */
+import { act, renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { OriginConversationProvider } from './originConversation';
+import { useAcceptanceRailState } from './useAcceptanceRailState';
+
+const TopicPanel = () => null;
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(OriginConversationProvider, { TopicPanel, children });
+
+describe('useAcceptanceRailState', () => {
+  it('reopens the source conversation after collapsing the rail', () => {
+    const { result } = renderHook(
+      () => useAcceptanceRailState({ focused: false, isNarrowViewport: false }),
+      { wrapper },
+    );
+    act(() => result.current.originConversation?.openTopicDrawer('topic-1'));
+    expect(result.current.expand).toBe(true);
+
+    act(() => result.current.onExpandChange(false));
+    expect(result.current.expand).toBe(false);
+    expect(result.current.originConversation?.isOpen).toBe(false);
+
+    act(() => result.current.originConversation?.openTopicDrawer('topic-1'));
+    expect(result.current.expand).toBe(true);
+  });
+});

--- a/src/features/Acceptance/Viewer/useAcceptanceRailState.ts
+++ b/src/features/Acceptance/Viewer/useAcceptanceRailState.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import { useOriginConversation } from './originConversation';
+
+export const useAcceptanceRailState = ({
+  focused,
+  isNarrowViewport,
+}: {
+  focused: boolean;
+  isNarrowViewport: boolean;
+}) => {
+  const originConversation = useOriginConversation();
+  const originTopicOpen = Boolean(originConversation?.isOpen);
+  const [expand, setExpand] = useState(false);
+
+  useEffect(() => {
+    if (isNarrowViewport) setExpand(false);
+  }, [isNarrowViewport]);
+
+  useEffect(() => {
+    if (focused) setExpand(false);
+  }, [focused]);
+
+  useEffect(() => {
+    if (originTopicOpen && !focused) setExpand(true);
+  }, [focused, originTopicOpen]);
+
+  const onExpandChange = (next: boolean) => {
+    setExpand(next);
+    // The topic chip must be able to transition from closed to open again.
+    if (!next) originConversation?.closeTopicDrawer();
+  };
+
+  return { expand, onExpandChange, originConversation };
+};

--- a/src/features/Electron/HeterogeneousAgent/StatusGuide/GuideShell.tsx
+++ b/src/features/Electron/HeterogeneousAgent/StatusGuide/GuideShell.tsx
@@ -35,14 +35,25 @@ const GuideShell = ({
 }: GuideShellProps) => {
   const { t } = useTranslation('common');
   const showHeader = variant !== 'embedded';
-  // Compact cards keep the actions on the same row as the title/description
-  // (right-aligned) so the whole status reads as a single tight line.
+  // Compact cards keep actions alongside the status when space permits,
+  // wrapping them below it in narrow conversation panes.
   const actionsInHeader = compact && showHeader;
   const content = (
     <Flexbox gap={compact ? 8 : 12}>
       {showHeader ? (
-        <Flexbox horizontal align="center" gap={compact ? 10 : 12} justify="space-between">
-          <Flexbox horizontal align="center" gap={compact ? 10 : 12} style={{ minWidth: 0 }}>
+        <Flexbox
+          horizontal
+          align="center"
+          gap={compact ? 8 : 12}
+          justify="space-between"
+          style={compact ? { flexWrap: 'wrap' } : undefined}
+        >
+          <Flexbox
+            horizontal
+            align="center"
+            gap={compact ? 8 : 12}
+            style={{ flex: compact ? '1 1 260px' : undefined, minWidth: 0 }}
+          >
             <Avatar
               avatar={icon}
               background={cssVar.colorFillQuaternary}
@@ -51,14 +62,17 @@ const GuideShell = ({
               style={{ color: cssVar.colorText }}
             />
             <Flexbox gap={2} style={{ minWidth: 0 }}>
-              <Text ellipsis={compact} style={{ fontSize: compact ? 14 : 16, fontWeight: 600 }}>
-                {title}
-              </Text>
+              <Text style={{ fontSize: compact ? 14 : 16, fontWeight: 600 }}>{title}</Text>
               {headerDescription}
             </Flexbox>
           </Flexbox>
           {(actionsInHeader || onDismiss) && (
-            <Flexbox horizontal align="center" gap={8} style={{ flexShrink: 0 }}>
+            <Flexbox
+              horizontal
+              align="center"
+              gap={8}
+              style={{ flexShrink: 0, marginInlineStart: 'auto', maxWidth: '100%' }}
+            >
               {actionsInHeader && actions}
               {onDismiss && (
                 <Tooltip title={t('close')}>

--- a/src/features/Electron/HeterogeneousAgent/StatusGuide/states/OverloadedState.tsx
+++ b/src/features/Electron/HeterogeneousAgent/StatusGuide/states/OverloadedState.tsx
@@ -1,11 +1,20 @@
 import { Flexbox, Highlighter, Icon } from '@lobehub/ui';
 import { Button, Text } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
 import { Ban, Loader2, RotateCcw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import GuideActions from '../GuideActions';
 import GuideShell from '../GuideShell';
 import type { HeterogeneousAgentGuideStateProps } from '../types';
+
+const styles = createStaticStyles(({ css }) => ({
+  errorDetails: css`
+    && pre {
+      padding: 12px;
+    }
+  `,
+}));
 
 const OverloadedState = ({
   autoRetry,
@@ -75,8 +84,8 @@ const OverloadedState = ({
           <Highlighter
             wrap
             actionIconSize={'small'}
+            classNames={{ content: styles.errorDetails }}
             language={'log'}
-            padding={12}
             style={{ maxHeight: 200, overflow: 'auto' }}
             variant={'outlined'}
           >


### PR DESCRIPTION
## Summary

Codex's “Selected model is at capacity” failures now enter the existing overload retry flow, matching Claude Code overload handling. Both Codex adapters preserve non-capacity error classification and avoid duplicate retries.

The retry card wraps its actions in narrow conversations and uses compact error-detail spacing. Acceptance comparison images no longer add nested borders, rounded corners, or fixed Before/After labels. The origin conversation panel uses the container background and the source Agent's avatar, with a single collapse action. Collapsing clears the open-topic state so the source topic can be opened again.

## Validation

- Targeted lint and 95 related tests passed for capacity handling and evidence rendering.
- Targeted lint and 7 tests passed for the origin conversation panel.
- Existing UI verification: https://app.lobehub.com/acceptance/6c9c4935-d8b6-41d9-b7ce-2c6b9350725e?r=3
- Origin conversation UI verification passed (white background, Agent avatar, collapse and reopen): https://app.lobehub.com/acceptance/6c9c4935-d8b6-41d9-b7ce-2c6b9350725e?r=4
- Added a passing hook regression test for collapse and reopen.
- UI verification used an authenticated local test topic and a local Acceptance data fixture; no messages were sent and production review state was not changed.
