### PR TITLE
⚡️ perf(model-bank): keep the aiModels catalog off the boot path

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -156,6 +156,24 @@ export default eslint(
     },
   },
   {
+    // Any static import of the model-bank root barrel drags the whole aiModels
+    // catalog (1.4 MB raw) into the importing route's closure.
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': createRestrictedImportRule({
+        paths: [
+          {
+            allowTypeImports: true,
+            message:
+              'Do not import the model-bank root barrel; it re-exports the full aiModels catalog. Use a subpath such as "model-bank/aiModel", "model-bank/modelProvider", "model-bank/standardParameters" or "model-bank/utils".',
+            name: 'model-bank',
+          },
+        ],
+      }),
+    },
+  },
+  {
     // Boot-path trees are statically reachable from the SPA entry. A heavy
     // @lobehub/ui member imported here lands in the first-screen chunk together
     // with shiki / katex / elkjs / emoji data; the CI entry-graph gate catches

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,11 +8,20 @@ const tsconfigRootDir = fileURLToPath(new URL('.', import.meta.url));
 
 const baseRestrictedImportOptions = restrictedImports.rules['no-restricted-imports'][1];
 
+// Shared by every src/** no-restricted-imports block: flat config replaces a
+// rule per file instead of merging it, so a scoped override would otherwise
+// drop these.
 const performanceRestrictedImportPaths = [
   {
     message:
       'Import the imperative facade from "@/features/ShareModal" so the modal implementation stays outside initial chunks.',
     name: '@/features/ShareModal/Modal',
+  },
+  {
+    allowTypeImports: true,
+    message:
+      'Do not import the model-bank root barrel; it re-exports the full aiModels catalog (1.4 MB raw). Use a subpath such as "model-bank/aiModel", "model-bank/modelProvider", "model-bank/standardParameters" or "model-bank/utils".',
+    name: 'model-bank',
   },
 ];
 
@@ -156,21 +165,10 @@ export default eslint(
     },
   },
   {
-    // Any static import of the model-bank root barrel drags the whole aiModels
-    // catalog (1.4 MB raw) into the importing route's closure.
-    files: ['src/**/*.{ts,tsx}'],
-    ignores: ['src/**/*.test.{ts,tsx}'],
+    // Bundle-size restrictions target shipped code; tests may reach the barrels.
+    files: ['src/**/*.test.{ts,tsx}'],
     rules: {
-      'no-restricted-imports': createRestrictedImportRule({
-        paths: [
-          {
-            allowTypeImports: true,
-            message:
-              'Do not import the model-bank root barrel; it re-exports the full aiModels catalog. Use a subpath such as "model-bank/aiModel", "model-bank/modelProvider", "model-bank/standardParameters" or "model-bank/utils".',
-            name: 'model-bank',
-          },
-        ],
-      }),
+      'no-restricted-imports': ['error', baseRestrictedImportOptions],
     },
   },
   {

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -2,8 +2,11 @@
   "name": "model-bank",
   "version": "1.0.0",
   "private": true,
+  "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./knowledgeCutoff": "./src/const/knowledgeCutoff.ts",
+    "./utils": "./src/utils.ts",
     "./aiModel": "./src/types/aiModel.ts",
     "./aiProvider": "./src/types/aiProvider.ts",
     "./modelProvider": "./src/const/modelProvider.ts",

--- a/packages/model-runtime/package.json
+++ b/packages/model-runtime/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./errors": "./src/errors/index.ts",
+    "./errors/specs": "./src/errors/specs.ts",
     "./getModelPropertyWithFallback": "./src/utils/getFallbackModelProperty.ts",
     "./helpers/parseToolCalls": "./src/helpers/parseToolCalls.ts",
     "./providers/anthropic/modelId": "./src/providers/anthropic/modelId.ts",

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -1,6 +1,6 @@
 import type { LobeAgentChatConfig } from '@lobechat/types';
-import type { AiModelReasoningConfig, ExtendParamsType } from 'model-bank';
-import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank';
+import type { AiModelReasoningConfig, ExtendParamsType } from 'model-bank/aiModel';
+import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank/aiModel';
 
 import { isAdaptiveThinkingDefaultOnModel } from '../providers/anthropic/modelId';
 

--- a/src/features/ChatInput/ActionBar/Params/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/Params/Controls.tsx
@@ -11,7 +11,7 @@ import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { debounce } from 'es-toolkit/compat';
 import isEqual from 'fast-deep-equal';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank';
+import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank/aiModel';
 import type { ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/ChatInput/hooks/useReasoningEffortControl.ts
+++ b/src/features/ChatInput/hooks/useReasoningEffortControl.ts
@@ -3,7 +3,7 @@
 import { resolveDefaultThinkingLevelForModel } from '@lobechat/model-runtime/utils/modelExtendParams';
 import isEqual from 'fast-deep-equal';
 import type { AiModelReasoningConfig } from 'model-bank';
-import { MODEL_REASONING_PARAM_DEFAULTS, MODEL_REASONING_PARAM_LEVELS } from 'model-bank';
+import { MODEL_REASONING_PARAM_DEFAULTS, MODEL_REASONING_PARAM_LEVELS } from 'model-bank/aiModel';
 import { useCallback } from 'react';
 
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';

--- a/src/features/Conversation/Error/ChatInvalidApiKey.tsx
+++ b/src/features/Conversation/Error/ChatInvalidApiKey.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@lobehub/ui/base-ui';
-import { ModelProvider } from 'model-bank';
+import { ModelProvider } from 'model-bank/modelProvider';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -4,7 +4,7 @@ import { Flexbox, Form } from '@lobehub/ui';
 import { Switch } from '@lobehub/ui/base-ui';
 import { Form as AntdForm } from 'antd';
 import isEqual from 'fast-deep-equal';
-import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank';
+import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank/aiModel';
 import type { ReactNode } from 'react';
 import { memo, useEffect, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningModeSegmented.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningModeSegmented.tsx
@@ -1,5 +1,5 @@
 import { Segmented } from '@lobehub/ui/base-ui';
-import { MODEL_REASONING_PARAM_LEVELS } from 'model-bank';
+import { MODEL_REASONING_PARAM_LEVELS } from 'model-bank/aiModel';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/Settings/provider/detail/azure/index.tsx
+++ b/src/features/Settings/provider/detail/azure/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ModelProvider } from 'model-bank';
+import { ModelProvider } from 'model-bank/modelProvider';
 import { AzureProviderCard } from 'model-bank/modelProviders';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/Settings/provider/detail/azureai/index.tsx
+++ b/src/features/Settings/provider/detail/azureai/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ModelProvider } from 'model-bank';
+import { ModelProvider } from 'model-bank/modelProvider';
 import { AzureAIProviderCard } from 'model-bank/modelProviders';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/Settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/features/Settings/provider/features/ModelList/ModelItem.tsx
@@ -4,7 +4,7 @@ import { ActionIcon, confirmModal, Switch, Tag, Text, toast } from '@lobehub/ui/
 import { createStaticStyles, cssVar } from 'antd-style';
 import { LucidePencil, TrashIcon } from 'lucide-react';
 import { type AiProviderModelListItem } from 'model-bank';
-import { AiModelSourceEnum } from 'model-bank';
+import { AiModelSourceEnum } from 'model-bank/aiModel';
 import React, { memo, use, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/helpers/getSearchConfig.ts
+++ b/src/helpers/getSearchConfig.ts
@@ -1,4 +1,4 @@
-import { resolveSearchDecision, type SearchDecision } from 'model-bank';
+import { resolveSearchDecision, type SearchDecision } from 'model-bank/utils';
 
 import { getAgentStoreState } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@lobehub/ui/base-ui';
-import { ModelProvider } from 'model-bank';
+import { ModelProvider } from 'model-bank/modelProvider';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';

--- a/src/routes/(main)/(create)/image/features/ConfigPanel/components/InputNumber/index.tsx
+++ b/src/routes/(main)/(create)/image/features/ConfigPanel/components/InputNumber/index.tsx
@@ -3,7 +3,7 @@
 import { Flexbox, InputNumber, Tooltip } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { Dices } from 'lucide-react';
-import { MAX_SEED } from 'model-bank';
+import { MAX_SEED } from 'model-bank/standardParameters';
 import { type CSSProperties } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/(create)/image/features/ConfigPanel/hooks/useAutoDimensions.ts
+++ b/src/routes/(main)/(create)/image/features/ConfigPanel/hooks/useAutoDimensions.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_DIMENSION_CONSTRAINTS } from 'model-bank';
+import { DEFAULT_DIMENSION_CONSTRAINTS } from 'model-bank/standardParameters';
 
 import { useImageStore } from '@/store/image';
 import { imageGenerationConfigSelectors } from '@/store/image/selectors';

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -7,7 +7,7 @@ import {
   type OpenAICompatibleKeyVault,
   type VertexAIKeyVault,
 } from '@lobechat/types';
-import { clientApiKeyManager } from '@lobechat/utils/client';
+import { clientApiKeyManager } from '@lobechat/utils/client/apiKeyManager';
 import { ModelProvider } from 'model-bank/modelProvider';
 
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';

--- a/src/store/aiInfra/slices/aiModel/selectors.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.ts
@@ -1,6 +1,8 @@
-import type { ExtendParamsType } from 'model-bank';
-import { MODEL_REASONING_EXTEND_PARAMS } from 'model-bank';
-import { AiModelSourceEnum } from 'model-bank/aiModel';
+import {
+  AiModelSourceEnum,
+  type ExtendParamsType,
+  MODEL_REASONING_EXTEND_PARAMS,
+} from 'model-bank/aiModel';
 
 import { type AIProviderStoreState } from '@/store/aiInfra/initialState';
 import { ModelSearchImplement } from '@/types/search';

--- a/src/store/file/slices/upload/action.test.ts
+++ b/src/store/file/slices/upload/action.test.ts
@@ -170,11 +170,9 @@ describe('FileUploadAction', () => {
       vi.mocked(getImageDimensions).mockResolvedValue(undefined);
       vi.spyOn(uploadService, 'uploadBase64ToS3').mockRejectedValue(new Error('Upload failed'));
 
-      await expect(
-        act(async () => {
-          await result.current.uploadBase64FileWithProgress(base64Data);
-        }),
-      ).rejects.toThrow('Upload failed');
+      await expect(result.current.uploadBase64FileWithProgress(base64Data)).rejects.toThrow(
+        'Upload failed',
+      );
     });
 
     it('should delegate handled base64 upload errors to the business upload error handler', async () => {
@@ -1035,13 +1033,7 @@ describe('FileUploadAction', () => {
         vi.mocked(getImageDimensions).mockResolvedValue(undefined);
         vi.spyOn(fileService, 'checkFileHash').mockRejectedValue(new Error('Hash check failed'));
 
-        await expect(
-          act(async () => {
-            await uploadWithProgress({
-              file: mockFile,
-            });
-          }),
-        ).rejects.toThrow('Hash check failed');
+        await expect(uploadWithProgress({ file: mockFile })).rejects.toThrow('Hash check failed');
       });
 
       it('should handle uploadFileToS3 errors', async () => {
@@ -1054,13 +1046,7 @@ describe('FileUploadAction', () => {
         vi.spyOn(fileService, 'checkFileHash').mockResolvedValue(mockCheckResult);
         vi.spyOn(uploadService, 'uploadFileToS3').mockRejectedValue(new Error('Upload failed'));
 
-        await expect(
-          act(async () => {
-            await uploadWithProgress({
-              file: mockFile,
-            });
-          }),
-        ).rejects.toThrow('Upload failed');
+        await expect(uploadWithProgress({ file: mockFile })).rejects.toThrow('Upload failed');
       });
 
       it('should handle createFile errors', async () => {
@@ -1081,13 +1067,7 @@ describe('FileUploadAction', () => {
         vi.spyOn(uploadService, 'uploadFileToS3').mockResolvedValue(mockUploadResult);
         vi.spyOn(fileService, 'createFile').mockRejectedValue(new Error('DB creation failed'));
 
-        await expect(
-          act(async () => {
-            await uploadWithProgress({
-              file: mockFile,
-            });
-          }),
-        ).rejects.toThrow('DB creation failed');
+        await expect(uploadWithProgress({ file: mockFile })).rejects.toThrow('DB creation failed');
       });
     });
   });

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -5,7 +5,7 @@ import {
   type RuntimeImageGenParamsKeys,
   type RuntimeImageGenParamsValue,
 } from 'model-bank';
-import { extractDefaultValues } from 'model-bank';
+import { extractDefaultValues } from 'model-bank/standardParameters';
 
 import { aiProviderSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';

--- a/src/store/image/slices/generationConfig/hooks.ts
+++ b/src/store/image/slices/generationConfig/hooks.ts
@@ -1,5 +1,5 @@
 import { type RuntimeImageGenParams, type RuntimeImageGenParamsKeys } from 'model-bank';
-import { DEFAULT_ASPECT_RATIO, PRESET_ASPECT_RATIOS } from 'model-bank';
+import { DEFAULT_ASPECT_RATIO, PRESET_ASPECT_RATIOS } from 'model-bank/standardParameters';
 import { useCallback, useMemo } from 'react';
 
 import { useImageStore } from '../../store';

--- a/src/store/image/slices/generationConfig/initialState.ts
+++ b/src/store/image/slices/generationConfig/initialState.ts
@@ -1,6 +1,7 @@
 import type { ModelParamsSchema, RuntimeImageGenParams } from 'model-bank';
-import { extractDefaultValues, ModelProvider } from 'model-bank';
 import { nanoBanana2Parameters } from 'model-bank/imageParameters';
+import { ModelProvider } from 'model-bank/modelProvider';
+import { extractDefaultValues } from 'model-bank/standardParameters';
 
 import { DEFAULT_IMAGE_CONFIG } from '@/const/settings';
 

--- a/src/store/video/slices/generationConfig/action.ts
+++ b/src/store/video/slices/generationConfig/action.ts
@@ -1,11 +1,11 @@
+import { type AIVideoModelCard } from 'model-bank/aiModel';
 import {
-  type AIVideoModelCard,
   extractVideoDefaultValues,
   type RuntimeVideoGenParams,
   type RuntimeVideoGenParamsKeys,
   type RuntimeVideoGenParamsValue,
   type VideoModelParamsSchema,
-} from 'model-bank';
+} from 'model-bank/standardParameters';
 
 import { aiProviderSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';

--- a/src/store/video/slices/generationConfig/initialState.ts
+++ b/src/store/video/slices/generationConfig/initialState.ts
@@ -1,12 +1,12 @@
 /* eslint-disable perfectionist/sort-interfaces */
+import { ModelProvider } from 'model-bank/modelProvider';
 import {
   extractVideoDefaultValues,
-  ModelProvider,
   PRESET_VIDEO_ASPECT_RATIOS,
   PRESET_VIDEO_RESOLUTIONS,
   type RuntimeVideoGenParams,
   type VideoModelParamsSchema,
-} from 'model-bank';
+} from 'model-bank/standardParameters';
 
 export const DEFAULT_AI_VIDEO_PROVIDER = ModelProvider.LobeHub;
 export const DEFAULT_AI_VIDEO_MODEL = 'dreamina-seedance-2-0-260128';

--- a/src/utils/aiProvider.ts
+++ b/src/utils/aiProvider.ts
@@ -1,5 +1,5 @@
 import type { BuiltinModelIdentifier, EnabledAiModel } from 'model-bank';
-import { isAiModelVisible } from 'model-bank';
+import { isAiModelVisible } from 'model-bank/aiModel';
 
 const getBuiltinModelIdentifierKey = ({ id, providerId }: BuiltinModelIdentifier) =>
   `${providerId}\u0000${id}`;

--- a/src/utils/errorResponse.ts
+++ b/src/utils/errorResponse.ts
@@ -1,5 +1,5 @@
 import { AUTH_REQUIRED_HEADER } from '@lobechat/desktop-bridge';
-import { getErrorCodeSpec } from '@lobechat/model-runtime/errors';
+import { getErrorCodeSpec } from '@lobechat/model-runtime/errors/specs';
 import type { ILobeAgentRuntimeErrorType } from '@lobechat/model-runtime/types/error';
 import type { ErrorResponse, ErrorType } from '@lobechat/types';
 import { ChatErrorType } from '@lobechat/types';


### PR DESCRIPTION
Third slice of the first-screen work from #19161, redone from `canary` as an independent PR.

The `model-bank` root barrel re-exports the full aiModels catalog (≈1.4 MB raw, 1600+ pricing rows). A few value imports on the boot path pulled it into the first-screen `model-runtime-client` chunk: `helpers/getSearchConfig` (via `services/chat`), `MODEL_REASONING_*` in the reasoning controls and the aiModel selectors, `extractDefaultValues` / preset ratios in the image and video generation stores, `ModelProvider` in error views, and `@lobechat/model-runtime/utils/modelExtendParams`.

- Every value import of the root barrel under `src/**` and in `model-runtime/utils/modelExtendParams` now uses a subpath: `model-bank/aiModel`, `model-bank/modelProvider`, `model-bank/standardParameters`, `model-bank/utils`. Type-only imports of the root are untouched.
- `packages/model-bank/package.json`: `sideEffects: false`, new `./utils` and `./knowledgeCutoff` exports.
- `eslint.config.mjs`: `no-restricted-imports` on `model-bank` across `src/**` (`allowTypeImports`), pointing at the subpaths.
- `src/utils/errorResponse.ts` imports `@lobechat/model-runtime/errors/specs` (new export) and `src/services/_auth.ts` imports `@lobechat/utils/client/apiKeyManager`, so `services/chat` no longer carries the error pattern tables or dompurify.

Web production `vite build`, entry + `modulepreload`, on top of current `canary` (without #19288 / #19289):

| | before | after |
| --- | --- | --- |
| first-screen gzip | 2299 KB | 2154 KB |
| aiModels catalog in eager chunks | yes (`model-runtime-client`) | no |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Import-path only. `bun run check` on the changed files (lint + 237 related tests), full `bun run check --type`, and the production web build.

#### 🔗 Related Issue

Related to LOBE-13719. Supersedes part of #19161.

https://claude.ai/code/session_01QKr8CsFLYmrgqbRTSipTNH