### PR TITLE
📝 docs: route trace investigations through host guidance

### DIFF
--- a/.agents/skills/agent-tracing/SKILL.md
+++ b/.agents/skills/agent-tracing/SKILL.md
@@ -6,6 +6,8 @@ user-invocable: false
 
 # Agent Tracing CLI Guide
 
+When using traces to investigate failed or unexpected agent behavior, use the host repository's investigation entrypoint if one is provided (for example, `debug-backend-issue` under the host's `.agents/skills/`). Read it once and follow its investigation workflow; do not assume it lives beside this shared skill. Standalone trace retrieval or inspection stays within this skill.
+
 `@lobechat/agent-tracing` is a zero-config local dev tool that records agent execution snapshots to disk and provides a CLI to inspect them.
 
 ## How It Works


### PR DESCRIPTION
Route failure investigations from the trace inspection skill to an optional host-repository investigation workflow. This prevents a tool-specific lookup from becoming the stopping point for an unfinished investigation, while keeping standalone trace requests bounded.

The shared skill does not assume a sibling investigation skill exists and reads host guidance only once.

#### Test

- [x] Tested locally: `bun run check lobehub/.agents/skills/agent-tracing/SKILL.md` (Cloud entry), lint clean.
- [x] No runtime tests needed: instruction-only change; independently reviewed routing and standalone behavior.
