### PR TITLE
🐛 fix(agent-runtime): show question in intervention summary

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -202,12 +202,29 @@ interface StoredHeterogeneousIntervention {
 }
 
 const HETEROGENEOUS_INTERVENTION_STATE_KEY = 'heterogeneousIntervention';
+const MAX_INTERVENTION_SUMMARY_LENGTH = 160;
 
-const interventionSummary = (request?: AgentInterventionRequestData): string => {
+const interventionSummary = (
+  request?: AgentInterventionRequestData,
+  reviewDetail?: Extract<
+    AgentInterventionReviewDetail,
+    { type: 'permission' | 'plan' | 'question' }
+  >,
+): string => {
+  if (reviewDetail?.type === 'question') {
+    const question = reviewDetail.questions[0]?.question.trim().replaceAll(/\s+/g, ' ');
+    if (question) {
+      const characters = [...question];
+      return characters.length > MAX_INTERVENTION_SUMMARY_LENGTH
+        ? `${characters.slice(0, MAX_INTERVENTION_SUMMARY_LENGTH - 1).join('')}…`
+        : question;
+    }
+  }
+
   const provider = request?.provider ?? 'heterogeneous-agent';
   const kind = request?.interactionKind ?? 'question';
   const apiName = request?.apiName || 'interaction';
-  return `${provider} ${kind}: ${apiName}`.slice(0, 160);
+  return `${provider} ${kind}: ${apiName}`.slice(0, MAX_INTERVENTION_SUMMARY_LENGTH);
 };
 
 const buildHeterogeneousReviewDetail = (
@@ -1299,8 +1316,9 @@ export class HeterogeneousPersistenceHandler {
       );
     }
 
-    const summary = interventionSummary(intent.request);
     const reviewRequest = sanitizeAgentInterventionRequestForReview(intent.request);
+    const reviewDetail = reviewRequest ? buildHeterogeneousReviewDetail(reviewRequest) : undefined;
+    const summary = interventionSummary(intent.request, reviewDetail);
     const transitionKey = `${state.operationId}:${intent.toolCallId}:${intent.transition}`;
     const pendingTransitionKey = `${state.operationId}:${intent.toolCallId}:pending`;
     const requiresPendingReviewNotification =
@@ -1309,7 +1327,7 @@ export class HeterogeneousPersistenceHandler {
       !state.notifiedInterventionTransitions.has(pendingTransitionKey);
     if (
       requiresPendingReviewNotification &&
-      (!reviewRequest?.interactionKind || !reviewRequest.provider)
+      (!reviewRequest?.interactionKind || !reviewRequest.provider || !reviewDetail)
     ) {
       throw new Error(
         `Unsafe heterogeneous intervention review payload toolCallId=${intent.toolCallId}`,
@@ -1336,7 +1354,7 @@ export class HeterogeneousPersistenceHandler {
     if (!this.deps.userId || state.notifiedInterventionTransitions.has(transitionKey)) return;
 
     if (!state.notifiedInterventionTransitions.has(pendingTransitionKey)) {
-      if (!reviewRequest?.interactionKind || !reviewRequest.provider) {
+      if (!reviewRequest?.interactionKind || !reviewRequest.provider || !reviewDetail) {
         throw new Error(
           `Unsafe heterogeneous intervention review payload toolCallId=${intent.toolCallId}`,
         );
@@ -1391,7 +1409,7 @@ export class HeterogeneousPersistenceHandler {
         items: [
           {
             allowedActions,
-            detail: buildHeterogeneousReviewDetail(reviewRequest),
+            detail: reviewDetail,
             interactionKind: reviewRequest.interactionKind,
             provider: reviewRequest.provider,
             requestRevision: {

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
@@ -1059,33 +1059,39 @@ describe('HeterogeneousPersistenceHandler — event branch coverage', () => {
       ]);
 
       expect(notifyAgentInterventionRequired).toHaveBeenCalledTimes(1);
-      expect(notifyAgentInterventionRequired.mock.calls[0][0].items[0]).toMatchObject({
-        detail: {
-          questions: [
-            {
-              header: 'Producer ACK E2E',
-              id: 'question_1',
-              multiple: false,
-              options: [
+      expect(notifyAgentInterventionRequired.mock.calls[0][0]).toMatchObject({
+        items: [
+          {
+            detail: {
+              questions: [
                 {
-                  description: 'Proceed with validation.',
-                  id: 'Continue',
-                  label: 'Continue',
-                },
-                {
-                  description: 'Halt validation.',
-                  id: 'Stop',
-                  label: 'Stop',
+                  header: 'Producer ACK E2E',
+                  id: 'question_1',
+                  multiple: false,
+                  options: [
+                    {
+                      description: 'Proceed with validation.',
+                      id: 'Continue',
+                      label: 'Continue',
+                    },
+                    {
+                      description: 'Halt validation.',
+                      id: 'Stop',
+                      label: 'Stop',
+                    },
+                  ],
+                  question: 'Continue read only validation?',
                 },
               ],
-              question: 'Continue read only validation?',
+              title: 'Producer ACK E2E',
+              type: 'question',
             },
-          ],
-          title: 'Producer ACK E2E',
-          type: 'question',
-        },
-        interactionKind: 'question',
-        provider: 'claude-code',
+            interactionKind: 'question',
+            provider: 'claude-code',
+            summary: 'Continue read only validation?',
+          },
+        ],
+        summary: 'Continue read only validation?',
       });
       expect(h.messageModel.updatePluginState).toHaveBeenCalledWith(
         expect.any(String),
@@ -1096,6 +1102,106 @@ describe('HeterogeneousPersistenceHandler — event branch coverage', () => {
           }),
         }),
       );
+    });
+
+    it('uses only the sanitized first question for a multi-question summary', async () => {
+      const h = createHarness({ topicAgentId: 'agent-test' });
+
+      await ingest(h, [
+        buildEvent('agent_intervention_request', 0, {
+          apiName: 'askUserQuestion',
+          arguments: JSON.stringify({
+            privateRawArgument: 'must not appear in the summary',
+            questions: [
+              {
+                header: 'Validation',
+                multiSelect: false,
+                options: [
+                  {
+                    description: 'Sensitive option detail',
+                    label: 'Continue',
+                  },
+                ],
+                question: 'Which validation path should I use?',
+              },
+              {
+                header: 'Follow-up',
+                multiSelect: false,
+                options: [{ label: 'Production' }],
+                question: 'Which environment should I target?',
+              },
+            ],
+          }),
+          deadline: 1_900_000_000_000,
+          identifier: 'claude-code',
+          interactionKind: 'question',
+          provider: 'claude-code',
+          toolCallId: 'claude-question-summary',
+        }),
+      ]);
+
+      const notification = notifyAgentInterventionRequired.mock.calls[0][0];
+      expect(notification.summary).toBe('Which validation path should I use?');
+      expect(notification.items[0].summary).toBe('Which validation path should I use?');
+    });
+
+    it('normalizes and safely truncates a long question summary', async () => {
+      const h = createHarness({ topicAgentId: 'agent-test' });
+      const longQuestion = `  Confirm\n\t${'😀'.repeat(170)}  now?  `;
+
+      await ingest(h, [
+        buildEvent('agent_intervention_request', 0, {
+          apiName: 'askUserQuestion',
+          arguments: JSON.stringify({
+            questions: [
+              {
+                header: 'Long question',
+                multiSelect: false,
+                options: [{ label: 'Continue' }],
+                question: longQuestion,
+              },
+            ],
+          }),
+          deadline: 1_900_000_000_000,
+          identifier: 'claude-code',
+          interactionKind: 'question',
+          provider: 'claude-code',
+          toolCallId: 'claude-long-question-summary',
+        }),
+      ]);
+
+      const summary = notifyAgentInterventionRequired.mock.calls[0][0].summary;
+      expect(summary).toBe(`Confirm ${'😀'.repeat(151)}…`);
+      expect([...summary]).toHaveLength(160);
+    });
+
+    it('keeps the technical fallback when the sanitized question has no visible text', async () => {
+      const h = createHarness({ topicAgentId: 'agent-test' });
+
+      await ingest(h, [
+        buildEvent('agent_intervention_request', 0, {
+          apiName: 'askUserQuestion',
+          arguments: JSON.stringify({
+            questions: [
+              {
+                header: 'Blank question',
+                multiSelect: false,
+                options: [{ label: 'Continue' }],
+                question: ' \n\t ',
+              },
+            ],
+          }),
+          deadline: 1_900_000_000_000,
+          identifier: 'claude-code',
+          interactionKind: 'question',
+          provider: 'claude-code',
+          toolCallId: 'claude-blank-question-summary',
+        }),
+      ]);
+
+      const notification = notifyAgentInterventionRequired.mock.calls[0][0];
+      expect(notification.summary).toBe('claude-code question: askUserQuestion');
+      expect(notification.items[0].summary).toBe('claude-code question: askUserQuestion');
     });
 
     it('notifies pending once, ignores the publish leg, and notifies terminal only on ACK', async () => {


### PR DESCRIPTION
## Summary

- show the sanitized first question as the summary for heterogeneous Agent question interventions
- normalize whitespace and truncate long summaries to 160 Unicode code points without splitting emoji
- preserve the existing technical fallback for blank questions and non-question interventions
- reuse the sanitized review detail for both validation and notification payload construction

| Before | After |
| ------ | ----- |
| `claude-code question: askUserQuestion` | `Continue the background-refresh validation?` |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts --lint --test --type` (lint clean, 89 tests passed, types clean)
- `git diff --check`

#### 🔗 Related Issue

- Related to LOBE-13216
- Related to https://github.com/lobehub/lobehub-mobile/pull/276
