### PR TITLE
🐛 fix(group): disable route-wide SWR suspense

### DIFF
--- a/src/libs/swr/groupRoute.integration.test.ts
+++ b/src/libs/swr/groupRoute.integration.test.ts
@@ -1,0 +1,105 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { createElement, Suspense } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { SWRConfig } from 'swr';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import GroupLayout from '@/routes/(main)/group/_layout';
+
+import { groupKeys } from './keys';
+import { useClientDataSWRWithSync } from './useClientDataSWRWithSync';
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  useActiveWorkspaceId: () => null,
+}));
+vi.mock('@/const/version', () => ({ isDesktop: false }));
+vi.mock('@/components/AsyncError', () => ({ default: () => null }));
+vi.mock('@/features/GroupNotFound', () => ({
+  GroupNotFoundGuard: ({ children }: PropsWithChildren) => children,
+}));
+vi.mock('@/features/ProtocolUrlHandler', () => ({ default: () => null }));
+vi.mock('@/hooks/useInitGroupConfig', () => ({ useInitGroupConfig: () => undefined }));
+vi.mock('@/routes/(main)/group/_layout/GroupIdSync', () => ({ default: () => null }));
+vi.mock('@/routes/(main)/group/_layout/RegisterHotkeys', () => ({ default: () => null }));
+vi.mock('@/routes/(main)/group/_layout/Sidebar', () => ({ default: () => null }));
+
+afterEach(cleanup);
+
+describe.each(['/group/group-1', '/group/group-1/profile'])('client data under %s', (path) => {
+  const wrapper = ({ children }: PropsWithChildren) =>
+    createElement(
+      SWRConfig,
+      { value: { provider: () => new Map(), shouldRetryOnError: false } },
+      createElement(
+        MemoryRouter,
+        { initialEntries: [path] },
+        createElement(
+          Suspense,
+          { fallback: null },
+          createElement(
+            Routes,
+            null,
+            createElement(
+              Route,
+              { element: createElement(GroupLayout), path: '/group/:gid' },
+              createElement(Route, { element: children, index: true }),
+              createElement(Route, { element: children, path: 'profile' }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+  it('commits while a cold request is pending and syncs the resolved data', async () => {
+    const group = { id: 'group-1' };
+    const onData = vi.fn<(data: typeof group) => void>();
+    let resolve!: (data: typeof group) => void;
+    const pending = new Promise<typeof group>((resolvePromise) => {
+      resolve = resolvePromise;
+    });
+
+    const { result } = renderHook(
+      () => useClientDataSWRWithSync(groupKeys.detail(group.id), () => pending, { onData }),
+      { wrapper },
+    );
+
+    try {
+      expect(result.current?.isLoading).toBe(true);
+      expect(onData).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        resolve(group);
+        await pending;
+      });
+    }
+
+    await waitFor(() => expect(result.current.data).toEqual(group));
+    await waitFor(() => expect(onData).toHaveBeenCalledWith(group));
+  });
+
+  it('returns a request error and recovers after retrying', async () => {
+    const group = { id: 'group-1' };
+    const error = new Error('Group request failed');
+    const fetcher = vi
+      .fn<() => Promise<typeof group>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(group);
+
+    const { result } = renderHook(
+      () => useClientDataSWRWithSync(groupKeys.detail(group.id), fetcher),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current?.error).toBe(error));
+
+    await act(async () => {
+      await result.current.mutate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(group);
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+});

--- a/src/routes/(main)/group/_layout/index.tsx
+++ b/src/routes/(main)/group/_layout/index.tsx
@@ -24,7 +24,7 @@ const Layout: FC = () => {
         {/* Keep the sidebar interactive when the routed group is gone (deleted
             or made private) — only the content area collapses to the 404 card. */}
         <GroupNotFoundGuard>
-          <SWRConfig value={{ suspense: true }}>
+          <SWRConfig value={{ suspense: false }}>
             <SuspenseRouteBoundary>
               <Outlet />
             </SuspenseRouteBoundary>


### PR DESCRIPTION
## Changes

The group layout introduced in v2.2.16 enables SWR Suspense for every child route. A cold descendant request can suspend the route, and a failed request can be thrown before the consumer reaches its existing loading/error handling.

- Disable inherited SWR Suspense within the group outlet while preserving `GroupNotFoundGuard` and `SuspenseRouteBoundary`.
- Add a real-layout SWR hook integration test for both the group and profile route paths. It covers mounting during a pending request, resolved-data synchronization, and recovery through `mutate()` after a failed request.

This is a candidate fix for #19197. The reported continuous flicker and Group Profile failure have not yet been reproduced in the affected macOS Cloud desktop environment; this PR remains a draft pending that validation. The hook tests do not render the actual chat/profile surfaces.

| Before | After |
| ------ | ----- |
| All 4 hook integration cases fail with route-level `suspense: true`. | All 4 pass with `suspense: false`. |

Desktop before/after recordings are still pending.

#### Test

- [x] Tested locally (automated regression tests and lint)
- [x] Added/updated tests
- [ ] No tests needed

Validation:
- Verified the regression tests fail before the configuration change and pass afterward: **4 passed**.
- `bun run check 'src/routes/(main)/group/_layout/index.tsx' src/libs/swr/groupRoute.integration.test.ts --lint --test --type`: lint clean, 4 tests passed; full type-check failed.
- Confirmed all **333 TypeScript diagnostics are identical on the unmodified canary baseline and the final patch** in the same local environment. These include stale `.next/dev/types/validator.ts` references and dependency export mismatches (installed `@lobehub/ui` 5.35.0 versus the checkout's required ^5.38.0). No dependency changes are included.
- `git diff --check` and pre-commit checks passed.

Pending manual validation:
- [ ] Reproduce and verify topic loading/switching in the affected Electron environment.
- [ ] Verify Group Profile and member profiles load.
- [ ] Verify visible error/retry behavior and attach before/after recordings.

#### 🔗 Related Issue

Related to #19197