### PR TITLE
🐛 fix(desktop): log renderer OTA compatibility and update lifecycle

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
@@ -94,6 +94,18 @@ export class RendererUpdateManager {
   initialize = () => {
     this.cleanupLegacyV1();
 
+    logger.info('Renderer OTA configuration', {
+      appVersion: APP_VERSION,
+      arch: process.arch,
+      buildChannel: BUILD_CHANNEL,
+      channel: this.activeChannel,
+      enabled: this.enabled,
+      hasPublicKey: !!PUBLIC_KEY,
+      hasServerUrl: !!UPDATE_SERVER_URL,
+      mainHash: MAIN_HASH,
+      platform: process.platform,
+    });
+
     if (!this.enabled) {
       logger.info('Renderer OTA disabled (dev build or missing MAIN_HASH/key/server url)');
       return;
@@ -101,6 +113,7 @@ export class RendererUpdateManager {
 
     mkdirSync(path.join(this.otaDir, 'versions'), { recursive: true });
     this.pointer = readPointer(this.otaDir, MAIN_HASH);
+    logger.info('Renderer OTA boot state', this.pointer);
 
     if (this.pointer.staged && this.versionDirValid(this.pointer.staged)) {
       logger.info(`Applying staged renderer ${this.pointer.staged} on boot`);
@@ -120,6 +133,10 @@ export class RendererUpdateManager {
 
   startScheduledChecks = () => {
     if (!this.enabled) return;
+    logger.info('Renderer OTA checks scheduled', {
+      firstCheckDelayMs: FIRST_CHECK_DELAY,
+      intervalMs: CHECK_INTERVAL,
+    });
     this.checkTimer = setTimeout(() => this.checkForUpdates(), FIRST_CHECK_DELAY);
     setInterval(() => this.checkForUpdates(), CHECK_INTERVAL);
   };
@@ -196,12 +213,23 @@ export class RendererUpdateManager {
   });
 
   checkForUpdates = async () => {
-    if (!this.enabled || this.state !== 'idle') return;
+    if (!this.enabled || this.state !== 'idle') {
+      logger.info('Renderer OTA check skipped', this.getStatus());
+      return;
+    }
     const generation = this.checkGeneration;
     const channel = this.activeChannel;
     const otaDir = this.otaDir;
     const pointer = this.pointer;
+    const startedAt = Date.now();
     this.state = 'checking';
+    logger.info('Renderer OTA check started', {
+      appVersion: APP_VERSION,
+      channel,
+      current: pointer.current ?? 'r0',
+      mainHash: MAIN_HASH,
+      staged: pointer.staged,
+    });
 
     try {
       const rendererUrl = this.rendererUrl(channel);
@@ -214,6 +242,12 @@ export class RendererUpdateManager {
         pointer.blacklist.includes(manifest.version) ||
         pointer.staged === manifest.version
       ) {
+        logger.info('Renderer OTA patch not selected', {
+          blacklisted: pointer.blacklist.includes(manifest.version),
+          current: pointer.current ?? 'r0',
+          remote: manifest.version,
+          staged: pointer.staged,
+        });
         return;
       }
 
@@ -236,6 +270,12 @@ export class RendererUpdateManager {
       if (generation === this.checkGeneration) logger.error('Renderer OTA check failed:', error);
       rmSync(path.join(otaDir, 'staging'), { force: true, recursive: true });
     } finally {
+      logger.info('Renderer OTA check finished', {
+        channel,
+        elapsedMs: Date.now() - startedAt,
+        state: this.state,
+        superseded: generation !== this.checkGeneration,
+      });
       if (generation === this.checkGeneration && this.state !== 'staged') this.state = 'idle';
     }
   };
@@ -261,11 +301,19 @@ export class RendererUpdateManager {
 
   private async fetchManifest(rendererUrl: string): Promise<RendererManifest | null> {
     const res = await fetch(`${rendererUrl}/latest.json`, { cache: 'no-store' });
+    logger.info('Renderer OTA manifest response', { status: res.status });
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`Manifest fetch failed: ${res.status}`);
 
     const raw = await res.json();
     if (!isValidManifestShape(raw)) throw new Error('Manifest shape invalid');
+    logger.info('Renderer OTA manifest compatibility', {
+      localAppVersion: APP_VERSION,
+      localMainHash: MAIN_HASH,
+      remoteAppVersion: raw.appVersion,
+      remoteMainHash: raw.mainHash,
+      remoteVersion: raw.version,
+    });
     if (raw.appVersion !== APP_VERSION) throw new Error('Manifest appVersion mismatch');
     if (raw.mainHash !== MAIN_HASH) throw new Error('Manifest mainHash mismatch');
     if (!verifyManifestSignature(raw, PUBLIC_KEY)) throw new Error('Manifest signature invalid');
@@ -408,12 +456,22 @@ export class RendererUpdateManager {
     artifact: RendererArtifact,
     expected: Parameters<typeof decodeRendererPack>[1],
   ) {
+    const startedAt = Date.now();
+    logger.info('Renderer OTA pack download started', {
+      ...expected,
+      bytes: artifact.size,
+    });
     const res = await fetch(`${rendererUrl}/${artifact.path}`);
     if (!res.ok) throw new Error(`Renderer pack fetch failed (${res.status}): ${artifact.path}`);
     const content = Buffer.from(await res.arrayBuffer());
     if (content.byteLength !== artifact.size || sha256File(content) !== artifact.sha256) {
       throw new Error(`Renderer pack integrity mismatch: ${artifact.path}`);
     }
+    logger.info('Renderer OTA pack download verified', {
+      ...expected,
+      bytes: content.byteLength,
+      elapsedMs: Date.now() - startedAt,
+    });
     return decodeRendererPack(content, expected);
   }
 

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
@@ -25,10 +25,12 @@ const SERVER = 'https://updates.test';
 
 let userDataDir: string;
 let builtinDir: string;
-const { updaterConfigMock } = vi.hoisted(() => ({
+const { loggerMock, updaterConfigMock } = vi.hoisted(() => ({
+  loggerMock: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
   updaterConfigMock: { buildChannel: 'stable' },
 }));
 
+vi.mock('@/utils/logger', () => ({ createLogger: () => loggerMock }));
 vi.mock('electron', () => ({
   app: { getPath: () => userDataDir, getVersion: () => APP_VERSION },
 }));
@@ -163,6 +165,7 @@ const loadManager = async (app: ReturnType<typeof makeApp>) => {
 };
 
 beforeEach(() => {
+  vi.clearAllMocks();
   updaterConfigMock.buildChannel = 'stable';
   userDataDir = mkdtempSync(path.join(tmpdir(), 'ota-user-'));
   builtinDir = mkdtempSync(path.join(tmpdir(), 'ota-builtin-'));
@@ -180,6 +183,37 @@ afterEach(() => {
 });
 
 describe('RendererUpdateManager V2 lifecycle', () => {
+  it('records both compatibility hashes and rejects the patch before downloading', async () => {
+    const app = makeApp();
+    const manager = await loadManager(app);
+    manager.initialize();
+    const feed = buildFeed('r1', {
+      'apps/desktop/index.html': entryHtml('v1'),
+      'assets/entry-e2e.js': 'console.log("v1")',
+    });
+    const { signature: _signature, ...unsigned } = feed.manifest;
+    feed.manifest = signManifest({ ...unsigned, mainHash: 'b'.repeat(64) });
+    stubFetch(feed);
+
+    await manager.checkForUpdates();
+
+    expect(loggerMock.info).toHaveBeenCalledWith('Renderer OTA manifest compatibility', {
+      localAppVersion: APP_VERSION,
+      localMainHash: MAIN_HASH,
+      remoteAppVersion: APP_VERSION,
+      remoteMainHash: 'b'.repeat(64),
+      remoteVersion: 'r1',
+    });
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'Renderer OTA check failed:',
+      expect.objectContaining({ message: 'Manifest mainHash mismatch' }),
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(manager.getStatus()).toMatchObject({ current: null, staged: null, state: 'idle' });
+    expect(app.browserManager.broadcastToAllWindows).not.toHaveBeenCalled();
+    expect(JSON.stringify(loggerMock.info.mock.calls)).not.toContain(PUBLIC_KEY_PEM);
+  });
+
   it('downloads one full pack, stages it, applies it, and commits after boot ping', async () => {
     const app = makeApp();
     const reloadIgnoringCache = vi.fn();


### PR DESCRIPTION
Packaged Canary clients repeatedly report `Manifest mainHash mismatch` without recording either hash, so the existing logs cannot identify which installed build and manifest disagree.

Add persistent OTA diagnostics for the installed version, platform/architecture, channel, local and remote compatibility hashes, boot state, scheduled checks, patch selection, and pack download timing. Existing compatibility and signature checks remain unchanged; keys and credentials are not logged.

#### Test

- [x] Tested locally: focused `bun run check` passed lint and 12 desktop integration tests; commit hooks passed.
- [x] Added/updated tests: a signed manifest with a mismatched main hash logs both hashes, downloads no pack, emits no update notification, and leaves the renderer unchanged.
- [ ] No tests needed

Runtime observation begins after installing a full build containing these main-process diagnostics: first automatic check after 90 seconds, subsequent checks hourly. A successful OTA lifecycle additionally requires a compatible patch to be published for that installed build.

#### 🔗 Related Issue

No linked issue.
