### PR TITLE
🐛 fix: support HTTP origins in agent topic copy actions

### DIFF
--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useTopicItemDropdownMenu } from './useDropdownMenu';
 
@@ -99,6 +99,35 @@ describe('useTopicItemDropdownMenu', () => {
     permissionMock.create_content = true;
     permissionMock.edit_own_content = true;
     versionMock.isDesktop = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(document, 'execCommand');
+  });
+
+  it.each([
+    ['copySessionId', 'topic-1'],
+    ['copyLink', 'https://example.com/agent/agent-1/topic-1'],
+  ])('copies %s when the Clipboard API is unavailable', async (key, expected) => {
+    vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue(undefined as never);
+    let copiedText: string | undefined;
+    const copy = vi.fn(() => {
+      copiedText = (document.activeElement as HTMLTextAreaElement).value;
+      return true;
+    });
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: copy });
+    const { result } = renderHook(() =>
+      useTopicItemDropdownMenu({ id: 'topic-1', title: 'Topic 1' }),
+    );
+    const item = getMenuItem(result.current.dropdownMenu(), key);
+    if (!item || !('onClick' in item)) throw new Error('Expected copy action');
+
+    await item.onClick?.({} as never);
+
+    expect(copy).toHaveBeenCalledWith('copy');
+    expect(copiedText).toBe(expected);
+    expect(document.querySelector('textarea')).toBeNull();
   });
 
   it('groups desktop topic actions by intent', () => {

--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -1,7 +1,7 @@
 import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
-import { Icon } from '@lobehub/ui';
+import { copyToClipboard, Icon } from '@lobehub/ui';
 import { toast } from '@lobehub/ui/base-ui';
 import {
   Archive,
@@ -217,8 +217,8 @@ export const useTopicItemDropdownMenu = ({
         icon: <Icon icon={Hash} />,
         key: 'copySessionId',
         label: t('actions.copySessionId'),
-        onClick: () => {
-          navigator.clipboard.writeText(id);
+        onClick: async () => {
+          await copyToClipboard(id);
           toast.success(t('actions.copySessionIdSuccess'));
         },
       },
@@ -226,10 +226,10 @@ export const useTopicItemDropdownMenu = ({
         icon: <Icon icon={Link2} />,
         key: 'copyLink',
         label: t('actions.copyLink'),
-        onClick: () => {
+        onClick: async () => {
           if (!activeAgentId) return;
           const url = `${appOrigin}${AGENT_CHAT_TOPIC_URL(activeAgentId, id)}`;
-          navigator.clipboard.writeText(url);
+          await copyToClipboard(url);
           toast.success(t('actions.copyLinkSuccess'));
         },
       },

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { act, render, renderHook, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useMenu } from './useMenu';
 
@@ -115,6 +115,32 @@ const isActionItem = (
 } => !!item && typeof item === 'object' && 'key' in item;
 
 describe('Conversation header action menu', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(document, 'execCommand');
+  });
+
+  it('copies the displayed topic ID without the Clipboard API', async () => {
+    useLocationMock.mockReturnValue({ pathname: '/agent/agent-1' });
+    vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue(undefined as never);
+    let copiedText: string | undefined;
+    const copy = vi.fn(() => {
+      copiedText = (document.activeElement as HTMLTextAreaElement).value;
+      return true;
+    });
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: copy });
+    const { result } = renderHook(() => useMenu());
+    const item = result.current
+      .menuItems()
+      .find((item) => isActionItem(item) && item.key === 'copySessionId');
+    if (!isActionItem(item)) throw new Error('Expected copy action');
+
+    await item.onClick?.();
+
+    expect(copy).toHaveBeenCalledWith('copy');
+    expect(copiedText).toBe('topic-1');
+    expect(document.querySelector('textarea')).toBeNull();
+  });
   it('includes the desktop popup-window action for the active topic', () => {
     useLocationMock.mockReturnValue({ pathname: '/agent/agent-1' });
 

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { DropdownItem } from '@lobehub/ui';
-import { Block, Flexbox, Icon } from '@lobehub/ui';
+import { Block, copyToClipboard, Flexbox, Icon } from '@lobehub/ui';
 import { confirmModal, type ModalInstance, Text, toast } from '@lobehub/ui/base-ui';
 import {
   Clock3Icon,
@@ -279,8 +279,8 @@ export const useMenu = (): { menuHeader?: ReactNode; menuItems: () => DropdownIt
           icon: <Icon icon={Hash} />,
           key: 'copySessionId',
           label: t('actions.copySessionId', { ns: 'topic' }),
-          onClick: () => {
-            void navigator.clipboard.writeText(topicId);
+          onClick: async () => {
+            await copyToClipboard(topicId);
             toast.success(t('actions.copySessionIdSuccess', { ns: 'topic' }));
           },
         },


### PR DESCRIPTION
Copy session ID throws on non-secure HTTP origins because the agent conversation header and topic sidebar call `navigator.clipboard.writeText` directly. Reuse the existing `@lobehub/ui` `copyToClipboard` helper used by message copying, including its textarea fallback. Apply the same fix to Copy link in the topic sidebar, and await copying before showing the success toast.

| Before | After |
| ------ | ----- |
| Copy session ID throws when the Clipboard API is unavailable; clipboard remains unchanged. | The shared helper falls back to copying the selected text. |

#### Test

- [x] Added/updated tests
- [x] Related checks: 8 tests passed; lint and commit hooks passed.
- All three new regression cases fail on the original code with the reported `writeText` error and pass after the fix; they execute the real helper and assert the fallback's exact text and textarea cleanup.
- [x] Tested locally in real Chrome against the PR worktree over a LAN HTTP origin. Confirmed `isSecureContext === false` and `typeof navigator.clipboard === 'undefined'` without mocking either. Header Copy session ID, sidebar Copy session ID, and sidebar Copy link all produced exact clipboard and Command+V paste readbacks.
- [Acceptance report with screenshots and clipboard readbacks](https://app.lobehub.com/acceptance/2fa16b73-14b8-4548-a5d1-3e35f45e02be?r=2)
- Scope is the agent conversation header and agent topic sidebar; other direct clipboard callers are outside this patch.

#### 🔗 Related Issue

Fixes #19278
