### PR TITLE
🐛 fix(desktop): route Better Auth through the backend proxy

### DIFF
--- a/src/features/Settings/profile/features/EmailRow.tsx
+++ b/src/features/Settings/profile/features/EmailRow.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import { Flexbox, Input } from '@lobehub/ui';
+import { isDesktop } from '@lobechat/const';
+import { Flexbox, Icon, Input } from '@lobehub/ui';
 import { Button, Text, toast } from '@lobehub/ui/base-ui';
+import { ExternalLinkIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import urlJoin from 'url-join';
 
+import { useAppOrigin } from '@/hooks/useAppOrigin';
 import { changeEmail } from '@/libs/better-auth/auth-client';
+import { electronSystemService } from '@/services/electron/system';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 import { saveToast } from '@/store/utils/saveToast';
@@ -20,6 +25,7 @@ const EmailRow = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [saving, setSaving] = useState(false);
+  const appOrigin = useAppOrigin();
 
   const handleStartEdit = () => {
     setEditValue('');
@@ -56,6 +62,32 @@ const EmailRow = () => {
       setSaving(false);
     }
   }, [editValue, t]);
+
+  // Desktop OIDC and Better Auth sessions are not bridged, so change-email can only
+  // be completed on the web app.
+  if (isDesktop)
+    return (
+      <ProfileRow
+        anchor={'profile-email'}
+        label={t('profile.email')}
+        action={
+          <Text
+            style={{ cursor: 'pointer', fontSize: 13 }}
+            onClick={() => {
+              if (!appOrigin) return;
+              void electronSystemService.openExternalLink(urlJoin(appOrigin, '/settings/profile'));
+            }}
+          >
+            <Flexbox horizontal align={'center'} gap={4}>
+              {t('profile.updateEmail')}
+              <Icon icon={ExternalLinkIcon} size={12} />
+            </Flexbox>
+          </Text>
+        }
+      >
+        <Text>{email || '--'}</Text>
+      </ProfileRow>
+    );
 
   return (
     <ProfileRow

--- a/src/features/Settings/profile/features/EmailRow.tsx
+++ b/src/features/Settings/profile/features/EmailRow.tsx
@@ -2,13 +2,13 @@
 
 import { Flexbox, Input } from '@lobehub/ui';
 import { Button, Text, toast } from '@lobehub/ui/base-ui';
-import { AnimatePresence, m } from 'motion/react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { changeEmail } from '@/libs/better-auth/auth-client';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
+import { saveToast } from '@/store/utils/saveToast';
 
 import ProfileRow from './ProfileRow';
 
@@ -20,18 +20,15 @@ const EmailRow = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
 
   const handleStartEdit = () => {
     setEditValue('');
-    setError('');
     setIsEditing(true);
   };
 
   const handleCancel = () => {
     setIsEditing(false);
     setEditValue('');
-    setError('');
   };
 
   const handleSave = useCallback(async () => {
@@ -39,93 +36,65 @@ const EmailRow = () => {
     if (!trimmed) return;
 
     if (!EMAIL_REGEX.test(trimmed)) {
-      setError(t('profile.emailInvalid'));
+      toast.error(t('profile.emailInvalid'));
       return;
     }
 
     try {
       setSaving(true);
-      setError('');
       const res = await changeEmail({ callbackURL: '/settings/profile', newEmail: trimmed });
       if (res.error) {
-        setError(res.error.message ?? res.error.statusText ?? 'Failed to change email');
+        toast.error(res.error.message ?? res.error.statusText ?? t('profile.saveError'));
         return;
       }
       setIsEditing(false);
       toast.success(t('profile.emailChangeSuccess'));
     } catch (err) {
       console.error('Failed to change email:', err);
-      setError(err instanceof Error ? err.message : String(err));
+      saveToast(err, { retry: () => void handleSave(), title: t('profile.saveError') });
     } finally {
       setSaving(false);
     }
   }, [editValue, t]);
-
-  const editingContent = (
-    <m.div
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -10 }}
-      initial={{ opacity: 0, y: -10 }}
-      key="editing"
-      transition={{ duration: 0.2 }}
-    >
-      <Flexbox gap={12}>
-        <Input
-          autoFocus
-          autoComplete="email"
-          inputMode="email"
-          placeholder={t('profile.emailPlaceholder')}
-          status={error ? 'error' : undefined}
-          type="email"
-          value={editValue}
-          onPressEnter={handleSave}
-          onChange={(e) => {
-            setEditValue(e.target.value);
-            if (error) setError('');
-          }}
-        />
-        {error && (
-          <Text style={{ fontSize: 12 }} type="danger">
-            {error}
-          </Text>
-        )}
-        <Flexbox horizontal gap={8} justify="flex-end">
-          <Button disabled={saving} size="small" onClick={handleCancel}>
-            {t('profile.cancel')}
-          </Button>
-          <Button loading={saving} size="small" type="primary" onClick={handleSave}>
-            {t('profile.save')}
-          </Button>
-        </Flexbox>
-      </Flexbox>
-    </m.div>
-  );
-
-  const displayContent = (
-    <m.div
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      initial={{ opacity: 0 }}
-      key="display"
-      transition={{ duration: 0.2 }}
-    >
-      <Text>{email || '--'}</Text>
-    </m.div>
-  );
 
   return (
     <ProfileRow
       anchor={'profile-email'}
       label={t('profile.email')}
       action={
-        !isEditing && (
+        isEditing ? (
+          <Flexbox horizontal gap={8}>
+            <Button disabled={saving} size="small" onClick={handleCancel}>
+              {t('profile.cancel')}
+            </Button>
+            <Button loading={saving} size="small" type="primary" onClick={handleSave}>
+              {t('profile.save')}
+            </Button>
+          </Flexbox>
+        ) : (
           <Text style={{ cursor: 'pointer', fontSize: 13 }} onClick={handleStartEdit}>
             {t('profile.updateEmail')}
           </Text>
         )
       }
     >
-      <AnimatePresence mode="wait">{isEditing ? editingContent : displayContent}</AnimatePresence>
+      {isEditing ? (
+        <Input
+          autoFocus
+          autoComplete="email"
+          inputMode="email"
+          placeholder={t('profile.emailPlaceholder')}
+          size="small"
+          style={{ flex: 1, minWidth: 0, width: '100%' }}
+          type="email"
+          value={editValue}
+          variant="filled"
+          onChange={(e) => setEditValue(e.target.value)}
+          onPressEnter={handleSave}
+        />
+      ) : (
+        <Text>{email || '--'}</Text>
+      )}
     </ProfileRow>
   );
 };

--- a/src/libs/better-auth/auth-client.desktop.test.ts
+++ b/src/libs/better-auth/auth-client.desktop.test.ts
@@ -14,13 +14,13 @@ const requestUrl = (input: RequestInfo | URL) => {
 
 describe('desktop better-auth client', () => {
   it('sends account requests to the renderer instead of the remote server', async () => {
-    const fetch = vi.fn(async () => Response.json({ status: true }));
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => Response.json({ status: true }));
     vi.stubGlobal('fetch', fetch);
 
     await changeEmail({ callbackURL: '/settings/profile', newEmail: 'new@example.com' });
     await listAccounts();
 
-    expect(fetch.mock.calls.map(([input]) => requestUrl(input as RequestInfo | URL))).toEqual([
+    expect(fetch.mock.calls.map(([input]) => requestUrl(input))).toEqual([
       '/api/auth/change-email',
       '/api/auth/list-accounts',
     ]);

--- a/src/libs/better-auth/auth-client.desktop.test.ts
+++ b/src/libs/better-auth/auth-client.desktop.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { changeEmail, listAccounts } from './auth-client.desktop';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const requestUrl = (input: RequestInfo | URL) => {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+};
+
+describe('desktop better-auth client', () => {
+  it('sends account requests to the renderer instead of the remote server', async () => {
+    const fetch = vi.fn(async () => Response.json({ status: true }));
+    vi.stubGlobal('fetch', fetch);
+
+    await changeEmail({ callbackURL: '/settings/profile', newEmail: 'new@example.com' });
+    await listAccounts();
+
+    expect(fetch.mock.calls.map(([input]) => requestUrl(input as RequestInfo | URL))).toEqual([
+      '/api/auth/change-email',
+      '/api/auth/list-accounts',
+    ]);
+  });
+});

--- a/src/libs/better-auth/auth-client.desktop.ts
+++ b/src/libs/better-auth/auth-client.desktop.ts
@@ -7,17 +7,22 @@ import {
 import { createAuthClient } from 'better-auth/react';
 
 import { type auth } from '@/auth';
-import { electronSyncSelectors } from '@/store/electron/selectors/sync';
-import { getElectronStoreState } from '@/store/electron/store';
 
 let _client: any = null;
 
+const desktopAuthFetch: typeof fetch = (input, init) => {
+  const url = new URL(input instanceof Request ? input.url : input.toString());
+  return fetch(`${url.pathname}${url.search}`, init);
+};
+
 function getClient() {
   if (!_client) {
-    const baseURL = electronSyncSelectors.remoteServerUrl(getElectronStoreState());
-
     _client = createAuthClient({
-      baseURL,
+      // better-auth getBaseURL only accepts http(s); app://renderer throws.
+      baseURL: 'http://lobehub.invalid',
+      fetchOptions: {
+        customFetchImpl: desktopAuthFetch,
+      },
       plugins: [
         adminClient(),
         inferAdditionalFields<typeof auth>(),


### PR DESCRIPTION
<!-- Brief and heads-up -->

Desktop Better Auth used the remote cloud URL as `baseURL`, so Settings → change email fetched `https://app.lobehub.com/api/auth/change-email` from `app://renderer` and failed CORS preflight. Send those requests as same-origin `/api/auth/*` so the existing main-process backend proxy forwards them and injects `Oidc-Auth`.

Bridging the Desktop OIDC session into a Better Auth session is out of scope — we decided not to solve it. Since change-email cannot complete without that session (it still 401s), Desktop's "Update Email" now opens the web app's `/settings/profile` in the external browser instead of editing in place. Web is unchanged.

| Before | After |
| ------ | ----- |
| `changeEmail` hits `https://app.lobehub.com/api/auth/change-email` from `app://renderer` (CORS) | Same-origin `app://renderer/api/auth/change-email` via backend proxy |
| Desktop "Update Email" opens an inline editor that always fails | Desktop "Update Email" opens the web profile page in the browser |
| Cancel / Save stacked under the input (CLS) | Actions on the right, same baseline; errors via toast |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`auth-client.desktop.test.ts` asserts `changeEmail` / `listAccounts` go to `/api/auth/...`, not the remote origin. Desktop Settings → Profile: "Update Email" opens `<remoteServerUrl>/settings/profile` externally. Per the repo testing rules, no new component test was added for the one-line desktop branch.

#### 🔗 Related Issue

Closes #19242 — Desktop 2.2.16: changing email fails CORS preflight for `content-type` (web works).

Related community reports on the same Desktop ↔ cloud auth seam:

- #15931 — Desktop sign-in loop: `/api/auth/get-session` returns null while the OIDC bearer token is valid. Same root cause as the 401 here: the OIDC session and the Better Auth session are separate.
- #9684 — LobeHub OIDC error when connecting the desktop client to a self-hosted instance.
- #11757 / #11707 — NextAuth → BetterAuth and Clerk → BetterAuth migration feedback, where the desktop account surfaces were first reported as partially broken.

Session bridging is tracked internally in LOBE-13931; this PR does not close it.

https://claude.ai/code/session_01A1Zzj85TAeJpa8yr5VbSmi
