### PR TITLE
🧪 test: add reproducible nanoGPT agentic pretraining pilot

### DIFF
--- a/scripts/experiments/nanogpt/README.md
+++ b/scripts/experiments/nanogpt/README.md
@@ -1,0 +1,64 @@
+# nanoGPT agentic 语料对照实验
+
+在本机用上游 [karpathy/nanoGPT](https://github.com/karpathy/nanoGPT) @ `3adf61e` 复现完整本地流程
+(数据 → tokenize → 训练 → checkpoint → resume → 采样 → held-out 评估), 并比较三类语料的
+next-byte 可预测性：公共普通文本 vs 个人 agentic 轨迹 (带 / 不带角色标记)。
+
+## 文件
+
+| 文件                                            | 作用                                                                                    |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `selection_rule.md`                             | agentic 语料选择规则 (先于抓取冻结；个人 ID 在私有 selection.json)                      |
+| `selection.example.json`                        | 私有选择文件的占位示例 (复制到 `.records/nanogpt/private/selection.json` 并填入真实 ID) |
+| `fetch_agentic.py`                              | 经 `lh` CLI 抓 topic / 消息，raw 只落盘不打印                                           |
+| `fetch_public.sh`                               | 下载公共领域 tiny-shakespeare 并记录 hash                                               |
+| `build_corpus.py`                               | 脱敏 → 共享消息片段 ledger → topic 级 70/15/15 → 去重 → byte257 bin                     |
+| `test_corpus_invariants.py`                     | 语料不变量可执行测试 (合成夹具)                                                         |
+| `test_payload_markers.py` / `test_eval_loss.py` | 回归测试 (正文含类标记文本 / EOT 排除口径)                                              |
+| `eval_loss.py`                                  | 独立 held-out 评估 (冻结窗口，NLL + bits/byte)                                          |
+| `run_matrix.py`                                 | 编排:smoke /train/resume /sample/eval                                                   |
+
+## 复跑
+
+以下命令在仓库根目录执行，首次运行使用新的 `.records/nanogpt` 目录。Python 依赖为本次验证的 torch 2.8.0、numpy 2.0.2；训练设备为 Apple MPS。个人数据与权重不公开，因此公开材料可复跑流程，不能独立重建本次私人语料。已保留本地 bins 时可直接复算评估，避免重新抽样。
+
+```bash
+mkdir -p .records/nanogpt/private .records/nanogpt/logs
+# 首次准备上游；已有本次 upstream 时跳过 clone/checkout/apply
+git clone https://github.com/karpathy/nanoGPT.git .records/nanogpt/upstream
+git -C .records/nanogpt/upstream checkout 3adf61e154c3fe3fca428ad6bc3818b27a3b8291
+git -C .records/nanogpt/upstream apply "$PWD/scripts/experiments/nanogpt/upstream.diff"
+cp scripts/experiments/nanogpt/selection.example.json .records/nanogpt/private/selection.json
+# 编辑私有 selection.json，填入自己账号的 agent/topic ID；lh 必须已登录。
+python3 scripts/experiments/nanogpt/test_corpus_invariants.py
+python3 -m unittest discover -s scripts/experiments/nanogpt -p 'test_*.py'
+python3 scripts/experiments/nanogpt/fetch_agentic.py
+bash scripts/experiments/nanogpt/fetch_public.sh
+python3 scripts/experiments/nanogpt/build_corpus.py
+# 首次初始化进度文件。复用已有实验时不要覆盖它。
+python3 -c 'import json,pathlib; pathlib.Path(".records/nanogpt/progress.json").write_text(json.dumps({"phases": {}}))'
+python3 scripts/experiments/nanogpt/run_matrix.py all
+# 对本次已有的九个模型，仅重新评估：
+python3 scripts/experiments/nanogpt/run_matrix.py eval
+```
+
+`protocol.record.json` 是本次冻结协议的副本。新数据运行应另存自己的协议与数据哈希，不沿用本次结果或冻结声明。`run_matrix.py train` 会按 run\_id 跳过已有结果；开始新的对照时使用新的记录目录，不混用旧模型。采样输出文件包含上游 stdout 头部，文件大小不是纯生成文本字节数。
+
+## 关键设计
+
+- **共享 ledger**: 每条消息切成 header/body/toolmark 段；截断、去重都作用于 ledger,
+  `agentic_full` 与 `agentic_norole` 是同一 ledger 的两种渲染，正文逐字节一致 (构建时逐 topic 断言)。
+- **精确 update 计数**: 上游终止条件为 `iter_num > max_iters`, 故正式 run 用 `--max_iters=1999`
+  得到恰好 2000 次 optimizer update (4,096,000 tokens); 上游 patch 在循环结束保存 `ckpt_final.pt`。
+- **resume**: 段 A `--max_iters=1000` 在 iter 1000 顶部落 `ckpt.pt`(恰 1000 updates 后的状态，
+  其后第 1001 次 update 被丢弃); 段 B `init_from=resume` 用同一 2000 步 LR 计划续训 iter 1000..1999。
+- **评估口径**:`bits_per_byte_excl_eot` 分子分母均排除 EOT 目标，是公开主指标；
+  另报含 EOT 的 bits/token。val 仅监控，不用于选 ckpt。
+
+详细协议与修订记录见 `.records/nanogpt/protocol.json`(训练前冻结，hash 在 `protocol.sha256`)。
+
+## 隐私
+
+raw / 脱敏语料 /bin/checkpoint/ 样本全部留在 `.records/nanogpt/private/`, 不入库不发布；
+公开聚合 (`.records/nanogpt/public/`) 只含白名单字段 (opaque run id、arm/seed、超参、指标、
+耗时、hash、命令模板)。本目录代码不含任何个人 ID。

--- a/scripts/experiments/nanogpt/README.md
+++ b/scripts/experiments/nanogpt/README.md
@@ -16,7 +16,7 @@ next-byte 可预测性：公共普通文本 vs 个人 agentic 轨迹 (带 / 不�
 | `test_corpus_invariants.py`                     | 语料不变量可执行测试 (合成夹具)                                                         |
 | `test_payload_markers.py` / `test_eval_loss.py` | 回归测试 (正文含类标记文本 / EOT 排除口径)                                              |
 | `eval_loss.py`                                  | 独立 held-out 评估 (冻结窗口，NLL + bits/byte)                                          |
-| `run_matrix.py`                                 | 编排:smoke /train/resume /sample/eval                                                   |
+| `run_matrix.py`                                 | 编排:smoke /train/resume/sample/eval                                                    |
 
 ## 复跑
 
@@ -62,3 +62,11 @@ python3 scripts/experiments/nanogpt/run_matrix.py eval
 raw / 脱敏语料 /bin/checkpoint/ 样本全部留在 `.records/nanogpt/private/`, 不入库不发布；
 公开聚合 (`.records/nanogpt/public/`) 只含白名单字段 (opaque run id、arm/seed、超参、指标、
 耗时、hash、命令模板)。本目录代码不含任何个人 ID。
+
+## Goal 端到端验收
+
+[研究验收第 2 轮](https://app.lobehub.com/acceptance/0392da18-016d-40dc-ae9c-cae848eee75b?r=2) 复用本目录的数据准备与评估工具，由 Goal 调度 Kimi Code 新跑 public\_plain /agentic\_full 两臂，各 seed 1337、2000 次更新、4,096,000 byte-token 曝光。产物另存 `.records/nanogpt-goal-e2e`；本目录三臂三 seed 的 `protocol.record.json` 记录的是前一轮协议，不是本轮 Goal 的执行范围。
+
+本轮独立参数量为 836,864（共享 embedding /lm\_head 不重复计数）。在同一个人轨迹测试集，两模型 BPB 分别为 8.488657 与 3.148964；在同一公共测试集分别为 2.808069 与 3.995108。四个数值均经独立重新评估核对。该结果仅表明本次分布内预测学习价值，不能证明 Agent 任务成功率提升、轨迹结构的因果收益或混合预训练收益。
+
+Goal 自动完成最终验收并进入 achieved，但期间有人工修复、重试与报告纠错。整体验收为部分通过：科学结果与图导航通过，自主执行项不通过。运行链路修复与实验容器 UI 见 [Goal PR #19261](https://github.com/lobehub/lobehub/pull/19261)。

--- a/scripts/experiments/nanogpt/build_corpus.py
+++ b/scripts/experiments/nanogpt/build_corpus.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""构建语料:脱敏 → 每 topic 生成共享消息片段 ledger → topic 级 70/15/15 划分
+→ exact-paragraph 去重(两 arm 删除相同正文片段)→ byte tokenizer(vocab=256 字节 + 256 号 <|eot|>)
+→ nanoGPT uint16 .bin。
+
+arm 定义(同一 ledger 的两种渲染,正文逐字节一致):
+- agentic-full:  header/toolmark 标记行 + 正文行
+- agentic-norole:仅正文行(删掉的只有渲染时生成的标记行)
+
+不变量(构建时断言,测试见 test_corpus_invariants.py):
+- 从 full 渲染结果中按序删去 ledger 生成的标记行后,与 norole 渲染结果逐字节相同;
+- 截断(100KB/topic、3MB 全局)作用于 ledger 的消息边界,先于两种渲染;
+- 去重后 train 与 val/test 的正文段落 exact 重叠率为 0。
+
+stdout 只输出统计,绝不输出正文。
+"""
+import hashlib
+import json
+import pickle
+import random
+import re
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[3]
+REC = ROOT / '.records' / 'nanogpt'
+PRIV = REC / 'private'
+RAW = PRIV / 'raw'
+PUBLIC_TXT = REC / 'data' / 'public' / 'input.txt'
+
+EOT = 256
+VOCAB_SIZE = 257
+SPLIT_SEED = 20260907
+TOPIC_CAP_BYTES = 100 * 1024
+GLOBAL_CAP_BYTES = 3 * 1024 * 1024
+PARA_MIN_CHARS = 50
+
+# ---------------- 脱敏(顺序敏感:先长后短) ----------------
+REDACTIONS = [
+    ('JWT', re.compile(r'eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}')),
+    ('KEY', re.compile(
+        r'\b(?:sk|pk|ghp|gho|ghu|ghs|ghr|glpat|xoxb|xoxp|xoxa|xoxr|xoxs|AKIA|AIza|hf)'
+        r'[-_][A-Za-z0-9_-]{10,}')),
+    ('EMAIL', re.compile(r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}')),
+    ('URL', re.compile(r'https?://[^\s/?#]+[^\s]*')),  # 保 scheme+host,去 path/query
+    ('PATH', re.compile(r'(?:/Users|/home|/private|/var|/tmp|/Volumes)\\?[^\s:()\[\]{}"\']+|C:\\Users\\\S+')),
+    ('TOKEN', re.compile(r'\b[A-Za-z0-9_-]{40,}\b')),
+]
+
+ROLE_NAMES = {'user', 'assistant', 'system', 'tool'}
+
+
+def redact(text: str, counter: dict) -> str:
+    for name, rx in REDACTIONS:
+        if name == 'URL':
+            def _url(m):
+                counter['URL'] += 1
+                parts = m.group(0).split('/')
+                return '//'.join(parts[:2]) + '/' + parts[2] + '/<|URLPATH|>'
+            text = rx.sub(_url, text)
+        else:
+            text, n = rx.subn(f'<|{name}|>', text)
+            counter[name] += n
+    return text
+
+
+def sha256_file(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+# ---------------- ledger:每 topic 一份,两个 arm 同源渲染 ----------------
+# segment = (kind, text);kind ∈ {header, body, toolmark}
+# header/toolmark 为渲染时生成的标记行;body 为(脱敏后的)消息正文。
+
+def topic_ledger(msgs, counter):
+    segs = []
+    for m in sorted(msgs, key=lambda x: x.get('createdAt') or ''):
+        role = m.get('role') or 'unknown'
+        content = m.get('content') or ''
+        if not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False)
+        content = redact(content, counter).strip()
+        tools = m.get('tools') or []
+        tool_names = []
+        if isinstance(tools, list):
+            for t in tools:
+                if isinstance(t, dict):
+                    nm = t.get('name') or t.get('toolName') or t.get('identifier') or 'unknown'
+                    tool_names.append(str(nm))
+        if role not in ROLE_NAMES:
+            role = 'unknown'
+        if tool_names and not content:
+            for nm in tool_names:
+                segs.append(('toolmark', f'<|tool-call:{nm}|>'))
+            continue
+        if not content:
+            continue
+        segs.append(('header', f'<|role:{role}|>'))
+        segs.append(('body', content))
+        for nm in tool_names:
+            segs.append(('toolmark', f'<|tool-call:{nm}|>'))
+    return segs
+
+
+def render_full(segs):
+    return ''.join(t + '\n' for _, t in segs)
+
+
+def render_norole(segs):
+    return ''.join(t + '\n' for k, t in segs if k == 'body')
+
+
+def strip_generated_markers(full_text, segs):
+    """按序从 full 文本中删去 ledger 生成的标记行,应还原出 norole。"""
+    # Match ledger spans by position, never by payload text: a body can itself
+    # contain a line identical to a later generated role marker.
+    offset, out = 0, []
+    for kind, text in segs:
+        serialized = text + '\n'
+        assert full_text.startswith(serialized, offset), 'rendered ledger span mismatch'
+        if kind == 'body':
+            out.append(full_text[offset:offset + len(serialized)])
+        offset += len(serialized)
+    assert offset == len(full_text), 'unexpected trailing bytes'
+    return ''.join(out)
+
+
+def assert_arm_invariant(segs):
+    full = render_full(segs)
+    norole = render_norole(segs)
+    restored = strip_generated_markers(full, segs)
+    assert restored == norole, 'arm 不变量被破坏:删去生成的标记行后正文不一致'
+
+
+def group_segments(segs):
+    """把平坦 ledger 按消息分组:header 开启新组;无 header 的 toolmark 序列自成一组。"""
+    groups, cur = [], []
+    for seg in segs:
+        if seg[0] == 'header' and cur:
+            groups.append(cur)
+            cur = []
+        cur.append(seg)
+    if cur:
+        groups.append(cur)
+    return groups
+
+
+def cap_ledger(segs, cap_bytes):
+    """按消息边界截断 ledger(以 full 渲染字节计);返回 (segs, truncated)。"""
+    out, total, truncated = [], 0, False
+    for group in group_segments(segs):
+        cost = sum(len(t.encode('utf-8')) + 1 for _, t in group)
+        if total + cost > cap_bytes:
+            truncated = True
+            break
+        out += group
+        total += cost
+    return out, truncated
+
+
+# ---------------- 段落去重 ----------------
+def split_paragraphs(text):
+    """返回 [(para_text, sep_text)];para 为内容块,sep 为其后的空行分隔符。"""
+    parts = re.split(r'(\n\s*\n)', text)
+    out = []
+    for i in range(0, len(parts), 2):
+        para = parts[i]
+        sep = parts[i + 1] if i + 1 < len(parts) else ''
+        out.append((para, sep))
+    return out
+
+
+def para_hash(text):
+    return hashlib.sha1(text.strip().encode('utf-8')).hexdigest()
+
+
+def ledger_paragraph_hashes(segs):
+    h = set()
+    for k, t in segs:
+        if k != 'body':
+            continue
+        for para, _ in split_paragraphs(t):
+            if len(para.strip()) >= PARA_MIN_CHARS:
+                h.add(para_hash(para))
+    return h
+
+
+def filter_body(body, collision_hashes, stats):
+    parts = split_paragraphs(body)
+    kept = []
+    for para, sep in parts:
+        if len(para.strip()) >= PARA_MIN_CHARS and para_hash(para) in collision_hashes:
+            stats['removed'] += 1
+            continue
+        kept.append(para + sep)
+    return ''.join(kept)
+
+
+def filter_ledger_dedup(segs, collision_hashes, stats):
+    """删除 train ledger 中与 val/test 碰撞的正文段落;空正文连同其 header 一起删除。"""
+    out = []
+    i = 0
+    while i < len(segs):
+        k, t = segs[i]
+        if k == 'header' and i + 1 < len(segs) and segs[i + 1][0] == 'body':
+            new_body = filter_body(segs[i + 1][1], collision_hashes, stats)
+            if new_body.strip():
+                out.append(segs[i])
+                out.append(('body', new_body))
+            else:
+                stats['dropped_msgs'] += 1
+            i += 2
+        elif k == 'body':
+            new_body = filter_body(t, collision_hashes, stats)
+            if new_body.strip():
+                out.append(('body', new_body))
+            i += 1
+        else:
+            out.append(segs[i])
+            i += 1
+    return out
+
+
+# ---------------- bin 写出 ----------------
+def docs_to_bin(docs, out_dir: Path, name: str):
+    ids = []
+    for doc in docs:
+        ids.extend(doc.encode('utf-8'))
+        ids.append(EOT)
+    arr = np.array(ids, dtype=np.uint16)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / 'meta.pkl').write_bytes(pickle.dumps({'vocab_size': VOCAB_SIZE, 'encoding': 'byte257'}))
+    path = out_dir / f'{name}.bin'
+    arr.tofile(path)
+    return {'tokens': int(arr.size), 'sha256': sha256_file(path)}
+
+
+def main():
+    counter = {name: 0 for name, _ in REDACTIONS}
+    stats = {'redaction': counter, 'topics': {}, 'splits': {}, 'dedup': {}, 'arms': {}}
+
+    # 1) raw → ledger(共享),先截断后渲染
+    ledgers = []  # (topic_file_stem, segs, truncated)
+    total_full_bytes = 0
+    global_stopped = False
+    for fp in sorted(RAW.glob('tpc_*.json')):
+        msgs = json.loads(fp.read_text(encoding='utf-8'))
+        segs = topic_ledger(msgs, counter)
+        segs, truncated = cap_ledger(segs, TOPIC_CAP_BYTES)
+        cost = len(render_full(segs).encode('utf-8'))
+        if total_full_bytes + cost > GLOBAL_CAP_BYTES:
+            global_stopped = True
+            break
+        total_full_bytes += cost
+        for seg_view in (segs,):
+            assert_arm_invariant(seg_view)
+        ledgers.append((fp.stem, segs, truncated))
+    stats['topics'] = {
+        'n_used': len(ledgers),
+        'n_truncated_100kb': sum(1 for x in ledgers if x[2]),
+        'global_cap_stopped': global_stopped,
+        'total_full_bytes': total_full_bytes,
+    }
+
+    # 2) topic 级 70/15/15 划分(固定 seed,按字节量贪心,topic 不跨 split)
+    rng = random.Random(SPLIT_SEED)
+    order = list(range(len(ledgers)))
+    rng.shuffle(order)
+    sizes = [len(render_full(ledgers[i][1]).encode('utf-8')) for i in order]
+    tot = sum(sizes) or 1
+    target = {'train': 0.70 * tot, 'val': 0.15 * tot, 'test': 0.15 * tot}
+    assign = {'train': [], 'val': [], 'test': []}
+    cur = {'train': 0, 'val': 0, 'test': 0}
+    for idx, sz in zip(order, sizes):
+        split = max(target, key=lambda s: (target[s] - cur[s]) / target[s])
+        assign[split].append(idx)
+        cur[split] += sz
+    for s in assign:
+        assign[s].sort()
+    stats['splits'] = {
+        'seed': SPLIT_SEED,
+        'method': 'topic-level, byte-greedy 70/15/15, no topic crosses splits',
+        'train': {'n_topics': len(assign['train']), 'bytes': cur['train']},
+        'val': {'n_topics': len(assign['val']), 'bytes': cur['val']},
+        'test': {'n_topics': len(assign['test']), 'bytes': cur['test']},
+    }
+
+    # 3) 去重:碰撞集合来自 val/test 的正文段落;train 两 arm 删除相同正文片段(共享 ledger)
+    val_hashes = set()
+    for s in ('val', 'test'):
+        for i in assign[s]:
+            val_hashes |= ledger_paragraph_hashes(ledgers[i][1])
+    before = {'train_paragraphs': 0, 'colliding': 0}
+    for i in assign['train']:
+        for k, t in ledgers[i][1]:
+            if k != 'body':
+                continue
+            for para, _ in split_paragraphs(t):
+                if len(para.strip()) >= PARA_MIN_CHARS:
+                    before['train_paragraphs'] += 1
+                    if para_hash(para) in val_hashes:
+                        before['colliding'] += 1
+    dstats = {'removed': 0, 'dropped_msgs': 0}
+    train_ledgers = [filter_ledger_dedup(ledgers[i][1], val_hashes, dstats) for i in assign['train']]
+    after_collide = 0
+    after_paras = 0
+    for segs in train_ledgers:
+        hs = ledger_paragraph_hashes(segs)
+        after_paras += len(hs)
+        after_collide += len(hs & val_hashes)
+    stats['dedup'] = {
+        'method': ('exact paragraph(>=50 字符,按空行分段,去首尾空白,sha1);'
+                   '与 val/test 碰撞的 train 段落从共享 ledger 删除(两 arm 删除相同正文片段,优先保留 test/val);'
+                   'train 内 exact 重复段落保留但统计'),
+        'train_paragraphs_before': before['train_paragraphs'],
+        'train_paragraphs_colliding_before': before['colliding'],
+        'cross_split_dup_rate_before': (before['colliding'] / before['train_paragraphs'])
+        if before['train_paragraphs'] else 0.0,
+        'paragraphs_removed': dstats['removed'],
+        'messages_dropped_empty': dstats['dropped_msgs'],
+        'sum_per_topic_unique_train_paragraphs_after': after_paras,
+        'cross_split_dup_rate_after': (after_collide / after_paras) if after_paras else 0.0,
+    }
+
+    # 4) 渲染两个 agentic arm 并写 bin(同一 ledger,渲染前再断言不变量)
+    split_ledgers = {
+        'train': train_ledgers,
+        'val': [ledgers[i][1] for i in assign['val']],
+        'test': [ledgers[i][1] for i in assign['test']],
+    }
+    for arm, render in (('agentic_full', render_full), ('agentic_norole', render_norole)):
+        out_dir = PRIV / 'bins' / arm
+        for split, lds in split_ledgers.items():
+            for segs in lds:
+                assert_arm_invariant(segs)
+            docs = [render(segs) for segs in lds]
+            stats['arms'].setdefault(arm, {})[split] = docs_to_bin(docs, out_dir, split)
+
+    # 不变量终检:full/norole train bin 解码后,删除标记行应一致(抽样逐 topic 已在上面断言,
+    # 这里对整体 token 数关系做记录)
+    stats['arm_invariant'] = 'asserted per-topic: strip_generated_markers(render_full(segs)) == render_norole(segs)'
+
+    # 5) public-plain:tiny-shakespeare 连续 70/15/15,train 截断对齐 agentic-full train token 数
+    raw = PUBLIC_TXT.read_text(encoding='utf-8')
+    n = len(raw)
+    b1 = raw.find('\n', int(n * 0.70)) + 1
+    b2 = raw.find('\n', int(n * 0.85)) + 1
+    pub = {'train': raw[:b1], 'val': raw[b1:b2], 'test': raw[b2:]}
+    target_train_tokens = stats['arms']['agentic_full']['train']['tokens']
+    out_dir = REC / 'data' / 'bins' / 'public_plain'
+    pub_truncated = len(pub['train'].encode('utf-8')) > target_train_tokens
+    for split, text in pub.items():
+        if split == 'train':
+            ids = list(text.encode('utf-8'))[:target_train_tokens]
+            ids.append(EOT)
+            arr = np.array(ids, dtype=np.uint16)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / 'meta.pkl').write_bytes(
+                pickle.dumps({'vocab_size': VOCAB_SIZE, 'encoding': 'byte257'}))
+            path = out_dir / 'train.bin'
+            arr.tofile(path)
+            info = {'tokens': int(arr.size), 'sha256': sha256_file(path)}
+        else:
+            info = docs_to_bin([text], out_dir, split)
+        stats['arms'].setdefault('public_plain', {})[split] = info
+    stats['public'] = {
+        'source': 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt',
+        'sha256': sha256_file(PUBLIC_TXT), 'bytes': n,
+        'split': 'contiguous 70/15/15 at newline boundaries (single continuous file of Early Modern English plays)',
+        'train_truncated_to_match_agentic_full_train': pub_truncated,
+        'language_note': 'public=早期现代英文戏剧;agentic=中英混杂+代码+工具标记,语言/内容混杂为已知混杂因素',
+    }
+
+    # 6) epoch-equivalent(固定 token 预算 4,096,000 / train tokens)
+    budget = 4_096_000
+    for arm in ('agentic_full', 'agentic_norole', 'public_plain'):
+        tt = stats['arms'][arm]['train']['tokens']
+        stats['arms'][arm]['epoch_equivalent'] = round(budget / tt, 3) if tt else None
+
+    (REC / 'corpus_stats.json').write_text(json.dumps(stats, ensure_ascii=False, indent=1))
+    print(json.dumps({
+        'topics_used': stats['topics']['n_used'],
+        'redaction': counter,
+        'splits': stats['splits'],
+        'dedup': stats['dedup'],
+        'arm_tokens': {a: {s: stats['arms'][a][s]['tokens'] for s in ('train', 'val', 'test')}
+                       for a in stats['arms']},
+        'epoch_equivalent': {a: stats['arms'][a]['epoch_equivalent'] for a in stats['arms']},
+    }, ensure_ascii=False, indent=1))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/nanogpt/eval_loss.py
+++ b/scripts/experiments/nanogpt/eval_loss.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""独立 held-out 评估:加载任一 ckpt,在任一 .bin 上计算确定性窗口 NLL。
+
+与训练日志无关:独立进程、独立脚本、固定窗口(协议冻结):
+- 窗口:从 offset 0 开始,stride=block_size 的非重叠窗口;x=data[i:i+B], y=data[i+1:i+B+1];
+- 指标:
+  - nll_per_token          = 总 NLL / 目标 token 数(含 eot 目标)
+  - bits_per_token_incl_eot= nll_per_token / ln2
+  - bits_per_byte_excl_eot = 字节目标 NLL / ln2 / 目标中字节 token(y != 256)数  ← 公开主指标
+输出仅 JSON 统计。
+"""
+import argparse
+from contextlib import redirect_stdout
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+UPSTREAM = Path(__file__).resolve().parents[3] / '.records' / 'nanogpt' / 'upstream'
+sys.path.insert(0, str(UPSTREAM))
+from model import GPT, GPTConfig  # noqa: E402
+
+EOT = 256
+
+
+def sha256_file(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--ckpt', required=True)
+    ap.add_argument('--bin', required=True)
+    ap.add_argument('--device', default='mps')
+    ap.add_argument('--batch', type=int, default=64)
+    args = ap.parse_args()
+
+    ckpt = torch.load(args.ckpt, map_location=args.device, weights_only=False)
+    conf = GPTConfig(**ckpt['model_args'])
+    with redirect_stdout(sys.stderr):
+        model = GPT(conf)
+    sd = ckpt['model']
+    for k in list(sd):
+        if k.startswith('_orig_mod.'):
+            sd[k[len('_orig_mod.'):]] = sd.pop(k)
+    model.load_state_dict(sd)
+    model.eval().to(args.device)
+    B = conf.block_size
+
+    data = np.memmap(args.bin, dtype=np.uint16, mode='r').astype(np.int64)
+    starts = list(range(0, len(data) - B, B))
+    assert starts, f'{args.bin} 太短,无法评估'
+
+    nll_sum = 0.0
+    byte_nll_sum = 0.0
+    n_tokens = 0
+    n_byte_targets = 0
+    with torch.no_grad():
+        for i in range(0, len(starts), args.batch):
+            chunk = starts[i:i + args.batch]
+            x = torch.stack([torch.from_numpy(data[s:s + B]) for s in chunk]).to(args.device)
+            y = torch.stack([torch.from_numpy(data[s + 1:s + B + 1]) for s in chunk]).to(args.device)
+            logits, _ = model(x, y)
+            loss = torch.nn.functional.cross_entropy(
+                logits.view(-1, logits.size(-1)).float(), y.reshape(-1), reduction='none')
+            nll_sum += loss.sum().item()
+            byte_nll_sum += loss[y.reshape(-1) != EOT].sum().item()
+            n_tokens += y.numel()
+            n_byte_targets += int((y != EOT).sum().item())
+
+    out = {
+        'ckpt': Path(args.ckpt).name,
+        'ckpt_sha256': sha256_file(args.ckpt),
+        'bin': Path(args.bin).name,
+        'bin_sha256': sha256_file(args.bin),
+        'ckpt_iter_num': ckpt.get('iter_num'),
+        'block_size': B,
+        'window_method': 'non-overlapping, offset 0, stride=block_size, x/y shifted by 1',
+        'n_windows': len(starts),
+        'n_target_tokens': n_tokens,
+        'n_byte_targets_excl_eot': n_byte_targets,
+        'nll_total': nll_sum,
+        'nll_byte_targets': byte_nll_sum,
+        'nll_per_token': nll_sum / n_tokens,
+        'bits_per_token_incl_eot': nll_sum / n_tokens / math.log(2),
+        'bits_per_byte_excl_eot': byte_nll_sum / math.log(2) / n_byte_targets,
+    }
+    print(json.dumps(out))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/nanogpt/export_public.py
+++ b/scripts/experiments/nanogpt/export_public.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""生成公开聚合结果到 .records/nanogpt/public/。
+
+只输出白名单字段:opaque run id、arm/seed、架构/超参、匿名计数、指标、耗时、
+upstream/protocol/code hash、命令模板、phase 成功证明。
+绝不包含:原始 topic id/正文、用户路径、凭据、样本/权重、未脱敏日志。
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+REC = ROOT / '.records' / 'nanogpt'
+PUB = REC / 'public'
+
+results = json.loads((REC / 'results.json').read_text())
+corpus = json.loads((REC / 'corpus_stats.json').read_text())
+progress = json.loads((REC / 'progress.json').read_text())
+protocol_sha = (REC / 'protocol.sha256').read_text()
+
+# opaque run id 映射(顺序固定,不含任何真实标识)
+run_ids = sorted(r['run_id'] for r in results['runs'])
+opaque = {rid: f'r{i + 1:02d}' for i, rid in enumerate(run_ids)}
+
+runs = []
+for r in sorted(results['runs'], key=lambda x: x['run_id']):
+    rid = r['run_id']
+    runs.append({
+        'run_id': opaque[rid], 'arm': r['arm'], 'seed': r['seed'],
+        'updates': r['updates'], 'train_tokens': r['tokens'],
+        'elapsed_s': r['elapsed_s'],
+        'final_train_loss': r['final_train_loss'],
+        'val_curve': r['val_curve'],
+        'ckpt_final_sha256': r['ckpt_final_sha256'],
+        'ckpt_final_iter_num': r['ckpt_final_iter_num'],
+        'status': r['status'],
+    })
+
+eval_matrix = {}
+for rid, per_test in results['eval']['matrix'].items():
+    eval_matrix[opaque[rid]] = per_test
+
+out = {
+    'experiment': 'nanogpt-agentic',
+    'generated_at': progress['updated_at'],
+    'upstream': {
+        'repo': 'https://github.com/karpathy/nanoGPT',
+        'commit': '3adf61e154c3fe3fca428ad6bc3818b27a3b8291',
+        'patches': ['train.py: 可配置 seed', 'train.py: 循环末保存 ckpt_final.pt',
+                    'sample.py: tiktoken 懒加载 + byte257 解码 + ckpt_name'],
+        'loop': '上游原生训练循环,未替换',
+    },
+    'protocol_sha256': protocol_sha,
+    'arch': {'n_layer': 4, 'n_head': 4, 'n_embd': 128, 'block_size': 128, 'dropout': 0.0,
+             'bias': False, 'vocab_size': 257, 'tokenizer': 'byte257(0..255 + eot=256)'},
+    'hyperparams': {'updates': 2000, 'tokens_per_iter': 2048, 'batch_size': 16,
+                    'grad_accum': 1, 'optimizer': 'AdamW(0.9,0.95)', 'lr': 6e-4,
+                    'warmup_iters': 100, 'lr_decay_iters': 2000, 'min_lr': 6e-5,
+                    'weight_decay': 0.1, 'grad_clip': 1.0, 'dtype': 'float32',
+                    'compile': False, 'device': 'mps'},
+    'seeds': [1337, 2024, 4242],
+    'data_anonymous_counts': {
+        'agentic_topics': corpus['topics']['n_used'],
+        'split_topics': {s: corpus['splits'][s]['n_topics'] for s in ('train', 'val', 'test')},
+        'split_method': corpus['splits']['method'],
+        'redaction_counts': corpus['redaction'],
+        'dedup': corpus['dedup'],
+        'arm_tokens': {a: {s: corpus['arms'][a][s]['tokens'] for s in ('train', 'val', 'test')}
+                       for a in corpus['arms']},
+        'epoch_equivalent': {a: corpus['arms'][a]['epoch_equivalent'] for a in corpus['arms']},
+        'public_source_sha256': corpus['public']['sha256'],
+        'language_confound': corpus['public']['language_note'],
+    },
+    'runs': runs,
+    'resume_proof': {
+        'arm': results['resume']['arm'], 'seed': results['resume']['seed'],
+        'segment_a_ckpt_iter': results['resume']['segment_a']['ckpt_iter_num'],
+        'segment_b_first_iter': results['resume']['segment_b']['first_iter'],
+        'segment_b_additional_updates': results['resume']['segment_b']['additional_updates'],
+        'final_iter_num': results['resume']['segment_b']['final_iter_num'],
+        'lr_schedule': results['resume']['lr_schedule'],
+        'bitwise_note': results['resume']['bitwise_note'],
+        'ckpt_final_sha256': results['resume']['ckpt_final_sha256'],
+    },
+    'samples': results['samples'],
+    'eval': {
+        'method': results['eval']['method'],
+        'primary_metric': 'bits_per_byte_excl_eot(分子分母均排除 eot 目标)',
+        'matrix': eval_matrix,
+        'summary_bpb_excl_eot': results['eval']['summary_bpb_excl_eot'],
+    },
+    'command_templates': {
+        'train': 'python3 train.py --dataset=<bin_dir> --out_dir=<run_dir> --seed=<seed> '
+                 '--device=mps --dtype=float32 --compile=False --n_layer=4 --n_head=4 '
+                 '--n_embd=128 --block_size=128 --batch_size=16 --gradient_accumulation_steps=1 '
+                 '--dropout=0.0 --bias=False --learning_rate=6e-4 --max_iters=1999 '
+                 '--lr_decay_iters=2000 --warmup_iters=100 --min_lr=6e-5 --weight_decay=0.1 '
+                 '--beta1=0.9 --beta2=0.95 --grad_clip=1.0 --eval_interval=500 --eval_iters=100 '
+                 '--log_interval=1',
+        'resume_b': '同上 + --init_from=resume(加载 model+optimizer+iter_num)',
+        'sample': 'python3 sample.py --out_dir=<run_dir> --ckpt_name=ckpt_final.pt --device=mps '
+                  '--dtype=float32 --num_samples=4 --max_new_tokens=400 --seed=1337',
+        'eval': 'python3 eval_loss.py --ckpt <ckpt_final.pt> --bin <test.bin> --device=mps',
+    },
+    'phase_proofs': {k: v.get('status') for k, v in progress['phases'].items()},
+    'claims_boundary': '仅 next-byte 预测误差差异;结构消融受结构 token 目标与内容曝光差别限制;'
+                       'n=3 seed,不做强显著性断言;不声称 agent 任务能力提升或纯因果收益',
+}
+
+PUB.mkdir(exist_ok=True)
+(PUB / 'results.json').write_text(json.dumps(out, ensure_ascii=False, indent=1))
+print(f"public/results.json 写出:{len(runs)} runs,opaque id 映射 {opaque}")

--- a/scripts/experiments/nanogpt/fetch_agentic.py
+++ b/scripts/experiments/nanogpt/fetch_agentic.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""按 selection_rule.md 经 lh CLI 抓取 agentic topic 消息。
+
+选择参数(agent/topic ID 等个人信息)从私有文件 .records/nanogpt/private/selection.json 读取;
+公开示例见同目录 selection.example.json(占位符)。
+
+安全约束:
+- 只把 lh 的 JSON 输出原样写进 .records/nanogpt/private/,绝不把正文打印到 stdout/日志;
+- stdout 只输出 topic/消息计数与文件 hash 等统计。
+"""
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+PRIV = ROOT / '.records' / 'nanogpt' / 'private'
+RAW = PRIV / 'raw'
+SELECTION_PATH = PRIV / 'selection.json'
+
+
+def lh(*args):
+    r = subprocess.run(['lh', *args], capture_output=True, text=True, timeout=120)
+    if r.returncode != 0:
+        raise RuntimeError(f"lh {' '.join(args)} 失败: {r.stderr[:200]}")
+    return r.stdout
+
+
+def main():
+    if not SELECTION_PATH.exists():
+        raise SystemExit(
+            f'缺少私有选择文件 {SELECTION_PATH};请参照 scripts/experiments/nanogpt/selection.example.json 创建')
+    sel = json.loads(SELECTION_PATH.read_text(encoding='utf-8'))
+    cutoff = sel['cutoff']
+    agents = [(a['label'], a['agent_id']) for a in sel['agents']]
+    exclude_ids = set(sel['exclude_topic_ids'])
+    exclude_keywords = [k.lower() for k in sel['exclude_title_keywords']]
+    per_agent = sel['per_agent_candidates']
+    target_total = sel['target_total']
+    max_msg = sel['max_messages_per_topic']
+    page_size = sel['page_size']
+
+    RAW.mkdir(parents=True, exist_ok=True)
+    # 1) 候选 topic 列表(落盘,不打印 title)
+    candidates = {}
+    for label, agent_id in agents:
+        out = lh('topic', 'list', '--agent-id', agent_id, '-L', str(per_agent),
+                 '--json', 'id,title,createdAt,updatedAt')
+        topics = json.loads(out)
+        (PRIV / f'topics_{label}.json').write_text(out, encoding='utf-8')
+        candidates[label] = topics
+
+    # 2) 过滤 + 确定性选择
+    selected = []
+    leftover = []
+    excluded_counts = {'id': 0, 'cutoff': 0, 'keyword': 0}
+    for label, _ in agents:
+        passed = []
+        for t in candidates[label]:
+            if t['id'] in exclude_ids:
+                excluded_counts['id'] += 1
+                continue
+            if t['createdAt'] > cutoff:
+                excluded_counts['cutoff'] += 1
+                continue
+            title = (t.get('title') or '').lower()
+            if any(k in title for k in exclude_keywords):
+                excluded_counts['keyword'] += 1
+                continue
+            passed.append(t['id'])
+        selected += [(label, tid) for tid in passed[:10]]
+        leftover += [(label, tid) for tid in passed[10:]]
+    deficit = target_total - len(selected)
+    if deficit > 0:
+        selected += leftover[:deficit]
+    selected = selected[:target_total]
+
+    # 3) 抓消息:每 topic 至多 max_msg 条,--end 截止,原样落盘
+    manifest = {'cutoff': cutoff, 'rule': 'selection_rule.md', 'topics': [],
+                'excluded_counts': excluded_counts}
+    for label, tid in selected:
+        msgs = []
+        page = 1
+        while len(msgs) < max_msg:
+            out = lh('message', 'list', '--topic-id', tid, '--end', cutoff,
+                     '-L', str(page_size), '-P', str(page), '--json')
+            batch = json.loads(out)
+            if not batch:
+                break
+            msgs += batch
+            if len(batch) < page_size:
+                break
+            page += 1
+        msgs = msgs[:max_msg]
+        blob = json.dumps(msgs, ensure_ascii=False).encode('utf-8')
+        fp = RAW / f'{tid}.json'
+        fp.write_bytes(blob)
+        manifest['topics'].append({
+            'agent': label,
+            'topic_hash': hashlib.sha256(tid.encode()).hexdigest()[:16],
+            'n_messages': len(msgs),
+            'bytes': len(blob),
+            'sha256': hashlib.sha256(blob).hexdigest(),
+        })
+        print(f'[fetch] agent={label} topic#{len(manifest["topics"])} msgs={len(msgs)} bytes={len(blob)}')
+
+    (PRIV / 'fetch_manifest.json').write_text(json.dumps(manifest, ensure_ascii=False, indent=1))
+    total_msgs = sum(t['n_messages'] for t in manifest['topics'])
+    total_bytes = sum(t['bytes'] for t in manifest['topics'])
+    print(f'[fetch] done: topics={len(selected)} msgs={total_msgs} raw_bytes={total_bytes} excluded={excluded_counts}')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/experiments/nanogpt/fetch_public.sh
+++ b/scripts/experiments/nanogpt/fetch_public.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# 下载公共领域语料 tiny-shakespeare(karpathy/char-rnn 镜像,莎士比亚作品集,公共领域)
+set -euo pipefail
+cd "$(dirname "$0")/../../.."
+mkdir -p .records/nanogpt/data/public
+curl -fsSL "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt" \
+  -o .records/nanogpt/data/public/input.txt
+shasum -a 256 .records/nanogpt/data/public/input.txt
+wc -c .records/nanogpt/data/public/input.txt

--- a/scripts/experiments/nanogpt/protocol.record.json
+++ b/scripts/experiments/nanogpt/protocol.record.json
@@ -1,0 +1,127 @@
+{
+  "arms": {
+    "public_plain": "公共领域文本 tiny-shakespeare,连续 70/15/15 切分",
+    "agentic_full": "个人 agentic 轨迹(角色标记行 + 正文 + 工具名标记)",
+    "agentic_norole": "与 agentic_full 同一 ledger 渲染,仅删生成的角色/工具标记行,正文逐字节一致(构建时逐 topic 断言)"
+  },
+  "data": {
+    "agentic_source": "lh CLI 读取本用户 3 个 coding-agent(claude/codex/kimi)topic;选择规则先于抓取冻结于 scripts/experiments/nanogpt/selection_rule.md;agent/topic ID 存私有 .records/nanogpt/private/selection.json",
+    "cutoff": "2026-09-07T17:30:00Z",
+    "selection": "每 agent 最近 20 候选过滤后取前 10,共 30 topic;排除当前 topic/验收/synthetic",
+    "caps": "每 topic ≤200 消息、≤100KB(共享 ledger 消息边界截断),全局 ≤3MB",
+    "redaction": "EMAIL/PATH/URL(保 host 去参数)/JWT/KEY/长 TOKEN 统一占位替换,序列化前应用于正文;tools 仅取工具名",
+    "split": "topic 级 70/15/15,seed=20260907,按字节贪心,topic 不跨 split",
+    "dedup": "exact paragraph(>=50 字符,空行分段,sha1);与 val/test 碰撞的 train 段落从共享 ledger 删除(两 arm 删相同正文,优先保留 test/val);报告去重前后跨 split 重复率",
+    "public_source": "tiny-shakespeare input.txt sha256=86c4e6aa9db7c042ec79f339dcb96d42b0075e16b8fc2e86bf0ca57e2dc565ed",
+    "public_split": "连续 70/15/15(换行边界);train 未达 agentic train 规模,epoch-equivalent 更高(如实报告)",
+    "language_confound": "public=早期现代英文;agentic=中英混杂+代码+工具结构;语言/内容混杂为已知混杂因素",
+    "epoch_equivalent": { "agentic_full": 2.528, "agentic_norole": 2.58, "public_plain": 5.246 }
+  },
+  "evaluation": {
+    "script": "scripts/experiments/nanogpt/eval_loss.py(独立脚本,不复制训练日志指标)",
+    "test_sets": [
+      "public(=public_plain test.bin)",
+      "agentic_full test.bin",
+      "agentic_norole test.bin"
+    ],
+    "windows": "冻结:offset 0 起,stride=block_size(128) 非重叠,x/y 错位 1",
+    "metrics": [
+      "nll_per_token(含 eot 目标)",
+      "bits_per_token_incl_eot",
+      "bits_per_byte_excl_eot(公开主指标:分子分母均排除 eot 目标,即仅字节目标的 NLL 均值 / ln2)"
+    ],
+    "reporting": "9 run × 3 test set 矩阵;每 seed 值 + mean/std(population) + 同 seed 配对差值;n=3,不做强显著性断言",
+    "claims_boundary": "仅报告 next-byte 预测误差差异;结构消融受结构 token 目标与内容曝光差别限制,不声称 agent 任务能力提升或纯因果收益"
+  },
+  "experiment": "nanogpt-agentic",
+  "frozen_at": "2026-09-08",
+  "model": {
+    "arch": "GPT",
+    "n_layer": 4,
+    "n_head": 4,
+    "n_embd": 128,
+    "block_size": 128,
+    "dropout": 0.0,
+    "bias": false,
+    "params_approx": "0.84M"
+  },
+  "privacy": {
+    "private": [".records/nanogpt/private/**(raw/redacted/bins/runs/samples)", "训练日志 logs/"],
+    "public_whitelist": [
+      "opaque run id",
+      "arm/seed",
+      "架构/超参",
+      "匿名计数",
+      "指标",
+      "耗时",
+      "upstream/protocol/code hash",
+      "命令模板",
+      "phase 成功证明"
+    ],
+    "never_public": ["原始 topic id/正文", "用户路径", "凭据", "样本/权重", "未脱敏日志"]
+  },
+  "resume_proof": {
+    "run": "agentic_full seed=1337",
+    "segment_a": "max_iters=1000, eval_interval=1000 → ckpt.pt 在 iter 1000 顶部保存(=恰好 1000 updates 后状态);该进程共执行 1001 次 update,第 1001 次在保存之后被丢弃",
+    "segment_b": "init_from=resume 加载 model+optimizer+iter_num,相同 LR 计划(warmup100/cosine 至 2000/min 6e-5),iter 1000..1999 = 额外恰好 1000 updates,final ckpt @2000",
+    "bitwise": "不保证与不中断 run 逐位一致(RNG 重新播种,data order 不恢复);model/optimizer/iter 均真实恢复"
+  },
+  "revisions": [
+    "2026-09-08 训练前方法审查(pre-training method review,主代理暂停上一轮,未训练任何正式 run)后合并修复:共享消息片段 ledger 先截断再分别渲染 full/norole;两 arm 删除相同正文段落;strip 标记后正文逐字节一致的构建时断言;去重后跨 split 重叠率复算(0);fetch_agentic.py 个人 ID 移至私有 selection.json;新增可执行不变量测试(抓取前通过);BPB 主指标排除 eot 目标;resume 段 A/B 保持完整 2000 步 LR 计划;冒烟验证 seed 真实生效",
+    "2026-09-08 角色标记由 <|user|> 改为 <|role:user|> 形式,降低与正文撞车概率;strip 算法按 ledger 段位置消费,不受正文中类标记文本影响",
+    "2026-09-08 bits_per_byte_excl_eot 口径定稿为分子分母均排除 eot 目标(仅字节目标 NLL/ln2/字节目标数),与合成回归测试 test_eval_loss.py 一致;以上均在正式训练前完成并重冻结 hash"
+  ],
+  "sampling": "每 arm(seed 1337)sample.py 4 样本 × 400 tokens;样本留 private,公开仅成功数/字节数/sha256",
+  "seed_policy": "train.py seed 配置项驱动 torch.manual_seed;模型初始化与 data order(torch.randint)均由该 seed 决定;3 个 seed 在 3 个 arm 间配对(同 seed 同初始化策略);冒烟阶段验证同 seed 可复现、异 seed 不同",
+  "seeds": [1337, 2024, 4242],
+  "status": "frozen before formal training",
+  "supersedes": ".records/nanogpt/plan.md (早期方案,已标 superseded)",
+  "tokenizer": {
+    "type": "shared byte-level",
+    "vocab": "0..255 原始字节 + 256 <|eot|> 文档分隔符",
+    "vocab_size": 257,
+    "deterministic": true,
+    "note": "无 BPE 训练,跨 arm 完全公平"
+  },
+  "training": {
+    "optimizer_updates_per_run": 2000,
+    "max_iters_cli": 1999,
+    "max_iters_note": "上游终止条件为 iter_num > max_iters,iter 0..1999 恰好 2000 次 optimizer update",
+    "tokens_per_iter": 2048,
+    "batch_size": 16,
+    "block_size": 128,
+    "gradient_accumulation_steps": 1,
+    "train_tokens_per_run": 4096000,
+    "optimizer": "AdamW",
+    "learning_rate": 6e-4,
+    "warmup_iters": 100,
+    "lr_schedule": "cosine decay to min_lr at lr_decay_iters=2000",
+    "min_lr": 6e-5,
+    "beta1": 0.9,
+    "beta2": 0.95,
+    "weight_decay": 0.1,
+    "grad_clip": 1.0,
+    "dtype": "float32",
+    "compile": false,
+    "device": "mps",
+    "ddp": false,
+    "eval_interval": 500,
+    "eval_iters": 100,
+    "eval_purpose": "val 仅监控,不用于选 ckpt/早停",
+    "final_ckpt": "ckpt_final.pt @ iter_num=2000(所有比较统一使用该固定步数 ckpt)"
+  },
+  "upstream": {
+    "repo": "https://github.com/karpathy/nanoGPT",
+    "commit": "3adf61e154c3fe3fca428ad6bc3818b27a3b8291",
+    "patches_file": ".records/nanogpt/patches/upstream.diff",
+    "patches": [
+      "train.py: 新增 seed 配置项(上游硬编码 1337),torch.manual_seed(seed + seed_offset)",
+      "train.py: 循环结束后保存 ckpt_final.pt(上游只在 eval 顶部保存 ckpt.pt,max_iters=1999 时末次 update 后的状态不会落盘);resume 仍读 ckpt.pt",
+      "sample.py: tiktoken 改为懒加载(环境未安装,且 byte tokenizer 不需要)",
+      "sample.py: 新增 ckpt_name 配置以便从 ckpt_final.pt 采样",
+      "sample.py: meta.encoding=='byte257' 时使用字节编解码(id 0..255 为字节,256 渲染为 <|eot|>)"
+    ],
+    "checkpoint_loading": "torch 2.8 默认 weights_only=True 可加载本实验 ckpt(已实测),无需 patch;自写 eval_loss.py 显式 weights_only=False",
+    "loop_unchanged": "训练循环/数据加载/优化器为上游原生实现,未替换为自写训练器"
+  }
+}

--- a/scripts/experiments/nanogpt/run_matrix.py
+++ b/scripts/experiments/nanogpt/run_matrix.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""实验编排:冒烟 → 9 个正式 run → resume 验证 → 采样 → 交叉评估。
+
+用法:
+  python3 run_matrix.py smoke    # 管道冒烟 + seed 生效验证 + resume 机制验证
+  python3 run_matrix.py train    # 9 个正式 run(串行),每 run 完成即更新 results.json/progress.json
+  python3 run_matrix.py resume   # resume 证明:1000 → 2000(完整 2000 步 LR 计划)
+  python3 run_matrix.py sample   # 每 arm(seed 1337)采样,样本留 private
+  python3 run_matrix.py eval     # 9 ckpt × 3 冻结 test set 交叉评估
+  python3 run_matrix.py all
+
+所有命令模板与 stdout 日志落 .records/nanogpt/logs/;不打印任何语料正文。
+"""
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+REC = ROOT / '.records' / 'nanogpt'
+PRIV = REC / 'private'
+UPSTREAM = REC / 'upstream'
+LOGS = REC / 'logs'
+RESULTS = REC / 'results.json'
+PROGRESS = REC / 'progress.json'
+
+ARMS = {
+    'public_plain': '../../data/bins/public_plain',
+    'agentic_full': '../../private/bins/agentic_full',
+    'agentic_norole': '../../private/bins/agentic_norole',
+}
+TEST_BINS = {
+    'public': REC / 'data' / 'bins' / 'public_plain' / 'test.bin',
+    'agentic_full': PRIV / 'bins' / 'agentic_full' / 'test.bin',
+    'agentic_norole': PRIV / 'bins' / 'agentic_norole' / 'test.bin',
+}
+SEEDS = [1337, 2024, 4242]
+
+BASE_ARGS = [
+    '--device=mps', '--dtype=float32', '--compile=False',
+    '--n_layer=4', '--n_head=4', '--n_embd=128', '--block_size=128',
+    '--batch_size=16', '--gradient_accumulation_steps=1',
+    '--dropout=0.0', '--bias=False',
+    '--learning_rate=6e-4', '--lr_decay_iters=2000', '--warmup_iters=100', '--min_lr=6e-5',
+    '--weight_decay=0.1', '--beta1=0.9', '--beta2=0.95', '--grad_clip=1.0',
+    '--eval_interval=500', '--eval_iters=100', '--log_interval=1',
+    '--always_save_checkpoint=True', '--wandb_log=False',
+]
+
+
+def sha256_file(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def update_progress(**kw):
+    p = json.loads(PROGRESS.read_text())
+    p['phases'].update(kw)
+    p['updated_at'] = time.strftime('%Y-%m-%dT%H:%M:%S%z')
+    PROGRESS.write_text(json.dumps(p, ensure_ascii=False, indent=1))
+
+
+def append_result(entry):
+    r = json.loads(RESULTS.read_text()) if RESULTS.exists() else {'runs': [], 'resume': None,
+                                                                  'samples': [], 'eval': None}
+    r['runs'].append(entry)
+    RESULTS.write_text(json.dumps(r, ensure_ascii=False, indent=1))
+
+
+def run_train(tag, dataset, out_dir, seed, extra_args, timeout=7200):
+    """调用上游 train.py;返回 (log_path, elapsed_s, parsed)。"""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_path = LOGS / f'{tag}.log'
+    cmd = ['python3', 'train.py', f'--dataset={dataset}', f'--out_dir={out_dir}',
+           f'--seed={seed}'] + BASE_ARGS + extra_args
+    t0 = time.time()
+    with open(log_path, 'w') as lf:
+        lf.write('# cmd: ' + ' '.join(cmd) + '\n')
+        lf.flush()
+        r = subprocess.run(cmd, cwd=UPSTREAM, stdout=lf, stderr=subprocess.STDOUT, timeout=timeout)
+    elapsed = time.time() - t0
+    if r.returncode != 0:
+        raise RuntimeError(f'{tag} 训练失败,见 {log_path}')
+    text = log_path.read_text()
+    iters = re.findall(r'^iter (\d+): loss ([\d.]+)', text, re.M)
+    steps = re.findall(r'^step (\d+): train loss ([\d.]+), val loss ([\d.]+)', text, re.M)
+    parsed = {
+        'n_train_updates_logged': len(iters),
+        'first_iter': int(iters[0][0]) if iters else None,
+        'last_iter': int(iters[-1][0]) if iters else None,
+        'final_train_loss': float(iters[-1][1]) if iters else None,
+        'val_curve': [{'iter': int(s[0]), 'train': float(s[1]), 'val': float(s[2])} for s in steps],
+    }
+    return log_path, elapsed, parsed
+
+
+def run_id(arm, seed):
+    return f'{arm}__s{seed}'
+
+
+def smoke():
+    print('== smoke: 20 更新小跑 ==')
+    log, el, parsed = run_train('smoke_public_s1337', ARMS['public_plain'],
+                                PRIV / 'runs' / 'smoke', 1337,
+                                ['--max_iters=19', '--eval_interval=10', '--eval_iters=5'])
+    ck = PRIV / 'runs' / 'smoke' / 'ckpt_final.pt'
+    assert ck.exists(), 'ckpt_final.pt 未生成'
+    import torch
+    ckpt = torch.load(ck, map_location='cpu', weights_only=False)
+    assert ckpt['iter_num'] == 20, f"最终 iter_num={ckpt['iter_num']} != 20(精确 update 计数失败)"
+    assert parsed['n_train_updates_logged'] == 20, parsed['n_train_updates_logged']
+    print(f'  OK 20 updates, ckpt_final iter_num=20, {el:.0f}s')
+
+    print('== smoke: seed 生效验证(3 updates × 3 次)==')
+    losses = {}
+    for tag, seed in (('a', 1337), ('b', 1337), ('c', 2024)):
+        log, _, p = run_train(f'smoke_seed_{tag}', ARMS['public_plain'],
+                              PRIV / 'runs' / f'smoke_seed_{tag}', seed,
+                              ['--max_iters=2', '--eval_interval=1000', '--eval_iters=2'])
+        text = log.read_text()
+        losses[tag] = re.findall(r'^iter 0: loss ([\d.]+)', text, re.M)[0]
+    assert losses['a'] == losses['b'], f"同 seed 不可复现: {losses}"
+    assert losses['a'] != losses['c'], f"seed 未生效: {losses}"
+    print(f"  OK seed 复现性: {losses}")
+
+    print('== smoke: resume 机制(10 → 20)==')
+    rd = PRIV / 'runs' / 'smoke_resume'
+    # 段 A:max_iters=10 + eval_interval=10 → ckpt.pt 在 iter 10 顶部保存(=10 updates 后的状态)
+    run_train('smoke_resume_a', ARMS['public_plain'], rd, 1337,
+              ['--max_iters=10', '--eval_interval=10', '--eval_iters=2'])
+    _, _, pb = run_train('smoke_resume_b', ARMS['public_plain'], rd, 1337,
+                         ['--init_from=resume', '--max_iters=19', '--eval_interval=10',
+                          '--eval_iters=2'])
+    assert pb['first_iter'] == 10, f"resume 起点={pb['first_iter']} != 10"
+    assert pb['n_train_updates_logged'] == 10, pb['n_train_updates_logged']
+    ckpt = torch.load(rd / 'ckpt_final.pt', map_location='cpu', weights_only=False)
+    assert ckpt['iter_num'] == 20
+    print('  OK resume: iter 10 → 20,额外 10 updates')
+    update_progress(smoke={'status': 'done', 'detail': '20 更新小跑+seed 复现+resume 机制均通过'})
+
+
+def train():
+    done = {r['run_id'] for r in json.loads(RESULTS.read_text())['runs']} if RESULTS.exists() else set()
+    n = 0
+    for arm, dataset in ARMS.items():
+        for seed in SEEDS:
+            rid = run_id(arm, seed)
+            if rid in done:
+                print(f'  skip {rid}(已完成)')
+                n += 1
+                continue
+            print(f'== train {rid} ==')
+            out_dir = PRIV / 'runs' / rid
+            log, el, parsed = run_train(rid, dataset, out_dir, seed, ['--max_iters=1999'])
+            ck = out_dir / 'ckpt_final.pt'
+            assert parsed['n_train_updates_logged'] == 2000, parsed['n_train_updates_logged']
+            entry = {
+                'run_id': rid, 'arm': arm, 'seed': seed,
+                'updates': 2000, 'tokens': 4_096_000,
+                'elapsed_s': round(el, 1),
+                'final_train_loss': parsed['final_train_loss'],
+                'val_curve': parsed['val_curve'],
+                'ckpt_final_sha256': sha256_file(ck),
+                'ckpt_final_iter_num': 2000,
+                'log': f'logs/{rid}.log',
+                'status': 'ok',
+            }
+            append_result(entry)
+            n += 1
+            update_progress(train_runs={'status': 'in_progress' if n < 9 else 'done',
+                                        'done': n, 'total': 9})
+            print(f'  OK {rid} loss={parsed["final_train_loss"]} {el:.0f}s ({n}/9)')
+
+
+def resume():
+    print('== resume 证明: agentic_full s1337, 1000 → 2000(完整 2000 步 LR 计划)==')
+    rd = PRIV / 'runs' / 'resume_agentic_full_s1337'
+    # 段 A:max_iters=1000 → 1001 updates,但 ckpt.pt 在 iter 1000 顶部保存(=恰好 1000 updates 后的状态),
+    # 多出的第 1001 次 update 发生在保存之后,其结果被丢弃(resume 从 ckpt.pt 读取)。
+    log_a, el_a, pa = run_train('resume_a_agentic_full_s1337', ARMS['agentic_full'], rd, 1337,
+                                ['--max_iters=1000', '--eval_interval=1000'])
+    import torch
+    cka = torch.load(rd / 'ckpt.pt', map_location='cpu', weights_only=False)
+    assert cka['iter_num'] == 1000, cka['iter_num']
+    assert 'optimizer' in cka and 'model' in cka
+    # 段 B:resume,相同 LR 计划(warmup100 / cosine 至 2000 / min 6e-5),iter 1000..1999 = 额外 1000 updates
+    log_b, el_b, pb = run_train('resume_b_agentic_full_s1337', ARMS['agentic_full'], rd, 1337,
+                                ['--init_from=resume', '--max_iters=1999'])
+    assert pb['first_iter'] == 1000, pb['first_iter']
+    assert pb['n_train_updates_logged'] == 1000, pb['n_train_updates_logged']
+    ckf = rd / 'ckpt_final.pt'
+    ckpt = torch.load(ckf, map_location='cpu', weights_only=False)
+    assert ckpt['iter_num'] == 2000, ckpt['iter_num']
+    r = json.loads(RESULTS.read_text())
+    r['resume'] = {
+        'arm': 'agentic_full', 'seed': 1337,
+        'segment_a': {'updates_logged': pa['n_train_updates_logged'],
+                      'ckpt_iter_num': 1000, 'elapsed_s': round(el_a, 1),
+                      'note': 'max_iters=1000 时进程共执行 1001 次 update;ckpt.pt 在第 1001 次之前'
+                              '于 iter 1000 顶部保存,故 ckpt 状态恰为 1000 updates,多出的 1 次被丢弃',
+                      'log': 'logs/resume_a_agentic_full_s1337.log'},
+        'segment_b': {'init_from': 'resume(model+optimizer+iter_num)', 'first_iter': pb['first_iter'],
+                      'additional_updates': pb['n_train_updates_logged'],
+                      'final_iter_num': 2000, 'elapsed_s': round(el_b, 1),
+                      'log': 'logs/resume_b_agentic_full_s1337.log'},
+        'lr_schedule': '两段均 warmup_iters=100, lr_decay_iters=2000, min_lr=6e-5(完整 2000 步计划)',
+        'bitwise_note': '不保证与不中断 run 逐位一致:resume 后 torch RNG 从 seed 重新播种,'
+                        'data order / dropout 序列不与单次连续运行相同;model+optimizer+iter 均真实恢复',
+        'ckpt_final_sha256': sha256_file(ckf),
+        'val_curve_b': pb['val_curve'],
+    }
+    RESULTS.write_text(json.dumps(r, ensure_ascii=False, indent=1))
+    update_progress(resume_proof={'status': 'done', 'detail': 'agentic_full s1337: 1000→2000,额外 1000 updates'})
+    print('  OK resume 完成,额外 1000 updates,final iter_num=2000')
+
+
+def sample():
+    print('== 采样: 每 arm(seed 1337)==')
+    sdir = PRIV / 'samples'
+    sdir.mkdir(exist_ok=True)
+    r = json.loads(RESULTS.read_text())
+    for arm in ARMS:
+        out_dir = PRIV / 'runs' / run_id(arm, 1337)
+        prompt = '\n'
+        log_path = LOGS / f'sample_{arm}.log'
+        cmd = ['python3', 'sample.py', f'--out_dir={out_dir}', '--ckpt_name=ckpt_final.pt',
+               '--device=mps', '--dtype=float32', '--num_samples=4', '--max_new_tokens=400',
+               '--temperature=0.8', '--top_k=200', '--seed=1337', f'--start={prompt}']
+        sample_file = sdir / f'{arm}__s1337.txt'
+        with open(log_path, 'w') as lf, open(sample_file, 'w') as sf:
+            lf.write('# cmd: ' + ' '.join(cmd) + '\n')
+            lf.flush()
+            p = subprocess.run(cmd, cwd=UPSTREAM, stdout=sf, stderr=lf, timeout=900)
+        if p.returncode != 0:
+            raise RuntimeError(f'{arm} 采样失败,见 {log_path}')
+        blob = sample_file.read_bytes()
+        r['samples'].append({
+            'arm': arm, 'seed': 1337, 'success': True,
+            'n_samples': 4, 'max_new_tokens': 400,
+            'bytes': len(blob), 'sha256': hashlib.sha256(blob).hexdigest(),
+            'note': '样本含私有语料风格内容,仅留 private/samples/,不发布',
+        })
+        print(f'  OK {arm}: {len(blob)} bytes')
+    RESULTS.write_text(json.dumps(r, ensure_ascii=False, indent=1))
+    update_progress(sampling={'status': 'done', 'detail': '3 arm 各 4 样本,留存 private'})
+
+
+def evaluate():
+    print('== 交叉评估: 9 ckpt × 3 冻结 test set ==')
+    r = json.loads(RESULTS.read_text())
+    matrix = {}
+    for arm in ARMS:
+        for seed in SEEDS:
+            rid = run_id(arm, seed)
+            ck = PRIV / 'runs' / rid / 'ckpt_final.pt'
+            for tname, tbin in TEST_BINS.items():
+                out = subprocess.run(
+                    ['python3', str(ROOT / 'scripts' / 'experiments' / 'nanogpt' / 'eval_loss.py'),
+                     '--ckpt', str(ck), '--bin', str(tbin), '--device=mps'],
+                    capture_output=True, text=True, timeout=1800)
+                if out.returncode != 0:
+                    raise RuntimeError(f'eval {rid}×{tname} 失败: {out.stderr[:300]}')
+                rec = json.loads(out.stdout)
+                matrix.setdefault(rid, {})[tname] = {
+                    'nll_per_token': rec['nll_per_token'],
+                    'bits_per_byte_excl_eot': rec['bits_per_byte_excl_eot'],
+                    'bits_per_token_incl_eot': rec['bits_per_token_incl_eot'],
+                    'n_windows': rec['n_windows'],
+                    'n_byte_targets_excl_eot': rec['n_byte_targets_excl_eot'],
+                }
+                print(f'  {rid} × {tname}: bpb={rec["bits_per_byte_excl_eot"]:.4f}')
+    # 汇总:mean/std + 配对差值(同 seed 两两 arm 差)
+    import statistics as st
+    summary = {}
+    for tname in TEST_BINS:
+        per_arm = {}
+        for arm in ARMS:
+            vals = [matrix[run_id(arm, s)][tname]['bits_per_byte_excl_eot'] for s in SEEDS]
+            per_arm[arm] = {'per_seed': dict(zip(map(str, SEEDS), vals)),
+                            'mean': st.mean(vals), 'std': st.pstdev(vals)}
+        paired = {}
+        arms = list(ARMS)
+        for i in range(len(arms)):
+            for j in range(i + 1, len(arms)):
+                a, b = arms[i], arms[j]
+                diffs = [matrix[run_id(a, s)][tname]['bits_per_byte_excl_eot']
+                         - matrix[run_id(b, s)][tname]['bits_per_byte_excl_eot'] for s in SEEDS]
+                paired[f'{a}_minus_{b}'] = {'per_seed': dict(zip(map(str, SEEDS), diffs)),
+                                            'mean': st.mean(diffs), 'std': st.pstdev(diffs)}
+        summary[tname] = {'per_arm': per_arm, 'paired_diffs': paired}
+    r['eval'] = {
+        'method': 'eval_loss.py 独立脚本;冻结窗口(non-overlapping, offset 0, stride=128);'
+                  'bpb 主指标排除 eot 目标(另报 bits/token 含 eot);ckpt 均为 ckpt_final.pt@2000',
+        'matrix': matrix, 'summary_bpb_excl_eot': summary,
+    }
+    RESULTS.write_text(json.dumps(r, ensure_ascii=False, indent=1))
+    update_progress(cross_eval={'status': 'done', 'detail': '9×3 矩阵 + mean/std + 配对差值'})
+    print('  OK 评估矩阵完成')
+
+
+def main():
+    LOGS.mkdir(exist_ok=True)
+    which = sys.argv[1] if len(sys.argv) > 1 else 'all'
+    if which in ('smoke', 'all'):
+        smoke()
+    if which in ('train', 'all'):
+        train()
+    if which in ('resume', 'all'):
+        resume()
+    if which in ('sample', 'all'):
+        sample()
+    if which in ('eval', 'all'):
+        evaluate()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/experiments/nanogpt/selection.example.json
+++ b/scripts/experiments/nanogpt/selection.example.json
@@ -1,0 +1,14 @@
+{
+  "agents": [
+    { "label": "agent-a", "agent_id": "agt_XXXXXXXXXXXX" },
+    { "label": "agent-b", "agent_id": "agt_YYYYYYYYYYYY" },
+    { "label": "agent-c", "agent_id": "agt_ZZZZZZZZZZZZ" }
+  ],
+  "cutoff": "2026-09-07T17:30:00Z",
+  "exclude_title_keywords": ["synthetic", "acceptance"],
+  "exclude_topic_ids": ["tpc_XXXXXXXXXXXX"],
+  "max_messages_per_topic": 200,
+  "page_size": 100,
+  "per_agent_candidates": 20,
+  "target_total": 30
+}

--- a/scripts/experiments/nanogpt/selection_rule.md
+++ b/scripts/experiments/nanogpt/selection_rule.md
@@ -1,0 +1,46 @@
+# Agentic 语料选择规则 (冻结于抓取之前)
+
+冻结时间：2026-09-08 (正式抓取前)。本规则先于任何数据读取落盘，抓取后不再修改选择逻辑；
+若实现 bug 导致重抓，重抓仅修复抓取 / 解析，不改变选择标准，并在 protocol.json 的 revisions 中记录。
+
+## 来源
+
+仅通过本机 `lh` CLI 读取当前用户三个 coding-agent 的话题。具体 agent-id、排除的
+topic-id 与关键词清单属于个人信息，存放于未纳入版本控制的私有输入文件
+`.records/nanogpt/private/selection.json`; 公开仓库内只保留占位示例
+`scripts/experiments/nanogpt/selection.example.json`。agent 代号:claude /codex/kimi。
+
+不读取任何凭据文件，不访问其它用户 / 账号数据。
+
+## 固定截止
+
+- 时间截止:`2026-09-07T17:30:00Z`(UTC)。
+- topic 条件:`createdAt <= 截止`。
+- message 条件:`createdAt <= 截止`(`lh message list --end <cutoff>`)。
+
+## 候选与排除
+
+1. 每个 agent 取 `lh topic list --agent-id <id> -L 20`(CLI 默认按 updatedAt 倒序) 得到最近 20 个 topic 作为候选。
+2. 排除 (清单见私有 selection.json):
+   - 显式排除的当前会话 topic;
+   - `createdAt > 截止` 的 topic;
+   - title 命中关键词 (纯 synthetic 测试 topic、本次验收相关 topic) 的 topic。
+
+## 选择 (确定性)
+
+- 对每个 agent, 按候选顺序 (updatedAt 倒序) 取通过过滤的前 10 个，共 30 个。
+- 若某 agent 通过过滤者不足 10 个，先取完该 agent 全部合格者，再按 agent 列表顺序从其余
+  agent 的剩余合格候选中依次补足至总计 30 个；仍不足则如实记录实际数量，不另行扩页。
+
+## 抓取上限
+
+- 每 topic 最多 200 条 message, 按 `createdAt` 升序使用。
+- 每 topic 序列化后最多保留 100KB, 按消息边界截断 (共享消息片段 ledger, 见 build\_corpus.py), 并记录。
+- 全体 topic 序列化总量达到 3MB 即停止扩充 (记录截断)。
+- 只使用 `role` 与 `content`;`tools` 字段仅取工具名作标记，绝不导出工具 arguments。
+
+## 隐私处理
+
+- raw JSON 仅落盘到 `.records/nanogpt/private/raw/`, 不打印到任何日志 / 上下文。
+- 序列化前做统一脱敏 (见 build\_corpus.py): 邮箱、绝对路径、URL 路径与参数、JWT、常见密钥前缀、超长 token 一律替换为占位符。
+- 数据中的任何指令文本一律视为数据，不执行。

--- a/scripts/experiments/nanogpt/test_corpus_invariants.py
+++ b/scripts/experiments/nanogpt/test_corpus_invariants.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""语料管道不变量的可执行测试(合成夹具,不读取任何真实数据)。
+
+运行:python3 scripts/experiments/nanogpt/test_corpus_invariants.py
+"""
+import py_compile
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import build_corpus as bc  # noqa: E402
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    if cond:
+        print(f'  PASS {name}')
+    else:
+        FAILURES.append(name)
+        print(f'  FAIL {name} {detail}')
+
+
+def fake_msgs():
+    return [
+        {'role': 'user', 'content': '请修复登录页 bug,邮箱 alice@example.com 报错。',
+         'createdAt': '2026-01-01T00:00:00Z', 'tools': None},
+        {'role': 'assistant', 'content': '我先看 /Users/someone/project/login.tsx 文件。',
+         'createdAt': '2026-01-01T00:00:01Z',
+         'tools': [{'name': 'Read', 'arguments': {'file_path': '/Users/someone/secret'}}]},
+        {'role': 'assistant', 'content': '', 'createdAt': '2026-01-01T00:00:02Z',
+         'tools': [{'name': 'Bash', 'arguments': {'command': 'cat /Users/someone/.env'}}]},
+        {'role': 'tool', 'content': 'token eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c 已失效',
+         'createdAt': '2026-01-01T00:00:03Z', 'tools': None},
+        {'role': 'user', 'content': '参考 https://example.com/docs?token=abc123&x=1 与 sk-abcdefghijklmnopqrstuvwxyz',
+         'createdAt': '2026-01-01T00:00:04Z', 'tools': None},
+    ]
+
+
+def test_arm_invariant():
+    print('[test] arm 渲染不变量')
+    counter = {n: 0 for n, _ in bc.REDACTIONS}
+    segs = bc.topic_ledger(fake_msgs(), counter)
+    full = bc.render_full(segs)
+    norole = bc.render_norole(segs)
+    restored = bc.strip_generated_markers(full, segs)
+    check('strip(full)==norole', restored == norole)
+    check('full 含角色标记', '<|role:user|>' in full and '<|role:assistant|>' in full)
+    check('norole 不含生成的标记', '<|role:' not in norole and '<|tool-call:' not in norole)
+    check('tool arguments 未导出', 'secret' not in full and '.env' not in full)
+    check('纯工具调用消息保留工具名标记', '<|tool-call:Bash|>' in full)
+    # 正文含类标记文本时:不全局剥除,正文保留原样
+    tricky = [{'role': 'user', 'content': '文档里写着 <|role:user|> 这个标记的用法。\n\n第二段内容保持不变。',
+               'createdAt': '2026-01-01T00:00:00Z', 'tools': None}]
+    segs2 = bc.topic_ledger(tricky, counter)
+    check('正文中的类标记文本不被误删',
+          '文档里写着 <|role:user|> 这个标记的用法。' in bc.render_norole(segs2))
+
+
+def test_cap_message_boundary():
+    print('[test] ledger 截断(消息边界,两 arm 一致)')
+    counter = {n: 0 for n, _ in bc.REDACTIONS}
+    # 用中文正文,避免触发 TOKEN 脱敏正则(那会改变字节数、干扰截断断言)
+    body_text = '正' * 300  # 900 字节 UTF-8
+    msgs = [{'role': 'user', 'content': body_text, 'createdAt': f'2026-01-01T00:00:{i:02d}Z',
+             'tools': None} for i in range(10)]
+    segs = bc.topic_ledger(msgs, counter)
+    capped, truncated = bc.cap_ledger(segs, 1000)
+    check('发生截断', truncated)
+    check('截断后不超过上限', len(bc.render_full(capped).encode()) <= 1000)
+    check('截断后两 arm 不变量仍成立',
+          bc.strip_generated_markers(bc.render_full(capped), capped) == bc.render_norole(capped))
+    n_bodies = sum(1 for k, _ in capped if k == 'body')
+    check('截断在消息边界(正文完整)', all(t == body_text for k, t in capped if k == 'body'),
+          f'bodies={n_bodies}')
+
+
+def test_dedup():
+    print('[test] 跨 split exact-paragraph 去重')
+    shared_para = '这是一段共享的模板文本,' * 10  # >=50 chars
+    train_segs = [('header', '<|role:user|>'), ('body', shared_para + '\n\n训练独有内容aaa')]
+    val_segs = [('header', '<|role:user|>'), ('body', '验证集内容\n\n' + shared_para)]
+    collision = bc.ledger_paragraph_hashes(val_segs)
+    stats = {'removed': 0, 'dropped_msgs': 0}
+    filtered = bc.filter_ledger_dedup(train_segs, collision, stats)
+    check('碰撞段落被删除', stats['removed'] == 1)
+    after = bc.ledger_paragraph_hashes(filtered)
+    check('去重后 train∩val 重叠为 0', len(after & collision) == 0)
+    check('非碰撞段落保留', any('训练独有内容aaa' in t for k, t in filtered if k == 'body'))
+    check('val/test 不被修改', bc.render_full(val_segs).count('共享的模板文本') == 10)
+    # 整条消息正文都被删时,header 一并删除
+    stats2 = {'removed': 0, 'dropped_msgs': 0}
+    only_shared = [('header', '<|role:user|>'), ('body', shared_para)]
+    filtered2 = bc.filter_ledger_dedup(only_shared, collision, stats2)
+    check('空正文连同 header 删除', len(filtered2) == 0 and stats2['dropped_msgs'] == 1)
+
+
+def test_redaction():
+    print('[test] 脱敏')
+    counter = {n: 0 for n, _ in bc.REDACTIONS}
+    text = ('mail bob@corp.io; path /Users/alice/x.ts; jwt eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM0NTY3ODkwIn0'
+            '.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c; key ghp_abcdefghijklmnop; '
+            'url https://site.io/a/b?token=zz')
+    out = bc.redact(text, counter)
+    check('邮箱已替换', 'bob@corp.io' not in out and '<|EMAIL|>' in out)
+    check('路径已替换', '/Users/alice' not in out and '<|PATH|>' in out)
+    check('JWT 已替换', 'eyJhbGciOiJIUzI1NiIs' not in out)
+    check('KEY 已替换', 'ghp_abcdefghijklmnop' not in out)
+    check('URL 参数去除但保留 host', 'token=zz' not in out and 'site.io' in out)
+
+
+def test_py_compile():
+    print('[test] 全部脚本 py_compile')
+    d = Path(__file__).resolve().parent
+    for f in sorted(d.glob('*.py')):
+        try:
+            py_compile.compile(str(f), doraise=True)
+            check(f'compile {f.name}', True)
+        except py_compile.PyCompileError as e:
+            check(f'compile {f.name}', False, str(e)[:120])
+
+
+def main():
+    test_arm_invariant()
+    test_cap_message_boundary()
+    test_dedup()
+    test_redaction()
+    test_py_compile()
+    if FAILURES:
+        print(f'\n{len(FAILURES)} 项失败: {FAILURES}')
+        return 1
+    print('\n全部不变量测试通过')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/experiments/nanogpt/test_eval_loss.py
+++ b/scripts/experiments/nanogpt/test_eval_loss.py
@@ -1,0 +1,49 @@
+"""Synthetic regression: every position evaluated; EOT excluded from byte NLL."""
+import json
+import math
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / '.records/nanogpt/upstream'))
+from model import GPT, GPTConfig
+
+
+class EvalRegression(unittest.TestCase):
+    def test_full_positions_and_byte_denominator(self):
+        torch.manual_seed(73)
+        model = GPT(GPTConfig(block_size=4, vocab_size=257, n_layer=1,
+                              n_head=1, n_embd=8, dropout=0.0))
+        model.eval()
+        data = np.array([0, 1, 256, 3, 4, 5, 256, 7, 8, 9, 10, 11, 12], dtype=np.uint16)
+        with tempfile.TemporaryDirectory() as folder:
+            p = Path(folder)
+            torch.save({'model': model.state_dict(), 'model_args': vars(model.config),
+                        'iter_num': 0}, p / 'ckpt.pt')
+            data.tofile(p / 'test.bin')
+            result = subprocess.run([sys.executable, str(Path(__file__).with_name('eval_loss.py')),
+                                     '--ckpt', str(p / 'ckpt.pt'), '--bin', str(p / 'test.bin'),
+                                     '--device', 'cpu', '--batch', '2'],
+                                    check=True, capture_output=True, text=True)
+            actual = json.loads(result.stdout.strip().splitlines()[-1])
+        starts = [0, 4, 8]
+        x = torch.tensor(np.stack([data[s:s+4] for s in starts]).astype(np.int64))
+        y = torch.tensor(np.stack([data[s+1:s+5] for s in starts]).astype(np.int64))
+        with torch.no_grad():
+            logits, _ = model(x, y)
+            losses = torch.nn.functional.cross_entropy(logits.reshape(-1, 257), y.reshape(-1), reduction='none')
+        mask = y.reshape(-1) != 256
+        self.assertEqual(actual['n_target_tokens'], y.numel())
+        self.assertEqual(actual['n_byte_targets_excl_eot'], int(mask.sum()))
+        self.assertAlmostEqual(actual['nll_per_token'], float(losses.mean()), places=5)
+        self.assertAlmostEqual(actual['bits_per_byte_excl_eot'], float(losses[mask].mean())/math.log(2), places=5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/experiments/nanogpt/test_payload_markers.py
+++ b/scripts/experiments/nanogpt/test_payload_markers.py
@@ -1,0 +1,23 @@
+import unittest
+
+from build_corpus import assert_arm_invariant, render_full, render_norole, strip_generated_markers
+
+
+class PayloadMarkerTest(unittest.TestCase):
+    def test_literal_future_role_marker_in_payload_is_preserved(self):
+        segments = [('header', '<|user|>'), ('body', 'Example:\n<|assistant|>\n正文'),
+                    ('header', '<|assistant|>'), ('body', 'actual reply')]
+        self.assertEqual(strip_generated_markers(render_full(segments), segments),
+                         'Example:\n<|assistant|>\n正文\nactual reply\n')
+        assert_arm_invariant(segments)
+
+    def test_literal_tool_marker_in_payload_is_preserved(self):
+        segments = [('header', '<|assistant|>'), ('body', '<|tool-call:Bash|>\nexample'),
+                    ('toolmark', '<|tool-call:Bash|>')]
+        self.assertEqual(strip_generated_markers(render_full(segments), segments),
+                         render_norole(segments))
+        assert_arm_invariant(segments)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/experiments/nanogpt/upstream.diff
+++ b/scripts/experiments/nanogpt/upstream.diff
@@ -1,0 +1,103 @@
+diff --git a/sample.py b/sample.py
+index d25d6e0..035a852 100644
+--- a/sample.py
++++ b/sample.py
+@@ -5,12 +5,13 @@ import os
+ import pickle
+ from contextlib import nullcontext
+ import torch
+-import tiktoken
++# [nanogpt-agentic patch] tiktoken imported lazily below (only needed for GPT-2 fallback)
+ from model import GPTConfig, GPT
+ 
+ # -----------------------------------------------------------------------------
+ init_from = 'resume' # either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')
+ out_dir = 'out' # ignored if init_from is not 'resume'
++ckpt_name = 'ckpt.pt' # [nanogpt-agentic patch] allow sampling from ckpt_final.pt
+ start = "\n" # or "<|endoftext|>" or etc. Can also specify a file, use as: "FILE:prompt.txt"
+ num_samples = 10 # number of samples to draw
+ max_new_tokens = 500 # number of tokens generated in each sample
+@@ -34,7 +35,7 @@ ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=
+ # model
+ if init_from == 'resume':
+     # init from a model saved in a specific directory
+-    ckpt_path = os.path.join(out_dir, 'ckpt.pt')
++    ckpt_path = os.path.join(out_dir, ckpt_name) # [nanogpt-agentic patch] was: 'ckpt.pt'
+     checkpoint = torch.load(ckpt_path, map_location=device)
+     gptconf = GPTConfig(**checkpoint['model_args'])
+     model = GPT(gptconf)
+@@ -62,13 +63,27 @@ if load_meta:
+     print(f"Loading meta from {meta_path}...")
+     with open(meta_path, 'rb') as f:
+         meta = pickle.load(f)
+-    # TODO want to make this more general to arbitrary encoder/decoder schemes
+-    stoi, itos = meta['stoi'], meta['itos']
+-    encode = lambda s: [stoi[c] for c in s]
+-    decode = lambda l: ''.join([itos[i] for i in l])
++    # [nanogpt-agentic patch] byte-level tokenizer branch: ids 0..255 are raw bytes,
++    # id 256 is the <|eot|> document separator (rendered as a visible marker, not decoded)
++    if meta.get('encoding') == 'byte257':
++        encode = lambda s: list(s.encode('utf-8'))
++        def decode(l):
++            out = bytearray()
++            for i in l:
++                if i == 256:
++                    out += b'\n<|eot|>\n'
++                elif i < 256:
++                    out.append(i)
++            return out.decode('utf-8', errors='replace')
++    else:
++        # TODO want to make this more general to arbitrary encoder/decoder schemes
++        stoi, itos = meta['stoi'], meta['itos']
++        encode = lambda s: [stoi[c] for c in s]
++        decode = lambda l: ''.join([itos[i] for i in l])
+ else:
+     # ok let's assume gpt-2 encodings by default
+     print("No meta.pkl found, assuming GPT-2 encodings...")
++    import tiktoken # [nanogpt-agentic patch] lazy import (not installed in this env)
+     enc = tiktoken.get_encoding("gpt2")
+     encode = lambda s: enc.encode(s, allowed_special={"<|endoftext|>"})
+     decode = lambda l: enc.decode(l)
+diff --git a/train.py b/train.py
+index de57850..5b8132b 100644
+--- a/train.py
++++ b/train.py
+@@ -72,6 +72,7 @@ backend = 'nccl' # 'nccl', 'gloo', etc.
+ device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
+ dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
+ compile = True # use PyTorch 2.0 to compile the model to be faster
++seed = 1337 # [nanogpt-agentic patch] make the RNG seed configurable (upstream hardcoded 1337)
+ # -----------------------------------------------------------------------------
+ config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
+ exec(open('configurator.py').read()) # overrides from command line or config file
+@@ -103,7 +104,7 @@ print(f"tokens per iteration will be: {tokens_per_iter:,}")
+ 
+ if master_process:
+     os.makedirs(out_dir, exist_ok=True)
+-torch.manual_seed(1337 + seed_offset)
++torch.manual_seed(seed + seed_offset) # [nanogpt-agentic patch] was: torch.manual_seed(1337 + seed_offset)
+ torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
+ torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
+ device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+@@ -332,5 +333,21 @@ while True:
+     if iter_num > max_iters:
+         break
+ 
++# [nanogpt-agentic patch] save a final checkpoint at loop exit. Upstream only saves
++# ckpt.pt at the top of eval iterations, so with max_iters=1999 (= exactly 2000
++# optimizer updates, iters 0..1999) the state after the last update would never be
++# persisted. ckpt_final.pt records the true final state; resume still reads ckpt.pt.
++if master_process and not eval_only:
++    checkpoint = {
++        'model': raw_model.state_dict(),
++        'optimizer': optimizer.state_dict(),
++        'model_args': model_args,
++        'iter_num': iter_num,
++        'best_val_loss': best_val_loss,
++        'config': config,
++    }
++    print(f"saving final checkpoint (iter_num={iter_num}) to {out_dir}/ckpt_final.pt")
++    torch.save(checkpoint, os.path.join(out_dir, 'ckpt_final.pt'))
++
+ if ddp:
+     destroy_process_group()


### PR DESCRIPTION
提供可复查的 nanoGPT 个人 Agent 轨迹预训练实验工具：通过 CLI 拉取授权语料，在本地脱敏、按 topic 切分和精确段落去重，生成共享 byte257 语料，运行训练、恢复、采样及独立 BPB 评估。上游固定到 3adf61e，并保留 seed 与最终 checkpoint 补丁。

本 PR 只包含实验脚本、协议记录、合成测试和说明；个人数据、生成样本、权重与凭证均不入库。Goal 的实验容器、图导航与运行链路修复在 #19261。

最新 Goal 实测由 Kimi 新跑两臂各 2000 步、4,096,000 byte-token 曝光。同一个人轨迹测试集 BPB 为公共模型 8.49、轨迹模型 3.15，仅支持本次域内预测学习价值。Goal 自动 achieved，但经历人工修复与 retry，整体验收部分通过。目录中的三臂三 seed 协议记录属于前一轮，README 已区分本轮两臂范围。

验收：https://app.lobehub.com/acceptance/0392da18-016d-40dc-ae9c-cae848eee75b?r=2

验证：在最新 canary 的独立 worktree 重跑合成语料不变量检查及 3 个 unittest，均通过；评估测试复用本地固定版本上游依赖。未重新训练。真实训练与四项独立重算证据见验收。
