### PR TITLE
🐛 fix: make Acceptance file evidence identifiable and require descriptions in prompts

### DIFF
--- a/apps/cli/src/commands/acceptanceRun.ts
+++ b/apps/cli/src/commands/acceptanceRun.ts
@@ -18,6 +18,7 @@ import {
   type Decision,
   DECISIONS,
   deriveReportVerdict,
+  evidenceDescriptionForFile,
   evidenceTypeForFile,
   genericContextFromResult,
   inlineTextEvidenceForFile,
@@ -347,7 +348,7 @@ async function submitAction(options: SubmitOptions): Promise<void> {
         {
           capturedBy: options.by as any,
           content: inlineContent,
-          description: options.desc,
+          description: evidenceDescriptionForFile(options.desc, options.file),
           fileId,
           type: options.type as any,
         },
@@ -420,7 +421,7 @@ async function evidenceUploadAction(options: EvidenceUploadOptions): Promise<voi
     capturedBy: options.by as any,
     checkResultId: options.check,
     content: inlineContent,
-    description: options.desc,
+    description: evidenceDescriptionForFile(options.desc, options.file),
     fileId,
     type: options.type as any,
   });
@@ -777,7 +778,7 @@ async function ingestReportAction(reportDir: string, options: IngestReportOption
           // The filename, not the case title — the title already heads the
           // check card, so reusing it here just triples the same text.
           content: inlineContent,
-          description: evidenceInput.description ?? path.basename(abs),
+          description: evidenceDescriptionForFile(evidenceInput.description, abs),
           fileId: file?.id,
           metadata: evidenceInput.comparison ? { comparison: evidenceInput.comparison } : undefined,
           type,

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -25,6 +25,7 @@ import {
   visualizationMetadata,
 } from './verify';
 import { registerAcceptanceCommands } from './verifyAcceptance';
+import { evidenceDescriptionForFile } from './verifyHelpers';
 
 const { mockTrpcClient } = vi.hoisted(() => ({
   mockTrpcClient: {
@@ -1416,5 +1417,24 @@ describe('formatAnnotationRegion', () => {
   it('returns undefined when there is no location at all', () => {
     expect(formatAnnotationRegion({ comment: 'just a note' })).toBeUndefined();
     expect(formatAnnotationRegion({ rect: { x: 0.1 } })).toBeUndefined();
+  });
+});
+
+describe('file evidence descriptions', () => {
+  it('preserves an explicit description', () => {
+    expect(evidenceDescriptionForFile('Goal final state', '/tmp/state.json')).toBe(
+      'Goal final state',
+    );
+  });
+
+  it('retains the basename when a file is inlined without a description', () => {
+    expect(evidenceDescriptionForFile(undefined, '/tmp/goal-final-state.json')).toBe(
+      'goal-final-state.json',
+    );
+    expect(evidenceDescriptionForFile('  ', '/tmp/events.json')).toBe('events.json');
+  });
+
+  it('does not invent a description for inline content', () => {
+    expect(evidenceDescriptionForFile(undefined)).toBeUndefined();
   });
 });

--- a/apps/cli/src/commands/verifyHelpers.ts
+++ b/apps/cli/src/commands/verifyHelpers.ts
@@ -980,3 +980,11 @@ export function formatAnnotationRegion(
   if (!position) return label;
   return label ? `${label} @ ${position}` : position;
 }
+
+/** Keep file identity when small text artifacts are stored inline. */
+export function evidenceDescriptionForFile(
+  description?: string,
+  file?: string,
+): string | undefined {
+  return description?.trim() || (file ? path.basename(file) : undefined);
+}

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -174,6 +174,12 @@ needed.
   into `interaction-trace.jsonl`; optional, never hand-written —
   [interaction-cost.md](references/interaction-cost.md).
 
+**Every file submission MUST include a non-empty, reviewer-facing description**
+(`--desc` for CLI submissions; `description` for tools and ingest entries).
+Identify what the file contains and what it demonstrates for this criterion.
+A filename, path, artifact id, or generic label such as "evidence" is not a
+sufficient description. This also applies when a text file is stored inline.
+
 Shared rules for every artifact — media types, provenance, file vs inline,
 safety — are in [evidence.md](references/evidence.md).
 

--- a/packages/builtin-skills/src/acceptance/references/evidence.md
+++ b/packages/builtin-skills/src/acceptance/references/evidence.md
@@ -64,8 +64,19 @@ join an explanation from an older round with fresh execution output.
 - Use `--file` for binary artifacts and larger text/DOM/transcript files.
 - Use `--content` for short text assertions. Pass exactly one of `--file` and
   `--content`.
-- Keep the description factual: identify the action, observed state, and relevant
-  target. Do not place the verdict in the description unless explicitly asked.
+- **Description is mandatory for every file artifact.** Always supply a non-empty
+  `--desc` when using `--file`, and a `description` when attaching a `fileId` or
+  adding a file to an ingest manifest. Small text files converted to inline
+  content still require it; do not rely on the filename fallback.
+- Write a concise, factual sentence identifying the file's contents and their
+  relevance to the criterion, including the action, observed state, or target
+  where useful. The reviewer should know why to open it without inspecting the
+  payload. A filename, path, id, "JSON", or "evidence" alone is insufficient.
+  Do not invent conclusions or place the verdict in the description unless
+  explicitly asked.
+- Example: `goal-final-state.json` → "Goal final state after training: completion
+  status and the four final validation results." Describe each artifact
+  separately instead of repeating the criterion title for every file.
 
 ```bash
 # File artifact captured by the selected surface.

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -156,6 +156,12 @@ supersedes? }`.
 
 ## result.json schema
 
+Every `cases[].evidence` file entry must use `{ "path": "...", "description": "..." }`.
+Describe the file's contents and relevance to the criterion, following the
+[shared description requirements](evidence.md#file-versus-inline-content).
+Do not copy the legacy bare-path form: ingestion accepts it for compatibility,
+but its filename fallback does not satisfy the description requirement.
+
 ```json
 {
   "cases": [
@@ -166,7 +172,12 @@ supersedes? }`.
       "surface": "cli",
       "status": "pass",
       "observation": "root returned 3 nested children, depth 2",
-      "evidence": ["assets/task-tree.txt"]
+      "evidence": [
+        {
+          "path": "assets/task-tree.txt",
+          "description": "Task tree command output showing the root and its 3 nested children at depth 2."
+        }
+      ]
     },
     {
       "id": "2",
@@ -175,7 +186,12 @@ supersedes? }`.
       "surface": "cli",
       "status": "pass",
       "observation": "average precision improved from 0.742 to 0.796",
-      "evidence": ["assets/evaluation.json"],
+      "evidence": [
+        {
+          "path": "assets/evaluation.json",
+          "description": "Evaluation results comparing baseline and candidate average precision, including the observed change from 0.742 to 0.796."
+        }
+      ],
       "datasets": [
         {
           "id": "model-metrics",
@@ -325,8 +341,10 @@ measured delta on each side:
 ```json
 "evidence": [
   { "path": "assets/before.png",
+    "description": "Topic row before the change, showing the original 11px text size.",
     "comparison": { "id": "topic-row", "role": "before", "layout": "horizontal", "label": "before: 11px" } },
   { "path": "assets/after.png",
+    "description": "The same topic row after the change, showing the updated 12px text size.",
     "comparison": { "id": "topic-row", "role": "after", "layout": "horizontal", "label": "after: 12px" } }
 ]
 ```

--- a/packages/builtin-tool-acceptance-evidence/src/manifest.ts
+++ b/packages/builtin-tool-acceptance-evidence/src/manifest.ts
@@ -28,7 +28,11 @@ export const AcceptanceEvidenceManifest: BuiltinToolManifest = {
             items: {
               properties: {
                 content: { description: 'Inline evidence content.', type: 'string' },
-                description: { description: 'What this evidence demonstrates.', type: 'string' },
+                description: {
+                  description:
+                    'Required for file artifacts, including file contents submitted inline. A non-empty, reviewer-facing sentence explaining what the artifact contains and what it demonstrates for this criterion. A filename, path, id, or generic label alone is insufficient.',
+                  type: 'string',
+                },
                 documentId: {
                   description:
                     'An existing LobeHub document id from documents.id. Do not use an agent_documents.id binding id.',

--- a/packages/builtin-tool-acceptance-evidence/src/systemRole.ts
+++ b/packages/builtin-tool-acceptance-evidence/src/systemRole.ts
@@ -6,5 +6,6 @@ Call listCriteria to read the criteria of the current run, then submit evidence 
 - Use documentId only for an id from documents.id. Never pass an agent_documents.id binding id as documentId or fileId.
 - If you only know an agent document binding id, call listDocuments and use the returned documentId field.
 - Use fileId only for an id from files.id, such as an uploaded screenshot, video, or file artifact.
+- Every file artifact submitted with fileId MUST have a non-empty description: explain what the file contains and what it demonstrates for this criterion, so the reviewer knows why to open it. A filename, path, id, or generic label such as "JSON" or "evidence" is insufficient. Apply the same rule to file contents submitted inline. Base the description on the actual artifact; do not invent findings.
 - Do not decide whether a criterion passes and do not invent evidence.
 - If evidence is missing, state that plainly in a note for that criterion.`;

--- a/src/features/Acceptance/Report/MarkdownEvidence.tsx
+++ b/src/features/Acceptance/Report/MarkdownEvidence.tsx
@@ -172,7 +172,22 @@ const INLINE_RENDER_MAX_CHARS = 160;
  * and blank lines are skipped — a document that opens with a code block should
  * be labeled by its first code line, not by "```bash".
  */
-export const evidenceTitleFromMarkdown = (content: string): string => {
+export const evidenceTitleFromMarkdown = (
+  content: string,
+  description?: string | null,
+  fileName?: string | null,
+): string => {
+  const label = description?.trim() || fileName?.trim();
+  if (label) return label;
+  // Raw JSON has no prose heading; its first line is not a useful document title.
+  if (/^[{[]/.test(content.trim())) {
+    try {
+      JSON.parse(content);
+      return 'JSON';
+    } catch {
+      // Markdown links and non-JSON text still use their first meaningful line.
+    }
+  }
   for (const raw of content.split('\n')) {
     let line = raw.trim();
     if (!line || line.startsWith('```') || /^-{3,}$/.test(line)) continue;
@@ -202,7 +217,9 @@ export const resolveMarkdownEvidenceFold = (content: string, authoredTitle?: str
   const foldTitle = authoredTitle?.trim() || derivedTitle;
   const trimmed = content.trim();
   const inlineEligible = !trimmed.includes('\n') && trimmed.length <= INLINE_RENDER_MAX_CHARS;
-  const fold = Boolean(foldTitle) && (Boolean(authoredTitle?.trim()) || !inlineEligible);
+  const fold =
+    Boolean(foldTitle) &&
+    (Boolean(authoredTitle?.trim()) || derivedTitle === 'JSON' || !inlineEligible);
   return { fold, foldTitle };
 };
 

--- a/src/features/Acceptance/Report/ReportViewer.tsx
+++ b/src/features/Acceptance/Report/ReportViewer.tsx
@@ -841,7 +841,9 @@ const EvidenceItem = memo<{
         // becomes the fold row's title, not a supplement line below it. The
         // raw description, not the caption filter — with no fileName the label
         // IS the description, and the filter would null it out.
-        <CollapsibleMarkdownEvidence title={e.description ?? undefined}>
+        <CollapsibleMarkdownEvidence
+          title={e.description?.trim() || e.fileName?.trim() || undefined}
+        >
           {e.content}
         </CollapsibleMarkdownEvidence>
       ) : e.content ? (

--- a/src/features/Acceptance/Report/markdownEvidenceTitle.test.ts
+++ b/src/features/Acceptance/Report/markdownEvidenceTitle.test.ts
@@ -69,3 +69,33 @@ describe('resolveMarkdownEvidenceFold — authored alt as the fold title', () =>
     expect(foldTitle).toBe('环境说明');
   });
 });
+
+describe('evidence labels preserve artifact identity', () => {
+  it('uses the description instead of a JSON opening brace', () => {
+    expect(evidenceTitleFromMarkdown('{\n  "status": "done"\n}', 'Goal final state')).toBe(
+      'Goal final state',
+    );
+  });
+
+  it('keeps a file name when there is no meaningful description', () => {
+    expect(evidenceTitleFromMarkdown('{\n}', '  ', 'goal-final-state.json')).toBe(
+      'goal-final-state.json',
+    );
+  });
+
+  it('preserves markdown links as prose titles', () => {
+    expect(evidenceTitleFromMarkdown('[Report](https://example.com)')).toBe('Report');
+  });
+
+  it('labels legacy JSON objects and arrays without exposing raw payloads as titles', () => {
+    expect(evidenceTitleFromMarkdown('{\n  "status": "done"\n}')).toBe('JSON');
+    expect(evidenceTitleFromMarkdown('[{"id":"wk_123"}]')).toBe('JSON');
+  });
+});
+
+it('folds short JSON payloads behind a readable type label', () => {
+  expect(resolveMarkdownEvidenceFold('[{"id":"wk_123"}]')).toEqual({
+    fold: true,
+    foldTitle: 'JSON',
+  });
+});

--- a/src/features/Acceptance/Viewer/CheckList.tsx
+++ b/src/features/Acceptance/Viewer/CheckList.tsx
@@ -650,7 +650,10 @@ const EvidenceList = memo<{
           return (
             // An authored alt/description becomes the fold row's title itself —
             // the supplement below the row duplicated it one line later.
-            <CollapsibleMarkdownEvidence key={item.id} title={description ?? undefined}>
+            <CollapsibleMarkdownEvidence
+              key={item.id}
+              title={item.description?.trim() || item.fileName?.trim() || undefined}
+            >
               {item.content}
             </CollapsibleMarkdownEvidence>
           );


### PR DESCRIPTION
Small text evidence files can lose their names when converted to inline content, leaving Acceptance rows labeled with `{` or a raw JSON payload. Preserve a filename fallback during CLI submission and ingest, use the description or filename for collapsed rows, and fold unlabeled JSON behind a `JSON` label.

Require a meaningful, non-empty description in the Acceptance skill, evidence submission prompt, and tool parameter guidance for every file artifact, including files stored inline. Descriptions must explain the contents and relevance to the criterion; filenames, paths, IDs, and generic labels alone are insufficient. This is a prompt-level requirement; existing API payloads remain compatible.

| Before | After |
| ------ | ----- |
| Inlined JSON file without `--desc` loses its identity | Original basename is retained as the fallback description |
| Filename-like descriptions can be filtered out of fold titles | Raw description or filename identifies the artifact |
| Legacy JSON shows `{` or a raw one-line array | Collapsed row is labeled `JSON` |

#### Test

- [x] Added/updated regression tests
- [x] Lint passed for all 11 changed files
- [x] CLI `verify.test.ts`: 94 tests passed on the isolated canary-based branch
- [x] `markdownEvidenceTitle.test.ts`: 16 tests passed on the isolated branch
- Browser verification and screenshots not performed.
- Related `CheckList.test.ts` could not initialize with reused local dependencies: `PAGE_DOCUMENT_SOURCE_TYPES is not iterable`. The original workspace full type-check also reports numerous errors outside this change; no clean full type-check is claimed.

Prompt scenario: submit `goal-final-state.json` for a Goal completion criterion. Supply a description such as “Goal final state after training: completion status and the four final validation results,” rather than the filename alone.
