### PR TITLE
🐛 fix: preserve reviewed goal content and edit criteria in modals

### DIFF
--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -90,6 +90,23 @@ describe('GoalService', () => {
     expect(byId.get(criteriaIds[1])?.documentId).toBeTruthy();
   });
 
+  it('persists the reviewed goal document verbatim when structured criteria are supplied', async () => {
+    const service = new GoalService(serverDB, userId);
+    const instruction = '将办公体验提升到可交付水平，支持 PPT、XLSX、Word 的创建和定向修改。';
+    const graph = await service.create({
+      criteria: [{ instruction: '打开并编辑最终文件', title: '三类办公文档端到端可用' }],
+      problemDescription: instruction,
+      requirement: instruction,
+      tasks: ['Only task'],
+      title: '办公体验',
+    });
+
+    const persisted = await service.graph(graph.goal.id);
+    expect(persisted.goal.requirement).toBe(instruction);
+    expect(persisted.nodes.find((node) => node.kind === 'problem')?.description).toBe(instruction);
+    expect(persisted.goal.config?.acceptance?.criteriaIds).toHaveLength(1);
+  });
+
   it('rebinding criteria also updates the dispatched terminal acceptance task', async () => {
     // Editing the standard after the terminal Goal-acceptance Task exists must
     // not leave that Task's Acceptance gating on the stale id list.

--- a/apps/server/src/services/goal/index.ts
+++ b/apps/server/src/services/goal/index.ts
@@ -193,19 +193,11 @@ export class GoalService {
     // goal config so the page can edit them and the terminal acceptance Task
     // is gated on exactly these checks (not an AI re-derivation of the prose).
     let config = input.config;
-    let requirement = input.requirement;
-    if (input.criteria?.length) {
-      // The prose requirement must keep carrying the full standard (the goal
-      // page's 什么算完成 block and every Task's execution context read it).
-      // Callers normally compose it via `buildGoalRequirement`; guard API
-      // callers that pass criteria with a bare requirement.
-      const carriesCriteria = input.criteria.every((item) =>
-        input.requirement?.includes(item.title),
-      );
-      if (!carriesCriteria) {
-        requirement = buildGoalRequirement(input.title, input.criteria, input.requirement);
-      }
-    }
+    // A supplied requirement is the user-reviewed goal document. Criteria live
+    // separately; only synthesize a document when the caller omitted one.
+    const requirement =
+      input.requirement ??
+      (input.criteria?.length ? buildGoalRequirement(input.title, input.criteria) : undefined);
     if (input.criteria?.length) {
       const criteriaIds = await new VerifyPlanGeneratorService(
         this.db,

--- a/src/features/Acceptance/CriterionList/CriterionEditModal.test.ts
+++ b/src/features/Acceptance/CriterionList/CriterionEditModal.test.ts
@@ -1,15 +1,11 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { openCriterionEditModal } from './CriterionEditModal';
+import { CriterionEditor } from './CriterionEditor';
 
 const mocks = vi.hoisted(() => ({ createModal: vi.fn((options) => options) }));
-
-vi.mock('@lobehub/ui', () => ({
-  Flexbox: () => null,
-  Input: () => null,
-  Text: () => null,
-  TextArea: () => null,
-}));
 
 vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
   ...(await importOriginal<object>()),
@@ -27,4 +23,29 @@ describe('openCriterionEditModal', () => {
 
     expect(typeof options.title).not.toBe('string');
   });
+});
+
+describe('criterion modal persistence', () => {
+  it('keeps the editor open until saving succeeds', async () => {
+    let resolveSave!: () => void;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const onClose = vi.fn();
+    render(
+      createElement(CriterionEditor, {
+        initial: { title: 'Editable criterion', verifierType: 'agent' },
+        onClose,
+        onSubmit,
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'criterion.save' }));
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onClose).not.toHaveBeenCalled();
+    await act(async () => resolveSave());
+    expect(onClose).toHaveBeenCalledOnce();
+  }, 20_000);
 });

--- a/src/features/Acceptance/CriterionList/CriterionEditModal.tsx
+++ b/src/features/Acceptance/CriterionList/CriterionEditModal.tsx
@@ -28,7 +28,7 @@ export interface OpenCriterionEditModalProps {
   /** Create flow: the criterion only exists once it is saved. */
   isNew?: boolean;
   onDelete?: () => void;
-  onSubmit: (next: VerifyCriterionDraft) => void;
+  onSubmit: (next: VerifyCriterionDraft) => void | Promise<void>;
 }
 
 /** Imperatively open the shared criterion editor in a modal. */

--- a/src/features/Acceptance/CriterionList/CriterionEditor.tsx
+++ b/src/features/Acceptance/CriterionList/CriterionEditor.tsx
@@ -2,7 +2,7 @@
 
 import { type VerifierType, verifierTypes } from '@lobechat/const/verify';
 import { Flexbox, Input, TextArea } from '@lobehub/ui';
-import { Button, Select, Switch, Text } from '@lobehub/ui/base-ui';
+import { Button, Select, Switch, Text, toast } from '@lobehub/ui/base-ui';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -25,7 +25,7 @@ export interface CriterionEditorProps {
   onClose: () => void;
   /** Omitted when the criterion is brand-new and not yet committed. */
   onDelete?: () => void;
-  onSubmit: (next: VerifyCriterionDraft) => void;
+  onSubmit: (next: VerifyCriterionDraft) => void | Promise<void>;
 }
 
 /**
@@ -43,6 +43,7 @@ export const CriterionEditor = ({
 }: CriterionEditorProps) => {
   const { t } = useTranslation('verify');
   const [draft, setDraft] = useState<VerifyCriterionDraft>(initial);
+  const [saving, setSaving] = useState(false);
   const verifierType = draft.verifierType ?? 'llm';
   const isProgram = verifierType === 'program';
   const instructionLinked = hasLinkedInstruction(initial);
@@ -59,18 +60,25 @@ export const CriterionEditor = ({
     [t],
   );
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const title = draft.title.trim();
-    if (!title) return;
-    onSubmit({
-      ...draft,
-      description: draft.description?.trim() || undefined,
-      // Empty means "not overridden": criteria whose rubric lives in a linked
-      // document keep the documentId instead of gaining a blank inline rule.
-      instruction: draft.instruction?.trim() ? draft.instruction : undefined,
-      title,
-    });
-    onClose();
+    if (!title || saving) return;
+    setSaving(true);
+    try {
+      await onSubmit({
+        ...draft,
+        description: draft.description?.trim() || undefined,
+        // Empty means "not overridden": criteria whose rubric lives in a linked
+        // document keep the documentId instead of gaining a blank inline rule.
+        instruction: draft.instruction?.trim() ? draft.instruction : undefined,
+        title,
+      });
+      onClose();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('acceptance.actionError'));
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -170,7 +178,12 @@ export const CriterionEditor = ({
         )}
         <Flexbox horizontal gap={8}>
           <Button onClick={onClose}>{t('criterion.cancel')}</Button>
-          <Button disabled={!draft.title.trim()} type={'primary'} onClick={handleSave}>
+          <Button
+            disabled={!draft.title.trim()}
+            loading={saving}
+            type={'primary'}
+            onClick={handleSave}
+          >
             {t(isNew ? 'criterion.add' : 'criterion.save')}
           </Button>
         </Flexbox>

--- a/src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx
+++ b/src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { buildGoalRequirement, resolveGoalAttemptBudget } from '@lobechat/builtin-tool-goal';
+import { resolveGoalAttemptBudget } from '@lobechat/builtin-tool-goal';
 import type { CreateGoalParams, GoalCriterionDraft } from '@lobechat/builtin-tool-task';
 import { DEFAULT_GOAL_MAX_ROUNDS } from '@lobechat/const/verify';
 import { useEditor } from '@lobehub/editor/react';
@@ -18,7 +18,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type KeyboardEvent, memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import GeneratingBorder from '@/components/GeneratingBorder';
@@ -35,7 +35,7 @@ import { usePermission } from '@/hooks/usePermission';
 import { goalService } from '@/services/goal';
 import { shinyTextStyles } from '@/styles';
 
-import { buildGoalCreateInput } from './goalConfig';
+import { buildGoalCreateInput, buildReviewedGoalContent } from './goalConfig';
 import { createFallbackGoalCriterion, generateGoalCriteria } from './goalCriteria';
 import { deriveGoalTitle } from './goalTitle';
 
@@ -195,13 +195,6 @@ export const formatGoalGenerationRemainingTime = (seconds: number) => {
   return `${minutes}:${rest.toString().padStart(2, '0')}`;
 };
 
-const criterionRequirement = (drafts: GoalCriterionDraft[]) =>
-  drafts
-    .map((draft) => draft.title.trim())
-    .filter(Boolean)
-    .map((title) => `- ${title}`)
-    .join('\n');
-
 export interface CreateGoalContentProps {
   /** The agent that owns the goal. Goals are always agent-scoped. */
   agentId?: string;
@@ -243,7 +236,6 @@ const CreateGoalContent = memo<CreateGoalContentProps>((props) => {
 
   const editor = useEditor();
   const instructionRef = useRef(plan.instruction);
-  const requirement = useMemo(() => criterionRequirement(plan.criteria), [plan.criteria]);
 
   useEffect(() => {
     if (step !== 'preparing') return;
@@ -365,7 +357,6 @@ const CreateGoalContent = memo<CreateGoalContentProps>((props) => {
     const budget = buildGoalCreateInput({
       costBudget: plan.maxTotalCost,
       instruction,
-      requirement,
     });
 
     setIsCreating(true);
@@ -388,9 +379,8 @@ const CreateGoalContent = memo<CreateGoalContentProps>((props) => {
         maxTotalCost: budget.maxTotalCost ?? undefined,
         // No seed tasks: the coordinator plans the decomposition on first
         // advance, turning a complex ask into several explorable directions.
-        problemDescription: instruction,
+        ...buildReviewedGoalContent(instruction),
         projectId,
-        requirement: buildGoalRequirement(title, reviewedCriteria, budget.requirement),
         title,
       });
       // `goal.create` already queued the first advance server-side, but on a
@@ -407,7 +397,7 @@ const CreateGoalContent = memo<CreateGoalContentProps>((props) => {
     } finally {
       setIsCreating(false);
     }
-  }, [agentId, canCreate, close, onCreated, plan, projectId, requirement, t]);
+  }, [agentId, canCreate, close, onCreated, plan, projectId, t]);
 
   const handlePrimaryAction =
     step === 'describe' ? handleNext : step === 'review' ? handleSubmit : undefined;

--- a/src/features/AgentGoals/CreateGoalModal/goalConfig.test.ts
+++ b/src/features/AgentGoals/CreateGoalModal/goalConfig.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildGoalCreateInput, deriveInitialGoalCriterionTitle } from './goalConfig';
+import {
+  buildGoalCreateInput,
+  buildReviewedGoalContent,
+  deriveInitialGoalCriterionTitle,
+} from './goalConfig';
 
 describe('deriveInitialGoalCriterionTitle', () => {
   it('uses the instruction when a free-form goal has no dedicated requirement', () => {
@@ -42,5 +46,17 @@ describe('buildGoalCreateInput', () => {
       buildGoalCreateInput({ instruction: 'ship it', requirement: '  all links resolve  ' })
         .requirement,
     ).toBe('all links resolve');
+  });
+});
+
+describe('buildReviewedGoalContent', () => {
+  it('uses the reviewed instruction verbatim as the goal document and planning context', () => {
+    const instruction =
+      '创建、读取、修改并导出可继续编辑的 PPT、XLSX 和 Word；保留中文和原有格式。';
+
+    expect(buildReviewedGoalContent(instruction)).toEqual({
+      problemDescription: instruction,
+      requirement: instruction,
+    });
   });
 });

--- a/src/features/AgentGoals/CreateGoalModal/goalConfig.ts
+++ b/src/features/AgentGoals/CreateGoalModal/goalConfig.ts
@@ -25,9 +25,7 @@ export const deriveInitialGoalCriterionTitle = (
 ): string => requirement?.trim() || instruction.trim();
 
 /**
- * The budget half of the goal-creation payload. The criteria half is built by
- * `buildGoalRequirement` in `@lobechat/builtin-tool-goal`, so the modal and the
- * `/goal` tool write the same acceptance requirement.
+ * Normalize the budget and optional requirement for goal creation.
  */
 export const buildGoalCreateInput = ({
   costBudget,
@@ -38,4 +36,10 @@ export const buildGoalCreateInput = ({
   // as uncapped, so an empty / non-positive input maps back to `null`.
   maxTotalCost: typeof costBudget === 'number' && costBudget > 0 ? costBudget : null,
   requirement: requirement?.trim() || instruction.trim(),
+});
+
+/** Keep the reviewed description in both the planning context and goal document. */
+export const buildReviewedGoalContent = (instruction: string) => ({
+  problemDescription: instruction,
+  requirement: instruction,
 });

--- a/src/features/AgentGoals/CreateGoalModal/goalCriteria.test.ts
+++ b/src/features/AgentGoals/CreateGoalModal/goalCriteria.test.ts
@@ -65,7 +65,7 @@ describe('generateGoalCriteria', () => {
     ).rejects.toThrow('No goal plan was generated.');
   });
 
-  it('keeps the exact user goal when the generated instruction omits it', async () => {
+  it('replaces the original input with the generated review instruction', async () => {
     vi.spyOn(verifyService, 'generateGoalPlan').mockResolvedValue({
       criteria: [{ title: 'Training loop works' }],
       instruction: 'Implement a reproducible self-improvement training loop.',
@@ -76,9 +76,7 @@ describe('generateGoalCriteria', () => {
 
     const result = await generateGoalCriteria({ goal });
 
-    expect(result.instruction).toBe(
-      `${goal}\n\nImplement a reproducible self-improvement training loop.`,
-    );
+    expect(result.instruction).toBe('Implement a reproducible self-improvement training loop.');
   });
 
   it('uses the original goal as a reviewable criterion when AI generation fails', () => {

--- a/src/features/AgentGoals/CreateGoalModal/goalCriteria.ts
+++ b/src/features/AgentGoals/CreateGoalModal/goalCriteria.ts
@@ -8,13 +8,6 @@ interface GenerateGoalCriteriaParams {
   goal: string;
 }
 
-const preserveOriginalGoal = (goal: string, generatedInstruction: string) => {
-  const original = goal.trim();
-  const generated = generatedInstruction.trim();
-
-  return generated.includes(original) ? generated : `${original}\n\n${generated}`;
-};
-
 export interface GeneratedGoalPlan {
   criteria: GoalCriterionDraft[];
   instruction: string;
@@ -50,6 +43,6 @@ export const generateGoalCriteria = async ({
   return {
     ...generated,
     criteria: generated.criteria.map(withGoalCriterionDefaults),
-    instruction: preserveOriginalGoal(goal, generated.instruction),
+    instruction: generated.instruction.trim() || goal.trim(),
   };
 };

--- a/src/features/AgentGoals/GoalAcceptanceCriteria.tsx
+++ b/src/features/AgentGoals/GoalAcceptanceCriteria.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Block, Flexbox, Icon, Input, TextArea } from '@lobehub/ui';
+import { Block, Flexbox, Icon } from '@lobehub/ui';
 import { ActionIcon, Button, confirmModal, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { PencilIcon, PlusIcon, XIcon } from 'lucide-react';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { openCriterionEditModal } from '@/features/Acceptance';
 import { usePermission } from '@/hooks/usePermission';
 import { useClientDataSWR } from '@/libs/swr';
 import { goalService } from '@/services/goal';
@@ -30,14 +31,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-interface CriterionFormValue {
-  description: string;
-  instruction: string;
-  title: string;
-}
-
-const emptyForm: CriterionFormValue = { description: '', instruction: '', title: '' };
-
 /**
  * The goal's structured acceptance standard: the persisted verify criteria the
  * terminal Goal-acceptance Task is gated on. Rendered as its own section so the
@@ -59,21 +52,6 @@ const GoalAcceptanceCriteria = memo<{ criteriaIds: string[]; goalId: string }>(
       () => verifyService.getCriteria(criteriaIds),
     );
 
-    const [editingId, setEditingId] = useState<string | 'new' | null>(null);
-    const [form, setForm] = useState<CriterionFormValue>(emptyForm);
-    // The judge instruction the editor opened with — an unchanged instruction
-    // means the row can update in place; a changed one persists a replacement
-    // criterion (the rule body lives in an immutable linked document).
-    const [initialInstruction, setInitialInstruction] = useState('');
-    const [saving, setSaving] = useState(false);
-
-    const openEdit = (item: GoalCriterionWithInstruction) => {
-      const instruction = item.instruction ?? '';
-      setForm({ description: item.description ?? '', instruction, title: item.title });
-      setInitialInstruction(instruction);
-      setEditingId(item.id);
-    };
-
     const rebind = useCallback(
       async (nextIds: string[]) => {
         await goalService.setAcceptanceCriteria(goalId, nextIds);
@@ -83,43 +61,44 @@ const GoalAcceptanceCriteria = memo<{ criteriaIds: string[]; goalId: string }>(
       [goalId, mutate, refreshGoalGraph],
     );
 
-    const handleSave = useCallback(async () => {
-      const title = form.title.trim();
-      if (!title || saving) return;
-      setSaving(true);
-      try {
-        const instruction = form.instruction.trim();
-        if (editingId !== 'new' && editingId && instruction === initialInstruction.trim()) {
-          await verifyService.updateCriterion(editingId, {
-            description: form.description.trim() || null,
-            title,
-          });
-          await mutate();
-        } else {
-          const [createdId] = await verifyService.createCriteria([
-            {
-              description: form.description.trim() || undefined,
-              instruction: instruction || undefined,
-              onFail: 'manual',
-              required: true,
-              title,
-              verifierType: 'agent',
-            },
-          ]);
-          if (createdId) {
-            await rebind(
-              editingId === 'new'
-                ? [...criteriaIds, createdId]
-                : criteriaIds.map((id) => (id === editingId ? createdId : id)),
-            );
+    const openEdit = (item?: GoalCriterionWithInstruction) => {
+      openCriterionEditModal({
+        criterion: item
+          ? {
+              description: item.description ?? undefined,
+              instruction: item.instruction,
+              onFail: item.onFail,
+              required: item.required,
+              title: item.title,
+              verifierConfig: item.verifierConfig ?? undefined,
+              verifierType: item.verifierType,
+            }
+          : { onFail: 'manual', required: true, title: '', verifierType: 'agent' },
+        isNew: !item,
+        onSubmit: async (draft) => {
+          if (item && (draft.instruction ?? '').trim() === (item.instruction ?? '').trim()) {
+            await verifyService.updateCriterion(item.id, {
+              description: draft.description || null,
+              onFail: draft.onFail,
+              required: draft.required,
+              title: draft.title,
+              verifierConfig: draft.verifierConfig,
+              verifierType: draft.verifierType,
+            });
+            await mutate();
+          } else {
+            const [createdId] = await verifyService.createCriteria([draft]);
+            if (createdId) {
+              await rebind(
+                item
+                  ? criteriaIds.map((id) => (id === item.id ? createdId : id))
+                  : [...criteriaIds, createdId],
+              );
+            }
           }
-        }
-        setEditingId(null);
-        setForm(emptyForm);
-      } finally {
-        setSaving(false);
-      }
-    }, [criteriaIds, editingId, form, initialInstruction, mutate, rebind, saving]);
+        },
+      });
+    };
 
     const handleRemove = (item: GoalCriterionWithInstruction) => {
       confirmModal({
@@ -132,53 +111,11 @@ const GoalAcceptanceCriteria = memo<{ criteriaIds: string[]; goalId: string }>(
       });
     };
 
-    const editorForm = (
-      <Flexbox gap={8} paddingBlock={8}>
-        <Input
-          placeholder={t('goalAcceptance.form.titlePlaceholder')}
-          value={form.title}
-          onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-        />
-        <TextArea
-          autoSize={{ maxRows: 4, minRows: 1 }}
-          placeholder={t('goalAcceptance.form.descriptionPlaceholder')}
-          value={form.description}
-          onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-        />
-        <TextArea
-          autoSize={{ maxRows: 6, minRows: 2 }}
-          placeholder={t('goalAcceptance.form.instructionPlaceholder')}
-          value={form.instruction}
-          onChange={(event) => setForm((prev) => ({ ...prev, instruction: event.target.value }))}
-        />
-        <Flexbox horizontal gap={8}>
-          <Button
-            disabled={!form.title.trim()}
-            loading={saving}
-            size={'small'}
-            type={'primary'}
-            onClick={handleSave}
-          >
-            {t('save', { ns: 'common' })}
-          </Button>
-          <Button
-            size={'small'}
-            onClick={() => {
-              setEditingId(null);
-              setForm(emptyForm);
-            }}
-          >
-            {t('cancel', { ns: 'common' })}
-          </Button>
-        </Flexbox>
-      </Flexbox>
-    );
-
     // The section header (title + count + gate hint) belongs to the hosting
     // accordion row in ProcessControl — this renders the list body only.
     return (
       <Block paddingBlock={4} paddingInline={16} variant={'outlined'}>
-        {criteriaIds.length === 0 && editingId !== 'new' && (
+        {criteriaIds.length === 0 && (
           <Flexbox className={styles.row}>
             <Text fontSize={13} type={'secondary'}>
               {t('goalAcceptance.empty')}
@@ -187,68 +124,41 @@ const GoalAcceptanceCriteria = memo<{ criteriaIds: string[]; goalId: string }>(
         )}
         {(criteria ?? []).map((item, index) => (
           <Flexbox className={styles.row} gap={4} key={item.id}>
-            {editingId === item.id ? (
-              editorForm
-            ) : (
-              <>
-                <Flexbox horizontal align={'center'} gap={10}>
-                  <span className={styles.seq}>C{index + 1}</span>
-                  <Text style={{ flex: 1, minWidth: 0 }} weight={500}>
-                    {item.title}
-                  </Text>
-                  {canEdit && (
-                    <Flexbox horizontal gap={2} style={{ flex: 'none' }}>
-                      <ActionIcon
-                        icon={PencilIcon}
-                        size={'small'}
-                        title={t('goalAcceptance.edit')}
-                        onClick={() => openEdit(item)}
-                      />
-                      <ActionIcon
-                        icon={XIcon}
-                        size={'small'}
-                        title={t('goalAcceptance.remove')}
-                        onClick={() => handleRemove(item)}
-                      />
-                    </Flexbox>
-                  )}
+            <Flexbox horizontal align={'center'} gap={10}>
+              <span className={styles.seq}>C{index + 1}</span>
+              <Text style={{ flex: 1, minWidth: 0 }} weight={500}>
+                {item.title}
+              </Text>
+              {canEdit && (
+                <Flexbox horizontal gap={2} style={{ flex: 'none' }}>
+                  <ActionIcon
+                    icon={PencilIcon}
+                    size={'small'}
+                    title={t('goalAcceptance.edit')}
+                    onClick={() => openEdit(item)}
+                  />
+                  <ActionIcon
+                    icon={XIcon}
+                    size={'small'}
+                    title={t('goalAcceptance.remove')}
+                    onClick={() => handleRemove(item)}
+                  />
                 </Flexbox>
-                {item.description && (
-                  <Text fontSize={13} style={{ paddingInlineStart: 30 }} type={'secondary'}>
-                    {item.description}
-                  </Text>
-                )}
-                {item.instruction && (
-                  <Text
-                    fontSize={12}
-                    style={{ color: cssVar.colorTextTertiary, paddingInlineStart: 30 }}
-                  >
-                    {t('goalAcceptance.judgePrefix')}
-                    {item.instruction}
-                  </Text>
-                )}
-              </>
-            )}
+              )}
+            </Flexbox>
           </Flexbox>
         ))}
-        {editingId === 'new' ? (
-          <Flexbox className={styles.row}>{editorForm}</Flexbox>
-        ) : (
-          canEdit && (
-            <Flexbox horizontal className={styles.row}>
-              <Button
-                icon={<Icon icon={PlusIcon} />}
-                size={'small'}
-                type={'text'}
-                onClick={() => {
-                  setForm(emptyForm);
-                  setEditingId('new');
-                }}
-              >
-                {t('goalAcceptance.add')}
-              </Button>
-            </Flexbox>
-          )
+        {canEdit && (
+          <Flexbox horizontal className={styles.row}>
+            <Button
+              icon={<Icon icon={PlusIcon} />}
+              size={'small'}
+              type={'text'}
+              onClick={() => openEdit()}
+            >
+              {t('goalAcceptance.add')}
+            </Button>
+          </Flexbox>
         )}
       </Block>
     );


### PR DESCRIPTION
创建目标时，确认页的润色结果应原样成为目标正文。此前页面会拼接原始输入，提交时又使用验收标准重新组装正文，导致创建后的内容与用户确认的文本不一致。

本次将最终确认文本同时用于目标正文和规划上下文，验收标准独立保存；标准列表仅显示标题，新增和编辑复用统一弹窗，异步保存成功后关闭，失败时保留输入。

| Before | After |
| ------ | ----- |
| 原始输入与润色结果叠加，创建后正文被标准模板替换 | 润色结果覆盖原始输入，最终确认文本原样保存 |
| 标准列表展开详细说明，点击编辑变为行内表单 | 列表只显示标题，点击编辑打开弹窗 |

截图及真实页面操作证据：[第 1 轮：目标正文](https://app.lobehub.com/acceptance/9589f966-5934-4d5f-9064-f690032c7e48?r=1)、[第 3 轮：弹窗、取消与保存后刷新](https://app.lobehub.com/acceptance/9589f966-5934-4d5f-9064-f690032c7e48?r=3)。

#### Test

- [x] Tested locally
- [x] Added/updated tests
- 创建场景：描述 PPT/XLSX/Word 办公能力目标，润色后补充确认文本，创建并核对正文与独立标准。
- 编辑场景：弹窗正确带入原值，取消不落库；保存标题后刷新仍保留，目标正文和其他标准完整，测试标题已恢复。
- 独立 PR 分支：11 个文件 lint 通过，13 项前端回归测试通过。
- 原工作区：此前相关后端回归与实际验收通过；独立 worktree 后端复跑在收集阶段被链接依赖的 `@/config/db` 路径解析阻塞，未执行测试。
- 全仓类型检查此前存在无关错误，未作为本次通过结论。
