### PR TITLE
💄 style(updater): use caption size for update toast copy

### DIFF
--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -57,7 +57,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 12px 8px;
     border-radius: ${cssVar.borderRadiusLG};
 
-    font-size: 14px;
+    font-size: ${cssVar.fontSizeSM};
     line-height: 1.25;
     color: ${cssVar.colorText};
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

The desktop app-update toast in the bottom-left corner used 14px body type next to `size="small"` buttons (12px). The label read heavier than the actions on a compact corner bar.

| Before | After |
| ------ | ----- |
| Toast label at 14px body size | Toast label at `fontSizeSM` (12px), matching adjacent small buttons |

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure CSS type-scale change on `UpdateNotification`. The toast only appears when an update is ready, so no unit snapshot is worth adding.

#### 🔗 Related Issue

N/A