### PR TITLE
🐛 fix(auth): keep the desktop re-login modal reachable and stop the 14-day OIDC grant cap

### DIFF
--- a/src/libs/oidc-provider/provider.test.ts
+++ b/src/libs/oidc-provider/provider.test.ts
@@ -116,7 +116,7 @@ describe('OIDC Provider - Market Client Integration', () => {
         BackchannelAuthenticationRequest: 600,
         ClientCredentials: 600,
         DeviceCode: 600,
-        Grant: 14 * 24 * 60 * 60,
+        Grant: 365 * 24 * 60 * 60,
         IdToken: 3600,
         Interaction: 3600,
         RefreshToken: 30 * 24 * 60 * 60,
@@ -128,6 +128,23 @@ describe('OIDC Provider - Market Client Integration', () => {
         expect(Number.isSafeInteger(ttl)).toBe(true);
         expect(ttl).toBeGreaterThan(0);
       }
+
+      vi.doUnmock('@/envs/app');
+    }, 10000);
+
+    it('keeps the grant alive longer than a rotating refresh token', async () => {
+      vi.doMock('@/envs/app', () => ({
+        appEnv: {
+          APP_URL: 'https://example.com',
+          MARKET_BASE_URL: undefined,
+        },
+      }));
+
+      const { oidcArtifactTTL } = await import('./provider');
+      const dayFifteen = 15 * 24 * 60 * 60;
+
+      expect(oidcArtifactTTL.Grant).toBeGreaterThan(dayFifteen);
+      expect(oidcArtifactTTL.Grant).toBeGreaterThanOrEqual(oidcArtifactTTL.RefreshToken);
 
       vi.doUnmock('@/envs/app');
     }, 10000);

--- a/src/libs/oidc-provider/provider.ts
+++ b/src/libs/oidc-provider/provider.ts
@@ -30,7 +30,9 @@ export const oidcArtifactTTL = {
   BackchannelAuthenticationRequest: 10 * MINUTE_SECONDS,
   ClientCredentials: 10 * MINUTE_SECONDS,
   DeviceCode: 10 * MINUTE_SECONDS,
-  Grant: 14 * DAY_SECONDS,
+  // oidc-provider never extends Grant.exp on refresh, so this is the absolute cap on a
+  // signed-in session no matter how often the refresh token rotates.
+  Grant: 365 * DAY_SECONDS,
   IdToken: HOUR_SECONDS,
   Interaction: HOUR_SECONDS,
   RefreshToken: 30 * DAY_SECONDS,

--- a/src/routes/(main)/_layout/DesktopAutoOidcOnFirstOpen.tsx
+++ b/src/routes/(main)/_layout/DesktopAutoOidcOnFirstOpen.tsx
@@ -56,4 +56,6 @@ const DesktopAutoOidcOnFirstOpen = memo(() => {
   return null;
 });
 
+DesktopAutoOidcOnFirstOpen.displayName = 'DesktopAutoOidcOnFirstOpen';
+
 export default DesktopAutoOidcOnFirstOpen;

--- a/src/routes/(main)/_layout/authMount.test.ts
+++ b/src/routes/(main)/_layout/authMount.test.ts
@@ -51,12 +51,15 @@ const nameOf = (type: unknown): string | undefined =>
   (type as { displayName?: string; name?: string } | null)?.displayName ??
   (type as { name?: string } | null)?.name;
 
-const findByName = (node: ReactNode, name: string): ReactElement | undefined => {
-  let hit: ReactElement | undefined;
+const findByName = (
+  node: ReactNode,
+  name: string,
+): ReactElement<{ children?: ReactNode }> | undefined => {
+  let hit: ReactElement<{ children?: ReactNode }> | undefined;
   Children.forEach(node, (child) => {
     if (hit || !isValidElement(child)) return;
     if (nameOf(child.type) === name) {
-      hit = child;
+      hit = child as ReactElement<{ children?: ReactNode }>;
       return;
     }
     hit = findByName((child.props as { children?: ReactNode }).children, name);
@@ -76,7 +79,7 @@ describe.each(layouts)('main layout (%s)', (_name, load) => {
     async () => {
       const { default: Layout } = await load();
 
-      const tree = (Layout as FC)({});
+      const tree = await (Layout as FC)({});
       const slot = findByName(tree, 'WorkspaceContextSlot');
 
       expect(slot).toBeDefined();

--- a/src/routes/(main)/_layout/authMount.test.ts
+++ b/src/routes/(main)/_layout/authMount.test.ts
@@ -1,0 +1,89 @@
+import { Children, type FC, isValidElement, type ReactElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { nullComponent, passthrough } = vi.hoisted(() => ({
+  nullComponent: () => ({ default: () => null }),
+  passthrough: () => ({ default: ({ children }: { children?: unknown }) => children }),
+}));
+
+vi.mock('@/const/version', () => ({ isDesktop: true }));
+vi.mock('@/hooks/usePlatform', () => ({ usePlatform: () => ({ isPWA: false }) }));
+vi.mock('@/store/serverConfig', () => ({
+  featureFlagsSelectors: () => ({ showCloudPromotion: false }),
+  useServerConfigStore: (selector: (s: unknown) => unknown) => selector({}),
+}));
+vi.mock('@/libs/next/dynamic', () => ({ default: () => () => null }));
+vi.mock('@/features/Electron/shell', () => ({
+  useDesktopDocumentTitle: () => {},
+  useLastWorkspaceSlugSync: () => {},
+  useWindowUrlMirror: () => {},
+}));
+vi.mock('@/features/Electron/TabHost', () => ({
+  TabHost: () => null,
+  useSeedTabsOnBoot: () => {},
+}));
+vi.mock('@/features/ResourceManager/DndContextWrapper', () => ({ DndContextWrapper: () => null }));
+vi.mock('@/features/AlertBanner/CloudBanner', () => ({ BANNER_HEIGHT: 0, default: () => null }));
+vi.mock('@/features/RouteMeta', () => ({ RouteMetaBridge: () => null }));
+vi.mock('./style', () => ({ styles: {} }));
+vi.mock('react-router', () => ({ Outlet: () => null }));
+
+vi.mock('@/components/Skeleton/RouteSegment', nullComponent);
+vi.mock('@/features/DesktopBrowserGatewayBridge', nullComponent);
+vi.mock('@/features/DesktopFileMenuBridge', nullComponent);
+vi.mock('@/features/DesktopLayoutContainer', passthrough);
+vi.mock('@/features/DesktopNavigationBridge', nullComponent);
+vi.mock('@/features/Electron/ActiveConversationBridge', nullComponent);
+vi.mock('@/features/Electron/ScreenCapture/OverlayCaptureUploader', nullComponent);
+vi.mock('@/features/Electron/ScreenCapture/OverlayMessageDispatcher', nullComponent);
+vi.mock('@/features/Electron/ScreenCapture/OverlaySnapshotPublisher', nullComponent);
+vi.mock('@/features/Electron/system/ZoomHUD', nullComponent);
+vi.mock('@/features/Electron/titlebar/TabBar/TabCacheBridges', nullComponent);
+vi.mock('@/features/Electron/titlebar/TitleBar', nullComponent);
+vi.mock('@/features/HotkeyHelperPanel', nullComponent);
+vi.mock('@/features/NavPanel/Shell', nullComponent);
+vi.mock('@/layout/GlobalProvider/CmdkLazy', nullComponent);
+vi.mock('./RegisterHotkeys', nullComponent);
+vi.mock('../home', nullComponent);
+vi.mock('../home/_layout', passthrough);
+
+const nameOf = (type: unknown): string | undefined =>
+  (type as { displayName?: string; name?: string } | null)?.displayName ??
+  (type as { name?: string } | null)?.name;
+
+const findByName = (node: ReactNode, name: string): ReactElement | undefined => {
+  let hit: ReactElement | undefined;
+  Children.forEach(node, (child) => {
+    if (hit || !isValidElement(child)) return;
+    if (nameOf(child.type) === name) {
+      hit = child;
+      return;
+    }
+    hit = findByName((child.props as { children?: ReactNode }).children, name);
+  });
+  return hit;
+};
+
+const layouts = [
+  ['desktop', () => import('./index.desktop')],
+  ['web', () => import('./index')],
+] as const;
+
+describe.each(layouts)('main layout (%s)', (_name, load) => {
+  it(
+    'keeps auth recovery outside WorkspaceContextSlot so a blocked shell cannot hide it',
+    { timeout: 20_000 },
+    async () => {
+      const { default: Layout } = await load();
+
+      const tree = (Layout as FC)({});
+      const slot = findByName(tree, 'WorkspaceContextSlot');
+
+      expect(slot).toBeDefined();
+      for (const name of ['AuthRequiredModal', 'DesktopAutoOidcOnFirstOpen']) {
+        expect(findByName(tree, name)).toBeDefined();
+        expect(findByName(slot!.props.children, name)).toBeUndefined();
+      }
+    },
+  );
+});

--- a/src/routes/(main)/_layout/index.desktop.tsx
+++ b/src/routes/(main)/_layout/index.desktop.tsx
@@ -55,11 +55,12 @@ const Layout: FC = () => {
 
   return (
     <HotkeysProvider initiallyActiveScopes={[HotkeyScopeEnum.Global]}>
+      <DesktopAutoOidcOnFirstOpen />
+      <AuthRequiredModal />
       <WorkspaceContextSlot>
         <ActiveConversationBridge />
         <TabCacheBridges />
         <Suspense fallback={null}>
-          <DesktopAutoOidcOnFirstOpen />
           <DesktopNavigationBridge />
           <DesktopFileMenuBridge />
           <DesktopBrowserGatewayBridge />
@@ -68,7 +69,6 @@ const Layout: FC = () => {
           <OverlayMessageDispatcher />
           {showCloudPromotion && <CloudBanner />}
         </Suspense>
-        <AuthRequiredModal />
         <ZoomHUD />
 
         <Suspense fallback={null}>

--- a/src/routes/(main)/_layout/index.tsx
+++ b/src/routes/(main)/_layout/index.tsx
@@ -48,11 +48,12 @@ const Layout: FC = () => {
 
   return (
     <HotkeysProvider initiallyActiveScopes={[HotkeyScopeEnum.Global]}>
+      {isDesktop && <DesktopAutoOidcOnFirstOpen />}
+      {isDesktop && <AuthRequiredModal />}
       <WorkspaceContextSlot>
         <RouteMetaBridge />
         {isDesktop && <TabCacheBridges />}
         <Suspense fallback={null}>
-          {isDesktop && <DesktopAutoOidcOnFirstOpen />}
           {isDesktop && <DesktopNavigationBridge />}
           {isDesktop && <DesktopFileMenuBridge />}
           {isDesktop && <DesktopBrowserGatewayBridge />}
@@ -61,7 +62,6 @@ const Layout: FC = () => {
           {isDesktop && <OverlayMessageDispatcher />}
           {showCloudPromotion && <CloudBanner />}
         </Suspense>
-        {isDesktop && <AuthRequiredModal />}
         {isDesktop && <ZoomHUD />}
 
         <Suspense fallback={null}>{isDesktop && <TitleBar />}</Suspense>


### PR DESCRIPTION
Triage of a production desktop log (v2.2.16, user stuck on "Still loading…" with endless 401s) exposed two independent bugs; this PR fixes both.

#### 1. Every signed-in session died at day 14 (`invalid_grant`)

`ttl.Grant` was 14 days. oidc-provider validates `grant.isExpired` on every `refresh_token` grant (`lib/helpers/grant_source.js`) but never extends `Grant.exp`, so the grant was the absolute cap on a session regardless of the 30-day rotating refresh token. The user's log showed three full cycles matching this exactly: refresh ok at day 7, failing at day 14 (or squeaking through minutes before the grant expired and dying at day 21). Because oidc-provider reuses a live grant on re-login, even a fresh sign-in could inherit an almost-dead grant.

`Grant` is now 365 days, so a user who opens the app at least once every 30 days (refresh-token idle window) never re-authenticates, with a yearly hard re-auth.

#### 2. The re-login modal could never mount on workspace URLs

Reproduced in the cloud dev Electron by answering every `/trpc/lambda/*` call with 401 + `X-Auth-Required`. The cloud `WorkspaceContextSlot` renders the app-shell skeleton while `isUserStateInit` is false on a `/<workspaceSlug>/…` URL; a 401 on `getUserState` keeps it pending forever. `AuthRequiredModal` and `DesktopAutoOidcOnFirstOpen` were children of that slot, so the main process broadcast `authorizationRequired` 107 times with no listener. Both now mount as siblings of the slot in `index.tsx` and `index.desktop.tsx`.

| Before | After |
| ------ | ----- |
| "Still loading…" forever on a workspace URL after the grant dies, no way to sign in | Re-login modal opens over the skeleton; after sign-in the pending `getUserState` retry releases the shell |

Follow-ups (not in this PR): cloud `WorkspaceContextSlot` should treat `isUserStateInitError` as boot-resolved; shortening `AccessToken` from 7d to 1h; a reuse grace window for refresh-token rotation.

#### Test

- `provider.test.ts`: grant TTL must exceed day 15 and be ≥ the refresh-token TTL (fails on 14d, passes on 365d).
- `authMount.test.ts`: calls each main layout and asserts the auth-recovery elements are not descendants of `WorkspaceContextSlot` (fails on the old tree, passes now).
- Manual: CDP 401 injection in the dev Electron before/after.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Related to #19240

https://claude.ai/code/session_011omJDiC1VRmp9aaAPyMFQe