### PR TITLE
⚡️ perf(icons): mount the brand icon catalog and emoji picker through lazy()

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,30 @@ const tsconfigRootDir = fileURLToPath(new URL('.', import.meta.url));
 
 const baseRestrictedImportOptions = restrictedImports.rules['no-restricted-imports'][1];
 
+// Shared by every src/** no-restricted-imports block: flat config replaces a
+// rule per file instead of merging it, so a scoped override would otherwise
+// drop these.
 const performanceRestrictedImportPaths = [
+  {
+    allowTypeImports: true,
+    importNames: ['ModelIcon', 'ModelTag', 'ProviderCombine', 'ProviderIcon'],
+    message:
+      'These features statically import every brand icon (~3 MB). Import them from "@/components/LobeIcons", which mounts them through lazy().',
+    name: '@lobehub/icons',
+  },
+  {
+    allowTypeImports: true,
+    message:
+      'Import ProviderIcon / ProviderCombine from "@/components/LobeIcons", which mounts them through lazy().',
+    name: '@/libs/providerIcon',
+  },
+  {
+    allowTypeImports: true,
+    importNames: ['EmojiPicker'],
+    message:
+      'EmojiPicker carries the emoji-mart dataset. Use "@/components/EmojiPicker", which mounts it through lazy().',
+    name: '@lobehub/ui',
+  },
   {
     message:
       'Import the imperative facade from "@/features/ShareModal" so the modal implementation stays outside initial chunks.',
@@ -156,6 +179,13 @@ export default eslint(
     },
   },
   {
+    // Bundle-size restrictions target shipped code; tests may reach the barrels.
+    files: ['src/**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': ['error', baseRestrictedImportOptions],
+    },
+  },
+  {
     // Boot-path trees are statically reachable from the SPA entry. A heavy
     // @lobehub/ui member imported here lands in the first-screen chunk together
     // with shiki / katex / elkjs / emoji data; the CI entry-graph gate catches
@@ -200,41 +230,6 @@ export default eslint(
             message:
               'The builtin tool client barrel exports the whole render registry. Import the dedicated subpath (e.g. "/client/displayControls") or resolve renders lazily.',
             regex: '^@lobechat/builtin-tool-[^/]+/client(?:$|/index$)',
-          },
-        ],
-      }),
-    },
-  },
-  {
-    // Catalog-backed icon features and the emoji picker statically import the
-    // whole brand-icon set / emoji-mart dataset into the importing route's
-    // closure; the wrappers mount them through lazy().
-    files: ['src/**/*.{ts,tsx}'],
-    ignores: [
-      'src/**/*.test.{ts,tsx}',
-      'src/components/EmojiPicker/index.tsx',
-      'src/components/LobeIcons/index.tsx',
-      'src/libs/providerIcon.ts',
-    ],
-    rules: {
-      'no-restricted-imports': createRestrictedImportRule({
-        paths: [
-          {
-            importNames: ['ModelIcon', 'ModelTag', 'ProviderCombine', 'ProviderIcon'],
-            message:
-              'These features statically import every brand icon. Import them from "@/components/LobeIcons", which mounts them through lazy().',
-            name: '@lobehub/icons',
-          },
-          {
-            message:
-              'Import ProviderIcon / ProviderCombine from "@/components/LobeIcons", which mounts them through lazy().',
-            name: '@/libs/providerIcon',
-          },
-          {
-            importNames: ['EmojiPicker'],
-            message:
-              'EmojiPicker carries the emoji-mart dataset. Use "@/components/EmojiPicker", which mounts it through lazy().',
-            name: '@lobehub/ui',
           },
         ],
       }),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -206,6 +206,41 @@ export default eslint(
     },
   },
   {
+    // Catalog-backed icon features and the emoji picker statically import the
+    // whole brand-icon set / emoji-mart dataset into the importing route's
+    // closure; the wrappers mount them through lazy().
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      'src/**/*.test.{ts,tsx}',
+      'src/components/EmojiPicker/index.tsx',
+      'src/components/LobeIcons/index.tsx',
+      'src/libs/providerIcon.ts',
+    ],
+    rules: {
+      'no-restricted-imports': createRestrictedImportRule({
+        paths: [
+          {
+            importNames: ['ModelIcon', 'ModelTag', 'ProviderCombine', 'ProviderIcon'],
+            message:
+              'These features statically import every brand icon. Import them from "@/components/LobeIcons", which mounts them through lazy().',
+            name: '@lobehub/icons',
+          },
+          {
+            message:
+              'Import ProviderIcon / ProviderCombine from "@/components/LobeIcons", which mounts them through lazy().',
+            name: '@/libs/providerIcon',
+          },
+          {
+            importNames: ['EmojiPicker'],
+            message:
+              'EmojiPicker carries the emoji-mart dataset. Use "@/components/EmojiPicker", which mounts it through lazy().',
+            name: '@lobehub/ui',
+          },
+        ],
+      }),
+    },
+  },
+  {
     files: ['src/components/Skeleton/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': createRestrictedImportRule({

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -1,14 +1,23 @@
 import { type EmojiPickerProps } from '@lobehub/ui';
-import { EmojiPicker as LobeEmojiPicker } from '@lobehub/ui';
-import { memo } from 'react';
+import { Skeleton } from '@lobehub/ui/base-ui';
+import { lazy, memo, Suspense } from 'react';
 
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
 
+// @lobehub/ui's EmojiPicker bundles the emoji-mart dataset (~600 KB); load it
+// on mount so the picker never sits inside a route's static closure.
+const LobeEmojiPicker = lazy(() => import('@lobehub/ui/es/EmojiPicker/index'));
+
 export const EmojiPicker = memo<EmojiPickerProps>(({ shape = 'square', ...rest }) => {
   const locale = useGlobalStore(globalGeneralSelectors.currentLanguage);
+  const size = rest.size ?? 40;
 
-  return <LobeEmojiPicker shape={shape} {...rest} defaultAvatar={null as any} locale={locale} />;
+  return (
+    <Suspense fallback={<Skeleton height={size} width={size} />}>
+      <LobeEmojiPicker shape={shape} {...rest} defaultAvatar={null as any} locale={locale} />
+    </Suspense>
+  );
 });
 
 export default EmojiPicker;

--- a/src/components/LobeIcons/index.tsx
+++ b/src/components/LobeIcons/index.tsx
@@ -1,0 +1,56 @@
+import type {
+  ModelIcon as LobeModelIcon,
+  ModelTag as LobeModelTag,
+  ProviderCombine as LobeProviderCombine,
+  ProviderIcon as LobeProviderIcon,
+} from '@lobehub/icons';
+import { Skeleton } from '@lobehub/ui/base-ui';
+import type { ComponentProps } from 'react';
+import { lazy, Suspense } from 'react';
+
+// The catalog-backed features of @lobehub/icons statically import every brand
+// icon (~3 MB). Mounting them through lazy() keeps that catalog in one shared
+// chunk that loads after paint instead of inside each route's closure.
+const LazyModelIcon = lazy(() => import('@lobehub/icons/es/features/ModelIcon'));
+const LazyModelTag = lazy(() => import('@lobehub/icons/es/features/ModelTag'));
+const LazyProviderIcon = lazy(() =>
+  import('@/libs/providerIcon').then(({ ProviderIcon }) => ({ default: ProviderIcon })),
+);
+const LazyProviderCombine = lazy(() =>
+  import('@/libs/providerIcon').then(({ ProviderCombine }) => ({ default: ProviderCombine })),
+);
+
+const DEFAULT_SIZE = 24;
+
+export const ModelIcon = (props: ComponentProps<typeof LobeModelIcon>) => {
+  const size = props.size ?? DEFAULT_SIZE;
+  return (
+    <Suspense fallback={<Skeleton height={size} width={size} />}>
+      <LazyModelIcon {...props} />
+    </Suspense>
+  );
+};
+
+export const ProviderIcon = (props: ComponentProps<typeof LobeProviderIcon>) => {
+  const size = props.size ?? DEFAULT_SIZE;
+  return (
+    <Suspense fallback={<Skeleton height={size} width={size} />}>
+      <LazyProviderIcon {...props} />
+    </Suspense>
+  );
+};
+
+export const ModelTag = (props: ComponentProps<typeof LobeModelTag>) => (
+  <Suspense fallback={<Skeleton height={22} width={96} />}>
+    <LazyModelTag {...props} />
+  </Suspense>
+);
+
+export const ProviderCombine = (props: ComponentProps<typeof LobeProviderCombine>) => {
+  const size = props.size ?? DEFAULT_SIZE;
+  return (
+    <Suspense fallback={<Skeleton height={size} width={size * 4} />}>
+      <LazyProviderCombine {...props} />
+    </Suspense>
+  );
+};

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -1,6 +1,6 @@
 import { type ChatModelCard } from '@lobechat/types';
 import { type IconAvatarProps } from '@lobehub/icons';
-import { LobeHub, ModelIcon } from '@lobehub/icons';
+import { LobeHub } from '@lobehub/icons';
 import { type FlexboxProps } from '@lobehub/ui';
 import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Avatar, Tag, Text } from '@lobehub/ui/base-ui';
@@ -20,7 +20,7 @@ import { type CSSProperties, type FC } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ProviderIcon } from '@/libs/providerIcon';
+import { ModelIcon, ProviderIcon } from '@/components/LobeIcons';
 import { type AiProviderSourceType } from '@/types/aiProvider';
 import { formatTokenNumber } from '@/utils/format';
 

--- a/src/components/OllamaSetupGuide/index.tsx
+++ b/src/components/OllamaSetupGuide/index.tsx
@@ -6,7 +6,7 @@ import { readableColor } from 'polished';
 import React, { memo, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { ProviderCombine } from '@/libs/providerIcon';
+import { ProviderCombine } from '@/components/LobeIcons';
 
 const prefixCls = 'ant';
 

--- a/src/features/AgentProfileCard/AgentProfilePopup.tsx
+++ b/src/features/AgentProfileCard/AgentProfilePopup.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { agentDisplayName, type AgentItem } from '@lobechat/types';
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Icon, Popover } from '@lobehub/ui';
 import { ActionIcon, Skeleton, Text } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
@@ -11,6 +10,7 @@ import { memo, type PropsWithChildren, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { ArticleSkeleton } from '@/components/Skeleton';
 import ModelSelect from '@/features/ModelSelect';
 import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';

--- a/src/features/AgentUsage/ModelBreakdown.tsx
+++ b/src/features/AgentUsage/ModelBreakdown.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { Table } from 'antd';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { type AgentUsageModelRow } from '@/types/usage/usageRecord';
 import { formatNumber, formatUsageValue } from '@/utils/format';
 

--- a/src/features/ChatInput/ActionBar/Model/SelectorMenu.tsx
+++ b/src/features/ChatInput/ActionBar/Model/SelectorMenu.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import {
   DropdownMenuItem,
   DropdownMenuItemContent,
@@ -19,6 +18,7 @@ import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { ModelSwitchSubmenuPopup } from '@/features/ModelSwitchPanel';
 
 import type { SelectorSubmenuItem } from '../../components/buildSelectorSubmenu';

--- a/src/features/Conversation/Error/ChatInvalidApiKey.tsx
+++ b/src/features/Conversation/Error/ChatInvalidApiKey.tsx
@@ -4,9 +4,9 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { ProviderIcon } from '@/components/LobeIcons';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useProviderName } from '@/hooks/useProviderName';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { type GlobalLLMProviderKey } from '@/types/user/settings/modelProvider';
 
 import { useConversationStore } from '../store';

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
@@ -1,5 +1,4 @@
 import { getCachedTextInputUnitRate, getWriteCacheInputUnitRate } from '@lobechat/utils';
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Tabs } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -8,6 +7,7 @@ import { type LobeDefaultAiModelListItem } from 'model-bank';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -4,7 +4,6 @@ import {
 } from '@lobechat/heterogeneous-agents';
 import type { ModelPerformance, ModelUsage } from '@lobechat/types';
 import { unwrapServerDefaultHeterogeneousModel } from '@lobechat/types';
-import { ModelIcon } from '@lobehub/icons';
 import { Center, Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
@@ -12,6 +11,7 @@ import { CircleDollarSignIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';

--- a/src/features/Conversation/components/History/index.tsx
+++ b/src/features/Conversation/components/History/index.tsx
@@ -1,4 +1,3 @@
-import { ModelTag } from '@lobehub/icons';
 import { Center, Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -6,6 +5,7 @@ import { ScrollText } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelTag } from '@/components/LobeIcons';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useAgentStore } from '@/store/agent/store';
 

--- a/src/features/Home/NewModelShortcuts/index.tsx
+++ b/src/features/Home/NewModelShortcuts/index.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { Avatar, Button, Skeleton, Text } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
@@ -10,6 +9,7 @@ import type { BusinessModelModeConfig } from '@/business/client/hooks/useBusines
 import { useBusinessModelModeConfig } from '@/business/client/hooks/useBusinessAgentMode';
 import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
 import { useHomeNewModels } from '@/business/client/hooks/useHomeNewModels';
+import { ModelIcon } from '@/components/LobeIcons';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
 import { agentService } from '@/services/agent';

--- a/src/features/MobileHome/SessionListContent/List/Item/index.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/index.tsx
@@ -1,8 +1,8 @@
-import { ModelTag } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import React, { memo, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
 
+import { ModelTag } from '@/components/LobeIcons';
 import { DEFAULT_AVATAR } from '@/const/meta';
 import { INBOX_SESSION_ID } from '@/const/session';
 import { isDesktop } from '@/const/version';

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { Button, Select, type SelectProps, Switch, Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -6,6 +5,7 @@ import { type ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { ModelItemRender, ProviderItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { type EnabledProviderWithModels } from '@/types/aiProvider';

--- a/src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx
+++ b/src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx
@@ -47,10 +47,10 @@ vi.mock('@lobehub/ui/base-ui', () => ({
 
 vi.mock('@lobehub/icons', () => ({
   LobeHub: { Morden: () => <span /> },
-  ModelIcon: () => <span />,
 }));
 
-vi.mock('@/libs/providerIcon', () => ({
+vi.mock('@/components/LobeIcons', () => ({
+  ModelIcon: () => <span />,
   ProviderIcon: () => <span />,
 }));
 

--- a/src/features/Settings/provider/(list)/ProviderGrid/Card.tsx
+++ b/src/features/Settings/provider/(list)/ProviderGrid/Card.tsx
@@ -7,8 +7,8 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { BrandingProviderCard } from '@/business/client/features/BrandingProviderCard';
+import { ProviderCombine, ProviderIcon } from '@/components/LobeIcons';
 import { useIsDark } from '@/hooks/useIsDark';
-import { ProviderCombine, ProviderIcon } from '@/libs/providerIcon';
 import { type AiProviderListItem } from '@/types/aiProvider';
 
 import EnableSwitch from './EnableSwitch';

--- a/src/features/Settings/provider/ProviderMenu/Item.tsx
+++ b/src/features/Settings/provider/ProviderMenu/Item.tsx
@@ -6,9 +6,9 @@ import { memo, useMemo } from 'react';
 import { useLocation } from 'react-router';
 
 import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { ProviderIcon } from '@/components/LobeIcons';
 import { isCustomBranding } from '@/const/version';
 import NavItem from '@/features/NavPanel/components/NavItem';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { type AiProviderListItem } from '@/types/aiProvider';
 import { AiProviderSourceEnum } from '@/types/aiProvider';
 

--- a/src/features/Settings/provider/ProviderMenu/SortProviderModal/GroupItem.tsx
+++ b/src/features/Settings/provider/ProviderMenu/SortProviderModal/GroupItem.tsx
@@ -2,7 +2,7 @@ import { Flexbox, SortableList } from '@lobehub/ui';
 import { Avatar } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
-import { ProviderIcon } from '@/libs/providerIcon';
+import { ProviderIcon } from '@/components/LobeIcons';
 import { type AiProviderListItem } from '@/types/aiProvider';
 
 interface GroupItemProps extends AiProviderListItem {

--- a/src/features/Settings/provider/features/CreateNewProvider/Content.tsx
+++ b/src/features/Settings/provider/features/CreateNewProvider/Content.tsx
@@ -7,8 +7,8 @@ import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ProviderIcon } from '@/components/LobeIcons';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { useAiInfraStore } from '@/store/aiInfra/store';
 import { type CreateAiProviderParams } from '@/types/aiProvider';
 

--- a/src/features/Settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/features/Settings/provider/features/ModelList/ModelItem.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import { copyToClipboard, Flexbox } from '@lobehub/ui';
 import { ActionIcon, confirmModal, Switch, Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -8,6 +7,7 @@ import { AiModelSourceEnum } from 'model-bank';
 import React, { memo, use, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import NewModelBadge from '@/components/ModelSelect/NewModelBadge';
 import { useIsMobile } from '@/hooks/useIsMobile';

--- a/src/features/Settings/provider/features/ModelList/SortModelModal/ListItem.tsx
+++ b/src/features/Settings/provider/features/ModelList/SortModelModal/ListItem.tsx
@@ -1,7 +1,8 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, SortableList } from '@lobehub/ui';
 import { type AiProviderModelListItem } from 'model-bank';
 import { memo } from 'react';
+
+import { ModelIcon } from '@/components/LobeIcons';
 
 interface ListItemProps extends AiProviderModelListItem {
   disabled?: boolean;

--- a/src/features/Settings/provider/features/ProviderConfig/Checker.tsx
+++ b/src/features/Settings/provider/features/ProviderConfig/Checker.tsx
@@ -4,7 +4,6 @@ import { CheckCircleFilled } from '@ant-design/icons';
 import { type ChatMessageError } from '@lobechat/types';
 import { TraceNameMap } from '@lobechat/types';
 import { isRecord, pickTrimmedString } from '@lobechat/utils/object';
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Highlighter, Icon } from '@lobehub/ui';
 import { Alert, Button, Select } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -13,6 +12,7 @@ import { type ReactNode } from 'react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { usePermission } from '@/hooks/usePermission';
 import { useProviderName } from '@/hooks/useProviderName';
 import { chatService } from '@/services/chat';

--- a/src/features/Settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
+++ b/src/features/Settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
@@ -19,8 +19,8 @@ import { BrainIcon } from 'lucide-react';
 import { memo, type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ProviderIcon } from '@/components/LobeIcons';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { useAiInfraStore } from '@/store/aiInfra/store';
 import { type AiProviderDetailItem, type UpdateAiProviderParams } from '@/types/aiProvider';
 

--- a/src/features/Settings/provider/features/ProviderConfig/index.tsx
+++ b/src/features/Settings/provider/features/ProviderConfig/index.tsx
@@ -16,9 +16,9 @@ import { Trans, useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
 import { FormInput, FormPassword } from '@/components/FormInput';
+import { ProviderCombine, ProviderIcon } from '@/components/LobeIcons';
 import { SkeletonInput, SkeletonSwitch } from '@/components/Skeleton';
 import { usePermission } from '@/hooks/usePermission';
-import { ProviderCombine, ProviderIcon } from '@/libs/providerIcon';
 import { lambdaQuery } from '@/libs/trpc/client';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';

--- a/src/features/Settings/stats/features/rankings/ModelsRank.tsx
+++ b/src/features/Settings/stats/features/rankings/ModelsRank.tsx
@@ -1,6 +1,5 @@
 import { type ModelRankItem } from '@lobechat/types';
 import { BarList } from '@lobehub/charts';
-import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon } from '@lobehub/ui/base-ui';
 import { MaximizeIcon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -8,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
 import ImperativeModal from '@/components/ImperativeModal';
+import { ModelIcon } from '@/components/LobeIcons';
 import { useClientDataSWR } from '@/libs/swr';
 import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
@@ -1,5 +1,4 @@
 import { CategoryBar, useThemeColorRange } from '@lobehub/charts';
-import { ModelIcon } from '@lobehub/icons';
 import { Collapse, Flexbox } from '@lobehub/ui';
 import { Avatar, Skeleton, Tag } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
@@ -7,7 +6,7 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import InlineTable from '@/components/InlineTable';
-import { ProviderIcon } from '@/libs/providerIcon';
+import { ModelIcon, ProviderIcon } from '@/components/LobeIcons';
 import { type UsageLog, type UsageRecordItem } from '@/types/usage/usageRecord';
 import { formatPrice } from '@/utils/format';
 

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
@@ -10,11 +10,8 @@ import type { UsageLog } from '@/types/usage/usageRecord';
 import { GroupBy } from '../../../../types';
 import ActiveModels from './index';
 
-vi.mock('@lobehub/icons', () => ({
+vi.mock('@/components/LobeIcons', () => ({
   ModelIcon: ({ model }: { model: string }) => <span>{model}</span>,
-}));
-
-vi.mock('@/libs/providerIcon', () => ({
   ProviderIcon: ({ provider }: { provider: string }) => <span>{provider}</span>,
 }));
 

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { ActionIcon, Avatar } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
@@ -7,9 +6,9 @@ import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ImperativeModal from '@/components/ImperativeModal';
+import { ModelIcon, ProviderIcon } from '@/components/LobeIcons';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { type UsageLog } from '@/types/usage/usageRecord';
 import { formatNumber } from '@/utils/format';
 

--- a/src/features/Settings/stats/features/usage/UsageTable.test.tsx
+++ b/src/features/Settings/stats/features/usage/UsageTable.test.tsx
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import UsageTable from './UsageTable';
 
-vi.mock('@/libs/providerIcon', () => ({
+vi.mock('@/components/LobeIcons', () => ({
   ProviderIcon: ({ provider }: { provider: string }) => <span>{provider}</span>,
 }));
 

--- a/src/features/Settings/stats/features/usage/UsageTable.tsx
+++ b/src/features/Settings/stats/features/usage/UsageTable.tsx
@@ -6,11 +6,11 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import InlineTable from '@/components/InlineTable';
+import { ProviderIcon } from '@/components/LobeIcons';
 import SpendType, { type SpendTypeValue } from '@/components/SpendType';
 import TablePagination from '@/components/TablePagination';
 import TotalToken from '@/components/TotalToken';
 import { parseAsInteger, useQueryStates } from '@/hooks/useQueryParam';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { useClientDataSWR } from '@/libs/swr';
 import { statsKeys } from '@/libs/swr/keys';
 import { usageService } from '@/services/usage';

--- a/src/features/ShareModal/ShareImage/Preview.tsx
+++ b/src/features/ShareModal/ShareImage/Preview.tsx
@@ -1,11 +1,11 @@
 import { agentDisplayName, type ConversationContext, type UIChatMessage } from '@lobechat/types';
-import { ModelTag } from '@lobehub/icons';
 import { Flexbox, Markdown } from '@lobehub/ui';
 import { Avatar, Text } from '@lobehub/ui/base-ui';
 import { cx } from 'antd-style';
 import { memo } from 'react';
 
 import { ProductLogo } from '@/components/Branding';
+import { ModelTag } from '@/components/LobeIcons';
 import PluginTag from '@/features/PluginTag';
 import { filterToolIds } from '@/helpers/toolFilters';
 import { useAgentStore } from '@/store/agent';

--- a/src/libs/providerIcon.ts
+++ b/src/libs/providerIcon.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- the lazy wrapper in @/components/LobeIcons is the only importer
 import { ProviderCombine, ProviderIcon, providerMappings, Unsloth } from '@lobehub/icons';
 
 /**

--- a/src/routes/(main)/(create)/components/GenerationModelItem.tsx
+++ b/src/routes/(main)/(create)/components/GenerationModelItem.tsx
@@ -2,7 +2,6 @@
 
 import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { CREDITS_PER_DOLLAR } from '@lobechat/const/currency';
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Popover } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
@@ -11,6 +10,7 @@ import numeral from 'numeral';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import NewModelBadge from '@/components/ModelSelect/NewModelBadge';
 import { useIsDark } from '@/hooks/useIsDark';
 import { useServerConfigStore } from '@/store/serverConfig';

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
@@ -6,10 +6,10 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { ProviderIcon } from '@/components/LobeIcons';
 import BaseErrorForm from '@/features/Conversation/Error/BaseErrorForm';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useProviderName } from '@/hooks/useProviderName';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { type GlobalLLMProviderKey } from '@/types/user/settings/modelProvider';
 
 interface GenerationInvalidAPIKeyProps {

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/BatchItem.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/BatchItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import { ModelIcon } from '@lobehub/icons';
 import { ActionIconGroup, Block, Flexbox, Grid, Image, Markdown } from '@lobehub/ui';
 import { Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -14,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import useRenderBusinessBatchItem from '@/business/client/hooks/useRenderBusinessBatchItem';
+import { ModelIcon } from '@/components/LobeIcons';
 import { GenerationInvalidAPIKey } from '@/routes/(main)/(create)/features/GenerationInput';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useImageStore } from '@/store/image';

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { ActionIcon, Switch, Tabs, Text } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
@@ -9,6 +8,7 @@ import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { loginRequired } from '@/components/Error/loginRequiredNotification';
+import { ModelIcon } from '@/components/LobeIcons';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import PromptTransformAction from '@/features/PromptTransform/PromptTransformAction';

--- a/src/routes/(main)/(create)/video/features/GenerationFeed/BatchItem.tsx
+++ b/src/routes/(main)/(create)/video/features/GenerationFeed/BatchItem.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { ActionIconGroup, Block, Flexbox, Markdown } from '@lobehub/ui';
 import { Tag, Text, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -12,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import useRenderBusinessVideoBatchItem from '@/business/client/hooks/useRenderBusinessVideoBatchItem';
+import { ModelIcon } from '@/components/LobeIcons';
 import { GenerationInvalidAPIKey } from '@/routes/(main)/(create)/features/GenerationInput';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useVideoStore } from '@/store/video';

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, InputNumber } from '@lobehub/ui';
 import { ActionIcon, SliderWithInput, Switch, Tabs, Text } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
@@ -10,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import VideoFreeQuotaInfo from '@/business/client/features/VideoFreeQuotaInfo';
 import { loginRequired } from '@/components/Error/loginRequiredNotification';
+import { ModelIcon } from '@/components/LobeIcons';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import PromptTransformAction from '@/features/PromptTransform/PromptTransformAction';

--- a/src/routes/(main)/community/(detail)/model/features/Details/Overview/ProviderList/index.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Details/Overview/ProviderList/index.tsx
@@ -9,10 +9,10 @@ import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
 import InlineTable from '@/components/InlineTable';
+import { ProviderIcon } from '@/components/LobeIcons';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import { BASE_PROVIDER_DOC_URL } from '@/const/url';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { formatPriceByCurrency, formatTokenNumber } from '@/utils/format';
 import { getTextInputUnitRate, getTextOutputUnitRate } from '@/utils/pricing';
 

--- a/src/routes/(main)/community/(detail)/model/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Header.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Icon } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
@@ -8,6 +7,7 @@ import { DotIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import PublishedTime from '@/components/PublishedTime';
 import ModelTypeIcon from '@/routes/(main)/community/(list)/model/features/List/ModelTypeIcon';

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
@@ -7,9 +7,9 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { ProviderIcon } from '@/components/LobeIcons';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
-import { ProviderIcon } from '@/libs/providerIcon';
 
 import { useDetailContext } from '../../DetailProvider';
 

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 import urlJoin from 'url-join';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { OFFICIAL_URL } from '@/const/url';
 
 import ShareButton from '../../../../features/ShareButton';

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx
@@ -1,10 +1,10 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { type DiscoverModelItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
@@ -4,7 +4,7 @@ import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ProviderIcon } from '@/libs/providerIcon';
+import { ProviderIcon } from '@/components/LobeIcons';
 import { type DiscoverModelDetailProviderItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {

--- a/src/routes/(main)/community/(detail)/provider/features/Details/Overview/ModelList/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Details/Overview/ModelList/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { ActionIcon } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
@@ -10,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
 import InlineTable from '@/components/InlineTable';
+import { ModelIcon } from '@/components/LobeIcons';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { formatPriceByCurrency, formatTokenNumber } from '@/utils/format';

--- a/src/routes/(main)/community/(detail)/provider/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Header.tsx
@@ -9,7 +9,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
-import { ProviderCombine } from '@/libs/providerIcon';
+import { ProviderCombine } from '@/components/LobeIcons';
 
 import { useDetailContext } from './DetailProvider';
 

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { ModelTag } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { Tag } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { ModelTag, ProviderIcon } from '@/components/LobeIcons';
 import { OFFICIAL_URL } from '@/const/url';
-import { ProviderIcon } from '@/libs/providerIcon';
 
 import ShareButton from '../../../../features/ShareButton';
 import { useDetailContext } from '../../DetailProvider';

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
@@ -4,7 +4,7 @@ import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ProviderIcon } from '@/libs/providerIcon';
+import { ProviderIcon } from '@/components/LobeIcons';
 import { type DiscoverProviderItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
@@ -1,10 +1,10 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ModelIcon } from '@/components/LobeIcons';
 import { type DiscoverProviderDetailModelItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {

--- a/src/routes/(main)/community/(list)/model/features/Category/useCategory.tsx
+++ b/src/routes/(main)/community/(list)/model/features/Category/useCategory.tsx
@@ -4,7 +4,7 @@ import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ProviderIcon } from '@/libs/providerIcon';
+import { ProviderIcon } from '@/components/LobeIcons';
 
 export const useCategory = () => {
   const { t } = useTranslation('discover');

--- a/src/routes/(main)/community/(list)/model/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/model/features/List/Item.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox, Icon, Popover } from '@lobehub/ui';
 import { Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -10,11 +9,11 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { ModelIcon, ProviderIcon } from '@/components/LobeIcons';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import PublishedTime from '@/components/PublishedTime';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
-import { ProviderIcon } from '@/libs/providerIcon';
 import { type DiscoverModelItem } from '@/types/discover';
 
 import ModelTypeIcon from './ModelTypeIcon';

--- a/src/routes/(main)/community/(list)/provider/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/provider/features/List/Item.tsx
@@ -1,4 +1,4 @@
-import { Github, ModelTag } from '@lobehub/icons';
+import { Github } from '@lobehub/icons';
 import { Block, Flexbox, MaskShadow, stopPropagation } from '@lobehub/ui';
 import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -7,10 +7,10 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { ModelTag, ProviderCombine } from '@/components/LobeIcons';
 import { GITHUB } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
-import { ProviderCombine } from '@/libs/providerIcon';
 import { type DiscoverProviderItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {


### PR DESCRIPTION
Fourth slice of the first-screen work from #19161, redone from `canary` as an independent PR. This one targets the first navigation (main layout + home route) rather than the entry chunk.

`ModelIcon` / `ProviderIcon` / `ModelTag` / `ProviderCombine` from `@lobehub/icons` statically import every brand icon (~3 MB raw, 202 KB gzip), and `@lobehub/ui`'s `EmojiPicker` carries the emoji-mart dataset (~600 KB raw, 107 KB gzip). Any route rendering one of them paid for the whole set inside its closure; the home route did through `Home/NewModelShortcuts` and the avatar editor reached from the sidebar's create menu.

- `src/components/LobeIcons/index.tsx` wraps the four features in `lazy()` with a size-matched `Skeleton` fallback; all 46 call sites import from it (the `@/libs/providerIcon` Unsloth shim stays and is loaded through the same `import()`).
- `src/components/EmojiPicker` mounts `@lobehub/ui/es/EmojiPicker/index` through `lazy()`.
- `eslint.config.mjs`: `no-restricted-imports` across `src/**` for the four `@lobehub/icons` features, `@/libs/providerIcon`, and `EmojiPicker` from `@lobehub/ui`, pointing at the wrappers.
- Three tests that mocked `@lobehub/icons` / `@/libs/providerIcon` now mock `@/components/LobeIcons`.

Web production `vite build` on top of current `canary` (without #19288 / #19289 / #19291), chunk closure walked from the built graph (`chunk.imports`, eager chunks excluded from the route closure):

| | before | after |
| --- | --- | --- |
| first screen (entry + static imports) | 80 chunks / 2398 KB gzip | 80 / 2398 KB (unchanged) |
| home route closure (main layout + home page) | 200 chunks / 2103 KB gzip | 195 / 1630 KB |
| brand icon catalog in home closure | `ModelIcon-*.js` 202 KB | absent |
| emoji-mart in home closure | 107 KB | absent |

The catalog and the emoji dataset now load as shared chunks the first time an icon / picker mounts.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check` on the changed files (lint + related tests), full `bun run check --type`, and the production web build.

#### 🔗 Related Issue

Related to LOBE-13719. Supersedes part of #19161.

https://claude.ai/code/session_01QKr8CsFLYmrgqbRTSipTNH