### PR TITLE
🐛 fix: stabilize group chat loading and profile navigation

### DIFF
--- a/e2e/src/features/regression/agent-group/profile-loading.feature
+++ b/e2e/src/features/regression/agent-group/profile-loading.feature
@@ -6,3 +6,9 @@ Feature: 群组档案的独立加载
     Given a group profile exists for the loading regression
     When I open the group profile
     Then the group profile content remains available
+
+  Scenario: 离开群组档案不会清空刚选中的话题
+    Given a group profile exists for the loading regression
+    And a topic exists for the group profile navigation regression
+    When I open the group profile
+    Then I can return to the selected group topic

--- a/e2e/src/features/regression/agent-group/profile-loading.feature
+++ b/e2e/src/features/regression/agent-group/profile-loading.feature
@@ -1,0 +1,8 @@
+@regression @agent-group @P0
+Feature: 群组档案的独立加载
+  群组档案的可选功能加载失败时，仍然能够查看和编辑群组资料。
+
+  Scenario: 群组档案不会因可选组件加载而整页失败
+    Given a group profile exists for the loading regression
+    When I open the group profile
+    Then the group profile content remains available

--- a/e2e/src/steps/agent-group/profile-loading.steps.ts
+++ b/e2e/src/steps/agent-group/profile-loading.steps.ts
@@ -1,0 +1,51 @@
+import { After, Given, Then, When } from '@cucumber/cucumber';
+import { expect, request } from '@playwright/test';
+
+import type { CustomWorld } from '../../support/world';
+
+Given('a group profile exists for the loading regression', async function (this: CustomWorld) {
+  const response = await this.page.request.post('/trpc/lambda/group.createGroup', {
+    data: {
+      json: { content: 'Group profile loading regression', title: 'Loading regression group' },
+    },
+  });
+  expect(response.ok()).toBe(true);
+  const body = await response.json();
+  this.testContext.loadingRegressionGroupId = body.result.data.json.group.id;
+  this.testContext.loadingRegressionAuth = await this.browserContext.storageState();
+});
+
+When('I open the group profile', { timeout: 120_000 }, async function (this: CustomWorld) {
+  await this.page.goto(`/group/${this.testContext.loadingRegressionGroupId}/profile`);
+  await expect(
+    this.page.getByText('Loading regression group', { exact: true }).first(),
+  ).toBeVisible({ timeout: 90_000 });
+});
+
+Then('the group profile content remains available', async function (this: CustomWorld) {
+  await expect(this.page.getByRole('button', { name: /Start Conversation|开始对话/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    this.page.getByText('Group profile loading regression', { exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(this.page.getByText(/Failed to load|加载失败/, { exact: true })).toHaveCount(0);
+  this.attach(await this.takeScreenshot('group-profile-loading'), 'image/png');
+});
+
+After({ tags: '@agent-group' }, async function (this: CustomWorld) {
+  const id = this.testContext.loadingRegressionGroupId;
+  if (!id) return;
+  const api = await request.newContext({
+    baseURL: process.env.BASE_URL || `http://localhost:${process.env.PORT || 3006}`,
+    storageState: this.testContext.loadingRegressionAuth,
+  });
+  try {
+    const response = await api.post('/trpc/lambda/group.deleteGroup', {
+      data: { json: { id } },
+    });
+    expect(response.ok()).toBe(true);
+  } finally {
+    await api.dispose();
+  }
+});

--- a/e2e/src/steps/agent-group/profile-loading.steps.ts
+++ b/e2e/src/steps/agent-group/profile-loading.steps.ts
@@ -16,7 +16,10 @@ Given('a group profile exists for the loading regression', async function (this:
 });
 
 When('I open the group profile', { timeout: 120_000 }, async function (this: CustomWorld) {
-  await this.page.goto(`/group/${this.testContext.loadingRegressionGroupId}/profile`);
+  await this.page.goto(`/group/${this.testContext.loadingRegressionGroupId}/profile`, {
+    timeout: 90_000,
+    waitUntil: 'domcontentloaded',
+  });
   await expect(
     this.page.getByText('Loading regression group', { exact: true }).first(),
   ).toBeVisible({ timeout: 90_000 });
@@ -48,4 +51,47 @@ After({ tags: '@agent-group' }, async function (this: CustomWorld) {
   } finally {
     await api.dispose();
   }
+});
+
+Given(
+  'a topic exists for the group profile navigation regression',
+  async function (this: CustomWorld) {
+    const groupId = this.testContext.loadingRegressionGroupId;
+    const topicResponse = await this.page.request.post('/trpc/lambda/topic.createTopic', {
+      data: { json: { groupId, title: 'Profile navigation regression', trigger: 'chat' } },
+    });
+    expect(topicResponse.ok()).toBe(true);
+    const topicId = (await topicResponse.json()).result.data.json;
+    this.testContext.loadingRegressionTopicId = topicId;
+
+    const messageResponse = await this.page.request.post('/trpc/lambda/message.createMessage', {
+      data: {
+        json: {
+          content: 'Group topic must survive leaving profile',
+          groupId,
+          role: 'user',
+          topicId,
+        },
+      },
+    });
+    expect(messageResponse.ok()).toBe(true);
+  },
+);
+
+Then('I can return to the selected group topic', async function (this: CustomWorld) {
+  await expect(this.page.getByRole('button', { name: /Start Conversation|开始对话/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await this.page.getByRole('link', { name: 'Profile navigation regression', exact: true }).click();
+  await expect(
+    this.page.locator('[data-message-id]').getByText('Group topic must survive leaving profile', {
+      exact: true,
+    }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(this.page).toHaveURL(
+    new RegExp(
+      `/group/${this.testContext.loadingRegressionGroupId}/${this.testContext.loadingRegressionTopicId}`,
+    ),
+  );
+  this.attach(await this.takeScreenshot('group-profile-return-topic'), 'image/png');
 });

--- a/src/features/SkillsList/useProjectSkills.ts
+++ b/src/features/SkillsList/useProjectSkills.ts
@@ -171,6 +171,6 @@ export const useProjectSkills = (
     onOpenFile,
     onOpenSkill,
     projectItems,
-    raw: data,
+    raw: data ?? undefined,
   };
 };

--- a/src/hooks/useFetchProjectSkills.test.ts
+++ b/src/hooks/useFetchProjectSkills.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook, type RenderHookResult, waitFor } from '@testing-library/react';
+import { createElement, type PropsWithChildren, Suspense } from 'react';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { projectSkillService } from '@/services/projectSkill';
+
+import { useFetchProjectSkills } from './useFetchProjectSkills';
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  useActiveWorkspaceId: () => undefined,
+}));
+
+vi.mock('@/services/projectSkill', () => ({
+  projectSkillService: { listProjectSkills: vi.fn() },
+}));
+
+const wrapper = ({ children }: PropsWithChildren) =>
+  createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), suspense: true } },
+    createElement(Suspense, { fallback: 'Loading' }, children),
+  );
+
+const renderSkills = async (...args: Parameters<typeof useFetchProjectSkills>) => {
+  let rendered!: RenderHookResult<ReturnType<typeof useFetchProjectSkills>, unknown>;
+  await act(async () => {
+    rendered = renderHook(() => useFetchProjectSkills(...args), { wrapper });
+  });
+  return rendered;
+};
+
+describe('useFetchProjectSkills', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('settles an unavailable device response instead of suspending again on rerender', async () => {
+    vi.mocked(projectSkillService.listProjectSkills).mockResolvedValue(undefined);
+    const { result, rerender } = await renderSkills('/project', 'offline-device');
+
+    await waitFor(() => {
+      expect(result.current?.data).toBeNull();
+      expect(result.current.isValidating).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+    });
+    const settledCalls = vi.mocked(projectSkillService.listProjectSkills).mock.calls.length;
+    await act(async () => rerender());
+    expect(result.current.data).toBeNull();
+    expect(projectSkillService.listProjectSkills).toHaveBeenCalledTimes(settledCalls);
+    expect(projectSkillService.listProjectSkills).toHaveBeenCalledWith({
+      deviceId: 'offline-device',
+      scope: '/project',
+    });
+  });
+
+  it('can recover from an unavailable device when revalidated', async () => {
+    const available = { root: '/project', skills: [], source: null };
+    vi.mocked(projectSkillService.listProjectSkills).mockResolvedValue(undefined);
+    const { result } = await renderSkills('/project', 'device');
+    await waitFor(() => expect(result.current?.data).toBeNull());
+
+    vi.mocked(projectSkillService.listProjectSkills).mockResolvedValue(available);
+    await act(async () => {
+      await result.current.mutate();
+    });
+    expect(result.current.data).toEqual(available);
+  });
+
+  it('does not scan without a working directory', async () => {
+    const { result } = await renderSkills(undefined, 'device');
+    expect(result.current.data).toBeUndefined();
+    expect(projectSkillService.listProjectSkills).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useFetchProjectSkills.ts
+++ b/src/hooks/useFetchProjectSkills.ts
@@ -14,9 +14,12 @@ import { projectSkillService } from '@/services/projectSkill';
  */
 export const useFetchProjectSkills = (workingDirectory: string | undefined, deviceId?: string) => {
   const isRemote = !!deviceId;
-  return useClientDataSWR<ListProjectSkillsResult | undefined>(
+  return useClientDataSWR<ListProjectSkillsResult | null>(
     workingDirectory ? ['project-skills', deviceId ?? 'local', workingDirectory] : null,
-    () => projectSkillService.listProjectSkills({ deviceId, scope: workingDirectory! }),
+    // An offline or older device can answer without a result. `undefined`
+    // means "not loaded" to SWR and keeps inherited Suspense retrying forever.
+    async () =>
+      (await projectSkillService.listProjectSkills({ deviceId, scope: workingDirectory! })) ?? null,
     // Remote skills live on a device this client can't watch for filesystem
     // changes, so refetch on focus to pick up edits made on the device. The
     // local IPC path stays off-focus — its scan is cheap to trigger explicitly

--- a/src/routes/(main)/group/_layout/index.tsx
+++ b/src/routes/(main)/group/_layout/index.tsx
@@ -24,7 +24,9 @@ const Layout: FC = () => {
         {/* Keep the sidebar interactive when the routed group is gone (deleted
             or made private) — only the content area collapses to the 404 card. */}
         <GroupNotFoundGuard>
-          <SWRConfig value={{ suspense: true }}>
+          {/* Hydration and optional editor requests manage their own loading state.
+              Keep optional fetches from suspending or failing the entire route. */}
+          <SWRConfig value={{ suspense: false }}>
             <SuspenseRouteBoundary>
               <Outlet />
             </SuspenseRouteBoundary>

--- a/src/routes/(main)/group/profile/StoreSync.tsx
+++ b/src/routes/(main)/group/profile/StoreSync.tsx
@@ -33,10 +33,9 @@ const StoreSync = memo(() => {
     const urlTopicId = builderTopicId ?? undefined;
     useChatStore.setState({ activeTopicId: urlTopicId });
 
-    return () => {
-      // Clear activeTopicId when unmounting (leaving group profile page)
-      useChatStore.setState({ activeTopicId: undefined }, false, 'GroupProfileUnmounted');
-    };
+    // The destination route owns its next topic. A passive unmount cleanup
+    // runs after that route has selected/hydrated it and would erase it.
+    // GroupIdSync clears the global context when leaving the group entirely.
   }, [builderTopicId]);
 
   // Register hotkeys


### PR DESCRIPTION
Group-wide SWR Suspense can hide the conversation when an unavailable device returns no project skills, and can turn an optional Profile resource failure into a route error. Let group components own their loading states and normalize an empty skills response to `null` so SWR can cache completion and later revalidate. Also remove Profile unmount cleanup that overwrites the topic selected by the destination Electron tab.

| Before | After |
| ------ | ----- |
| Unavailable device repeatedly requests skills and leaves the chat behind a skeleton; Profile can fail to load. | Chat and composer remain usable; Profile opens. |
| Returning from Profile can clear the selected Electron topic. | The selected topic and its messages remain visible. |

Recordings, screenshots, and execution traces: [Acceptance round 2](https://app.lobehub.com/acceptance/af834d94-c521-4582-adbf-eeec0f150c4d?r=2) — `group-loading` and `group-profile`. The loading recording reproduces a persistent skeleton/repeated-request path; it does not claim a frame-for-frame replay of the reporter’s alternating flicker GIF.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- Skills regression: old implementation fails 2 cases; fixed implementation passes all 3, including recovery after an unavailable-device response.
- Web Cucumber: 2 scenarios / 7 steps passed. Electron: 3 topic-switch cycles, 150 visibility samples, draft editing, and Profile → original topic passed; restoring the old Profile cleanup fails the final message-visibility assertion.
- Lint and related tests passed on this split branch. Full type check passed on the combined acceptance commit `2ce87b10d5`; the acceptance recording was captured on that commit before splitting the two independent fixes onto current `canary`.

#### 🔗 Related Issue

Fixes #19197
