### PR TITLE
💄 style(conversation): rework the working Overview panel motion and layout

### DIFF
--- a/src/features/Conversation/WorkingSidebar/OverviewSlot.tsx
+++ b/src/features/Conversation/WorkingSidebar/OverviewSlot.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { createContext, memo, type ReactNode, use, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface OverviewSlotContextValue {
+  el: HTMLElement | null;
+  setEl: (el: HTMLElement | null) => void;
+}
+
+const OverviewSlotContext = createContext<OverviewSlotContextValue>({
+  el: null,
+  setEl: () => {},
+});
+
+const Provider = memo<{ children: ReactNode }>(({ children }) => {
+  const [el, setEl] = useState<HTMLElement | null>(null);
+  const value = useMemo<OverviewSlotContextValue>(() => ({ el, setEl }), [el]);
+  return <OverviewSlotContext value={value}>{children}</OverviewSlotContext>;
+});
+
+Provider.displayName = 'OverviewSlotProvider';
+
+const Outlet = () => {
+  const { setEl } = use(OverviewSlotContext);
+  return <div ref={setEl} style={{ display: 'contents' }} />;
+};
+
+const OverviewSlot = memo<{ children: ReactNode }>(({ children }) => {
+  const { el } = use(OverviewSlotContext);
+  if (!el) return children;
+  return createPortal(children, el);
+});
+
+OverviewSlot.displayName = 'OverviewSlot';
+
+export default Object.assign(OverviewSlot, { Outlet, Provider });

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -115,6 +115,15 @@ const globalStore = vi.hoisted(() => ({
   },
 }));
 
+vi.mock('motion/react', () => ({
+  AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  m: {
+    div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
 vi.mock('@/features/RightPanel', () => ({
   default: (props: CapturedRightPanelProps) => {
     rightPanel.current = props;
@@ -1138,16 +1147,6 @@ describe('AgentWorkingSidebar — tab strip', () => {
     expect(globalStore.toggleRightPanel).toHaveBeenCalledWith(false);
   });
 
-  it('keeps the independent Overview panel closable', () => {
-    localStorageState.openTabsByContext = {};
-    globalStore.status.workingSidebarTab = 'overview';
-
-    render(<AgentWorkingSidebar />);
-    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
-
-    expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ showWorkingOverview: false });
-  });
-
   it('does not show Overview beside a legacy persisted open workspace panel', () => {
     globalStore.status.showRightPanel = true;
     globalStore.status.showWorkingOverview = undefined;
@@ -1156,20 +1155,6 @@ describe('AgentWorkingSidebar — tab strip', () => {
 
     expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
     expect(rightPanel.current?.expand).toBe(true);
-  });
-
-  it('lets the independent Overview close without removing pinned tabs', () => {
-    agentStore.activeAgentId = 'agent';
-    localStorageState.openTabsByContext = {};
-    localStorageState.pinnedTabsByAgent = { agent: ['works'] };
-    globalStore.status.workingSidebarTab = 'overview';
-
-    render(<AgentWorkingSidebar />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
-
-    expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ showWorkingOverview: false });
-    expect(localStorageState.pinnedTabsByAgent).toEqual({ agent: ['works'] });
   });
 
   it('reopens a closed tab when the same external target is requested again', async () => {

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -23,6 +23,7 @@ import {
   SquareTerminalIcon,
   XIcon,
 } from 'lucide-react';
+import { AnimatePresence, m } from 'motion/react';
 import {
   Activity,
   lazy,
@@ -70,6 +71,7 @@ import { type ComposerTarget, createComposerTarget, resolveThreadComposerTarget 
 import Files from './Files';
 import { sidebarWidthBudget } from './fitsBesidePortal';
 import Overview from './Overview';
+import OverviewSlot from './OverviewSlot';
 import ResourcesSection from './ResourcesSection';
 import Review from './Review';
 import WorkspaceTab from './WorkspaceTab';
@@ -123,10 +125,10 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   overviewPanel: css`
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
     flex-shrink: 0;
-    align-self: flex-start;
 
-    width: min(340px, calc(100% - 32px));
     max-height: calc(100% - 32px);
     margin: 16px;
     border: 1px solid ${cssVar.colorBorderSecondary};
@@ -134,6 +136,18 @@ const styles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorBgContainer};
     box-shadow: ${cssVar.boxShadowTertiary};
+  `,
+  overviewSlot: css`
+    overflow: hidden;
+    display: flex;
+    flex-shrink: 0;
+    align-items: flex-start;
+
+    height: 100%;
+
+    @container agent-chat-layout (min-width: 1200px) {
+      padding-block-start: 44px;
+    }
   `,
   overviewTitle: css`
     overflow: hidden;
@@ -173,6 +187,13 @@ const styles = createStaticStyles(({ css }) => ({
 const REVIEW_TREE_STORAGE_KEY = 'lobechat-review-tree';
 const OPEN_TABS_STORAGE_KEY = 'lobechat-working-sidebar-open-tabs-v1';
 const PINNED_TABS_STORAGE_KEY = 'lobechat-working-sidebar-pinned-tabs-v1';
+const OVERVIEW_PANEL_WIDTH = 340;
+const OVERVIEW_SLOT_TRANSITION = { bounce: 0.1, duration: 0.4, type: 'spring' } as const;
+const OVERVIEW_CARD_TRANSITION = {
+  opacity: { bounce: 0, duration: 0.2, type: 'spring' },
+  scale: { bounce: 0.15, duration: 0.45, type: 'spring' },
+} as const;
+const OVERVIEW_CARD_EXIT_TRANSITION = { bounce: 0, duration: 0.15, type: 'spring' } as const;
 const MIN_PANEL_WIDTH = 300;
 const MAX_PANEL_WIDTH = 1200;
 // Two-pane Review (diff list + file-tree rail) is cramped below this.
@@ -910,40 +931,47 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     toggleTerminalPanel,
   ]);
 
-  const overviewPanel = showWorkingOverview && overviewFits && (
-    <Flexbox className={styles.overviewPanel} role={'complementary'}>
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={styles.overviewHeader}
-        gap={8}
-        justify={'space-between'}
-      >
-        <span className={styles.overviewTitle}>{t('workingPanel.overview.title')}</span>
-        <ActionIcon
-          aria-label={t('workingPanel.tabs.closePanel')}
-          icon={XIcon}
-          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
-          title={t('workingPanel.tabs.closePanel')}
-          onClick={() => updateSystemStatus({ showWorkingOverview: false })}
-        />
-      </Flexbox>
-      <Flexbox className={styles.overviewBody}>
-        {!contentReady && <SkeletonList paddingBlock={8} paddingInline={8} rows={6} />}
-        {contentReady && (
-          <Overview
-            active
-            agentId={activeAgentId}
-            deviceId={remoteDeviceId}
-            environmentAvailable={filesystemEnvironmentAvailable}
-            repoType={environmentRepoType}
-            sourcePath={sourceWorkingDirectory}
-            workingDirectory={environmentWorkingDirectory}
-            onOpenTab={openTab}
-          />
+  const overviewWidth = Math.min(OVERVIEW_PANEL_WIDTH, widthBudget - 32);
+  const overviewPanel = (
+    <OverviewSlot>
+      <AnimatePresence initial={false}>
+        {showWorkingOverview && overviewFits && (
+          <m.div
+            animate={{ width: overviewWidth + 32 }}
+            className={styles.overviewSlot}
+            exit={{ width: 0 }}
+            initial={{ width: 0 }}
+            transition={OVERVIEW_SLOT_TRANSITION}
+          >
+            <m.div
+              animate={{ opacity: 1, scale: 1 }}
+              className={styles.overviewPanel}
+              exit={{ opacity: 0, scale: 0.8, transition: OVERVIEW_CARD_EXIT_TRANSITION }}
+              initial={{ opacity: 0, scale: 0.8 }}
+              role={'complementary'}
+              style={{ transformOrigin: 'top right', width: overviewWidth }}
+              transition={OVERVIEW_CARD_TRANSITION}
+            >
+              <Flexbox horizontal align={'center'} className={styles.overviewHeader} gap={8}>
+                <span className={styles.overviewTitle}>{t('workingPanel.overview.title')}</span>
+              </Flexbox>
+              <Flexbox className={styles.overviewBody}>
+                <Overview
+                  active
+                  agentId={activeAgentId}
+                  deviceId={remoteDeviceId}
+                  environmentAvailable={filesystemEnvironmentAvailable}
+                  repoType={environmentRepoType}
+                  sourcePath={sourceWorkingDirectory}
+                  workingDirectory={environmentWorkingDirectory}
+                  onOpenTab={openTab}
+                />
+              </Flexbox>
+            </m.div>
+          </m.div>
         )}
-      </Flexbox>
-    </Flexbox>
+      </AnimatePresence>
+    </OverviewSlot>
   );
 
   return (

--- a/src/routes/(main)/agent/(chat)/_layout/index.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/index.tsx
@@ -8,6 +8,7 @@ import { Outlet } from 'react-router';
 
 import ChatTerminalPanel from '@/features/ChatTerminal';
 import AgentWorkingSidebar from '@/features/Conversation/WorkingSidebar';
+import OverviewSlot from '@/features/Conversation/WorkingSidebar/OverviewSlot';
 import ChatHeader from '@/routes/(main)/agent/features/Conversation/Header';
 import Portal from '@/routes/(main)/agent/features/Portal';
 
@@ -32,27 +33,39 @@ const ChatLayout = memo(() => {
 
   return (
     <HeaderSlot.Provider>
-      <Flexbox flex={1} height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }} width={'100%'}>
+      <OverviewSlot.Provider>
         <Flexbox
-          horizontal
           flex={1}
-          ref={rowRef}
-          style={{ minHeight: 0, overflow: 'hidden', position: 'relative' }}
+          height={'100%'}
+          style={{ minHeight: 0, overflow: 'hidden' }}
           width={'100%'}
         >
           <Flexbox
-            className={styles.conversationColumn}
+            horizontal
             flex={1}
-            style={{ minHeight: 0, minWidth: 0 }}
+            ref={rowRef}
+            style={{ minHeight: 0, overflow: 'hidden', position: 'relative' }}
+            width={'100%'}
           >
-            <ChatHeader />
-            <Outlet />
+            <Flexbox
+              className={styles.conversationColumn}
+              flex={1}
+              style={{ minHeight: 0, minWidth: 0 }}
+            >
+              <ChatHeader />
+              <Flexbox horizontal flex={1} style={{ minHeight: 0, minWidth: 0 }}>
+                <Flexbox flex={1} style={{ minHeight: 0, minWidth: 0 }}>
+                  <Outlet />
+                </Flexbox>
+                <OverviewSlot.Outlet />
+              </Flexbox>
+            </Flexbox>
+            <Portal />
+            <AgentWorkingSidebar availableWidth={rowSize?.width} />
           </Flexbox>
-          <Portal />
-          <AgentWorkingSidebar availableWidth={rowSize?.width} />
+          <ChatTerminalPanel />
         </Flexbox>
-        <ChatTerminalPanel />
-      </Flexbox>
+      </OverviewSlot.Provider>
     </HeaderSlot.Provider>
   );
 });

--- a/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/WorkingPanelToggle/index.tsx
@@ -39,18 +39,21 @@ const WorkingPanelToggle = memo(() => {
 
   return (
     <>
-      {!showWorkingOverview && (
-        <ActionIcon
-          aria-label={t('workingPanel.overview.title')}
-          icon={LayoutDashboardIcon}
-          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
-          title={t('workingPanel.overview.title')}
-          onClick={() => {
-            toggleRightPanel(false);
-            updateSystemStatus({ showWorkingOverview: true });
-          }}
-        />
-      )}
+      <ActionIcon
+        active={showWorkingOverview}
+        aria-label={t('workingPanel.overview.title')}
+        icon={LayoutDashboardIcon}
+        size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+        title={t('workingPanel.overview.title')}
+        onClick={() => {
+          if (showWorkingOverview) {
+            updateSystemStatus({ showWorkingOverview: false });
+            return;
+          }
+          toggleRightPanel(false);
+          updateSystemStatus({ showWorkingOverview: true });
+        }}
+      />
       {!showRightPanel && (
         <ActionIcon
           aria-label={t('workingPanel.title')}


### PR DESCRIPTION
Opening the working **Overview** card used to shift the chat header's action icons and snap the conversation area to a new width, because the card was rendered as a sibling of the whole conversation column (header included) and mounted/unmounted with no transition.

**Layout** — the Overview card is now portalled into a slot *inside* the conversation column, below the header, through a new `OverviewSlot` that mirrors the existing `HeaderSlot`. The header spans the full column width and its icons stay put. The slot is offset by 44px under the floating-header container query, matching the message list's `floatingHeaderSpacer`.

**Motion** — all transitions are springs:

| Target | Spring |
| --- | --- |
| slot width | `bounce: 0.1, duration: 0.4` |
| card `scale` (origin `top right`) | `bounce: 0.15, duration: 0.45` |
| card `opacity` (enter) | `bounce: 0, duration: 0.2` |
| card exit (`opacity` + `scale`) | `bounce: 0, duration: 0.15` |

The slot width drives the reflow, so the conversation area eases open and closed instead of snapping; the card itself only scales and fades.

**Toggle** — the card's close button is gone. The header toggle stays mounted in both states and uses its `active` state to signal that the Overview is expanded, so that icon no longer appears and disappears.

Also drops the deferred-mount skeleton inside the card: it was gated on `useDeferredMount` (one frame), not on a network wait, so it only produced a height jump from 6 skeleton rows to the real content.

| Before | After |
| ------ | ----- |
| Header icons shift, panel pops in/out, card has its own ✕ | Header icons fixed, panel springs open/closed, toggle shows active state |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test` on the touched files: lint clean, 47 tests passing. Two tests that only exercised the removed close button were dropped; a replacement test for the header toggle was not added because the repo's testing skill disallows new React component tests and the change is a small click branch.

To verify by hand: `bun run dev:spa`, then toggle the Overview from the chat header at a column width both above and below 1200px (the header switches between floating and in-flow at that breakpoint).

#### 🔗 Related Issue

<!-- none -->

https://claude.ai/code/session_01Lk5cTZdAgb4wVLFmVDeupj