### PR TITLE
🐛 fix: refine Acceptance onboarding and serve installation guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,8 @@ COPY --from=builder /app/.next/static /app/.next/static
 COPY --from=builder /app/public/_spa /app/public/_spa
 COPY --from=builder /app/public/_spa-share /app/public/_spa-share
 COPY --from=builder /app/public/_spa-workbench /app/public/_spa-workbench
+# Public Acceptance installation guide
+COPY --from=builder /app/public/acceptance /app/public/acceptance
 # Copy database migrations
 COPY --from=builder /app/packages/database/migrations /app/migrations
 COPY --from=builder /app/scripts/migrateServerDB/docker.cjs /app/docker.cjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,6 @@ COPY --from=builder /app/.next/static /app/.next/static
 COPY --from=builder /app/public/_spa /app/public/_spa
 COPY --from=builder /app/public/_spa-share /app/public/_spa-share
 COPY --from=builder /app/public/_spa-workbench /app/public/_spa-workbench
-# Public Acceptance installation guide
-COPY --from=builder /app/public/acceptance /app/public/acceptance
 # Copy database migrations
 COPY --from=builder /app/packages/database/migrations /app/migrations
 COPY --from=builder /app/scripts/migrateServerDB/docker.cjs /app/docker.cjs

--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -350,7 +350,7 @@
   "acceptance.workspace.merge.title": "Merge acceptance",
   "acceptance.workspace.merge.windowHint": "Only the {{count}} most recent acceptances are listed here.",
   "acceptance.workspace.onboarding.agent.description": "Copy this prompt to your coding agent and let it complete the setup.",
-  "acceptance.workspace.onboarding.agent.prompt": "Read https://lobehub.com/acceptance/skill.md and follow the instructions to install Acceptance.",
+  "acceptance.workspace.onboarding.agent.prompt": "Read https://app.lobehub.com/acceptance/skill.md and follow the instructions to install Acceptance.",
   "acceptance.workspace.onboarding.agent.title": "Install with an Agent",
   "acceptance.workspace.onboarding.description": "Add the Acceptance skill to your project, then start a review from your coding agent.",
   "acceptance.workspace.onboarding.enable.description": "Run this from your project root.",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -350,7 +350,7 @@
   "acceptance.workspace.merge.title": "合并验收",
   "acceptance.workspace.merge.windowHint": "这里只列出最近 {{count}} 条验收。",
   "acceptance.workspace.onboarding.agent.description": "复制这段提示词发送给编程 Agent，由它完成安装。",
-  "acceptance.workspace.onboarding.agent.prompt": "阅读 https://lobehub.com/acceptance/skill.md，并按照说明安装 Acceptance。",
+  "acceptance.workspace.onboarding.agent.prompt": "阅读 https://app.lobehub.com/acceptance/skill.md，并按照说明安装 Acceptance。",
   "acceptance.workspace.onboarding.agent.title": "使用 Agent 安装",
   "acceptance.workspace.onboarding.description": "将 Acceptance Skill 安装到项目中，再从编程 Agent 发起验收。",
   "acceptance.workspace.onboarding.enable.description": "在项目根目录执行。",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -390,7 +390,7 @@ export default {
   'acceptance.workspace.onboarding.agent.description':
     'Copy this prompt to your coding agent and let it complete the setup.',
   'acceptance.workspace.onboarding.agent.prompt':
-    'Read https://lobehub.com/acceptance/skill.md and follow the instructions to install Acceptance.',
+    'Read https://app.lobehub.com/acceptance/skill.md and follow the instructions to install Acceptance.',
   'acceptance.workspace.onboarding.agent.title': 'Install with an Agent',
   'acceptance.workspace.onboarding.enable.description': 'Run this from your project root.',
   'acceptance.workspace.onboarding.enable.title': 'Enable Acceptance',

--- a/public/acceptance/skill.md
+++ b/public/acceptance/skill.md
@@ -1,0 +1,44 @@
+# Install Acceptance for LobeHub
+
+Acceptance lets a coding agent verify a delivery and publish evidence for human review in LobeHub.
+Run the following setup from the root of the project the user wants to verify.
+
+## 1. Install the CLI
+
+If `lh --version` is unavailable, install the LobeHub CLI:
+
+```sh
+npm install -g @lobehub/cli
+```
+
+## 2. Connect to LobeHub
+
+Check the current account with `lh whoami`. If authentication is needed, run:
+
+```sh
+lh login
+```
+
+Let the user complete the browser sign-in. Never request passwords or tokens in chat.
+
+## 3. Install the Acceptance skill
+
+From the project root, run:
+
+```sh
+lh acceptance install
+```
+
+This downloads the deployed Acceptance skill and its companion resources into
+`.agents/skills/acceptance/` and wires supported coding-agent skill directories.
+Existing files are preserved by default. Use `lh acceptance update` only when the
+user wants to refresh an existing installation.
+
+## 4. Verify setup and start a review
+
+Confirm that `.agents/skills/acceptance/SKILL.md` exists, read it, and follow its
+instructions and referenced resources. Do not replace it with this installation guide.
+
+Tell the user which project was configured and whether installation completed.
+The user can then invoke `/acceptance` in their coding agent to verify a delivery.
+Published reviews appear at <https://app.lobehub.com/acceptance>.

--- a/src/features/Acceptance/Workspace/AcceptanceOnboarding.tsx
+++ b/src/features/Acceptance/Workspace/AcceptanceOnboarding.tsx
@@ -4,7 +4,7 @@ import { CopyButton, Flexbox, Icon } from '@lobehub/ui';
 import { Button, TabsIndicator, TabsList, TabsRoot, TabsTab } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ArrowLeft, Bot, ClipboardCheck, Terminal } from 'lucide-react';
-import { memo, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -20,13 +20,14 @@ const styles = createStaticStyles(({ css }) => ({
     font-size: 14px;
     line-height: 1.6;
     color: ${cssVar.colorTextSecondary};
-    text-align: start;
+    text-align: center;
   `,
   container: css`
     overflow: auto;
+    flex: 1;
 
     width: 100%;
-    height: 100%;
+    min-height: 0;
     border: 1px solid ${cssVar.colorBorder};
     border-radius: ${cssVar.borderRadius};
 
@@ -34,9 +35,9 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   content: css`
     width: 100%;
-    max-width: 960px;
-    margin: auto;
-    padding-block: 12px 16px;
+    max-width: 720px;
+    margin-inline: auto;
+    padding-block: clamp(32px, 8vh, 96px) 48px;
     padding-inline: 24px;
 
     @media (width <= 680px) {
@@ -49,23 +50,23 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: center;
     justify-content: center;
 
-    width: 40px;
-    height: 40px;
+    width: 56px;
+    height: 56px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadius};
 
     color: ${cssVar.colorTextSecondary};
 
-    background: ${cssVar.colorBgContainer};
+    background: ${cssVar.colorFillQuaternary};
   `,
   method: css`
     min-width: 0;
-    padding: 16px;
+    padding: 24px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadius};
   `,
   methodDescription: css`
-    font-size: 13px;
+    font-size: ${cssVar.fontSize};
     line-height: 1.55;
     color: ${cssVar.colorTextTertiary};
   `,
@@ -73,14 +74,14 @@ const styles = createStaticStyles(({ css }) => ({
     color: ${cssVar.colorTextTertiary};
   `,
   methodTitle: css`
-    font-size: 15px;
+    font-size: ${cssVar.fontSize};
     font-weight: 600;
     color: ${cssVar.colorText};
   `,
   step: css`
     display: grid;
     grid-template-columns: 24px minmax(0, 1fr);
-    gap: 10px;
+    gap: 12px;
 
     min-width: 0;
     padding: 12px;
@@ -104,8 +105,8 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   steps: css`
     display: grid;
-    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 0.9fr);
-    gap: 10px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
 
     @media (width <= 680px) {
       grid-template-columns: 1fr;
@@ -122,9 +123,12 @@ const styles = createStaticStyles(({ css }) => ({
     width: 100%;
   `,
   page: css`
+    flex: 1;
+
     width: 100%;
     min-width: 0;
-    height: 100dvh;
+    height: 100%;
+    min-height: 0;
     padding: 8px;
 
     background: ${cssVar.colorBgLayout};
@@ -133,7 +137,7 @@ const styles = createStaticStyles(({ css }) => ({
     flex: 1;
 
     font-family: ${cssVar.fontFamilyCode};
-    font-size: 13px;
+    font-size: ${cssVar.fontSize};
     line-height: 1.65;
     color: ${cssVar.colorText};
     overflow-wrap: anywhere;
@@ -150,16 +154,16 @@ const styles = createStaticStyles(({ css }) => ({
     color: ${cssVar.colorText};
   `,
   title: css`
-    font-size: 22px;
+    font-size: ${cssVar.fontSizeHeading2};
     font-weight: 600;
     line-height: 1.25;
     color: ${cssVar.colorText};
-    text-align: start;
+    text-align: center;
     letter-spacing: -0.02em;
   `,
 }));
 
-const AcceptanceOnboarding = memo(() => {
+const AcceptanceOnboarding = () => {
   const { t } = useTranslation('verify');
   const navigate = useNavigate();
   const [mode, setMode] = useState<'agent' | 'manual'>('agent');
@@ -172,12 +176,12 @@ const AcceptanceOnboarding = memo(() => {
             {t('back', { ns: 'common' })}
           </Button>
         </Flexbox>
-        <Flexbox className={styles.content} gap={16}>
-          <Flexbox horizontal align={'center'} gap={12}>
+        <Flexbox className={styles.content} gap={32}>
+          <Flexbox align={'center'} gap={16}>
             <span className={styles.icon}>
-              <Icon icon={ClipboardCheck} size={20} />
+              <Icon icon={ClipboardCheck} size={28} />
             </span>
-            <Flexbox gap={4}>
+            <Flexbox align={'center'} gap={12}>
               <span className={styles.title}>{t('acceptance.workspace.onboarding.title')}</span>
               <span className={styles.description}>
                 {t('acceptance.workspace.onboarding.description')}
@@ -243,7 +247,7 @@ const AcceptanceOnboarding = memo(() => {
                 ].map((step, index) => (
                   <div className={styles.step} key={step.title}>
                     <span className={styles.stepIndex}>{index + 1}</span>
-                    <Flexbox gap={6}>
+                    <Flexbox gap={8}>
                       <span className={styles.methodTitle}>{step.title}</span>
                       <span className={styles.methodDescription}>{step.description}</span>
                       <CommandLine command={step.command} />
@@ -257,8 +261,6 @@ const AcceptanceOnboarding = memo(() => {
       </Flexbox>
     </Flexbox>
   );
-});
-
-AcceptanceOnboarding.displayName = 'AcceptanceOnboarding';
+};
 
 export default AcceptanceOnboarding;

--- a/src/libs/next/proxy/define-config.test.ts
+++ b/src/libs/next/proxy/define-config.test.ts
@@ -1,6 +1,8 @@
 /**
  * @vitest-environment node
  */
+import { readFile } from 'node:fs/promises';
+
 import { NextRequest } from 'next/server';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -109,5 +111,24 @@ describe('defineConfig Share SPA rewrite', () => {
     const rewrite = await run('http://localhost:3010/shared-workspace/settings?hl=en-US');
 
     expect(new URL(rewrite!).pathname).toMatch(/^\/spa\/[^/]+\/shared-workspace\/settings$/);
+  });
+});
+
+describe('Acceptance installation guide', () => {
+  it('serves the public Markdown asset without authentication or SPA rewrites', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth.api.getSession).mockClear();
+    const response = await middleware(new NextRequest('http://localhost:3010/acceptance/skill.md'));
+
+    expect(response?.headers.get('x-middleware-next')).toBe('1');
+    expect(response?.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(response?.headers.get('location')).toBeNull();
+    expect(auth.api.getSession).not.toHaveBeenCalled();
+
+    const guide = await readFile('public/acceptance/skill.md', 'utf8');
+    expect(guide).toContain('npm install -g @lobehub/cli');
+    expect(guide).toContain('lh login');
+    expect(guide).toContain('lh acceptance install');
+    expect(guide).toContain('.agents/skills/acceptance/SKILL.md');
   });
 });

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -57,6 +57,9 @@ export function defineConfig() {
     const url = new URL(request.url);
     logDefault('Processing request: %s %s', request.method, request.url);
 
+    // Public installation instructions must remain readable by coding agents.
+    if (url.pathname === '/acceptance/skill.md') return NextResponse.next();
+
     // skip all api requests
     if (backendApiEndpoints.some((path) => url.pathname.startsWith(path))) {
       logDefault('Skipping API request: %s', url.pathname);


### PR DESCRIPTION
The Acceptance welcome page leaves excessive space above setup, and its copied installation prompt points to a URL without a public guide. Constrain and top-align the welcome content, stack the manual steps, and point the English and Chinese prompts to `https://app.lobehub.com/acceptance/skill.md`.

Serve a public Markdown installation guide without SPA rewriting or authentication.

#### Test

- [x] Added a regression check for anonymous Markdown access without SPA rewriting or session lookup.
- [x] Scoped lint and related tests passed (10 tests) on the original working tree.
- [x] Pre-commit formatting, Stylelint, and ESLint checks passed on the PR branch.
- [x] Local full-stack HTTP request returned `200` with `Content-Type: text/markdown` and no redirect.
- [ ] Visual and interaction verification: blocked by persistent local Vite timeouts after a restart. No valid after screenshot is available yet.
- [ ] Full type-check: result unavailable.

[Acceptance report](https://app.lobehub.com/acceptance/69e5eda6-948b-44c8-81cc-28d466e17117): 1 of 3 checks passed; layout and installation interactions remain blocked. All 5 collected evidence artifacts were uploaded and reconciled.

