### PR TITLE
🐛 fix: improve mobile acceptance rows and use standard controls

### DIFF
--- a/src/features/Acceptance/Viewer/Checks/AcceptanceCheckInventory.tsx
+++ b/src/features/Acceptance/Viewer/Checks/AcceptanceCheckInventory.tsx
@@ -45,9 +45,8 @@ const AcceptanceCheckInventory = ({
   toolbar,
 }: AcceptanceCheckInventoryProps) => {
   const { t } = useTranslation('verify');
-  const { lg = true, md = true } = useResponsive();
+  const { md = true } = useResponsive();
   const { acceptanceId, embedded } = useAcceptanceScope();
-  const compactToolbar = embedded || !lg;
   const { data, mutate } = useAcceptanceBundle(acceptanceId);
   const [searchParams, setSearchParams] = useSearchParams();
   const [localFilter, setLocalFilter] = useState<CheckFilter>('all');
@@ -200,7 +199,7 @@ const AcceptanceCheckInventory = ({
         {toolbar}
         <Select
           size={'small'}
-          style={{ height: compactToolbar ? 44 : 34, width: 118 }}
+          style={{ width: 118 }}
           value={filter}
           variant={'filled'}
           options={[
@@ -221,7 +220,7 @@ const AcceptanceCheckInventory = ({
         {data.rounds.length > 1 && (
           <Select
             size={'small'}
-            style={{ height: compactToolbar ? 44 : 34, width: 110 }}
+            style={{ width: 110 }}
             value={roundFilter === null ? 'all' : String(roundFilter)}
             variant={'filled'}
             options={[

--- a/src/features/Acceptance/Viewer/Checks/AcceptanceCheckInventory.tsx
+++ b/src/features/Acceptance/Viewer/Checks/AcceptanceCheckInventory.tsx
@@ -2,7 +2,7 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { ActionIcon, Select, Text, toast } from '@lobehub/ui/base-ui';
-import { useResponsive } from 'antd-style';
+import { createStaticStyles, useResponsive } from 'antd-style';
 import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useState } from 'react';
@@ -32,6 +32,28 @@ import {
   userReviewState,
 } from './checkState';
 import { EMPTY_ID_SET, setAggregateEntry } from './expandState';
+
+const styles = createStaticStyles(({ css }) => ({
+  filters: css`
+    @media (width <= 767px) {
+      width: 100%;
+    }
+  `,
+  filterSelect: css`
+    width: 118px;
+
+    @media (width <= 767px) {
+      flex: 1;
+      width: 0;
+      min-width: 0;
+    }
+  `,
+  toolbarHeading: css`
+    @media (width <= 767px) {
+      flex-basis: 100%;
+    }
+  `,
+}));
 
 interface AcceptanceCheckInventoryProps {
   children?: ReactNode;
@@ -192,59 +214,69 @@ const AcceptanceCheckInventory = ({
   return (
     <>
       <Flexbox horizontal align={'center'} gap={8} wrap={'wrap'}>
-        <Text strong style={{ fontSize: 14, whiteSpace: 'nowrap' }}>
-          {t('acceptance.checks.title')}
-        </Text>
-        <Flexbox flex={1} />
-        {toolbar}
-        <Select
-          size={'small'}
-          style={{ width: 118 }}
-          value={filter}
-          variant={'filled'}
-          options={[
-            { label: t('acceptance.filter.all', { count: counts.total }), value: 'all' },
-            { label: t('acceptance.filter.pending', { count: counts.pending }), value: 'pending' },
-            {
-              label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
-              value: 'needsFix',
-            },
-            {
-              label: t('acceptance.filter.accepted', { count: counts.accepted }),
-              value: 'accepted',
-            },
-            { label: t('acceptance.filter.ignored', { count: counts.ignored }), value: 'ignored' },
-          ]}
-          onChange={(value) => setFilter(value as CheckFilter)}
-        />
-        {data.rounds.length > 1 && (
+        <Flexbox horizontal align={'center'} className={styles.toolbarHeading} flex={1} gap={8}>
+          <Text strong style={{ fontSize: 14, whiteSpace: 'nowrap' }}>
+            {t('acceptance.checks.title')}
+          </Text>
+          <Flexbox flex={1} />
+          {toolbar}
+        </Flexbox>
+        <Flexbox horizontal align={'center'} className={styles.filters} gap={8}>
           <Select
-            size={'small'}
-            style={{ width: 110 }}
-            value={roundFilter === null ? 'all' : String(roundFilter)}
+            className={styles.filterSelect}
+            value={filter}
             variant={'filled'}
             options={[
-              { label: t('acceptance.filter.roundAll'), value: 'all' },
-              ...[...data.rounds].reverse().map((round) => ({
-                label: t('acceptance.round', { round: round.run.roundIndex }),
-                value: String(round.run.roundIndex),
-              })),
+              { label: t('acceptance.filter.all', { count: counts.total }), value: 'all' },
+              {
+                label: t('acceptance.filter.pending', { count: counts.pending }),
+                value: 'pending',
+              },
+              {
+                label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
+                value: 'needsFix',
+              },
+              {
+                label: t('acceptance.filter.accepted', { count: counts.accepted }),
+                value: 'accepted',
+              },
+              {
+                label: t('acceptance.filter.ignored', { count: counts.ignored }),
+                value: 'ignored',
+              },
             ]}
-            onChange={(value) => setRoundFilter(value === 'all' ? null : Number(value))}
+            onChange={(value) => setFilter(value as CheckFilter)}
           />
-        )}
-        {grouped && (
-          <ActionIcon
-            icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
-            size={'small'}
-            title={
-              allGroupsCollapsed
-                ? t('acceptance.group.expandAll')
-                : t('acceptance.group.collapseAll')
-            }
-            onClick={() => setCollapsedGroups(allGroupsCollapsed ? new Set() : new Set(groupKeys))}
-          />
-        )}
+          {data.rounds.length > 1 && (
+            <Select
+              className={styles.filterSelect}
+              value={roundFilter === null ? 'all' : String(roundFilter)}
+              variant={'filled'}
+              options={[
+                { label: t('acceptance.filter.roundAll'), value: 'all' },
+                ...[...data.rounds].reverse().map((round) => ({
+                  label: t('acceptance.round', { round: round.run.roundIndex }),
+                  value: String(round.run.roundIndex),
+                })),
+              ]}
+              onChange={(value) => setRoundFilter(value === 'all' ? null : Number(value))}
+            />
+          )}
+          {grouped && (
+            <ActionIcon
+              icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
+              size={'small'}
+              title={
+                allGroupsCollapsed
+                  ? t('acceptance.group.expandAll')
+                  : t('acceptance.group.collapseAll')
+              }
+              onClick={() =>
+                setCollapsedGroups(allGroupsCollapsed ? new Set() : new Set(groupKeys))
+              }
+            />
+          )}
+        </Flexbox>
       </Flexbox>
       {children}
       <CheckList

--- a/src/features/Acceptance/Viewer/Checks/CheckRow.tsx
+++ b/src/features/Acceptance/Viewer/Checks/CheckRow.tsx
@@ -438,7 +438,7 @@ export const AcceptanceCheckRow = memo<{
                 </Tooltip>
               )}
             </Flexbox>
-            <Flexbox align={'center'} height={22}>
+            <Flexbox align={'center'} className={styles.rowChevron} height={22}>
               <Icon
                 color={cssVar.colorTextQuaternary}
                 icon={ChevronRight}

--- a/src/features/Acceptance/Viewer/Checks/CheckRow.tsx
+++ b/src/features/Acceptance/Viewer/Checks/CheckRow.tsx
@@ -301,6 +301,7 @@ export const AcceptanceCheckRow = memo<{
             <Flexbox
               horizontal
               align={'center'}
+              className={styles.rowTitle}
               flex={1}
               gap={8}
               style={{ minWidth: 0 }}

--- a/src/features/Acceptance/Viewer/Checks/styles.ts
+++ b/src/features/Acceptance/Viewer/Checks/styles.ts
@@ -122,7 +122,7 @@ export const styles = createStaticStyles(({ css }) => ({
     transition: opacity 0.2s;
 
     @media (width <= 767px) {
-      grid-column: 3 / -1;
+      grid-area: 1 / 3;
       flex-wrap: wrap;
       min-width: 0;
 
@@ -134,6 +134,11 @@ export const styles = createStaticStyles(({ css }) => ({
     @media (hover: hover) and (pointer: fine) {
       pointer-events: none;
       opacity: 0;
+    }
+  `,
+  rowTitle: css`
+    @media (width <= 767px) {
+      grid-area: 2 / 1 / auto / -1;
     }
   `,
   rowHeader: css`

--- a/src/features/Acceptance/Viewer/Checks/styles.ts
+++ b/src/features/Acceptance/Viewer/Checks/styles.ts
@@ -168,7 +168,8 @@ export const styles = createStaticStyles(({ css }) => ({
     @media (width <= 767px) {
       display: grid;
       grid-template-columns: 16px max-content minmax(0, 1fr) 14px;
-      row-gap: 6px;
+      row-gap: 4px;
+      padding-block: 8px;
     }
   `,
   stepDot: css`

--- a/src/features/Acceptance/Viewer/Checks/styles.ts
+++ b/src/features/Acceptance/Viewer/Checks/styles.ts
@@ -124,6 +124,7 @@ export const styles = createStaticStyles(({ css }) => ({
     @media (width <= 767px) {
       grid-area: 1 / 3;
       flex-wrap: wrap;
+      justify-content: flex-end;
       min-width: 0;
 
       &:empty {
@@ -169,7 +170,9 @@ export const styles = createStaticStyles(({ css }) => ({
       display: grid;
       grid-template-columns: 16px max-content minmax(0, 1fr) 14px;
       row-gap: 4px;
+
       padding-block: 8px;
+      padding-inline: 0;
     }
   `,
   stepDot: css`

--- a/src/features/Acceptance/Viewer/Checks/styles.ts
+++ b/src/features/Acceptance/Viewer/Checks/styles.ts
@@ -113,8 +113,23 @@ export const styles = createStaticStyles(({ css }) => ({
     opacity: 0;
     transition: opacity 0.2s;
   `,
+  rowChevron: css`
+    @media (width <= 767px) {
+      grid-area: 1 / 4;
+    }
+  `,
   rowMeta: css`
     transition: opacity 0.2s;
+
+    @media (width <= 767px) {
+      grid-column: 3 / -1;
+      flex-wrap: wrap;
+      min-width: 0;
+
+      &:empty {
+        display: none;
+      }
+    }
 
     @media (hover: hover) and (pointer: fine) {
       pointer-events: none;
@@ -143,6 +158,12 @@ export const styles = createStaticStyles(({ css }) => ({
        white page just severs the title from its content, so no wash there. */
     &:not([data-expanded]):hover {
       background: ${cssVar.colorFillQuaternary};
+    }
+
+    @media (width <= 767px) {
+      display: grid;
+      grid-template-columns: 16px max-content minmax(0, 1fr) 14px;
+      row-gap: 6px;
     }
   `,
   stepDot: css`

--- a/src/features/Acceptance/Viewer/Focus/AcceptanceEnterFocus.tsx
+++ b/src/features/Acceptance/Viewer/Focus/AcceptanceEnterFocus.tsx
@@ -2,6 +2,7 @@
 
 import { Icon } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
 import { ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
@@ -11,6 +12,14 @@ import { acceptanceCheckPath } from '../routes';
 import { checksForTurn } from '../turnChecks';
 import { useAcceptanceBundle } from '../useAcceptanceBundle';
 import { readAcceptanceTurn } from '../useAcceptanceTurn';
+
+const styles = createStaticStyles(({ css }) => ({
+  button: css`
+    @media (width <= 767px) {
+      display: none;
+    }
+  `,
+}));
 
 const AcceptanceEnterFocus = () => {
   const { t } = useTranslation('verify');
@@ -23,6 +32,7 @@ const AcceptanceEnterFocus = () => {
 
   return (
     <Button
+      className={styles.button}
       icon={<Icon icon={ChevronRight} />}
       size={'small'}
       style={{ alignSelf: 'flex-start', minHeight: 44 }}

--- a/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
+++ b/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
@@ -48,7 +48,6 @@ const AcceptanceTabs = ({
     <Tabs
       activeKey={active}
       style={{ minWidth: 0, overflowX: 'auto' }}
-      variant={'square'}
       items={tabs
         .filter((tab) => tab.key !== 'flow' || flowCount > 0)
         .map((tab) => ({
@@ -57,7 +56,7 @@ const AcceptanceTabs = ({
           label: (
             <Flexbox horizontal align={'center'} gap={6}>
               {tab.label}
-              <Tag>{tab.count}</Tag>
+              <Tag shape={'round'}>{tab.count}</Tag>
             </Flexbox>
           ),
         }))}

--- a/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
+++ b/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
@@ -48,6 +48,7 @@ const AcceptanceTabs = ({
     <Tabs
       activeKey={active}
       style={{ minWidth: 0, overflowX: 'auto' }}
+      variant={'square'}
       items={tabs
         .filter((tab) => tab.key !== 'flow' || flowCount > 0)
         .map((tab) => ({

--- a/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
+++ b/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
@@ -29,12 +29,8 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   tab: css`
     cursor: pointer;
-
     position: relative;
-
-    padding-block: 8px;
     padding-inline: 10px;
-
     white-space: nowrap;
 
     &:hover {
@@ -95,7 +91,6 @@ const AcceptanceTabs = ({
             aria-pressed={tab.key === active}
             className={cx(styles.tab, tab.key === active && styles.tabActive)}
             key={tab.key}
-            style={{ minHeight: 44 }}
             type={'text'}
             onClick={() => onChange(tab.key)}
           >

--- a/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
+++ b/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Flexbox, Icon } from '@lobehub/ui';
-import { Button, Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { Tabs, Tag } from '@lobehub/ui/base-ui';
 import { ListChecks, Paperclip, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -15,43 +14,6 @@ interface AcceptanceTabsProps {
   onChange: (key: AcceptanceTabKey) => void;
   resourceCount: number;
 }
-
-const styles = createStaticStyles(({ css }) => ({
-  count: css`
-    padding-block: 0;
-    padding-inline: 6px;
-    border-radius: 99px;
-
-    font-size: 11px;
-    color: ${cssVar.colorTextSecondary};
-
-    background: ${cssVar.colorFillSecondary};
-  `,
-  tab: css`
-    cursor: pointer;
-    position: relative;
-    padding-inline: 10px;
-    white-space: nowrap;
-
-    &:hover {
-      color: ${cssVar.colorText};
-    }
-  `,
-  tabActive: css`
-    &::after {
-      content: '';
-
-      position: absolute;
-      inset-block-end: -1px;
-      inset-inline: 6px;
-
-      block-size: 2px;
-      border-radius: 2px;
-
-      background: ${cssVar.colorPrimary};
-    }
-  `,
-}));
 
 /**
  * The delivery's two faces: the checks a person judges, and the artefacts the
@@ -83,25 +45,24 @@ const AcceptanceTabs = ({
   ];
 
   return (
-    <Flexbox horizontal align={'center'} gap={2}>
-      {tabs
+    <Tabs
+      activeKey={active}
+      style={{ minWidth: 0, overflowX: 'auto' }}
+      variant={'square'}
+      items={tabs
         .filter((tab) => tab.key !== 'flow' || flowCount > 0)
-        .map((tab) => (
-          <Button
-            aria-pressed={tab.key === active}
-            className={cx(styles.tab, tab.key === active && styles.tabActive)}
-            key={tab.key}
-            type={'text'}
-            onClick={() => onChange(tab.key)}
-          >
-            <Icon icon={tab.icon} size={14} style={{ color: cssVar.colorTextTertiary }} />
-            <Text fontSize={13} weight={tab.key === active ? 600 : 400}>
+        .map((tab) => ({
+          icon: <Icon icon={tab.icon} size={16} />,
+          key: tab.key,
+          label: (
+            <Flexbox horizontal align={'center'} gap={6}>
               {tab.label}
-            </Text>
-            <Text className={styles.count}>{tab.count}</Text>
-          </Button>
-        ))}
-    </Flexbox>
+              <Tag>{tab.count}</Tag>
+            </Flexbox>
+          ),
+        }))}
+      onChange={(key) => onChange(key as AcceptanceTabKey)}
+    />
   );
 };
 

--- a/src/features/Acceptance/Viewer/Review/DecisionBar.tsx
+++ b/src/features/Acceptance/Viewer/Review/DecisionBar.tsx
@@ -2,7 +2,7 @@
 
 import { Flexbox, Icon } from '@lobehub/ui';
 import { Button, Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import {
   BadgeCheck,
   CircleAlert,
@@ -26,7 +26,8 @@ const styles = createStaticStyles(({ css }) => ({
     inset-block-end: 16px;
 
     display: flex;
-    gap: 10px;
+    flex-wrap: wrap;
+    gap: 12px;
     align-items: center;
 
     width: 100%;
@@ -35,29 +36,34 @@ const styles = createStaticStyles(({ css }) => ({
     padding-block: 12px;
     padding-inline: 16px;
     border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: 14px;
+    border-radius: ${cssVar.borderRadiusLG};
 
     background: ${cssVar.colorBgElevated};
     box-shadow: ${cssVar.boxShadowTertiary};
 
     @media (width <= 767px) {
       inset-block-end: max(8px, env(safe-area-inset-bottom));
-      flex-wrap: wrap;
-      gap: 8px;
       padding: 12px;
+    }
+  `,
+  summary: css`
+    flex: 1;
+    min-width: 160px;
+  `,
+  actions: css`
+    flex: none;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+
+    > button {
+      flex: none;
+    }
+
+    @media (width <= 480px) {
+      width: 100%;
 
       > button {
-        min-height: 44px;
-      }
-
-      > .acceptance-decision-actions {
-        flex-wrap: wrap;
-        width: 100%;
-      }
-
-      .acceptance-decision-actions > button {
         flex: 1;
-        min-height: 44px;
       }
     }
   `,
@@ -225,7 +231,6 @@ const DecisionBar = memo<DecisionBarProps>(
     totalCount,
   }) => {
     const { t } = useTranslation('verify');
-    const { md = true } = useResponsive();
 
     const stateMeta = {
       accepted: { color: cssVar.colorSuccess, icon: BadgeCheck },
@@ -263,79 +268,68 @@ const DecisionBar = memo<DecisionBarProps>(
 
     return (
       <div className={styles.bar}>
-        {stateMeta ? (
-          // accepted / live / rejected — a plain coloured status mark.
-          <Icon
-            color={stateMeta.color}
-            icon={stateMeta.icon}
-            size={22}
-            spin={state === 'live'}
-            style={{ flex: 'none' }}
-          />
-        ) : allConfirmed ? (
-          // Every check signed off — the same clean badge the accepted state carries.
-          <Icon
-            className={justCompleted ? styles.completePop : undefined}
-            color={cssVar.colorSuccess}
-            icon={BadgeCheck}
-            size={22}
-            style={{ flex: 'none' }}
-          />
-        ) : settledNeedsFix ? (
-          <Icon
-            className={justCompleted ? styles.completePop : undefined}
-            color={cssVar.colorWarning}
-            icon={CircleAlert}
-            size={22}
-            style={{ flex: 'none' }}
-          />
-        ) : (
-          <ProgressRing done={decidedCount} total={totalCount} />
-        )}
-        <Flexbox gap={2} style={{ flex: '0 1 auto', minWidth: 0 }}>
-          <Text ellipsis strong style={{ fontSize: 14 }}>
-            {!md && state === 'settled'
-              ? t('acceptance.bar.mobileProgress', { done: decidedCount, total: totalCount })
-              : statusText}
-          </Text>
-          {subText && (
-            <Text ellipsis fontSize={12} type={'secondary'}>
-              {subText}
-            </Text>
+        <Flexbox horizontal align={'center'} className={styles.summary} gap={8}>
+          {stateMeta ? (
+            // accepted / live / rejected — a plain coloured status mark.
+            <Icon
+              color={stateMeta.color}
+              icon={stateMeta.icon}
+              size={22}
+              spin={state === 'live'}
+              style={{ flex: 'none' }}
+            />
+          ) : allConfirmed ? (
+            // Every check signed off — the same clean badge the accepted state carries.
+            <Icon
+              className={justCompleted ? styles.completePop : undefined}
+              color={cssVar.colorSuccess}
+              icon={BadgeCheck}
+              size={22}
+              style={{ flex: 'none' }}
+            />
+          ) : settledNeedsFix ? (
+            <Icon
+              className={justCompleted ? styles.completePop : undefined}
+              color={cssVar.colorWarning}
+              icon={CircleAlert}
+              size={22}
+              style={{ flex: 'none' }}
+            />
+          ) : (
+            <ProgressRing done={decidedCount} total={totalCount} />
           )}
-        </Flexbox>
+          <Flexbox gap={2} style={{ flex: '0 1 auto', minWidth: 0 }}>
+            <Text ellipsis type={'secondary'}>
+              {statusText}
+            </Text>
+            {subText && (
+              <Text ellipsis fontSize={12} type={'secondary'}>
+                {subText}
+              </Text>
+            )}
+          </Flexbox>
 
-        {/* The clearing list — every note this round queues for the next one.
+          {/* The clearing list — every note this round queues for the next one.
             Sits with the status reading on the left: it explains that reading,
             while the right side stays pure actions. */}
-        {feedbackCount > 0 && (
-          <Button
-            icon={<Icon icon={ListTodo} />}
-            size={'small'}
-            style={{ flex: 'none' }}
-            type={'text'}
-            onClick={onOpenFeedback}
-          >
-            {t('acceptance.bar.feedback', { count: feedbackCount })}
-          </Button>
-        )}
-
-        <Flexbox
-          horizontal
-          className={'acceptance-decision-actions'}
-          gap={8}
-          style={{ marginInlineStart: 'auto' }}
-        >
+          {feedbackCount > 0 && (
+            <Button
+              icon={<Icon icon={ListTodo} />}
+              size={'small'}
+              style={{ flex: 'none' }}
+              type={'text'}
+              onClick={onOpenFeedback}
+            >
+              {t('acceptance.bar.feedback', { count: feedbackCount })}
+            </Button>
+          )}
+        </Flexbox>
+        <Flexbox horizontal className={styles.actions} gap={8}>
           {/* A dispatched send-back (repairing) keeps the copy entry alive —
             the reviewer may still hand the prompt to another agent. Embedded,
             the composer beside it already receives the draft. */}
           {state === 'live' && hasFeedback && !embedded && (
-            <Button
-              disabled={pending}
-              style={{ flex: 'none' }}
-              type={'fill'}
-              onClick={onCopyReview}
-            >
+            <Button disabled={pending} type={'fill'} onClick={onCopyReview}>
               {t('acceptance.bar.copyReview')}
             </Button>
           )}
@@ -346,12 +340,7 @@ const DecisionBar = memo<DecisionBarProps>(
               // bar's job is getting the repair round started.
               <>
                 {!embedded && (
-                  <Button
-                    disabled={pending}
-                    style={{ flex: 'none' }}
-                    type={'primary'}
-                    onClick={onCopyReview}
-                  >
+                  <Button disabled={pending} type={'primary'} onClick={onCopyReview}>
                     {t('acceptance.bar.copyReview')}
                   </Button>
                 )}
@@ -360,7 +349,6 @@ const DecisionBar = memo<DecisionBarProps>(
                 <Button
                   disabled={pending}
                   icon={<Icon icon={MessageSquarePlus} />}
-                  style={{ flex: 'none' }}
                   type={'fill'}
                   onClick={onAddComment}
                 >
@@ -370,7 +358,6 @@ const DecisionBar = memo<DecisionBarProps>(
                   <Button
                     disabled={pending}
                     loading={rerunPending}
-                    style={{ flex: 'none' }}
                     type={'primary'}
                     onClick={onRerun}
                   >
@@ -382,17 +369,11 @@ const DecisionBar = memo<DecisionBarProps>(
               // Clean review — accept carries primary weight only once every
               // check is signed off; before that it stays a quiet option.
               <>
-                <Button
-                  disabled={pending}
-                  style={{ flex: 'none' }}
-                  type={'text'}
-                  onClick={onRejectComment}
-                >
+                <Button disabled={pending} type={'text'} onClick={onRejectComment}>
                   {t('acceptance.bar.rejectComment')}
                 </Button>
                 <Button
                   disabled={pending}
-                  style={{ flex: 'none' }}
                   type={allConfirmed ? 'primary' : 'fill'}
                   onClick={onAccept}
                 >

--- a/src/features/Acceptance/Viewer/Review/DecisionBar.tsx
+++ b/src/features/Acceptance/Viewer/Review/DecisionBar.tsx
@@ -339,11 +339,6 @@ const DecisionBar = memo<DecisionBarProps>(
               // Feedback is queued — the delivery isn't being accepted now; the
               // bar's job is getting the repair round started.
               <>
-                {!embedded && (
-                  <Button disabled={pending} type={'primary'} onClick={onCopyReview}>
-                    {t('acceptance.bar.copyReview')}
-                  </Button>
-                )}
                 {/* Last words before the repair leaves — a global note the next
                   round reads, for what the queued per-check feedback missed. */}
                 <Button
@@ -354,6 +349,11 @@ const DecisionBar = memo<DecisionBarProps>(
                 >
                   {t('acceptance.bar.addComment')}
                 </Button>
+                {!embedded && (
+                  <Button disabled={pending} type={'primary'} onClick={onCopyReview}>
+                    {t('acceptance.bar.copyReview')}
+                  </Button>
+                )}
                 {embedded && rerunAvailable && (
                   <Button
                     disabled={pending}


### PR DESCRIPTION
Acceptance checklist titles competed with status, file, and round metadata for space on phones, while custom control sizes made the page bulky.

Below 768px, place status, check number, file types, and round metadata together above a full-width title. Remove horizontal row padding on mobile and right-align file and round metadata before the expand arrow. Reduce mobile row padding to 8px and the gap between the two lines to 4px. Hide the top per-check review entry on mobile. Group status and round filters beneath the heading using default-size Select controls, and retain underline Tabs with round count Tags. Separate decision-bar progress from its actions, remove the forced 44px mobile button height, and distribute actions evenly below progress on narrow screens. Desktop rows and the per-check review entry retain their existing layout. In the reviewed-with-feedback state, place Copy repair prompt after Add comment so the primary action is rightmost.

Validation: lint and 42 related tests passed. The latest padding and metadata-alignment feedback was verified in the real local Web app at 320/390/767px touch and 768px desktop widths, including zero horizontal row padding, full-width titles, right-aligned metadata, entry visibility, row expansion/collapse, last-item readability, and horizontal overflow. Mobile rows are 10px shorter while desktop row heights are unchanged. Earlier 320/1280px checks cover the repair-prompt action position, copy confirmation, and the comment dialog. Earlier rounds also cover Tab switching, keyboard navigation, footer actions, and dialog cancellation.

[Acceptance round 8 — latest feedback addressed, all required screenshots uploaded](https://app.lobehub.com/acceptance/67ef0d09-4623-4af6-b260-84ee8b076b74?r=8)

Scope: dark Chromium responsive emulation; native iOS Safari, Electron, and embedded views were not exercised.
