### PR TITLE
⚡️ perf(home): cut the first navigation's closure in half

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -165,6 +165,12 @@ export default eslint(
       'src/spa/**/*.{ts,tsx}',
       'src/store/**/*.{ts,tsx}',
       'src/utils/**/*.{ts,tsx}',
+      // The main layout and the home route are the first navigation's closure.
+      'src/routes/**/_layout/**/*.{ts,tsx}',
+      'src/routes/(main)/home/**/*.{ts,tsx}',
+      'src/features/Home/**/*.{ts,tsx}',
+      'src/features/HomeSidebar/**/*.{ts,tsx}',
+      'src/features/NavPanel/**/*.{ts,tsx}',
     ],
     ignores: ['src/**/*.test.{ts,tsx}', 'src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx'],
     rules: {

--- a/src/components/ChangelogModal/index.tsx
+++ b/src/components/ChangelogModal/index.tsx
@@ -3,14 +3,19 @@
 import { createModal } from '@lobehub/ui/base-ui';
 import { t } from 'i18next';
 import { ArrowUpRightIcon } from 'lucide-react';
+import { lazy, Suspense } from 'react';
 
 import { CHANGELOG_URL } from '@/const/url';
 
-import ChangelogModalContent from './ChangelogModalContent';
+const ChangelogModalContent = lazy(() => import('./ChangelogModalContent'));
 
 export const openChangelogModal = () =>
   createModal({
-    content: <ChangelogModalContent />,
+    content: (
+      <Suspense fallback={null}>
+        <ChangelogModalContent />
+      </Suspense>
+    ),
     footer: null,
     maskClosable: true,
     styles: {

--- a/src/components/ErrorBoundary/AlertFallback.tsx
+++ b/src/components/ErrorBoundary/AlertFallback.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Highlighter } from '@lobehub/ui';
 import { Alert } from '@lobehub/ui/base-ui';
-import { memo } from 'react';
+import { lazy, memo, Suspense } from 'react';
+
+const Highlighter = lazy(() => import('@lobehub/ui/es/Highlighter/index'));
 
 interface AlertFallbackProps {
   error: Error;
@@ -22,9 +23,16 @@ const AlertFallback = memo<AlertFallbackProps>(({ error, resetErrorBoundary, tit
       type="secondary"
       extra={
         error?.stack ? (
-          <Highlighter actionIconSize="small" language="plaintext" padding={8} variant="borderless">
-            {error.stack}
-          </Highlighter>
+          <Suspense fallback={null}>
+            <Highlighter
+              actionIconSize="small"
+              language="plaintext"
+              padding={8}
+              variant="borderless"
+            >
+              {error.stack}
+            </Highlighter>
+          </Suspense>
         ) : undefined
       }
       onClose={resetErrorBoundary}

--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -3,7 +3,7 @@ import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Button, Text, toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Check, SquarePen, Workflow } from 'lucide-react';
-import { memo, useCallback, useState } from 'react';
+import { lazy, memo, Suspense, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
 
@@ -11,8 +11,9 @@ import { useBriefStore } from '@/store/brief';
 import { useTaskStore } from '@/store/task';
 
 import { BriefActionLink } from './BriefActionLink';
-import CommentInput from './CommentInput';
 import { styles } from './style';
+
+const CommentInput = lazy(() => import('./CommentInput'));
 
 export interface BriefCardActionsProps {
   /** Brief actions from the brief payload — falls back to DEFAULT_BRIEF_ACTIONS by type. */
@@ -241,7 +242,11 @@ const BriefCardActions = memo<BriefCardActionsProps>(
       );
     }
     if (commentMode) {
-      return <CommentInput onCancel={() => setCommentMode(null)} onSubmit={handleCommentSubmit} />;
+      return (
+        <Suspense fallback={null}>
+          <CommentInput onCancel={() => setCommentMode(null)} onSubmit={handleCommentSubmit} />
+        </Suspense>
+      );
     }
 
     const commentActions = actions.find((a) => a.type === 'comment');

--- a/src/features/DailyBrief/BriefCardSummary.tsx
+++ b/src/features/DailyBrief/BriefCardSummary.tsx
@@ -1,11 +1,13 @@
-import { Flexbox, Markdown, MaskShadow } from '@lobehub/ui';
+import { Flexbox, MaskShadow } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { useSize } from 'ahooks';
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from 'lucide-react';
-import { memo, useEffect, useRef, useState } from 'react';
+import { lazy, memo, Suspense, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from './style';
+
+const Markdown = lazy(() => import('@lobehub/ui/es/Markdown/index'));
 
 export const COLLAPSED_MAX_HEIGHT = 180;
 
@@ -26,9 +28,11 @@ const BriefCardSummary = memo<BriefCardSummaryProps>(({ summary }) => {
   }, [size]);
 
   const content = (
-    <Markdown ref={ref} style={{ overflow: 'unset' }} variant={'chat'}>
-      {summary}
-    </Markdown>
+    <Suspense fallback={null}>
+      <Markdown ref={ref} style={{ overflow: 'unset' }} variant={'chat'}>
+        {summary}
+      </Markdown>
+    </Suspense>
   );
 
   return (

--- a/src/features/DailyBrief/BriefCardSummary.tsx
+++ b/src/features/DailyBrief/BriefCardSummary.tsx
@@ -27,12 +27,16 @@ const BriefCardSummary = memo<BriefCardSummaryProps>(({ summary }) => {
     setIsOverflow(size.height > COLLAPSED_MAX_HEIGHT);
   }, [size]);
 
+  // The ref must land on an eagerly mounted element: while Markdown suspends,
+  // the boundary renders its fallback and useSize would never observe it.
   const content = (
-    <Suspense fallback={null}>
-      <Markdown ref={ref} style={{ overflow: 'unset' }} variant={'chat'}>
-        {summary}
-      </Markdown>
-    </Suspense>
+    <div ref={ref}>
+      <Suspense fallback={null}>
+        <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
+          {summary}
+        </Markdown>
+      </Suspense>
+    </div>
   );
 
   return (

--- a/src/features/DailyBrief/__tests__/BriefCardSummary.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardSummary.test.tsx
@@ -21,10 +21,12 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('BriefCardSummary', () => {
-  it('should render summary text', () => {
+  it('should render summary text', async () => {
     vi.mocked(useSize).mockReturnValue(undefined);
     render(<BriefCardSummary summary="Test summary content" />);
-    expect(screen.getByText('Test summary content')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Test summary content', {}, { timeout: 10_000 }),
+    ).toBeInTheDocument();
   });
 
   it('should not show expand link when content does not overflow', () => {

--- a/src/features/DailyBrief/__tests__/BriefCardSummary.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardSummary.test.tsx
@@ -29,6 +29,14 @@ describe('BriefCardSummary', () => {
     ).toBeInTheDocument();
   });
 
+  it('measures an eagerly mounted wrapper so the lazy markdown is observed', () => {
+    vi.mocked(useSize).mockReturnValue(undefined);
+    render(<BriefCardSummary summary="Test summary content" />);
+
+    const ref = vi.mocked(useSize).mock.calls.at(-1)![0] as { current: HTMLElement | null };
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
   it('should not show expand link when content does not overflow', () => {
     vi.mocked(useSize).mockReturnValue({ height: COLLAPSED_MAX_HEIGHT - 10, width: 100 });
     render(<BriefCardSummary summary="Short" />);

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -6,7 +6,6 @@ import { lazy, memo, Suspense, useCallback, useEffect, useState } from 'react';
 
 import { useHomeUsageWidgetActive } from '@/business/client/features/HomeUsageWidget';
 import { useHomePromoLine } from '@/business/client/features/useHomePromoLine';
-import HomeInbox from '@/features/HomeInbox';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -61,6 +60,9 @@ const clearOnboardingHomeModeParam = () => {
 // actually opened.
 const TopicChatDrawer = lazy(() => import('@/features/AgentTasks/AgentTaskDetail/TopicChatDrawer'));
 const AcceptancePortalDrawer = lazy(() => import('./AcceptancePortalDrawer'));
+// The inbox renders markdown, briefs and an editor; keeping it lazy leaves the
+// greeting and the input box as the only static content of the home route.
+const HomeInbox = lazy(() => import('@/features/HomeInbox'));
 
 /** Trailing gutter that keeps the rail's cards off the page's scroll lane. */
 const RAIL_GUTTER = 14;
@@ -442,7 +444,9 @@ const Home = memo(() => {
           id={'home-rail'}
           inert={railCollapsed}
         >
-          <HomeInbox {...RAIL_INBOX_PROPS} variant={'rail'} />
+          <Suspense fallback={null}>
+            <HomeInbox {...RAIL_INBOX_PROPS} variant={'rail'} />
+          </Suspense>
         </aside>
       )}
 

--- a/src/features/HomeInbox/NewsList.tsx
+++ b/src/features/HomeInbox/NewsList.tsx
@@ -1,9 +1,9 @@
 import { agentDisplayName } from '@lobechat/types';
-import { Flexbox, Icon, Markdown } from '@lobehub/ui';
+import { Flexbox, Icon } from '@lobehub/ui';
 import { Avatar, Button, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
-import { memo, useCallback, useState } from 'react';
+import { lazy, memo, Suspense, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import BriefCardArtifacts from '@/features/DailyBrief/BriefCardArtifacts';
@@ -12,6 +12,8 @@ import { type BriefItem } from '@/features/DailyBrief/types';
 import { homeType } from '@/features/Home/components/homeType';
 import Time from '@/features/Home/components/Time';
 import { useBriefStore } from '@/store/brief';
+
+const Markdown = lazy(() => import('@lobehub/ui/es/Markdown/index'));
 
 const AVATAR_SIZE = 20;
 const ROW_GAP = 10;
@@ -143,9 +145,11 @@ const NewsItem = memo<NewsItemProps>(({ bare, brief, showTime }) => {
       {expanded && (brief.summary || brief.artifacts) && (
         <Flexbox className={bare ? styles.bareBody : styles.body} gap={8}>
           {brief.summary && (
-            <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
-              {brief.summary}
-            </Markdown>
+            <Suspense fallback={null}>
+              <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
+                {brief.summary}
+              </Markdown>
+            </Suspense>
           )}
           <BriefCardArtifacts artifacts={brief.artifacts} />
         </Flexbox>

--- a/src/features/HomeInbox/UnreadTopicList.tsx
+++ b/src/features/HomeInbox/UnreadTopicList.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 
 import UnreadDot from '@/components/UnreadDot';
 import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
-import MarkdownMessage from '@/features/Conversation/Markdown';
 import { homeType } from '@/features/Home/components/homeType';
 import Time from '@/features/Home/components/Time';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -20,6 +19,8 @@ import AuthorChip from './AuthorChip';
 import { sanitizeInboxPreview } from './sanitizeInboxPreview';
 import { useHomeInboxMarkdown } from './useHomeInboxMarkdown';
 import { type InboxTopic } from './useHomeInboxTopics';
+
+const MarkdownMessage = lazy(() => import('@/features/Conversation/Markdown'));
 
 const DOT_WIDTH = 14;
 const ROW_GAP = 8;
@@ -209,9 +210,11 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
         {expanded && (
           <Flexbox className={bare ? styles.bareBody : styles.body} gap={8}>
             {assistantPreview && (
-              <MarkdownMessage {...markdownProps} style={{ overflow: 'unset' }}>
-                {assistantPreview}
-              </MarkdownMessage>
+              <Suspense fallback={null}>
+                <MarkdownMessage {...markdownProps} style={{ overflow: 'unset' }}>
+                  {assistantPreview}
+                </MarkdownMessage>
+              </Suspense>
             )}
 
             {replying ? (

--- a/src/features/HomeSidebar/Header/components/InboxModal/NotificationDetailModal.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxModal/NotificationDetailModal.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { Flexbox, Markdown } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
 import { Button, createModal, Text, useModalContext } from '@lobehub/ui/base-ui';
 import dayjs from 'dayjs';
-import { memo } from 'react';
+import { lazy, memo, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const Markdown = lazy(() => import('@lobehub/ui/es/Markdown/index'));
 
 interface NotificationDetailParams {
   content: string;
@@ -29,9 +31,11 @@ const NotificationDetailContent = memo<Omit<NotificationDetailParams, 'title'>>(
             {context}
           </Text>
         )}
-        <Markdown fontSize={14} variant={'chat'}>
-          {content}
-        </Markdown>
+        <Suspense fallback={null}>
+          <Markdown fontSize={14} variant={'chat'}>
+            {content}
+          </Markdown>
+        </Suspense>
         {onAction && (
           <Flexbox horizontal justify="flex-end">
             <Button

--- a/src/features/HomeSidebar/hooks/useProjectMenuItems.tsx
+++ b/src/features/HomeSidebar/hooks/useProjectMenuItems.tsx
@@ -4,7 +4,7 @@ import { BoxIcon } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useCreateNewModal } from '@/features/LibraryModal';
+import { useCreateNewModal } from '@/features/LibraryModal/CreateNew';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 
 /**

--- a/src/features/Projects/CreateProjectContent.tsx
+++ b/src/features/Projects/CreateProjectContent.tsx
@@ -1,0 +1,157 @@
+import { Flexbox, Input } from '@lobehub/ui';
+import { Button, ModalFooter, Text, toast, useModalContext } from '@lobehub/ui/base-ui';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { type ProjectListItem, useProjectStore } from '@/store/project';
+
+import {
+  getCreateProjectInput,
+  getProjectFieldSuggestions,
+  isProjectIdentifierValid,
+  isProjectSlugValid,
+} from './createProjectForm';
+
+export interface CreateProjectOptions {
+  /**
+   * Handle the created project instead of opening it. Callers that create a
+   * project as a step of another action (filing a delivery under a new one)
+   * must not have the user navigated away from what they were doing.
+   */
+  onCreated?: (project: ProjectListItem) => void;
+}
+
+interface CreateProjectFormState {
+  identifier: string;
+  identifierEdited: boolean;
+  loading: boolean;
+  name: string;
+  slug: string;
+  slugEdited: boolean;
+}
+
+export const CreateProjectTitle = memo(() => {
+  const { t } = useTranslation('project');
+
+  return t('create.title');
+});
+
+const CreateProjectContent = memo<CreateProjectOptions>(({ onCreated }) => {
+  const { t } = useTranslation(['project', 'common']);
+  const { close } = useModalContext();
+  const navigate = useWorkspaceAwareNavigate();
+  const createProject = useProjectStore((s) => s.createProject);
+  const [form, setForm] = useState<CreateProjectFormState>({
+    identifier: '',
+    identifierEdited: false,
+    loading: false,
+    name: '',
+    slug: '',
+    slugEdited: false,
+  });
+  const createInput = getCreateProjectInput(form);
+  const identifierValid = isProjectIdentifierValid(form.identifier);
+  const identifierInvalid =
+    (form.identifierEdited || Boolean(form.name.trim())) && !identifierValid;
+  const slugValid = isProjectSlugValid(form.slug);
+
+  const updateForm = (patch: Partial<CreateProjectFormState>) => {
+    setForm((current) => ({ ...current, ...patch }));
+  };
+
+  const updateName = (name: string) => {
+    const suggestions = getProjectFieldSuggestions(name);
+    setForm((current) => ({
+      ...current,
+      identifier: current.identifierEdited ? current.identifier : suggestions.identifier,
+      name,
+      slug: current.slugEdited ? current.slug : suggestions.slug,
+    }));
+  };
+
+  const handleCreate = async () => {
+    if (!createInput || form.loading) return;
+    updateForm({ loading: true });
+    try {
+      const project = await createProject(createInput);
+      close();
+      if (onCreated) onCreated(project);
+      else navigate(`/project/${project.slug ?? project.id}`);
+    } catch (error) {
+      console.error('Failed to create project', error);
+      toast.error(t('operationFailed', { ns: 'common' }));
+    } finally {
+      updateForm({ loading: false });
+    }
+  };
+
+  return (
+    <>
+      <Flexbox gap={16} padding={16}>
+        <Flexbox gap={6}>
+          <Text fontSize={13} weight={500}>
+            {t('create.nameLabel')}
+          </Text>
+          <Input
+            autoFocus
+            maxLength={255}
+            placeholder={t('create.namePlaceholder')}
+            value={form.name}
+            onChange={(event) => updateName(event.target.value)}
+            onPressEnter={handleCreate}
+          />
+        </Flexbox>
+        <Flexbox gap={6}>
+          <Text fontSize={13} weight={500}>
+            {t('create.identifierLabel')}
+          </Text>
+          <Input
+            maxLength={6}
+            placeholder={t('create.identifierPlaceholder')}
+            status={identifierInvalid ? 'error' : undefined}
+            value={form.identifier}
+            onPressEnter={handleCreate}
+            onChange={(event) =>
+              updateForm({ identifier: event.target.value.toUpperCase(), identifierEdited: true })
+            }
+          />
+          <Text fontSize={12} type={identifierInvalid ? 'danger' : 'secondary'}>
+            {t(identifierInvalid ? 'create.identifierInvalid' : 'create.identifierDescription')}
+          </Text>
+        </Flexbox>
+        <Flexbox gap={6}>
+          <Text fontSize={13} weight={500}>
+            {t('create.slugLabel')}
+          </Text>
+          <Input
+            maxLength={100}
+            placeholder={t('create.slugPlaceholder')}
+            status={slugValid ? undefined : 'error'}
+            value={form.slug}
+            onPressEnter={handleCreate}
+            onChange={(event) =>
+              updateForm({ slug: event.target.value.toLowerCase(), slugEdited: true })
+            }
+          />
+          <Text fontSize={12} type={slugValid ? 'secondary' : 'danger'}>
+            {t(slugValid ? 'create.slugDescription' : 'create.slugInvalid')}
+          </Text>
+        </Flexbox>
+      </Flexbox>
+      <ModalFooter>
+        <Button onClick={close}>{t('cancel', { ns: 'common' })}</Button>
+        <Button
+          disabled={!createInput}
+          loading={form.loading}
+          type="primary"
+          onClick={handleCreate}
+        >
+          {t('create.action')}
+        </Button>
+      </ModalFooter>
+    </>
+  );
+});
+
+export default CreateProjectContent;

--- a/src/features/Projects/CreateProjectModal.tsx
+++ b/src/features/Projects/CreateProjectModal.tsx
@@ -1,171 +1,26 @@
-import { Flexbox, Input } from '@lobehub/ui';
-import {
-  Button,
-  createModal,
-  ModalFooter,
-  Text,
-  toast,
-  useModalContext,
-} from '@lobehub/ui/base-ui';
-import { memo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { createModal } from '@lobehub/ui/base-ui';
+import { lazy, Suspense } from 'react';
 
-import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
-import { type ProjectListItem, useProjectStore } from '@/store/project';
+import type { CreateProjectOptions } from './CreateProjectContent';
 
-import {
-  getCreateProjectInput,
-  getProjectFieldSuggestions,
-  isProjectIdentifierValid,
-  isProjectSlugValid,
-} from './createProjectForm';
-
-interface CreateProjectOptions {
-  /**
-   * Handle the created project instead of opening it. Callers that create a
-   * project as a step of another action (filing a delivery under a new one)
-   * must not have the user navigated away from what they were doing.
-   */
-  onCreated?: (project: ProjectListItem) => void;
-}
-
-interface CreateProjectFormState {
-  identifier: string;
-  identifierEdited: boolean;
-  loading: boolean;
-  name: string;
-  slug: string;
-  slugEdited: boolean;
-}
-
-const CreateProjectTitle = memo(() => {
-  const { t } = useTranslation('project');
-
-  return t('create.title');
-});
-
-const CreateProjectContent = memo<CreateProjectOptions>(({ onCreated }) => {
-  const { t } = useTranslation(['project', 'common']);
-  const { close } = useModalContext();
-  const navigate = useWorkspaceAwareNavigate();
-  const createProject = useProjectStore((s) => s.createProject);
-  const [form, setForm] = useState<CreateProjectFormState>({
-    identifier: '',
-    identifierEdited: false,
-    loading: false,
-    name: '',
-    slug: '',
-    slugEdited: false,
-  });
-  const createInput = getCreateProjectInput(form);
-  const identifierValid = isProjectIdentifierValid(form.identifier);
-  const identifierInvalid =
-    (form.identifierEdited || Boolean(form.name.trim())) && !identifierValid;
-  const slugValid = isProjectSlugValid(form.slug);
-
-  const updateForm = (patch: Partial<CreateProjectFormState>) => {
-    setForm((current) => ({ ...current, ...patch }));
-  };
-
-  const updateName = (name: string) => {
-    const suggestions = getProjectFieldSuggestions(name);
-    setForm((current) => ({
-      ...current,
-      identifier: current.identifierEdited ? current.identifier : suggestions.identifier,
-      name,
-      slug: current.slugEdited ? current.slug : suggestions.slug,
-    }));
-  };
-
-  const handleCreate = async () => {
-    if (!createInput || form.loading) return;
-    updateForm({ loading: true });
-    try {
-      const project = await createProject(createInput);
-      close();
-      if (onCreated) onCreated(project);
-      else navigate(`/project/${project.slug ?? project.id}`);
-    } catch (error) {
-      console.error('Failed to create project', error);
-      toast.error(t('operationFailed', { ns: 'common' }));
-    } finally {
-      updateForm({ loading: false });
-    }
-  };
-
-  return (
-    <>
-      <Flexbox gap={16} padding={16}>
-        <Flexbox gap={6}>
-          <Text fontSize={13} weight={500}>
-            {t('create.nameLabel')}
-          </Text>
-          <Input
-            autoFocus
-            maxLength={255}
-            placeholder={t('create.namePlaceholder')}
-            value={form.name}
-            onChange={(event) => updateName(event.target.value)}
-            onPressEnter={handleCreate}
-          />
-        </Flexbox>
-        <Flexbox gap={6}>
-          <Text fontSize={13} weight={500}>
-            {t('create.identifierLabel')}
-          </Text>
-          <Input
-            maxLength={6}
-            placeholder={t('create.identifierPlaceholder')}
-            status={identifierInvalid ? 'error' : undefined}
-            value={form.identifier}
-            onPressEnter={handleCreate}
-            onChange={(event) =>
-              updateForm({ identifier: event.target.value.toUpperCase(), identifierEdited: true })
-            }
-          />
-          <Text fontSize={12} type={identifierInvalid ? 'danger' : 'secondary'}>
-            {t(identifierInvalid ? 'create.identifierInvalid' : 'create.identifierDescription')}
-          </Text>
-        </Flexbox>
-        <Flexbox gap={6}>
-          <Text fontSize={13} weight={500}>
-            {t('create.slugLabel')}
-          </Text>
-          <Input
-            maxLength={100}
-            placeholder={t('create.slugPlaceholder')}
-            status={slugValid ? undefined : 'error'}
-            value={form.slug}
-            onPressEnter={handleCreate}
-            onChange={(event) =>
-              updateForm({ slug: event.target.value.toLowerCase(), slugEdited: true })
-            }
-          />
-          <Text fontSize={12} type={slugValid ? 'secondary' : 'danger'}>
-            {t(slugValid ? 'create.slugDescription' : 'create.slugInvalid')}
-          </Text>
-        </Flexbox>
-      </Flexbox>
-      <ModalFooter>
-        <Button onClick={close}>{t('cancel', { ns: 'common' })}</Button>
-        <Button
-          disabled={!createInput}
-          loading={form.loading}
-          type="primary"
-          onClick={handleCreate}
-        >
-          {t('create.action')}
-        </Button>
-      </ModalFooter>
-    </>
-  );
-});
+const CreateProjectContent = lazy(() => import('./CreateProjectContent'));
+const CreateProjectTitle = lazy(() =>
+  import('./CreateProjectContent').then((m) => ({ default: m.CreateProjectTitle })),
+);
 
 export const openCreateProjectModal = (options: CreateProjectOptions = {}) =>
   createModal({
-    content: <CreateProjectContent {...options} />,
+    content: (
+      <Suspense fallback={null}>
+        <CreateProjectContent {...options} />
+      </Suspense>
+    ),
     footer: null,
     styles: { content: { padding: 0 } },
-    title: <CreateProjectTitle />,
+    title: (
+      <Suspense fallback={null}>
+        <CreateProjectTitle />
+      </Suspense>
+    ),
     width: 460,
   });

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -15,7 +15,6 @@ import { RECOMMENDATION_ICON_SIZE } from '@/features/Recommendations/iconSize';
 import { ConnectorAuthRow } from './ConnectorAuthRow';
 import { resolveTemplateIcon } from './resolveTemplateIcon';
 import { styles } from './style';
-import { createTaskTemplateDetailModal } from './TaskTemplateDetailModal';
 import { INTEREST_ICON_MAP, TemplateBriefIcon } from './TemplateBriefIcon';
 import { useScheduleText } from './useScheduleText';
 import { useTaskTemplateCreate } from './useTaskTemplateCreate';
@@ -60,7 +59,9 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(
     );
 
     const handleOpenDetail = useCallback(() => {
-      createTaskTemplateDetailModal({ onCreated, template });
+      void import('./TaskTemplateDetailModal').then(({ createTaskTemplateDetailModal }) =>
+        createTaskTemplateDetailModal({ onCreated, template }),
+      );
     }, [onCreated, template]);
 
     const handlePrimaryClick = useCallback(

--- a/src/features/ResourceManager/DndContextWrapper.tsx
+++ b/src/features/ResourceManager/DndContextWrapper.tsx
@@ -6,15 +6,16 @@ import { toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { FileText, FolderIcon } from 'lucide-react';
 import { type PropsWithChildren } from 'react';
-import { createContext, memo, use, useEffect, useRef, useState } from 'react';
+import { createContext, lazy, memo, Suspense, use, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
-import FileIcon from '@/components/FileIcon';
 import { usePermission } from '@/hooks/usePermission';
 import { useTreeStore } from '@/store/tree';
 
 import { useResourceManagerStore } from './store';
+
+const FileIcon = lazy(() => import('@/components/FileIcon'));
 
 /**
  * Pre-create a transparent 1x1 pixel image for drag operations
@@ -279,11 +280,13 @@ export const DndContextWrapper = memo<PropsWithChildren>(({ children }) => {
                     ) : currentDrag.data.fileType === CUSTOM_DOCUMENT_FILE_TYPE ? (
                       <Icon icon={FileText} size={20} />
                     ) : (
-                      <FileIcon
-                        fileName={currentDrag.data.name}
-                        fileType={currentDrag.data.fileType}
-                        size={20}
-                      />
+                      <Suspense fallback={null}>
+                        <FileIcon
+                          fileName={currentDrag.data.name}
+                          fileType={currentDrag.data.fileType}
+                          size={20}
+                        />
+                      </Suspense>
                     )}
                   </div>
                   <span

--- a/src/hooks/useInterceptingRoutes.test.ts
+++ b/src/hooks/useInterceptingRoutes.test.ts
@@ -44,7 +44,7 @@ describe('useOpenChatSettings', () => {
     expect(mockNavigate).toHaveBeenCalledWith(`/agent/123/settings?showMobileWorkspace=true`);
   });
 
-  it('opens desktop agent settings overlay when not on mobile', () => {
+  it('opens desktop agent settings overlay when not on mobile', async () => {
     useAgentStore.setState({ activeAgentId: '456' });
     vi.mocked(useIsMobile).mockReturnValue(false);
 
@@ -54,7 +54,7 @@ describe('useOpenChatSettings', () => {
       result.current();
     });
 
-    expect(openAgentSettingsModal).toHaveBeenCalled();
+    await vi.waitFor(() => expect(openAgentSettingsModal).toHaveBeenCalled());
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useInterceptingRoutes.ts
+++ b/src/hooks/useInterceptingRoutes.ts
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { openAgentSettingsModal } from '@/routes/(main)/agent/profile/features/AgentSettings';
 import { useAgentStore } from '@/store/agent';
 import { ChatSettingsTabs } from '@/store/global/initialState';
 
@@ -19,7 +18,9 @@ export const useOpenChatSettings = (tab: ChatSettingsTabs = ChatSettingsTabs.Ope
       return () => navigate(`/agent/${activeAgentId}/settings?showMobileWorkspace=true`);
 
     return () => {
-      openAgentSettingsModal();
+      void import('@/routes/(main)/agent/profile/features/AgentSettings').then((m) =>
+        m.openAgentSettingsModal(),
+      );
     };
   }, [activeAgentId, navigate, location.pathname, tab, isMobile]);
 };

--- a/src/routes/(main)/_layout/index.tsx
+++ b/src/routes/(main)/_layout/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { HotkeyScopeEnum } from '@lobechat/const/hotkeys';
-import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { Flexbox } from '@lobehub/ui';
 import { cx } from 'antd-style';
 import { type FC } from 'react';
@@ -13,17 +12,8 @@ import WorkspaceContextSlot from '@/business/client/WorkspaceContextSlot';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import { isDesktop } from '@/const/version';
 import { BANNER_HEIGHT } from '@/features/AlertBanner/CloudBanner';
-import DesktopBrowserGatewayBridge from '@/features/DesktopBrowserGatewayBridge';
-import DesktopFileMenuBridge from '@/features/DesktopFileMenuBridge';
 import DesktopLayoutContainer from '@/features/DesktopLayoutContainer';
-import DesktopNavigationBridge from '@/features/DesktopNavigationBridge';
 import AuthRequiredModal from '@/features/Electron/AuthRequiredModal';
-import OverlayCaptureUploader from '@/features/Electron/ScreenCapture/OverlayCaptureUploader';
-import OverlayMessageDispatcher from '@/features/Electron/ScreenCapture/OverlayMessageDispatcher';
-import OverlaySnapshotPublisher from '@/features/Electron/ScreenCapture/OverlaySnapshotPublisher';
-import ZoomHUD from '@/features/Electron/system/ZoomHUD';
-import TabCacheBridges from '@/features/Electron/titlebar/TabBar/TabCacheBridges';
-import TitleBar from '@/features/Electron/titlebar/TitleBar';
 import HotkeyHelperPanel from '@/features/HotkeyHelperPanel';
 import NavPanelShell from '@/features/NavPanel/Shell';
 import { DndContextWrapper } from '@/features/ResourceManager/DndContextWrapper';
@@ -42,6 +32,9 @@ import { styles } from './style';
 const CloudBanner = dynamic(() => import('@/features/AlertBanner/CloudBanner'));
 const GlobalApprovalNotification = dynamic(() => import('@/features/GlobalApprovalNotification'));
 
+// The Electron shell (title bar, tab bridges, overlays, zoom HUD) lives in
+// index.desktop.tsx; only the auth recovery pair stays here so a desktop build
+// that falls back to this layout can still re-login.
 const Layout: FC = () => {
   const { isPWA } = usePlatform();
   const { showCloudPromotion } = useServerConfigStore(featureFlagsSelectors);
@@ -52,31 +45,13 @@ const Layout: FC = () => {
       {isDesktop && <AuthRequiredModal />}
       <WorkspaceContextSlot>
         <RouteMetaBridge />
-        {isDesktop && <TabCacheBridges />}
-        <Suspense fallback={null}>
-          {isDesktop && <DesktopNavigationBridge />}
-          {isDesktop && <DesktopFileMenuBridge />}
-          {isDesktop && <DesktopBrowserGatewayBridge />}
-          {isDesktop && <OverlaySnapshotPublisher />}
-          {isDesktop && <OverlayCaptureUploader />}
-          {isDesktop && <OverlayMessageDispatcher />}
-          {showCloudPromotion && <CloudBanner />}
-        </Suspense>
-        {isDesktop && <ZoomHUD />}
-
-        <Suspense fallback={null}>{isDesktop && <TitleBar />}</Suspense>
+        <Suspense fallback={null}>{showCloudPromotion && <CloudBanner />}</Suspense>
         <DndContextWrapper>
           <Flexbox
             horizontal
             className={cx(isPWA ? styles.mainContainerPWA : styles.mainContainer)}
+            height={showCloudPromotion ? `calc(100% - ${BANNER_HEIGHT}px)` : '100%'}
             width={'100%'}
-            height={
-              isDesktop
-                ? `calc(100% - ${TITLE_BAR_HEIGHT}px)`
-                : showCloudPromotion
-                  ? `calc(100% - ${BANNER_HEIGHT}px)`
-                  : '100%'
-            }
           >
             <NavPanelShell />
             <DesktopLayoutContainer>


### PR DESCRIPTION
Seventh slice of the first-screen work from #19161, redone from `canary` as an independent PR. Target: the first navigation's closure (main layout + home page, everything the shell has to download after the entry before the home screen renders).

- **Web main layout**: `src/routes/(main)/_layout/index.tsx` statically mounted every Electron-only feature behind `isDesktop &&` (title bar, tab cache bridges, navigation / file-menu / browser-gateway bridges, screen-capture overlays, zoom HUD). `index.desktop.tsx` already owns them, so the web layout drops those imports and keeps only `DesktopAutoOidcOnFirstOpen` + `AuthRequiredModal` (which `authMount.test.ts` requires outside `WorkspaceContextSlot` on both layouts). The title bar's update notification alone pulled `@lobehub/ui` Markdown and with it elkjs, katex, octicons, mermaid and parse5 (785 KB gzip) into every web route.
- **Lazy leaves** behind `lazy()` / `import()`: the home inbox rail, notification detail, inbox news and unread-topic previews, brief summary and its comment editor (`@lobehub/editor`), the changelog body, create-project content (pinyin-pro, split into `CreateProjectContent.tsx`), task template detail, the error-fallback `Highlighter`, the drag preview's `FileIcon` (icon map), and the agent-settings modal that `useOpenChatSettings` pulled into hotkey registration. `useProjectMenuItems` imports `LibraryModal/CreateNew` directly instead of the barrel.
- `eslint.config.mjs`: the boot-path `no-restricted-imports` rule now also covers `src/routes/**/_layout`, `src/routes/(main)/home`, `features/Home`, `features/HomeSidebar` and `features/NavPanel`; all 159 files there lint clean.

Web production `vite build` on top of current `canary` (without #19288 / #19289 / #19291 / #19292 / #19293 / #19294), closure walked from the built chunk graph with the eager set excluded:

| | before | after |
| --- | --- | --- |
| first screen (entry + static imports) | 80 chunks / 2398 KB gzip | 82 / 2397 KB (unchanged) |
| home route closure | 200 chunks / 2103 KB gzip | 182 / 1134 KB |
| markdown stack (elkjs / katex / mermaid) in home closure | 785 KB chunk | absent |
| pinyin-pro / Electron title bar in home closure | yes | absent |

Together with the other six PRs, home → first paint drops from ≈4.5 MB to ≈2.5 MB gzip of JavaScript. A build-time gate with budgets for the first screen and the home closure follows as a separate PR once these have merged, so its numbers can be measured on `canary`.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check` on the changed files (lint + related tests), `authMount`, `useCreateModal`, `BriefCardSummary` and `useInterceptingRoutes` tests explicitly, eslint over the 159 newly covered files, full `bun run check --type`, and the production web build.

#### 🔗 Related Issue

Related to LOBE-13719. Supersedes part of #19161.

https://claude.ai/code/session_01QKr8CsFLYmrgqbRTSipTNH