### PR TITLE
🐛 fix: prevent personal conversations leaking into team recent topics

### DIFF
--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -686,7 +686,9 @@ describe('RecentModel', () => {
         await serverDB
           .insert(workspaces)
           .values({ id: workspaceId, name: 'ws', primaryOwnerId: userId, slug: workspaceId });
-        await serverDB.insert(agents).values({ id: 'agent-ws', userId, slug: 'inbox' });
+        await serverDB
+          .insert(agents)
+          .values({ id: 'agent-ws', userId, slug: 'inbox', workspaceId });
         await serverDB.insert(topics).values([
           {
             agentId: 'agent-ws',
@@ -720,6 +722,66 @@ describe('RecentModel', () => {
         expect(result.map((r) => r.id)).toEqual(['topic-ws-mine']);
         expect(result[0].userId).toBe(userId);
       });
+
+      it.each(['agent', 'group'] as const)(
+        'filters private %s topics by resource owner before pagination and preview loading',
+        async (kind) => {
+          const resources = [
+            { id: 'recent-private-mine', userId, visibility: 'private' as const, workspaceId },
+            {
+              id: 'recent-private-other',
+              userId: otherUserId,
+              visibility: 'private' as const,
+              workspaceId,
+            },
+            {
+              id: 'recent-public-other',
+              userId: otherUserId,
+              visibility: 'public' as const,
+              workspaceId,
+            },
+          ];
+          if (kind === 'agent') await serverDB.insert(agents).values(resources);
+          else await serverDB.insert(chatGroups).values(resources);
+
+          await serverDB.insert(topics).values(
+            resources.map((resource, index) => ({
+              agentId: kind === 'agent' ? resource.id : null,
+              groupId: kind === 'group' ? resource.id : null,
+              id: `topic-${resource.id}`,
+              title: resource.id,
+              updatedAt: minutesAgo(-10 + index),
+              // Access follows the resource owner, not the topic author.
+              userId,
+              workspaceId,
+            })),
+          );
+          await serverDB.insert(messages).values({
+            content: 'Private reply',
+            role: 'assistant',
+            topicId: 'topic-recent-private-other',
+            userId: otherUserId,
+            workspaceId,
+          });
+
+          for (const mineOnly of [false, true]) {
+            const result = await workspaceModel.queryRecent(2, ['topic'], true, mineOnly);
+            expect(result.map((row) => row.id)).toEqual([
+              'topic-recent-private-mine',
+              'topic-recent-public-other',
+            ]);
+            expect(result.every((row) => row.lastAssistantMessage === null)).toBe(true);
+          }
+
+          const otherModel = new RecentModel(serverDB, otherUserId, workspaceId);
+          const result = await otherModel.queryRecent(2, ['topic'], true);
+          expect(result.map((row) => row.id)).toEqual([
+            'topic-recent-private-other',
+            'topic-recent-public-other',
+          ]);
+          expect(result[0].lastAssistantMessage).toBe('Private reply');
+        },
+      );
     });
   });
 });

--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -724,6 +724,69 @@ describe('RecentModel', () => {
       });
 
       it.each(['agent', 'group'] as const)(
+        'never exposes personal or foreign-workspace %s conversations in the team feed',
+        async (kind) => {
+          const foreignWorkspaceId = 'recent-foreign-workspace';
+          await serverDB.insert(workspaces).values({
+            id: foreignWorkspaceId,
+            name: 'Other workspace',
+            primaryOwnerId: otherUserId,
+            slug: foreignWorkspaceId,
+          });
+          const resources = [
+            { id: 'personal-resource', userId: otherUserId, workspaceId: null },
+            {
+              id: 'foreign-resource',
+              userId: otherUserId,
+              workspaceId: foreignWorkspaceId,
+            },
+          ];
+          // Personal scope must be enforced even if visibility is public (the
+          // default on legacy/personal rows). It is independent of private.
+          if (kind === 'agent') await serverDB.insert(agents).values(resources);
+          else await serverDB.insert(chatGroups).values(resources);
+
+          const conversations = resources.flatMap((resource) =>
+            [resource.workspaceId, workspaceId].map((topicWorkspaceId, index) => ({
+              agentId: kind === 'agent' ? resource.id : null,
+              description: 'Confidential conversation summary',
+              groupId: kind === 'group' ? resource.id : null,
+              id: `${resource.id}-topic-${index}`,
+              title: 'Confidential conversation title',
+              updatedAt: minutesAgo(-10),
+              userId: otherUserId,
+              // Cover both correctly scoped personal topics and legacy rows
+              // stamped with the team workspace despite a personal parent.
+              workspaceId: topicWorkspaceId,
+            })),
+          );
+          await serverDB.insert(topics).values(conversations);
+          await serverDB.insert(messages).values(
+            conversations.map((topic) => ({
+              content: 'Confidential assistant reply',
+              role: 'assistant' as const,
+              topicId: topic.id,
+              userId: otherUserId,
+              workspaceId: topic.workspaceId,
+            })),
+          );
+
+          for (const viewerId of [userId, otherUserId]) {
+            const viewer = new RecentModel(serverDB, viewerId, workspaceId);
+            const result = await viewer.queryRecent(2, ['topic'], true, false);
+            expect(result.map((row) => row.id)).toEqual(['topic-ws-mine', 'topic-ws-other']);
+            expect(result.every((row) => row.description === null)).toBe(true);
+            expect(result.every((row) => row.lastAssistantMessage === null)).toBe(true);
+          }
+
+          const personalModel = new RecentModel(serverDB, otherUserId);
+          const personal = await personalModel.queryRecent(2, ['topic'], true);
+          expect(personal.map((row) => row.id)).toEqual(['personal-resource-topic-0']);
+          expect(personal[0].lastAssistantMessage).toBe('Confidential assistant reply');
+        },
+      );
+
+      it.each(['agent', 'group'] as const)(
         'filters private %s topics by resource owner before pagination and preview loading',
         async (kind) => {
           const resources = [

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -115,6 +115,9 @@ export class RecentModel {
               // surface a visitor's conversation in the creator's own Recent feed.
               notShareVisitorTopic(),
               mineTopicWhere,
+              // Topic scope alone is insufficient: stale/mismatched rows can
+              // point at a personal or foreign-workspace agent/group. Check
+              // the parent scope before returning titles or loading previews.
               or(
                 and(isNotNull(topics.groupId), buildWorkspaceWhere(scope, chatGroups)),
                 and(

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -3,7 +3,15 @@ import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'dri
 import { unionAll } from 'drizzle-orm/pg-core';
 import removeMarkdown from 'remove-markdown';
 
-import { agents, DOCUMENT_FOLDER_TYPE, documents, messages, tasks, topics } from '../schemas';
+import {
+  agents,
+  chatGroups,
+  DOCUMENT_FOLDER_TYPE,
+  documents,
+  messages,
+  tasks,
+  topics,
+} from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { notShareVisitorTopic } from '../utils/shareVisitor';
 import { buildWorkspaceWhere } from '../utils/workspace';
@@ -97,6 +105,7 @@ export class RecentModel {
       })
       .from(topics)
       .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
       .where(
         requestedTypes && !requestedTypes.has('topic')
           ? sql`false`
@@ -107,9 +116,12 @@ export class RecentModel {
               notShareVisitorTopic(),
               mineTopicWhere,
               or(
-                isNotNull(topics.groupId),
-                eq(agents.slug, 'inbox'),
-                and(isNull(topics.groupId), ne(agents.virtual, true)),
+                and(isNotNull(topics.groupId), buildWorkspaceWhere(scope, chatGroups)),
+                and(
+                  isNull(topics.groupId),
+                  buildWorkspaceWhere(scope, agents),
+                  or(eq(agents.slug, 'inbox'), ne(agents.virtual, true)),
+                ),
               ),
               or(isNull(topics.trigger), not(inArray(topics.trigger, SYSTEM_TOPIC_TRIGGERS))),
               or(isNull(topics.status), not(inArray(topics.status, TOPIC_INBOX_STATUSES))),


### PR DESCRIPTION
The team Recent tab could return a topic linked to a personal agent when the topic row carried the team workspace ID. The old query checked only the topic workspace, allowing the conversation title, summary and assistant preview into another member’s feed. This is a data-isolation issue.

Require both the topic and its owning agent/group to belong to the requested workspace, and apply the parent’s visibility rules before pagination and preview loading. A personal parent (`workspaceId = null`) or foreign-workspace parent is excluded even when the topic is stamped with the current team workspace. Personal-workspace reads remain scoped to the owner.

#### Test

- [x] Tested locally: lint and 32 database integration tests passed.
- [x] Added/updated tests: personal and foreign-workspace agents/groups, correctly scoped and mismatched topic rows, both the owner and another team member reading the team feed, title/summary/preview exclusion before pagination, and personal-owner access.
- [x] Both new cross-workspace regression cases fail against the original query (returning personal and foreign-workspace conversations) and pass with the fix.
- [x] Workspace-private agent/group visibility remains covered separately in mine/team modes.
- Full repository type-check in the PR worktree fails on errors outside the two changed files; neither changed file reports errors.
- Production data has not been inspected; tests reproduce the cross-workspace query failure with controlled database fixtures.

#### 🔗 Related Issue

Fixes LOBE-13881
