### PR TITLE
🐛 fix: honor user media capabilities in server agent runs

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.test.ts
@@ -86,6 +86,72 @@ beforeEach(() => {
 });
 
 describe('resolveServerCallLlmContextHints - user media capabilities', () => {
+  it.each(['lookup failure', 'settings changed'])(
+    'preserves discovered vision after %s',
+    async (scenario) => {
+      if (scenario === 'lookup failure') {
+        findByIdAndProviderMock.mockRejectedValue(new Error('Temporary database failure'));
+      } else {
+        findByIdAndProviderMock.mockResolvedValue({ abilities: { vision: false } });
+      }
+      const hints = await resolveServerCallLlmContextHints({
+        ctx: {
+          ...createCtx({}),
+          modelRuntimeConfig: {
+            mediaCapabilities: { vision: true },
+            model: 'custom-model',
+            provider: 'custom-provider',
+          },
+        },
+        llmPayload,
+        model: 'custom-model',
+        provider: 'custom-provider',
+      });
+
+      expect(hints.capabilities.isCanUseVision('custom-model', 'custom-provider')).toBe(true);
+    },
+  );
+
+  it.each([
+    { model: 'other-model', provider: 'custom-provider' },
+    { model: 'custom-model', provider: 'other-provider' },
+  ])('does not reuse a snapshot for $model/$provider', async ({ model, provider }) => {
+    const hints = await resolveServerCallLlmContextHints({
+      ctx: {
+        ...createCtx({}),
+        modelRuntimeConfig: {
+          mediaCapabilities: { vision: true },
+          model: 'custom-model',
+          provider: 'custom-provider',
+        },
+      },
+      llmPayload,
+      model,
+      provider,
+    });
+
+    expect(hints.capabilities.isCanUseVision(model, provider)).toBe(false);
+  });
+
+  it('keeps an unknown-model snapshot disabled after settings change', async () => {
+    findByIdAndProviderMock.mockResolvedValue({ abilities: { vision: true } });
+    const hints = await resolveServerCallLlmContextHints({
+      ctx: {
+        ...createCtx({}),
+        modelRuntimeConfig: {
+          mediaCapabilities: {},
+          model: 'custom-model',
+          provider: 'custom-provider',
+        },
+      },
+      llmPayload,
+      model: 'custom-model',
+      provider: 'custom-provider',
+    });
+
+    expect(hints.capabilities.isCanUseVision('custom-model', 'custom-provider')).toBe(false);
+  });
+
   it('keeps custom-model images in the native payload and advertises user-enabled vision', async () => {
     findByIdAndProviderMock.mockResolvedValue({ abilities: { vision: true } });
     const model = 'custom-vision-model';

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.test.ts
@@ -1,4 +1,6 @@
 import type { CallLLMPayload } from '@lobechat/agent-runtime';
+import { MessagesEngine } from '@lobechat/context-engine';
+import type { UIChatMessage } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RuntimeExecutorContext } from '../context';
@@ -81,6 +83,102 @@ beforeEach(() => {
   findByIdAndProviderMock.mockResolvedValue(undefined);
   getModelReasoningConfigMock.mockResolvedValue(undefined);
   findTopicByIdMock.mockResolvedValue(undefined);
+});
+
+describe('resolveServerCallLlmContextHints - user media capabilities', () => {
+  it('keeps custom-model images in the native payload and advertises user-enabled vision', async () => {
+    findByIdAndProviderMock.mockResolvedValue({ abilities: { vision: true } });
+    const model = 'custom-vision-model';
+    const provider = 'custom-provider';
+    const hints = await resolveServerCallLlmContextHints({
+      ctx: createCtx({}),
+      llmPayload,
+      model,
+      provider,
+    });
+    const result = await new MessagesEngine({
+      capabilities: hints.capabilities,
+      enableSystemDate: false,
+      messages: [
+        {
+          content: 'Describe this image',
+          createdAt: 1,
+          id: 'message-1',
+          imageList: [{ id: 'image-1', url: 'https://example.com/image.png' }],
+          role: 'user',
+          updatedAt: 1,
+        } as UIChatMessage,
+      ],
+      model,
+      provider,
+    }).process();
+
+    expect
+      .soft(result.messages.find((message) => message.role === 'system')?.content)
+      .toContain('vision=true');
+    expect(result.messages.find((message) => message.role === 'user')?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          image_url: expect.objectContaining({ url: 'https://example.com/image.png' }),
+          type: 'image_url',
+        }),
+      ]),
+    );
+  });
+
+  it.each(['audio', 'video', 'vision'] as const)(
+    'honors a user override for builtin %s capability',
+    async (ability) => {
+      loadModelsMock.mockResolvedValue([
+        { abilities: { [ability]: false }, id: 'model', providerId: 'provider' },
+      ]);
+      findByIdAndProviderMock.mockResolvedValue({ abilities: { [ability]: true } });
+      const hints = await resolveServerCallLlmContextHints({
+        ctx: createCtx({}),
+        llmPayload,
+        model: 'model',
+        provider: 'provider',
+      });
+      const selectors = {
+        audio: hints.capabilities.isCanUseAudio,
+        video: hints.capabilities.isCanUseVideo,
+        vision: hints.capabilities.isCanUseVision,
+      };
+      expect(selectors[ability]('model', 'provider')).toBe(true);
+      expect(selectors[ability]('model', 'another-provider')).toBe(false);
+    },
+  );
+
+  it.each([
+    { abilities: { vision: false }, expected: false },
+    { abilities: { functionCall: true }, expected: false },
+    { abilities: {}, expected: true },
+    { abilities: null, expected: true },
+    { abilities: undefined, expected: true },
+  ])('matches the client abilities replacement for $abilities', async ({ abilities, expected }) => {
+    loadModelsMock.mockResolvedValue([
+      { abilities: { vision: true }, id: 'model', providerId: 'provider' },
+    ]);
+    findByIdAndProviderMock.mockResolvedValue({ abilities });
+    const hints = await resolveServerCallLlmContextHints({
+      ctx: createCtx({}),
+      llmPayload,
+      model: 'model',
+      provider: 'provider',
+    });
+    expect(hints.capabilities.isCanUseVision('model', 'provider')).toBe(expected);
+  });
+
+  it('does not apply the active row to a different model under the same provider', async () => {
+    findByIdAndProviderMock.mockResolvedValue({ abilities: { vision: true } });
+    const hints = await resolveServerCallLlmContextHints({
+      ctx: createCtx({}),
+      llmPayload,
+      model: 'custom-model',
+      provider: 'custom-provider',
+    });
+    expect(hints.capabilities.isCanUseVision('another-model', 'custom-provider')).toBe(false);
+  });
 });
 
 describe('resolveServerCallLlmContextHints - topic reasoning pin', () => {

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
@@ -22,6 +22,7 @@ import { TopicModel } from '@/database/models/topic';
 
 import type { RuntimeExecutorContext } from '../context';
 import { log } from '../executorHelpers';
+import { resolveModelMediaCapabilities } from '../resolveModelMediaCapabilities';
 
 interface ResolveServerCallLlmContextHintsInput {
   ctx: RuntimeExecutorContext;
@@ -311,21 +312,27 @@ export const resolveServerCallLlmContextHints = async ({
     ? (llmPayload.messages as UIChatMessage[])
     : stripAssistantReasoningForReplay(llmPayload.messages as UIChatMessage[]);
 
-  const findModelInfo = (targetModel: string, targetProvider: string) =>
-    builtinModels.find((item) => item.id === targetModel && item.providerId === targetProvider) ??
-    builtinModels.find((item) => item.id === targetModel);
+  const findMediaCapabilities = (targetModel: string, targetProvider: string) =>
+    resolveModelMediaCapabilities({
+      builtinModels,
+      model: targetModel,
+      provider: targetProvider,
+      // This row belongs only to the active attempt, never to another model/provider.
+      userAbilities:
+        targetModel === model && targetProvider === provider ? userModelRow?.abilities : undefined,
+    });
 
   return {
     capabilities: {
       isCanUseAudio: (targetModel, targetProvider) =>
-        findModelInfo(targetModel, targetProvider)?.abilities?.audio ?? false,
+        findMediaCapabilities(targetModel, targetProvider)?.audio ?? false,
       isCanUseFC: (targetModel, targetProvider) =>
         builtinModels.find((item) => item.id === targetModel && item.providerId === targetProvider)
           ?.abilities?.functionCall ?? true,
       isCanUseVideo: (targetModel, targetProvider) =>
-        findModelInfo(targetModel, targetProvider)?.abilities?.video ?? false,
+        findMediaCapabilities(targetModel, targetProvider)?.video ?? false,
       isCanUseVision: (targetModel, targetProvider) =>
-        findModelInfo(targetModel, targetProvider)?.abilities?.vision ?? false,
+        findMediaCapabilities(targetModel, targetProvider)?.vision ?? false,
     },
     messagesForContext,
     modelDisplayName,

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
@@ -312,8 +312,20 @@ export const resolveServerCallLlmContextHints = async ({
     ? (llmPayload.messages as UIChatMessage[])
     : stripAssistantReasoningForReplay(llmPayload.messages as UIChatMessage[]);
 
-  const findMediaCapabilities = (targetModel: string, targetProvider: string) =>
-    resolveModelMediaCapabilities({
+  const findMediaCapabilities = (targetModel: string, targetProvider: string) => {
+    const snapshot = ctx.modelRuntimeConfig;
+    // Tool discovery is fixed for the operation; keep native inputs on the same
+    // snapshot across retries, settings edits, and subsequent worker invocations.
+    if (
+      snapshot?.model === targetModel &&
+      snapshot.provider === targetProvider &&
+      snapshot.mediaCapabilities
+    ) {
+      return snapshot.mediaCapabilities;
+    }
+
+    // Older operations have no snapshot. Preserve their existing lookup path.
+    return resolveModelMediaCapabilities({
       builtinModels,
       model: targetModel,
       provider: targetProvider,
@@ -321,6 +333,7 @@ export const resolveServerCallLlmContextHints = async ({
       userAbilities:
         targetModel === model && targetProvider === provider ? userModelRow?.abilities : undefined,
     });
+  };
 
   return {
     capabilities: {

--- a/apps/server/src/modules/AgentRuntime/context.ts
+++ b/apps/server/src/modules/AgentRuntime/context.ts
@@ -69,6 +69,7 @@ export interface RuntimeExecutorContext {
   hookDispatcher?: HookDispatcher;
   loadAgentState?: (operationId: string) => Promise<AgentState | null>;
   messageModel: MessageModel;
+  modelRuntimeConfig?: AgentState['modelRuntimeConfig'];
   operationId: string;
   searchDecision?: SearchDecision;
   serverDB: LobeChatDatabase;

--- a/apps/server/src/modules/AgentRuntime/resolveModelMediaCapabilities.ts
+++ b/apps/server/src/modules/AgentRuntime/resolveModelMediaCapabilities.ts
@@ -1,6 +1,14 @@
 import { isRecord } from '@lobechat/utils/object';
 import type { LobeDefaultAiModelListItem, ModelAbilities } from 'model-bank';
 
+interface ResolveModelMediaCapabilitiesParams {
+  builtinModels: LobeDefaultAiModelListItem[];
+  model: string;
+  provider: string;
+  /** The database stores abilities as an untyped JSON column. */
+  userAbilities?: unknown;
+}
+
 /**
  * Match the client's enabled-model merge: a nonempty user abilities object
  * replaces the bundled abilities, including explicit false values. Media
@@ -11,13 +19,8 @@ export const resolveModelMediaCapabilities = ({
   model,
   provider,
   userAbilities,
-}: {
-  builtinModels: LobeDefaultAiModelListItem[];
-  model: string;
-  provider: string;
-  /** The database stores abilities as an untyped JSON column. */
-  userAbilities?: unknown;
-}): Pick<ModelAbilities, 'audio' | 'video' | 'vision'> | undefined => {
+}: ResolveModelMediaCapabilitiesParams):
+  Pick<ModelAbilities, 'audio' | 'video' | 'vision'> | undefined => {
   if (isRecord(userAbilities) && Object.keys(userAbilities).length > 0) {
     return {
       audio: userAbilities.audio === true,

--- a/apps/server/src/modules/AgentRuntime/resolveModelMediaCapabilities.ts
+++ b/apps/server/src/modules/AgentRuntime/resolveModelMediaCapabilities.ts
@@ -1,0 +1,34 @@
+import { isRecord } from '@lobechat/utils/object';
+import type { LobeDefaultAiModelListItem, ModelAbilities } from 'model-bank';
+
+/**
+ * Match the client's enabled-model merge: a nonempty user abilities object
+ * replaces the bundled abilities, including explicit false values. Media
+ * routing and context assembly must agree or native attachments are discarded.
+ */
+export const resolveModelMediaCapabilities = ({
+  builtinModels,
+  model,
+  provider,
+  userAbilities,
+}: {
+  builtinModels: LobeDefaultAiModelListItem[];
+  model: string;
+  provider: string;
+  /** The database stores abilities as an untyped JSON column. */
+  userAbilities?: unknown;
+}): Pick<ModelAbilities, 'audio' | 'video' | 'vision'> | undefined => {
+  if (isRecord(userAbilities) && Object.keys(userAbilities).length > 0) {
+    return {
+      audio: userAbilities.audio === true,
+      video: userAbilities.video === true,
+      vision: userAbilities.vision === true,
+    };
+  }
+
+  // Preserve the canonical-model fallback used by aggregation providers.
+  return (
+    builtinModels.find((item) => item.id === model && item.providerId === provider) ??
+    builtinModels.find((item) => item.id === model)
+  )?.abilities;
+};

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
@@ -321,7 +321,11 @@ describe('AI Agent Router Integration Tests', () => {
             agentId: testAgentId,
           }),
           autoStart: false,
-          modelRuntimeConfig: { model: 'gpt-4o-mini', provider: 'openai' },
+          modelRuntimeConfig: {
+            mediaCapabilities: expect.objectContaining({ vision: true }),
+            model: 'gpt-4o-mini',
+            provider: 'openai',
+          },
           userId,
         }),
       );

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -3771,6 +3771,7 @@ export class AgentRuntimeService {
       hookDispatcher,
       loadAgentState: this.coordinator.loadAgentState.bind(this.coordinator),
       messageModel: this.messageModel,
+      modelRuntimeConfig: metadata?.modelRuntimeConfig,
       operationId,
       searchDecision: metadata?.searchDecision,
       serverDB: this.serverDB,

--- a/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
@@ -318,6 +318,26 @@ describe('AgentRuntimeService.executeStep - early exit on terminal state', () =>
     );
   });
 
+  it('restores the persisted model runtime snapshot into runtime executors', async () => {
+    vi.mocked(createRuntimeExecutors).mockClear();
+    const service = new AgentRuntimeService({} as any, 'user-1', { queueService: null });
+    const modelRuntimeConfig = {
+      mediaCapabilities: { audio: false, video: false, vision: true },
+      model: 'custom-vision-model',
+      provider: 'custom-provider',
+    };
+
+    await (service as any).createAgentRuntime({
+      metadata: { agentConfig: {}, modelRuntimeConfig, userId: 'user-1' },
+      operationId: 'op-model-runtime-snapshot',
+      stepIndex: 0,
+    });
+
+    expect(createRuntimeExecutors).toHaveBeenCalledWith(
+      expect.objectContaining({ modelRuntimeConfig }),
+    );
+  });
+
   it('disables early final visible output end for custom multi-step agents', async () => {
     vi.mocked(createRuntimeExecutors).mockClear();
     const service = new AgentRuntimeService({} as any, 'user-1', {

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -15,6 +15,7 @@ const {
   mockGetAgentConfig,
   mockGetBuiltinAgent,
   mockGetInfoForAIGeneration,
+  mockGetModelMetadata,
   mockIsAgentSignalEnabledForUser,
   mockMessageCreate,
   mockMessageQuery,
@@ -25,6 +26,7 @@ const {
   mockGetAgentConfig: vi.fn(),
   mockGetBuiltinAgent: vi.fn(),
   mockGetInfoForAIGeneration: vi.fn(),
+  mockGetModelMetadata: vi.fn(),
   mockIsAgentSignalEnabledForUser: vi.fn(),
   mockMessageCreate: vi.fn(),
   mockMessageQuery: vi.fn(),
@@ -52,6 +54,12 @@ vi.mock('@/database/models/message', () => ({
     getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: mockMessageQuery,
     update: vi.fn().mockResolvedValue({}),
+  })),
+}));
+
+vi.mock('@/database/models/aiModel', () => ({
+  AiModelModel: vi.fn().mockImplementation(() => ({
+    findByIdAndProvider: mockGetModelMetadata,
   })),
 }));
 
@@ -223,6 +231,7 @@ describe('AiAgentService.execAgent - builtin agent runtime config', () => {
       responseLanguage: 'en-US',
       userName: 'Test User',
     });
+    mockGetModelMetadata.mockResolvedValue(undefined);
     mockToolsEnv.MULTIMODAL_UNDERSTANDING_MODEL = 'vision-model';
     mockToolsEnv.MULTIMODAL_UNDERSTANDING_PROVIDER = 'test-provider';
     mockCreateOperation.mockResolvedValue({
@@ -696,5 +705,67 @@ describe('AiAgentService.execAgent - builtin agent runtime config', () => {
 
     const callArgs = vi.mocked(createServerAgentToolsEngine).mock.calls[0][1];
     expect(callArgs.agentConfig.plugins).not.toContain('lobe-agent');
+  });
+
+  it('should not inject lobe-agent when user model abilities support images natively', async () => {
+    mockGetAgentConfig.mockResolvedValue({
+      chatConfig: {},
+      id: 'agent-custom',
+      model: 'custom-vision-model',
+      plugins: [],
+      provider: 'custom-provider',
+      systemRole: '',
+    });
+    mockGetModelMetadata.mockResolvedValue({ abilities: { vision: true } });
+    mockMessageQuery.mockResolvedValue([
+      {
+        id: 'history-image',
+        imageList: [{ alt: 'image.png', id: 'file-image', url: 'https://example.com/image.png' }],
+        role: 'user',
+      },
+    ]);
+
+    await service.execAgent({
+      agentId: 'agent-custom',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'What is shown in the previous image?',
+    });
+
+    const callArgs = vi.mocked(createServerAgentToolsEngine).mock.calls[0][1];
+    expect(callArgs.agentConfig.plugins).not.toContain('lobe-agent');
+  });
+
+  it('should inject lobe-agent when user model abilities disable builtin image support', async () => {
+    mockGetAgentConfig.mockResolvedValue({
+      chatConfig: {},
+      id: 'agent-custom',
+      model: 'gpt-4',
+      plugins: [],
+      provider: 'openai',
+      systemRole: '',
+    });
+    mockGetModelMetadata.mockResolvedValue({ abilities: { vision: false } });
+    mockMessageQuery.mockResolvedValue([
+      {
+        id: 'history-image',
+        imageList: [{ alt: 'image.png', id: 'file-image', url: 'https://example.com/image.png' }],
+        role: 'user',
+      },
+    ]);
+
+    await service.execAgent({
+      agentId: 'agent-custom',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'What is shown in the previous image?',
+    });
+
+    expect(createServerAgentToolsEngine).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        agentConfig: expect.objectContaining({
+          plugins: expect.arrayContaining(['lobe-agent']),
+        }),
+      }),
+    );
   });
 });

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -768,4 +768,24 @@ describe('AiAgentService.execAgent - builtin agent runtime config', () => {
       }),
     );
   });
+
+  it('should preserve builtin image output support when user abilities override vision', async () => {
+    mockGetAgentConfig.mockResolvedValue({
+      chatConfig: {},
+      id: 'agent-custom',
+      model: 'gemini-3.1-flash-image',
+      plugins: [],
+      provider: 'google',
+      systemRole: '',
+    });
+    mockGetModelMetadata.mockResolvedValue({ abilities: { vision: false } });
+
+    await service.execAgent({
+      agentId: 'agent-custom',
+      prompt: 'Generate an image',
+    });
+
+    const callArgs = vi.mocked(createServerAgentToolsEngine).mock.calls[0][1];
+    expect(callArgs.modelAbilities).toMatchObject({ imageOutput: true });
+  });
 });

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
@@ -332,7 +332,11 @@ describe('AiAgentService.execAgent - model/provider override', () => {
     const callArgs = mockCreateOperation.mock.calls[0][0];
     expect(callArgs.agentConfig.model).toBe('step-3.7-flash');
     expect(callArgs.agentConfig.provider).toBe('stepfun');
-    expect(callArgs.modelRuntimeConfig).toEqual({ model: 'step-3.7-flash', provider: 'stepfun' });
+    expect(callArgs.modelRuntimeConfig).toEqual({
+      mediaCapabilities: { video: true, vision: true },
+      model: 'step-3.7-flash',
+      provider: 'stepfun',
+    });
   });
 
   it('keeps the topic provider when only the model is overridden', async () => {
@@ -347,7 +351,11 @@ describe('AiAgentService.execAgent - model/provider override', () => {
     });
 
     const callArgs = mockCreateOperation.mock.calls[0][0];
-    expect(callArgs.modelRuntimeConfig).toEqual({ model: 'step-3.7-flash', provider: 'stepfun' });
+    expect(callArgs.modelRuntimeConfig).toEqual({
+      mediaCapabilities: { video: true, vision: true },
+      model: 'step-3.7-flash',
+      provider: 'stepfun',
+    });
   });
 
   it('uses the caller model preference when the workspace Agent allows member selection', async () => {

--- a/apps/server/src/services/aiAgent/pipeline/startOperation.ts
+++ b/apps/server/src/services/aiAgent/pipeline/startOperation.ts
@@ -119,6 +119,7 @@ export const startOperation = async (
     userInterventionConfig,
     userTimezone,
   } = input;
+  const { audio, video, vision } = discovery.modelMediaCapabilities;
 
   log(
     'execAgent: creating operation %s — agentDocuments=%d, knowledgeBases=%s, tools=%d, skills=%d',
@@ -257,7 +258,15 @@ export const startOperation = async (
           }
         : {}),
       maxSteps,
-      modelRuntimeConfig: { model, provider },
+      modelRuntimeConfig: {
+        mediaCapabilities: {
+          ...(typeof audio === 'boolean' && { audio }),
+          ...(typeof video === 'boolean' && { video }),
+          ...(typeof vision === 'boolean' && { vision }),
+        },
+        model,
+        provider,
+      },
       hooks,
       operationId,
       parentOperationId,

--- a/apps/server/src/services/aiAgent/pipeline/toolDiscovery.ts
+++ b/apps/server/src/services/aiAgent/pipeline/toolDiscovery.ts
@@ -45,6 +45,7 @@ import {
 } from '@/helpers/executionTarget';
 import { buildConnectorManifests } from '@/libs/mcp/buildConnectorManifests';
 import { patchManifestWithPermissions } from '@/libs/mcp/connectorPermissionCheck';
+import { resolveModelMediaCapabilities } from '@/server/modules/AgentRuntime/resolveModelMediaCapabilities';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import type { ServerAgentToolsContext } from '@/server/modules/Mecha';
 import { createServerAgentToolsEngine } from '@/server/modules/Mecha';
@@ -577,9 +578,12 @@ export const discoverTools = async (
 
     // Dynamically inject turn-scoped builtin tools.
     const hasTopicReference = /refer_topic/.test(prompt ?? '');
-    const modelAbilities =
-      builtinModels.find((item) => item.id === model && item.providerId === provider)?.abilities ??
-      builtinModels.find((item) => item.id === model)?.abilities;
+    const modelAbilities = resolveModelMediaCapabilities({
+      builtinModels,
+      model,
+      provider,
+      userAbilities: activeModelAbilities,
+    });
     const externalFileTypes = files?.map((file) => file.mimeType ?? '') ?? [];
     let attachedFileTypes: string[] = [];
     if (attachedFileIds && attachedFileIds.length > 0) {

--- a/apps/server/src/services/aiAgent/pipeline/toolDiscovery.ts
+++ b/apps/server/src/services/aiAgent/pipeline/toolDiscovery.ts
@@ -138,6 +138,7 @@ export interface ToolDiscoveryResult {
   hasAgentDocuments: boolean;
   hasEnabledKnowledgeBases: boolean;
   lobehubSkillManifests: LobeToolManifest[];
+  modelMediaCapabilities: Pick<ModelAbilities, 'audio' | 'video' | 'vision'>;
   onlineDevices: DeviceAttachment[];
   operationAgentGroup?: AgentGroupConfig;
   searchDecision: ReturnType<typeof resolveServerSearchDecision>;
@@ -287,6 +288,13 @@ export const discoverTools = async (
   const activeProviderMetadata =
     providerMetadataResult.status === 'fulfilled' ? providerMetadataResult.value : undefined;
   const activeModelAbilities = activeModelMetadata?.abilities as ModelAbilities | undefined;
+  const modelMediaCapabilities =
+    resolveModelMediaCapabilities({
+      builtinModels,
+      model,
+      provider,
+      userAbilities: activeModelAbilities,
+    }) ?? {};
   const searchDecision = resolveServerSearchDecision({
     builtinModels,
     chatConfig: agentConfig.chatConfig ?? undefined,
@@ -578,12 +586,9 @@ export const discoverTools = async (
 
     // Dynamically inject turn-scoped builtin tools.
     const hasTopicReference = /refer_topic/.test(prompt ?? '');
-    const modelAbilities = resolveModelMediaCapabilities({
-      builtinModels,
-      model,
-      provider,
-      userAbilities: activeModelAbilities,
-    });
+    const modelAbilities =
+      builtinModels.find((item) => item.id === model && item.providerId === provider)?.abilities ??
+      builtinModels.find((item) => item.id === model)?.abilities;
     const externalFileTypes = files?.map((file) => file.mimeType ?? '') ?? [];
     let attachedFileTypes: string[] = [];
     if (attachedFileIds && attachedFileIds.length > 0) {
@@ -598,22 +603,22 @@ export const discoverTools = async (
 
     if (
       multimodalUnderstandingConfigured &&
-      ((!modelAbilities?.audio && !inputMediaAvailability.hasAudios) ||
-        (!modelAbilities?.vision && !inputMediaAvailability.hasImages) ||
-        (!modelAbilities?.video && !inputMediaAvailability.hasVideos))
+      ((!modelMediaCapabilities?.audio && !inputMediaAvailability.hasAudios) ||
+        (!modelMediaCapabilities?.vision && !inputMediaAvailability.hasImages) ||
+        (!modelMediaCapabilities?.video && !inputMediaAvailability.hasVideos))
     ) {
       historyMediaAvailability = getMediaAvailabilityFromMessages(await loadHistoryMessages());
     }
 
     const needsAudioUnderstanding =
       (inputMediaAvailability.hasAudios || historyMediaAvailability.hasAudios) &&
-      !modelAbilities?.audio;
+      !modelMediaCapabilities?.audio;
     const needsImageUnderstanding =
       (inputMediaAvailability.hasImages || historyMediaAvailability.hasImages) &&
-      !modelAbilities?.vision;
+      !modelMediaCapabilities?.vision;
     const needsVideoUnderstanding =
       (inputMediaAvailability.hasVideos || historyMediaAvailability.hasVideos) &&
-      !modelAbilities?.video;
+      !modelMediaCapabilities?.video;
     const shouldEnableMultimodalUnderstanding =
       multimodalUnderstandingConfigured &&
       (needsAudioUnderstanding || needsImageUnderstanding || needsVideoUnderstanding);
@@ -1166,6 +1171,7 @@ export const discoverTools = async (
     hasAgentDocuments,
     hasEnabledKnowledgeBases,
     lobehubSkillManifests,
+    modelMediaCapabilities,
     onlineDevices,
     operationAgentGroup,
     searchDecision,

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -6,6 +6,8 @@ import {
   type RuntimeAdditionalContextFragment,
 } from '@lobechat/types';
 
+import type { AgentState } from './state';
+
 export interface GeneralAgentCallLLMInstructionPayload {
   additionalContexts?: readonly RuntimeAdditionalContextFragment[];
   allowedToolNames?: string[];
@@ -108,18 +110,7 @@ export interface GeneralAgentConfig {
    * When not provided, defaults to [createSecurityBlacklistGlobalAudit()]
    */
   globalInterventionAudits?: GlobalInterventionAuditConfig[];
-  modelRuntimeConfig?: {
-    /**
-     * Compression model configuration
-     * Used for context compression tasks
-     */
-    compressionModel?: {
-      model: string;
-      provider: string;
-    };
-    model: string;
-    provider: string;
-  };
+  modelRuntimeConfig?: AgentState['modelRuntimeConfig'];
   operationId: string;
   /** Phase-level tools exposed to this agent run. Falls back to AgentState.tools. */
   tools?: any[];

--- a/packages/agent-runtime/src/types/state.ts
+++ b/packages/agent-runtime/src/types/state.ts
@@ -81,6 +81,15 @@ export interface AgentState {
    * Used as fallback when call_llm instruction doesn't specify model/provider
    */
   modelRuntimeConfig?: {
+    /**
+     * Immutable operation snapshot shared by tool discovery and context processing.
+     * Optional for operations created before this snapshot was introduced.
+     */
+    mediaCapabilities?: {
+      audio?: boolean;
+      video?: boolean;
+      vision?: boolean;
+    };
     model: string;
     provider: string;
     /**


### PR DESCRIPTION
Server agent runs ignored user-configured media abilities and consulted only bundled model cards. A custom model with vision enabled could therefore receive `vision=false`, lose native image parts, and unnecessarily activate media analysis.

Resolve media capabilities consistently for context assembly and tool discovery, using the existing user model row before bundled defaults. Nonempty user abilities replace bundled abilities, matching the client; explicit false values remain effective. Existing aggregation fallback is preserved. No additional database queries or migration are required.

Persist the discovered capabilities with the operation's model/provider so later steps and resumed workers keep the same snapshot even if settings change or a subsequent lookup fails. Older operations without a snapshot retain the lookup fallback. Tool-engine capability metadata remains separate so image-output restrictions are preserved.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- Regression tests failed before the fix: custom-model vision was advertised as false, user media overrides were ignored, and media analysis was unnecessarily activated.
- Verified native `image_url` preservation, vision prompt metadata, audio/video/vision overrides, explicit disablement, empty/null fallback, and model/provider isolation.
- `bun run check --lint --test --type` completed lint and type checks successfully. The test runner inherited the worktree app URL and exposed environment-sensitive failures in the existing runtime-service suite.
- Ran the same six focused Vitest files directly from the OSS root with process-only `APP_URL=http://localhost:3210`: 414 tests passed, including snapshot restoration, settings changes, lookup failure, effective-model overrides, and image-output restrictions. No timeout or source changes were needed for the environment-sensitive suite.
- Live provider verification remains pending: enable vision for a custom model, send an image through the server agent runtime, and verify native recognition without an unnecessary media-analysis call.
