### PR TITLE
📝 docs: add tester review checkpoints to acceptance

### DIFF
--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acceptance
-version: 0.3.0
+version: 0.4.0
 description: >
   End-to-end verification and self-evidence for a delivery in any repository,
   with or without a preconfigured verify plan. Discover an existing plan when
@@ -24,6 +24,20 @@ marks it `uncertain` and holds the delivery.
 ```
 author (or discover) the plan  →  pick the surface  →  capture evidence  →  publish the round  →  self-check coverage
 ```
+
+## Independent tester review
+
+The primary checks the environment, writes the plan, executes cases, inspects
+evidence, repairs failures, and publishes. Use one tester agent at two points:
+review requirement coverage before execution, then independently inspect the
+completed evidence before declaring acceptance complete. Reuse the tester when
+the host supports it; do not delegate execution or require per-case approval.
+
+Read [tester-review.md](references/tester-review.md) for the input/output contract,
+review boundaries, and repair follow-up. Tester review supplements the primary's
+own checks and any configured verifier; it does not replace either. If delegation
+or required media inspection is unavailable, disclose the missing review and
+unverified claims rather than claiming independent acceptance.
 
 ## Read the project layer first
 
@@ -193,6 +207,9 @@ simctl io` over host-window capture. Rounds land under `.acceptances/`, which
 - **Don't invent evidence.** Capture only the types a check declares.
 
 ## Reference map
+
+For both tester handoffs and review output, read
+[tester-review.md](references/tester-review.md).
 
 | Need                                           | Reference                                                                                                                                                                               |
 | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/builtin-skills/src/acceptance/index.ts
+++ b/packages/builtin-skills/src/acceptance/index.ts
@@ -14,6 +14,7 @@ import recordingCdp from './references/recording-cdp.md';
 import recordingIosSimulator from './references/recording-ios-simulator.md';
 import recordingNativeMacos from './references/recording-native-macos.md';
 import report from './references/report.md';
+import testerReview from './references/tester-review.md';
 import content from './SKILL.md';
 import cli from './surfaces/cli.md';
 import electron from './surfaces/electron.md';
@@ -74,6 +75,7 @@ export const AcceptanceSkill: BuiltinSkill = {
     'references/recording-ios-simulator.md': recordingIosSimulator,
     'references/recording-native-macos.md': recordingNativeMacos,
     'references/report.md': report,
+    'references/tester-review.md': testerReview,
     'surfaces/cli.md': cli,
     'surfaces/electron.md': electron,
     'surfaces/ios-simulator.md': iosSimulator,

--- a/packages/builtin-skills/src/acceptance/references/plan-format.md
+++ b/packages/builtin-skills/src/acceptance/references/plan-format.md
@@ -47,6 +47,11 @@ Only items with a non-empty `requiredEvidence` need an artifact; the rest are
 judged on the deliverable text — don't fabricate evidence for them. The `hint`
 usually implies the surface (SKILL.md, Pick the surface).
 
+Apply [tester-review.md](tester-review.md) before execution and at final handoff.
+Preserve frozen check IDs; report coverage gaps instead of silently changing the
+supplied plan. The tester's review does not replace the configured verifier or
+authorize overriding its verdict. Keep existing submission and round semantics.
+
 ## Your worklist → submit by checkItemId
 
 For each `verifyPlan[]` item with non-empty `requiredEvidence`, capture each

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -111,6 +111,8 @@ supersedes? }`.
    plausible-but-wrong nested shape parses as JSON, is dropped on ingest, and
    the round publishes green with its evidence silently degraded. Read every
    ingest warning as a failed publish.
+   Before execution, send the draft for [plan review](tester-review.md#1-plan-review)
+   and save the agreed plan and requirement mapping after resolving material gaps.
 2. **Collect evidence into `assets/` as you test.** Screenshots must be
    **visually verified with the Read tool before being cited** — never cite an
    image you haven't looked at. For metrics, time series, model or benchmark
@@ -130,7 +132,10 @@ supersedes? }`.
 5. **`report.md` is the narrative tail only** — this-round notes, follow-ups,
    score. Do NOT repeat the scope block or a case table; those double up on the
    page. Write it in the language the user is conversing in.
-6. **Publish:**
+6. **Review, then publish:** hand the completed plan, report, and original evidence
+   to the tester using [tester-review.md](tester-review.md). Resolve findings and
+   record review limitations in the narrative tail before declaring a pass.
+   The primary publishes; the tester does not operate the product or upload results.
 
    ```bash
    lh acceptance run ingest "$REPORT_DIR" --source agent-testing --json

--- a/packages/builtin-skills/src/acceptance/references/tester-review.md
+++ b/packages/builtin-skills/src/acceptance/references/tester-review.md
@@ -1,0 +1,112 @@
+# Tester review handoff
+
+Use a tester to catch missing cases and unsupported pass claims. The primary
+owns environment preparation, execution, evidence inspection, repairs, cleanup,
+and publication. The tester reviews the plan and final evidence only. Reuse one
+tester through both stages and follow-ups when supported; otherwise provide the
+same handoff and prior findings to its replacement. Never assume a role name or
+model parameter exists: use the current host's supported agent controls. Record
+the actual selection when known; an inherited model does not imply lower cost.
+
+## Shared contract
+
+Send a compact message with the stage, target revision/diff range, source paths,
+and requested output below. Reference existing plan/report files; do not create
+a second JSON schema or duplicate case tables. Keep review notes in the ignored
+acceptance directory and summarize the review in the existing narrative tail.
+Save the requirement-to-case mapping in those review notes and include its path
+in both handoffs; do not add a new field to the report schema.
+
+Both stages receive original requirement and feedback sources, including relevant
+screenshots and explicit scope decisions. Prefer source links, local message
+records, or verbatim excerpts over a rewritten implementation summary. Label
+unavailable sources and summaries; never invent a transcript. The tester must
+state coverage limits if the supplied sources are incomplete. Do not send the
+entire implementation conversation when focused source material is available.
+
+The tester starts with these inputs and reads related code only to resolve a
+specific gap or contradiction. It may inspect files, the specified Git diff,
+logs, and media metadata, or extract frames into an ignored review directory.
+It must not start services, change fixtures, run product cases, repair probes,
+edit product code, publish, or spawn other agents. Missing/unreadable artifacts
+are returned to the primary, not an invitation to debug the environment.
+
+## 1. Plan review
+
+Primary input:
+
+- Original sources and agreed non-goals, separately from implementation hypotheses.
+- Exact code revision and diff range; relevant implementation decisions.
+- Draft plan using the existing schema, with stable case IDs, requirement mapping,
+  preconditions, operations, observable expectations, and evidence requirements.
+  Put additional explanation in existing method/text fields or handoff notes.
+
+Tester procedure: read the original sources first and list the outcomes they
+require, then compare that list with the draft cases and relevant diff. Look for
+missing boundaries, ambiguous criteria, and probes that cannot distinguish success
+from failure. Check how fixtures/fault injections will be proven effective.
+Also identify duplicate or out-of-scope cases; review must not only expand scope.
+
+Tester output:
+
+- Decision: ready, or changes needed.
+- Requirement-to-case coverage, including uncovered requirements and source limits.
+- Findings: source/case ID, gap or unnecessary case, reason, minimal proposed change.
+  If none, say so; do not rewrite the whole plan.
+
+The primary resolves material findings before execution and saves the agreed plan.
+Existing authorization and project approval rules still apply. For frozen plans,
+record uncovered requirements in review notes and the final handoff; do not add
+items or switch report modes within that round. If a required outcome cannot be
+verified under the supplied plan, report the limitation and request a corrected
+plan from its owner rather than claiming full acceptance.
+
+## 2. Final evidence review
+
+Primary input:
+
+- Original sources again, agreed plan, saved requirement mapping and plan-review
+  findings, and any subsequent scope/plan changes.
+- Completed report and per-case evidence index: expected behavior, actual observation,
+  tested revision, original artifact paths, and the primary's proposed result.
+- Runtime/build provenance, fixture/injection evidence, unexecuted cases, reused
+  evidence and its original revision, and known limitations. File timestamps or
+  a checkout SHA alone do not prove which build produced a screenshot.
+  Correlate the target revision with the running instance's build/version marker,
+  or probe a changed value in that instance that distinguishes it from the old
+  implementation. State limits when exact build identity cannot be established.
+- For temporal claims, the original clip plus available timestamped frame sequence
+  and relevant intervals. Selected assertion frames are navigation aids, not proof
+  that the intervening transition was correct.
+
+Tester procedure: start with requirements and expectations, inspect the original
+evidence, then compare with the primary's observations and verdict. Open images;
+file existence and captions are not visual verification. For flicker or transitions,
+inspect the relevant sequence, extracting frames if necessary. Do not claim to
+have watched a video when only stills were inspected. State sampling limits; sparse
+frames cannot establish the absence of a one-frame defect. Recheck coverage against
+original sources, not only against the agreed plan.
+
+Tester output:
+
+- For every case: what the evidence shows, inspected paths/intervals, whether it
+  meets the expectation, and whether the primary's proposed result is supported.
+  Keep passing entries brief. For a disagreement or insufficient evidence, cite
+  the specific frame, timestamp, log excerpt, or missing artifact.
+- Action for each finding: supplement evidence, rerun, or repair then rerun.
+- Overall decision: evidence supports acceptance, or further work is required;
+  include uncovered requirements and inspection limitations.
+
+These are review notes, not new report status values. The primary maps unresolved
+findings to the existing schema without treating missing evidence as a pass. A
+tester label alone is not proof, and the primary must not silently override a
+supported objection. Resolve it with evidence or disclose the unresolved finding.
+
+## Follow-up
+
+The primary repairs or collects evidence. Send the repair diff, proposed affected
+cases, new artifacts and prior findings to the same tester. The tester verifies
+the affected set against the diff and may add missed regressions, then reviews
+only affected conclusions. Preserve unaffected results with their original
+provenance. Published rounds remain immutable; follow existing new-round rules.
+No per-case approval loop, independent execution worker, or third audit agent.


### PR DESCRIPTION
Acceptance can miss requirements or mark incorrect screenshots as passing when the implementing agent also performs every review. Add a tester checkpoint before execution to check requirement coverage, and a final checkpoint to inspect original evidence against expectations.

The primary retains environment setup, execution, repairs, and publication. A dedicated reference defines compact inputs and outputs for both reviews, source-to-case mapping, media inspection limits, and focused follow-up after repairs. Register the reference in the builtin bundle and bump the skill to 0.4.0.

#### Key Decisions / Non-goals

- Reuse one tester where supported; no delegated executor or per-case approval loop.
- Reuse existing report schemas and configured verifiers. No new timeout infrastructure or report status values.
- Review original requirements and evidence rather than trusting implementation summaries or pass labels.

#### Test

- [x] Tested locally: scoped lint and all 6 existing acceptance bundle tests pass.
- Independent Fable critique completed; handoff findings addressed.
- No live product acceptance run was performed for this instruction-only change.
