### PR TITLE
🐛 fix(desktop): repair email-change CORS and OIDC authentication

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -10,12 +10,12 @@ import { preloadDir, resourcesDir } from '@/const/dir';
 import { DESKTOP_EXTERNAL_NAVIGATION_HOSTS, isMac } from '@/const/env';
 import RemoteServerConfigCtr from '@/controllers/RemoteServerConfigCtr';
 import { backendProxyProtocolManager } from '@/core/infrastructure/BackendProxyProtocolManager';
-import { appendVercelCookie, setResponseHeader } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
 import { getSystemLanguage, resolveUILocale } from '@/utils/system-language';
 import { SYSTEM_LANGUAGE_ARG_PREFIX } from '~common/systemLanguage';
 
 import type { App } from '../App';
+import { setupCORSBypass } from './cors';
 import { WindowStateManager } from './WindowStateManager';
 import { WindowThemeManager } from './WindowThemeManager';
 
@@ -648,47 +648,7 @@ export default class Browser {
   private setupCORSBypass(browserWindow: BrowserWindow): void {
     logger.debug(`[${this.identifier}] Setting up CORS bypass for all requests`);
 
-    const session = browserWindow.webContents.session;
-    const originMap = new Map<number, string>();
-
-    session.webRequest.onBeforeSendHeaders((details, callback) => {
-      const requestHeaders = { ...details.requestHeaders };
-
-      if (requestHeaders['Origin']) {
-        originMap.set(details.id, requestHeaders['Origin']);
-        delete requestHeaders['Origin'];
-        logger.debug(`[${this.identifier}] Removed Origin header for: ${details.url}`);
-      }
-
-      appendVercelCookie(requestHeaders);
-
-      callback({ requestHeaders });
-    });
-
-    session.webRequest.onHeadersReceived((details, callback) => {
-      const responseHeaders = details.responseHeaders || {};
-      const origin = originMap.get(details.id) || '*';
-
-      // Force set CORS headers (replace existing to avoid duplicates from case-insensitive keys)
-      setResponseHeader(responseHeaders, 'Access-Control-Allow-Origin', origin);
-      setResponseHeader(
-        responseHeaders,
-        'Access-Control-Allow-Methods',
-        'GET, POST, PUT, DELETE, OPTIONS, PATCH',
-      );
-      setResponseHeader(responseHeaders, 'Access-Control-Allow-Headers', '*');
-      setResponseHeader(responseHeaders, 'Access-Control-Allow-Credentials', 'true');
-
-      originMap.delete(details.id);
-
-      if (details.method === 'OPTIONS') {
-        setResponseHeader(responseHeaders, 'Access-Control-Max-Age', '86400');
-        callback({ responseHeaders, statusLine: 'HTTP/1.1 200 OK' });
-        return;
-      }
-
-      callback({ responseHeaders });
-    });
+    setupCORSBypass(browserWindow.webContents.session);
 
     logger.debug(`[${this.identifier}] CORS bypass setup completed`);
   }

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -46,6 +46,7 @@ const {
       session: {
         webRequest: {
           onBeforeSendHeaders: vi.fn(),
+          onErrorOccurred: vi.fn(),
           onHeadersReceived: vi.fn(),
         },
       },

--- a/apps/desktop/src/main/core/browser/__tests__/cors.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/cors.test.ts
@@ -1,0 +1,101 @@
+import type { Session } from 'electron';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupCORSBypass } from '../cors';
+
+vi.mock('@/env', () => ({ getDesktopEnv: () => ({}) }));
+
+describe('desktop credentialed CORS', () => {
+  const webRequest = {
+    onBeforeSendHeaders: vi.fn(),
+    onErrorOccurred: vi.fn(),
+    onHeadersReceived: vi.fn(),
+  };
+
+  const send = (id: number, requestHeaders: Record<string, string>) => {
+    const callback = vi.fn();
+    webRequest.onBeforeSendHeaders.mock.calls[0][0](
+      { id, requestHeaders, url: 'https://app.lobehub.com/api/auth/change-email' },
+      callback,
+    );
+    return callback.mock.calls[0][0].requestHeaders;
+  };
+
+  const receive = (id: number, method = 'OPTIONS', responseHeaders = {}) => {
+    const callback = vi.fn();
+    webRequest.onHeadersReceived.mock.calls[0][0]({ id, method, responseHeaders }, callback);
+    return callback.mock.calls[0][0];
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupCORSBypass({ webRequest } as unknown as Session);
+  });
+
+  it.each([
+    ['Origin', 'Access-Control-Request-Headers'],
+    ['origin', 'access-control-request-headers'],
+    ['ORIGIN', 'ACCESS-CONTROL-REQUEST-HEADERS'],
+  ])('allows the email-change preflight with %s header casing', (origin, headers) => {
+    const outgoing = send(1, {
+      [origin]: 'app://renderer',
+      [headers]: 'content-type',
+      'Access-Control-Request-Method': 'POST',
+    });
+    expect(outgoing).not.toHaveProperty(origin);
+    expect(outgoing[headers]).toBe('content-type');
+
+    const response = receive(1, 'OPTIONS', {
+      'access-control-allow-headers': ['*'],
+      'access-control-allow-origin': ['*'],
+    });
+    expect(response.statusLine).toBe('HTTP/1.1 200 OK');
+    expect(response.responseHeaders).toMatchObject({
+      'Access-Control-Allow-Credentials': ['true'],
+      'Access-Control-Allow-Headers': ['content-type'],
+      'Access-Control-Allow-Origin': ['app://renderer'],
+    });
+    expect(response.responseHeaders).not.toHaveProperty('access-control-allow-headers');
+    expect(response.responseHeaders).not.toHaveProperty('access-control-allow-origin');
+  });
+
+  it('keeps concurrent preflight header lists separate', () => {
+    send(1, {
+      'Origin': 'app://renderer',
+      'Access-Control-Request-Headers': 'authorization, content-type, x-custom-header',
+    });
+    send(2, {
+      'Origin': 'http://localhost:9876',
+      'Access-Control-Request-Headers': 'x-other-header',
+    });
+    expect(receive(2).responseHeaders['Access-Control-Allow-Headers']).toEqual(['x-other-header']);
+    expect(receive(1).responseHeaders['Access-Control-Allow-Headers']).toEqual([
+      'authorization, content-type, x-custom-header',
+    ]);
+  });
+
+  it('preserves credentials and the origin for the actual POST without replacing its status', () => {
+    const outgoing = send(1, {
+      'Origin': 'app://renderer',
+      'Content-Type': 'application/json',
+      'Cookie': 'session=test',
+    });
+    expect(outgoing.Cookie).toBe('session=test');
+    expect(outgoing['Content-Type']).toBe('application/json');
+    const response = receive(1, 'POST');
+    expect(response).not.toHaveProperty('statusLine');
+    expect(response.responseHeaders['Access-Control-Allow-Origin']).toEqual(['app://renderer']);
+    expect(response.responseHeaders['Access-Control-Allow-Credentials']).toEqual(['true']);
+  });
+
+  it.each(['response', 'error'])('clears request context after a %s', (completion) => {
+    send(1, { 'Origin': 'app://renderer', 'Access-Control-Request-Headers': 'x-private-header' });
+    if (completion === 'response') receive(1);
+    else webRequest.onErrorOccurred.mock.calls[0][0]({ id: 1 });
+    const response = receive(1);
+    expect(response.responseHeaders['Access-Control-Allow-Headers']).toEqual([
+      'Content-Type, Authorization',
+    ]);
+    expect(response.responseHeaders['Access-Control-Allow-Origin']).toEqual(['*']);
+  });
+});

--- a/apps/desktop/src/main/core/browser/cors.ts
+++ b/apps/desktop/src/main/core/browser/cors.ts
@@ -1,0 +1,65 @@
+import type { Session } from 'electron';
+
+import { appendVercelCookie, setResponseHeader } from '@/utils/http-headers';
+
+/** Preserve the desktop CORS bypass for requests that include credentials. */
+export function setupCORSBypass(session: Session): void {
+  const requestMap = new Map<number, { origin?: string; requestedHeaders?: string }>();
+
+  session.webRequest.onBeforeSendHeaders((details, callback) => {
+    const requestHeaders = { ...details.requestHeaders };
+
+    const context: { origin?: string; requestedHeaders?: string } = {};
+
+    // Electron preserves header casing, while HTTP header names are case-insensitive.
+    for (const [name, value] of Object.entries(requestHeaders)) {
+      if (name.toLowerCase() === 'origin') {
+        context.origin = value;
+        delete requestHeaders[name];
+      } else if (name.toLowerCase() === 'access-control-request-headers') {
+        context.requestedHeaders = value;
+      }
+    }
+    requestMap.set(details.id, context);
+
+    appendVercelCookie(requestHeaders);
+
+    callback({ requestHeaders });
+  });
+
+  session.webRequest.onHeadersReceived((details, callback) => {
+    const responseHeaders = details.responseHeaders || {};
+    const context = requestMap.get(details.id);
+    const origin = context?.origin || '*';
+
+    // Force set CORS headers (replace existing to avoid duplicates from case-insensitive keys)
+    setResponseHeader(responseHeaders, 'Access-Control-Allow-Origin', origin);
+    setResponseHeader(
+      responseHeaders,
+      'Access-Control-Allow-Methods',
+      'GET, POST, PUT, DELETE, OPTIONS, PATCH',
+    );
+    // A wildcard is a literal header name for credentialed requests, so echo
+    // the preflight's explicit list (including Content-Type and Authorization).
+    setResponseHeader(
+      responseHeaders,
+      'Access-Control-Allow-Headers',
+      context?.requestedHeaders || 'Content-Type, Authorization',
+    );
+    setResponseHeader(responseHeaders, 'Access-Control-Allow-Credentials', 'true');
+
+    requestMap.delete(details.id);
+
+    if (details.method === 'OPTIONS') {
+      setResponseHeader(responseHeaders, 'Access-Control-Max-Age', '86400');
+      callback({ responseHeaders, statusLine: 'HTTP/1.1 200 OK' });
+      return;
+    }
+
+    callback({ responseHeaders });
+  });
+
+  session.webRequest.onErrorOccurred((details) => {
+    requestMap.delete(details.id);
+  });
+}

--- a/src/libs/better-auth/auth-client.desktop.ts
+++ b/src/libs/better-auth/auth-client.desktop.ts
@@ -10,6 +10,8 @@ import { type auth } from '@/auth';
 import { electronSyncSelectors } from '@/store/electron/selectors/sync';
 import { getElectronStoreState } from '@/store/electron/store';
 
+import { desktopAccountFetch } from './desktop-account-fetch';
+
 let _client: any = null;
 
 function getClient() {
@@ -18,6 +20,7 @@ function getClient() {
 
     _client = createAuthClient({
       baseURL,
+      fetchOptions: { customFetchImpl: desktopAccountFetch },
       plugins: [
         adminClient(),
         inferAdditionalFields<typeof auth>(),

--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -86,6 +86,10 @@ vi.mock('@/libs/better-auth/plugins/email-whitelist', () => ({
   emailWhitelist: vi.fn(() => ({ id: 'email-whitelist' })),
 }));
 
+vi.mock('@/libs/better-auth/plugins/desktop-oidc', () => ({
+  desktopOIDC: vi.fn(() => ({ id: 'desktop-oidc' })),
+}));
+
 vi.mock('@/libs/better-auth/sso', () => ({
   initBetterAuthSSOProviders: vi.fn(() => ({
     genericOAuthProviders: [],

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -20,6 +20,7 @@ import {
   getVerificationEmailTemplate,
   getVerificationOTPEmailTemplate,
 } from '@/libs/better-auth/email-templates';
+import { desktopOIDC } from '@/libs/better-auth/plugins/desktop-oidc';
 import { emailWhitelist } from '@/libs/better-auth/plugins/email-whitelist';
 import { initBetterAuthSSOProviders } from '@/libs/better-auth/sso';
 import { createSecondaryStorage, getTrustedOrigins } from '@/libs/better-auth/utils/config';
@@ -325,6 +326,7 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
     plugins: [
       ...customOptions.plugins,
       emailWhitelist(),
+      desktopOIDC(),
       expo(),
       admin(),
       // Email OTP plugin for mobile verification

--- a/src/libs/better-auth/desktop-account-fetch.test.ts
+++ b/src/libs/better-auth/desktop-account-fetch.test.ts
@@ -1,0 +1,41 @@
+import { createAuthClient } from 'better-auth/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { desktopAccountFetch } from './desktop-account-fetch';
+
+afterEach(() => vi.unstubAllGlobals());
+describe('desktop account transport', () => {
+  it('routes real auth client email and account calls through the desktop proxy', async () => {
+    const requests: Request[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input, init) => {
+        requests.push(new Request(input, init));
+        return Response.json({ status: true });
+      }),
+    );
+    const client = createAuthClient({
+      baseURL: 'https://cloud.example',
+      fetchOptions: { customFetchImpl: desktopAccountFetch },
+    });
+    await client.changeEmail({ newEmail: 'new@example.com', callbackURL: '/settings/profile' });
+    await client.listAccounts();
+    expect(requests.map((r) => r.url)).toEqual([
+      'app://renderer/api/auth/change-email',
+      'app://renderer/api/auth/list-accounts',
+    ]);
+    expect(await requests[0].json()).toEqual({
+      newEmail: 'new@example.com',
+      callbackURL: '/settings/profile',
+    });
+    expect(requests[0].method).toBe('POST');
+  });
+  it('preserves other authentication endpoints on the remote server', async () => {
+    const fetch = vi.fn(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetch);
+    await desktopAccountFetch('https://cloud.example/api/auth/sign-in/social', { method: 'POST' });
+    expect(fetch).toHaveBeenCalledWith('https://cloud.example/api/auth/sign-in/social', {
+      method: 'POST',
+    });
+  });
+});

--- a/src/libs/better-auth/desktop-account-fetch.ts
+++ b/src/libs/better-auth/desktop-account-fetch.ts
@@ -1,0 +1,9 @@
+/** Keep OAuth redirects on the server; route account requests through the authenticated desktop proxy. */
+export const desktopAccountFetch: typeof fetch = (input, init) => {
+  const url = new URL(input instanceof Request ? input.url : input.toString());
+  if (url.pathname === '/api/auth/change-email' || url.pathname === '/api/auth/list-accounts') {
+    const target = `app://renderer${url.pathname}${url.search}`;
+    return fetch(input instanceof Request ? new Request(target, input) : target, init);
+  }
+  return fetch(input, init);
+};

--- a/src/libs/better-auth/plugins/desktop-oidc.test.ts
+++ b/src/libs/better-auth/plugins/desktop-oidc.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment node
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { betterAuth } from 'better-auth/minimal';
+import { admin } from 'better-auth/plugins';
+import { exportJWK, generateKeyPair, type JWTPayload, SignJWT } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { desktopOIDC } from './desktop-oidc';
+
+const authEnv = vi.hoisted(() => ({ ENABLE_OIDC: true, JWKS_KEY: '' }));
+
+vi.mock('@/envs/app', () => ({ appEnv: { APP_URL: 'http://localhost:3099' } }));
+vi.mock('@/envs/auth', () => ({
+  authEnv,
+  LOBE_CHAT_OIDC_AUTH_HEADER: 'Oidc-Auth',
+}));
+
+const baseURL = 'http://localhost:3099';
+let key: Awaited<ReturnType<typeof generateKeyPair>>;
+let db: Record<string, any[]>;
+let auth: ReturnType<typeof createTestAuth>;
+let sendVerificationEmail = vi.fn();
+const user = (id = 'desktop-user') => ({
+  id,
+  name: id,
+  email: `${id}@example.com`,
+  emailVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  banned: false,
+  banExpires: null,
+});
+async function jwt(overrides: JWTPayload = {}, signingKey = key.privateKey) {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({
+    sub: 'desktop-user',
+    client_id: 'lobehub-desktop',
+    iss: `${baseURL}/oidc`,
+    aud: 'urn:lobehub:chat',
+    iat: now - 10,
+    exp: now + 600,
+    ...overrides,
+  })
+    .setProtectedHeader({ alg: 'RS256' })
+    .sign(signingKey);
+}
+async function request(path: string, token?: string, body?: unknown, cookie?: string) {
+  return auth.handler(
+    new Request(`${baseURL}/api/auth${path}`, {
+      method: body ? 'POST' : 'GET',
+      headers: {
+        ...(token ? { 'Oidc-Auth': token } : {}),
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...(cookie ? { cookie, origin: baseURL } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    }),
+  );
+}
+function createTestAuth(bridge = true, immediate = false) {
+  return betterAuth({
+    baseURL,
+    secret: 'desktop-test-secret-at-least-thirty-two-characters',
+    database: memoryAdapter(db),
+    plugins: [admin(), ...(bridge ? [desktopOIDC()] : [])],
+    user: { changeEmail: { enabled: true, updateEmailWithoutVerification: immediate } },
+    emailVerification: { sendVerificationEmail },
+    emailAndPassword: { enabled: true },
+    rateLimit: { enabled: false },
+  });
+}
+function setup(bridge = true, immediate = false) {
+  auth = createTestAuth(bridge, immediate);
+}
+beforeAll(async () => {
+  key = await generateKeyPair('RS256', { extractable: true });
+  authEnv.JWKS_KEY = JSON.stringify({
+    keys: [{ ...(await exportJWK(key.privateKey)), alg: 'RS256' }],
+  });
+});
+beforeEach(() => {
+  authEnv.ENABLE_OIDC = true;
+  db = {
+    user: [user(), user('web-user')],
+    session: [],
+    account: [
+      {
+        id: 'account-1',
+        userId: 'desktop-user',
+        providerId: 'github',
+        accountId: 'github-user',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    verification: [],
+  };
+  sendVerificationEmail = vi.fn();
+  setup();
+});
+
+describe('desktop OIDC account operations with the real Better Auth handler', () => {
+  it('reproduces the 401 without the bridge', async () => {
+    setup(false);
+    expect(
+      (await request('/change-email', await jwt(), { newEmail: 'new@example.com' })).status,
+    ).toBe(401);
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+  it('sends verification without changing email, issuing a cookie or creating a session', async () => {
+    const before = structuredClone(db);
+    const response = await request('/change-email', await jwt(), {
+      newEmail: 'new@example.com',
+      callbackURL: '/settings/profile',
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: true });
+    expect(sendVerificationEmail).toHaveBeenCalledOnce();
+    expect(sendVerificationEmail.mock.calls[0][0].user.email).toBe('new@example.com');
+    expect(new URL(sendVerificationEmail.mock.calls[0][0].url).pathname).toBe(
+      '/api/auth/verify-email',
+    );
+    expect(db).toEqual(before);
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+  it('lists only the token subject accounts', async () => {
+    const response = await request('/list-accounts', await jwt());
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      expect.objectContaining({ providerId: 'github', accountId: 'github-user' }),
+    ]);
+    expect(db.session).toEqual([]);
+    expect((await request('/list-accounts')).status).toBe(401);
+  });
+  it.each([
+    ['expired', { exp: 1 }],
+    ['missing expiry', { exp: undefined }],
+    ['wrong audience', { aud: 'another-service' }],
+    ['wrong issuer', { iss: 'https://other.example/oidc' }],
+    ['wrong client', { client_id: 'lobehub-cli' }],
+    ['delegated purpose', { purpose: 'hetero-operation' }],
+    ['missing issue time', { iat: undefined }],
+    ['future issue time', { iat: 9999999999 }],
+    ['deleted user', { sub: 'deleted-user' }],
+  ])('rejects %s credentials', async (_, claims) => {
+    expect(
+      (await request('/change-email', await jwt(claims), { newEmail: 'new@example.com' })).status,
+    ).toBe(401);
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+    expect(db.session).toEqual([]);
+  });
+  it('rejects an invalid signature', async () => {
+    const other = await generateKeyPair('RS256');
+    expect((await request('/list-accounts', await jwt({}, other.privateKey))).status).toBe(401);
+  });
+  it.each([null, new Date(Date.now() + 60000)])(
+    'rejects a banned user with ban expiry %s',
+    async (banExpires) => {
+      Object.assign(db.user[0], { banned: true, banExpires });
+      expect((await request('/list-accounts', await jwt())).status).toBe(401);
+    },
+  );
+  it('allows a user whose temporary ban has expired', async () => {
+    Object.assign(db.user[0], { banned: true, banExpires: new Date(1) });
+    expect((await request('/list-accounts', await jwt())).status).toBe(200);
+  });
+  it('does not authorize unrelated account/session APIs', async () => {
+    const token = await jwt();
+    expect(await (await request('/get-session', token)).json()).toBeNull();
+    expect((await request('/delete-user', token, {})).status).toBe(401);
+    expect(
+      (
+        await request('/change-password', token, {
+          newPassword: 'strong-password',
+          currentPassword: 'old-password',
+        })
+      ).status,
+    ).toBe(401);
+    expect((await request('/change-email', token)).status).not.toBe(200);
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+  it('requires credentials and honors disabled OIDC', async () => {
+    expect((await request('/list-accounts')).status).toBe(401);
+    authEnv.ENABLE_OIDC = false;
+    expect((await request('/list-accounts', await jwt())).status).toBe(401);
+  });
+  it('keeps cookie login working and uses the desktop token subject when both identities are present', async () => {
+    const signup = await auth.api.signUpEmail({
+      body: {
+        email: 'cookie-user@example.com',
+        name: 'Cookie user',
+        password: 'test-password-123',
+      },
+      asResponse: true,
+    });
+    expect(signup.status).toBe(200);
+    const cookie = signup.headers
+      .getSetCookie()
+      .map((value) => value.split(';')[0])
+      .join('; ');
+    expect(cookie).toBeTruthy();
+    const webResponse = await request(
+      '/change-email',
+      undefined,
+      { newEmail: 'web-new@example.com' },
+      cookie,
+    );
+    expect(webResponse.status).toBe(200);
+    expect(sendVerificationEmail.mock.calls.at(-1)![0].user.id).not.toBe('desktop-user');
+    const before = structuredClone(db);
+    const desktopResponse = await request(
+      '/change-email',
+      await jwt(),
+      { newEmail: 'desktop-new@example.com' },
+      cookie,
+    );
+    expect(desktopResponse.status).toBe(200);
+    expect(sendVerificationEmail.mock.calls.at(-1)![0].user.id).toBe('desktop-user');
+    expect(db).toEqual(before);
+    expect(desktopResponse.headers.get('set-cookie')).toBeNull();
+  });
+  it('refuses configurations allowing immediate email mutation', async () => {
+    db.user[0].emailVerified = false;
+    setup(true, true);
+    expect(
+      (await request('/change-email', await jwt(), { newEmail: 'new@example.com' })).status,
+    ).toBe(403);
+    expect(db.user[0].email).toBe('desktop-user@example.com');
+  });
+});

--- a/src/libs/better-auth/plugins/desktop-oidc.ts
+++ b/src/libs/better-auth/plugins/desktop-oidc.ts
@@ -1,0 +1,86 @@
+import { APIError, createAuthMiddleware } from 'better-auth/api';
+import { type BetterAuthPlugin } from 'better-auth/types';
+
+import { appEnv } from '@/envs/app';
+import { authEnv, LOBE_CHAT_OIDC_AUTH_HEADER } from '@/envs/auth';
+import { isOIDCUserBanned } from '@/libs/oidc-provider/access-control';
+import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
+
+/** Desktop OAuth credentials authorize only these account operations, not a web session. */
+export const desktopOIDC = (): BetterAuthPlugin => ({
+  id: 'desktop-oidc',
+  hooks: {
+    before: [
+      {
+        matcher: (ctx) =>
+          authEnv.ENABLE_OIDC &&
+          ((ctx.path === '/change-email' && ctx.method === 'POST') ||
+            (ctx.path === '/list-accounts' && ctx.method === 'GET')) &&
+          !!ctx.headers?.get(LOBE_CHAT_OIDC_AUTH_HEADER),
+        handler: createAuthMiddleware(async (ctx) => {
+          const token = ctx.headers!.get(LOBE_CHAT_OIDC_AUTH_HEADER)!;
+          let identity;
+          try {
+            identity = await validateOIDCJWT(token);
+          } catch (error) {
+            if ((error as { code?: string }).code !== 'UNAUTHORIZED') throw error;
+            throw new APIError('UNAUTHORIZED');
+          }
+
+          const { payload, userId } = identity;
+          const now = Date.now();
+          const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+          if (
+            payload.client_id !== 'lobehub-desktop' ||
+            payload.purpose !== undefined ||
+            payload.iss !== `${appEnv.APP_URL?.replace(/\/$/, '')}/oidc` ||
+            !audiences.includes('urn:lobehub:chat') ||
+            typeof payload.exp !== 'number' ||
+            payload.exp * 1000 <= now ||
+            typeof payload.iat !== 'number' ||
+            payload.iat * 1000 > now
+          ) {
+            throw new APIError('UNAUTHORIZED');
+          }
+
+          const user = await ctx.context.internalAdapter.findUserById(userId);
+          const ban = user as typeof user & { banExpires?: Date | null; banned?: boolean | null };
+          if (
+            !user ||
+            isOIDCUserBanned({ banExpires: ban?.banExpires ?? null, banned: ban?.banned ?? false })
+          ) {
+            throw new APIError('UNAUTHORIZED');
+          }
+
+          // This bridge must never enable an immediate email update for an unverified account.
+          if (
+            ctx.path === '/change-email' &&
+            ctx.context.options.user?.changeEmail?.updateEmailWithoutVerification
+          ) {
+            throw new APIError('FORBIDDEN');
+          }
+
+          // Request-local only: no session row or cookie is minted, and token expiry is preserved.
+          // The allowlist above keeps this out of password, deletion and session-management APIs.
+          return {
+            context: {
+              context: {
+                session: {
+                  user,
+                  session: {
+                    id: `desktop-oidc:${userId}`,
+                    token: '',
+                    userId,
+                    createdAt: new Date(payload.iat * 1000),
+                    updatedAt: new Date(payload.iat * 1000),
+                    expiresAt: new Date(payload.exp * 1000),
+                  },
+                },
+              },
+            },
+          };
+        }),
+      },
+    ],
+  },
+});


### PR DESCRIPTION
Desktop email changes fail in two stages: credentialed requests from app://renderer fail CORS preflight, and after that is resolved Better Auth rejects the desktop OIDC login with 401. This change fixes the preflight headers and lets the email-change and linked-account listing endpoints authenticate desktop requests.

The desktop auth client routes those two operations through the existing main-process backend proxy, which attaches Oidc-Auth. A narrowly scoped Better Auth plugin validates the signed token, issuer, audience, desktop client, issue/expiry times and active user, and rejects delegated-purpose tokens. It supplies request-local authentication only for POST /change-email and GET /list-accounts. It does not mint a web session or cookie, authorize other account-management endpoints, or enable immediate email mutation. Cookie-only web authentication continues to work; when both credentials are present, the validated desktop token determines the account.

Validation:
- Targeted lint and 98 tests pass, including the no-bridge 401 regression, real Better Auth handler email capture, unchanged account/session data, cookie identity behavior, rejected credentials and existing desktop CORS coverage.
- Full project type check passes.
- An isolated Electron 43 harness runs the actual client transport, backend proxy and CORS modules against the actual Better Auth handler with an in-memory database and captured mail. Email POST and account GET return 200; removing the token returns 401. One verification mail is captured, the original email remains unchanged, and no session/cookie is created.

This requires deploying the server patch as well as updating the desktop client. The official cloud is not running this server patch yet. Full settings-page success feedback and actual inbox delivery remain unverified. The user's logged-in test client was kept running and no real-account email change was submitted by the test harness.

[Acceptance evidence](https://app.lobehub.com/acceptance/7b2639ac-be9a-415b-8cdd-aa3d2b96aea3): both complete business criteria remain uncertain pending deployed-cloud UI and email verification.

Related to #19242.
