### PR TITLE
🐛 fix(acceptance): preserve check history when regrouping

### DIFF
--- a/apps/cli/src/commands/verifyAcceptance.regroup.test.ts
+++ b/apps/cli/src/commands/verifyAcceptance.regroup.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { registerAcceptanceCommands } from './verifyAcceptance';
+
+const { regroup, outputJson } = vi.hoisted(() => ({
+  regroup: vi.fn().mockResolvedValue({ version: 2 }),
+  outputJson: vi.fn(),
+}));
+vi.mock('../api/client', () => ({
+  getTrpcClient: async () => ({ acceptance: { regroupChecks: { mutate: regroup } } }),
+}));
+vi.mock('../utils/format', () => ({ outputJson }));
+afterEach(() => vi.clearAllMocks());
+
+it('submits only the requested grouping and version, without starting a verification round', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'acceptance-regroup-'));
+  try {
+    const input = {
+      expectedVersion: 1,
+      groups: [{ title: 'Reassignment', checkItemIds: ['C15-stable-id'] }],
+    };
+    const file = path.join(dir, 'groups.json');
+    await writeFile(file, JSON.stringify(input));
+    const program = new Command().exitOverride();
+    registerAcceptanceCommands(program);
+    await program.parseAsync([
+      'node',
+      'lh',
+      'acceptance',
+      'regroup',
+      'acceptance-id',
+      '--file',
+      file,
+    ]);
+    expect(regroup).toHaveBeenCalledOnce();
+    expect(regroup).toHaveBeenCalledWith({ ...input, id: 'acceptance-id' });
+    expect(outputJson).toHaveBeenCalledWith({ version: 2 });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/cli/src/commands/verifyAcceptance.ts
+++ b/apps/cli/src/commands/verifyAcceptance.ts
@@ -1,3 +1,6 @@
+import { readFile } from 'node:fs/promises';
+
+import type { AcceptanceCheckGroup } from '@lobechat/types';
 import type { Command } from 'commander';
 import pc from 'picocolors';
 
@@ -68,6 +71,19 @@ export function registerAcceptanceCommands(parent: Command, options?: { deprecat
     );
 
   attachAcceptanceFlowCommands(acceptance);
+
+  acceptance
+    .command('regroup <idOrSubject>')
+    .description('Change checklist business groups while preserving checks, evidence and history')
+    .requiredOption('--file <path>', 'JSON: expectedVersion and groups [{ title, checkItemIds }]')
+    .action(async (ref: string, options: { file: string }) => {
+      const id = await resolveAcceptanceId(ref);
+      const input: { expectedVersion: number; groups: AcceptanceCheckGroup[] } = JSON.parse(
+        await readFile(options.file, 'utf8'),
+      );
+      const client = await getTrpcClient();
+      outputJson(await client.acceptance.regroupChecks.mutate({ ...input, id }));
+    });
 
   acceptance
     .command('list')

--- a/apps/server/src/routers/lambda/acceptance.ts
+++ b/apps/server/src/routers/lambda/acceptance.ts
@@ -203,6 +203,25 @@ const applyAcceptanceStatus = async (
 };
 
 export const acceptanceRouter = router({
+  regroupChecks: acceptanceWriteProcedure
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        expectedVersion: z.number().int().nonnegative(),
+        groups: z
+          .array(
+            z.object({
+              title: z.string().trim().min(1).max(200),
+              checkItemIds: z.array(z.string().min(1)).min(1).max(1000),
+            }),
+          )
+          .max(100),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { service } = await resolveAcceptanceForWrite(ctx, input.id);
+      return service.regroupChecks(input.id, input.groups, input.expectedVersion);
+    }),
   publishFlow: acceptanceWriteProcedure
     .input(
       z.object({
@@ -547,6 +566,7 @@ export const acceptanceRouter = router({
 
       const checks = buildAcceptanceCheckUnion(
         runs.map((run) => ({ results: resultsByRun.get(run.id) ?? [], run })),
+        acceptance.metadata?.checkGrouping?.groups,
       );
 
       // Enrich the evidence backing every executed timeline step — the final

--- a/apps/server/src/services/verify/__tests__/acceptanceUnion.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceUnion.test.ts
@@ -1,10 +1,18 @@
 // @vitest-environment node
 import type { VerifyCheckItem } from '@lobechat/types';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { VerifyCheckResultItem, VerifyRunItem } from '@/database/schemas/verify';
 
-import { buildAcceptanceCheckUnion, buildCheckReviewOverlay } from '../acceptanceService';
+import {
+  AcceptanceService,
+  buildAcceptanceCheckUnion,
+  buildCheckReviewOverlay,
+} from '../acceptanceService';
+
+// Union/grouping checks never execute tasks; keep that external runtime out of this suite.
+vi.mock('@/server/services/task', () => ({ TaskService: class {} }));
+afterEach(() => vi.restoreAllMocks());
 
 const planItem = (id: string, overrides: Partial<VerifyCheckItem> = {}): VerifyCheckItem => ({
   id,
@@ -35,6 +43,106 @@ const result = (
   }) as VerifyCheckResultItem;
 
 describe('buildAcceptanceCheckUnion', () => {
+  it('rejects unknown checks and ambiguous group membership before storing organization', async () => {
+    const service = new AcceptanceService({} as never, 'owner');
+    vi.spyOn(service.acceptanceModel, 'findById').mockResolvedValue({ id: 'acceptance' } as never);
+    vi.spyOn(service, 'loadRounds').mockResolvedValue({
+      runs: [run('r1', 1, [planItem('known')])],
+      results: [],
+      evidence: [],
+      reports: [],
+    });
+    const save = vi
+      .spyOn(service.acceptanceModel, 'setCheckGroups')
+      .mockResolvedValue({ groups: [], version: 1 });
+    await expect(
+      service.regroupChecks('acceptance', [{ title: 'A', checkItemIds: ['foreign'] }], 0),
+    ).rejects.toThrow('Unknown check item');
+    await expect(
+      service.regroupChecks(
+        'acceptance',
+        [
+          { title: 'A', checkItemIds: ['known'] },
+          { title: 'B', checkItemIds: ['known'] },
+        ],
+        0,
+      ),
+    ).rejects.toThrow('multiple groups');
+    await expect(
+      service.regroupChecks('acceptance', [{ title: ' ', checkItemIds: ['known'] }], 0),
+    ).rejects.toThrow('unique, non-empty');
+    expect(save).not.toHaveBeenCalled();
+    await service.regroupChecks(
+      'acceptance',
+      [{ title: ' Reassignment ', checkItemIds: ['known'] }],
+      0,
+    );
+    expect(save).toHaveBeenCalledWith(
+      'acceptance',
+      [{ title: 'Reassignment', checkItemIds: ['known'] }],
+      0,
+    );
+  });
+
+  it('regroups existing flow checks without changing identity, verdict, review or history', () => {
+    const items = ['handoff', 'resume'].map((id) =>
+      planItem(id, {
+        category: 'Whole PR',
+        sourceCriterionId: 'shared-asset',
+        sourceFlowNode: { flowId: 'flow', nodeId: id },
+      }),
+    );
+    const passed = result('handoff', 'passed', {
+      userDecision: 'accepted',
+      userDecisionDetail: { decidedAt: '2026-09-08T00:00:00Z' },
+    });
+    const rounds = [{ run: run('r1', 1, items), results: [passed] }];
+    const before = buildAcceptanceCheckUnion(rounds);
+    const grouped = buildAcceptanceCheckUnion(rounds, [
+      { title: 'Continuation', checkItemIds: ['resume'] },
+      { title: 'Reassignment', checkItemIds: ['handoff'] },
+    ]);
+    expect(grouped.map((row) => [row.id, row.category, row.seq])).toEqual([
+      ['resume', 'Continuation', 2],
+      ['handoff', 'Reassignment', 1],
+    ]);
+    for (const row of grouped) {
+      const original = before.find((item) => item.id === row.id)!;
+      expect({ ...row, category: original.category }).toEqual(original);
+      expect(buildCheckReviewOverlay(row, new Map([[passed.id, passed]]), 1)).toEqual(
+        buildCheckReviewOverlay(original, new Map([[passed.id, passed]]), 1),
+      );
+    }
+    expect(items.every((item) => item.category === 'Whole PR')).toBe(true);
+    expect(buildAcceptanceCheckUnion(rounds, [])).toEqual(before);
+  });
+
+  it('leaves newly introduced checks and repeated asset occurrences ungrouped until assigned', () => {
+    const rows = buildAcceptanceCheckUnion(
+      [
+        {
+          run: run(
+            'r1',
+            1,
+            ['a', 'b'].map((id) =>
+              planItem(id, {
+                category: 'Original',
+                sourceCriterionId: 'shared',
+                sourceFlowNode: { flowId: 'f', nodeId: id },
+              }),
+            ),
+          ),
+          results: [],
+        },
+      ],
+      [{ title: 'Moved', checkItemIds: ['a'] }],
+    );
+    expect(rows.map((row) => [row.id, row.category])).toEqual([
+      ['a', 'Moved'],
+      ['b', 'Original'],
+    ]);
+  });
+
   it('resets a flow check for a new run while keeping earlier evidence and review in history', () => {
     const item = planItem('node', {
       sourceFlowNode: { flowId: 'flow', nodeId: 'n1' },

--- a/apps/server/src/services/verify/acceptanceService.ts
+++ b/apps/server/src/services/verify/acceptanceService.ts
@@ -1,6 +1,7 @@
 import { normalizeVerifySurface } from '@lobechat/const/verify';
 import type {
   AcceptanceAttachment,
+  AcceptanceCheckGroup,
   AcceptanceCheckReviewAction,
   AcceptanceConfig,
   AcceptanceRejectIntent,
@@ -143,7 +144,10 @@ const itemSurface = (item: VerifyCheckItem | undefined): VerifySurface | null =>
  *   item's iteration timeline, so a semantically-dead older wording stops
  *   showing up as its own row.
  */
-export const buildAcceptanceCheckUnion = (rounds: RoundInput[]): AcceptanceCheckRow[] => {
+export const buildAcceptanceCheckUnion = (
+  rounds: RoundInput[],
+  groups: AcceptanceCheckGroup[] = [],
+): AcceptanceCheckRow[] => {
   const ordered = [...rounds].sort((a, b) => (a.run.roundIndex ?? 0) - (b.run.roundIndex ?? 0));
 
   const rows = new Map<string, AcceptanceCheckRow>();
@@ -263,7 +267,16 @@ export const buildAcceptanceCheckUnion = (rounds: RoundInput[]): AcceptanceCheck
     }
   }
 
-  return [...rows.values()];
+  // Organization belongs to the current acceptance, not its immutable execution
+  // snapshots. Preserve IDs, numbering and result references when a check moves.
+  const grouped = new Map<string, AcceptanceCheckRow>();
+  for (const group of groups) {
+    for (const id of group.checkItemIds) {
+      const row = rows.get(id);
+      if (row) grouped.set(id, { ...row, category: group.title });
+    }
+  }
+  return [...grouped.values(), ...[...rows.values()].filter((row) => !grouped.has(row.id))];
 };
 
 // ============================================
@@ -763,6 +776,41 @@ export class AcceptanceService {
   latestRound = async (acceptanceId: string) => {
     const runs = await this.runModel.listByAcceptance(acceptanceId);
     return runs.at(-1) ?? null;
+  };
+
+  regroupChecks = async (
+    acceptanceId: string,
+    groups: AcceptanceCheckGroup[],
+    expectedVersion: number,
+  ) => {
+    const acceptance = await this.acceptanceModel.findById(acceptanceId);
+    if (!acceptance) throw new Error('Acceptance not found');
+    const { results, runs } = await this.loadRounds(acceptanceId);
+    const resultsByRun = new Map<string, VerifyCheckResultItem[]>();
+    for (const result of results) {
+      const bucket = resultsByRun.get(result.verifyRunId!) ?? [];
+      bucket.push(result);
+      resultsByRun.set(result.verifyRunId!, bucket);
+    }
+    const checks = buildAcceptanceCheckUnion(
+      runs.map((run) => ({ results: resultsByRun.get(run.id) ?? [], run })),
+    );
+    const known = new Set(checks.map((check) => check.id));
+    const assigned = new Set<string>();
+    const titles = new Set<string>();
+    const normalized = groups.map((group) => {
+      const title = group.title.trim();
+      if (!title || titles.has(title) || group.checkItemIds.length === 0)
+        throw new Error('Check groups need unique, non-empty titles and members');
+      titles.add(title);
+      for (const id of group.checkItemIds) {
+        if (!known.has(id)) throw new Error(`Unknown check item: ${id}`);
+        if (assigned.has(id)) throw new Error(`Check assigned to multiple groups: ${id}`);
+        assigned.add(id);
+      }
+      return { ...group, title };
+    });
+    return this.acceptanceModel.setCheckGroups(acceptanceId, normalized, expectedVersion);
   };
 
   /**

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acceptance
-version: 0.4.1
+version: 0.4.2
 description: >
   End-to-end verification and self-evidence for a delivery in any repository,
   with or without a preconfigured verify plan. Discover an existing plan when
@@ -131,7 +131,7 @@ planning, before implementation or verification begins. Keep the checklist paths
 above for independent checks;
 a graph is optional and does not replace evidence or human review.
 
-For flow-based plans, **each flow's title becomes its checks' checklist category**.
+For flow-based plans, **each flow's title is its checks' default checklist category**.
 Publish independent user journeys as separate flows in the same acceptance/run;
 use subflows for actual composed journeys. An umbrella flow containing checks
 for several independent tasks collapses them into one checklist group. Edges
@@ -139,6 +139,18 @@ must describe real user transitions, not artificial links added to make unrelate
 checks reachable. Start at the user entry and follow the journey through outcomes
 and recovery; UUIDs identify nodes and must not encode business order. Read back
 the published plan and inspect its groups and reading order before execution.
+
+For an existing acceptance that only needs different checklist groups, use
+`lh acceptance regroup <acceptanceId> --file groups.json`. Read the acceptance
+bundle first; write `{ expectedVersion, groups: [{ title, checkItemIds }] }`,
+using the exact union `checks[].id` values and
+`acceptance.metadata.checkGrouping.version` (0 when absent). The groups replace
+the current presentation grouping; an empty list restores plan categories.
+Unassigned checks keep their plan category. This preserves check IDs, numbering,
+evidence and review history without creating a round. It does not change flow
+transitions or verification conditions. Do not move execution nodes or start a
+new round just to reorganize the checklist; those operations have different
+execution semantics.
 
 1. Use the named acceptance (or create one with `lh acceptance create --help`).
    Write a JSON file with `definition: { title, entryNodeId, nodes, edges }`.

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -118,9 +118,27 @@ substitute a private agent plugin.
 
 ## Optional user-journey flows
 
+Before authoring checks, identify the independently reviewable user tasks in the
+requirement. Use those tasks as business groups, not the PR title or test surface.
+For example, reassignment, scheduled continuation, and failure recovery can be
+separate groups when the delivery covers all three; do not impose these groups
+on unrelated work. Each check should have an outcome the user can accept or
+reject independently. Keep shared entry/accessibility checks separate and avoid
+repeating their expectations across business checks.
+
 When acceptance depends on a sequence of user states, publish its graph during
-planning, before implementation or verification begins. Keep the checklist paths above for independent checks;
+planning, before implementation or verification begins. Keep the checklist paths
+above for independent checks;
 a graph is optional and does not replace evidence or human review.
+
+For flow-based plans, **each flow's title becomes its checks' checklist category**.
+Publish independent user journeys as separate flows in the same acceptance/run;
+use subflows for actual composed journeys. An umbrella flow containing checks
+for several independent tasks collapses them into one checklist group. Edges
+must describe real user transitions, not artificial links added to make unrelated
+checks reachable. Start at the user entry and follow the journey through outcomes
+and recovery; UUIDs identify nodes and must not encode business order. Read back
+the published plan and inspect its groups and reading order before execution.
 
 1. Use the named acceptance (or create one with `lh acceptance create --help`).
    Write a JSON file with `definition: { title, entryNodeId, nodes, edges }`.

--- a/packages/builtin-skills/src/acceptance/references/acceptance-checker.md
+++ b/packages/builtin-skills/src/acceptance/references/acceptance-checker.md
@@ -63,6 +63,11 @@ when sources are incomplete. Look for missing boundaries, ambiguous
 criteria, and probes that cannot distinguish success from failure. Check how
 fixtures/fault injections will be proven effective. Also identify duplicate or
 out-of-scope cases; review must not only expand scope.
+Check that groups reflect independently reviewable user tasks and that each check
+can be accepted or rejected on its own. For flow plans, inspect flow titles as
+the resulting default checklist categories: flag an umbrella PR group that hides
+distinct journeys. Check entry-to-outcome reading order, real transitions, and
+expectations duplicated across groups; coverage alone does not make a plan ready.
 
 Checker output:
 

--- a/packages/database/src/models/__tests__/acceptance.test.ts
+++ b/packages/database/src/models/__tests__/acceptance.test.ts
@@ -29,6 +29,31 @@ afterEach(async () => {
 });
 
 describe('AcceptanceModel', () => {
+  it('stores checklist groups without changing lifecycle or creating rounds, and rejects stale or foreign writes', async () => {
+    const model = new AcceptanceModel(serverDB, userId);
+    const acceptance = await model.create({
+      subjectType: 'topic',
+      subjectId: topicId,
+      status: 'accepted',
+      metadata: { title: 'Delivery', custom: 'keep' },
+    });
+    const groups = [{ title: 'Reassignment', checkItemIds: ['stable-check-id'] }];
+    const saved = await model.setCheckGroups(acceptance.id, groups, 0);
+    expect(saved).toEqual({ groups, version: 1 });
+    const current = await model.findById(acceptance.id);
+    expect(current?.status).toBe('accepted');
+    expect(current?.metadata).toEqual({ title: 'Delivery', custom: 'keep', checkGrouping: saved });
+    expect(await serverDB.select().from(verifyRuns)).toHaveLength(0);
+    await expect(model.setCheckGroups(acceptance.id, [], 0)).rejects.toThrow(
+      'Check grouping changed',
+    );
+    await expect(
+      new AcceptanceModel(serverDB, otherUserId).setCheckGroups(acceptance.id, [], 1),
+    ).rejects.toThrow('Acceptance not found');
+    expect((await model.findById(acceptance.id))?.metadata?.checkGrouping).toEqual(saved);
+    expect(await model.setCheckGroups(acceptance.id, [], 1)).toEqual({ groups: [], version: 2 });
+  });
+
   it('ensureForSubject creates once and converges on the same row', async () => {
     const model = new AcceptanceModel(serverDB, userId);
 

--- a/packages/database/src/models/__tests__/acceptanceFlow.test.ts
+++ b/packages/database/src/models/__tests__/acceptanceFlow.test.ts
@@ -83,6 +83,47 @@ async function roundPlan(id: string) {
 }
 
 describe('check assets and round snapshots', () => {
+  it('reads from the entry through each branch instead of sorting checks by UUID', async () => {
+    const ids = [9, 5, 1, 3].map((n) => `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`);
+    const titles = ['Choose how to continue', 'Reassign', 'Handoff complete', 'Wait for recovery'];
+    const journey: AcceptanceFlowDefinition = {
+      title: 'Continue work',
+      entryNodeId: ids[0],
+      nodes: ids.map((id, i) => ({
+        id,
+        check: { id: randomUUID(), title: titles[i], definition: { expected: titles[i] } },
+      })),
+      edges: [
+        [0, 1],
+        [1, 2],
+        [0, 3],
+        [2, 0],
+        [3, 2],
+      ].map(([source, target], i) => ({
+        id: `00000000-0000-4000-9000-${String(i).padStart(12, '0')}`,
+        sourceNodeId: ids[source],
+        targetNodeId: ids[target],
+        trigger: `${titles[source]} to ${titles[target]}`,
+        required: true,
+      })),
+    };
+    const { flowId } = await model.publish(acceptanceId, journey);
+    const run = await model.start(acceptanceId, flowId);
+    const round = await roundPlan(run.id);
+    expect(round.flowSnapshots?.[0].nodes.map((node) => node.id)).toEqual(ids);
+    expect(round.plan?.map((item) => item.title)).toEqual([
+      titles[0],
+      titles[0],
+      titles[1],
+      titles[2],
+      titles[2],
+      titles[3],
+    ]);
+    expect(round.plan?.map((item) => item.index)).toEqual([0, 1, 2, 3, 4, 5]);
+    const replay = await model.start(acceptanceId, flowId, undefined, run.id);
+    expect((await roundPlan(replay.id)).plan).toEqual(round.plan);
+  });
+
   it.each(['accepted', 'closed'] as const)(
     'requires reopening a %s acceptance before starting or replaying',
     async (status) => {
@@ -295,6 +336,7 @@ describe('check assets and round snapshots', () => {
     const run = await model.start(acceptanceId, parent.flowId);
     const initial = await roundPlan(run.id);
     expect(initial.plan).toHaveLength(6);
+    expect(initial.plan!.map((item) => item.index)).toEqual([0, 1, 2, 3, 4, 5]);
     expect(new Set(initial.plan!.map((item) => item.id)).size).toBe(6);
     const firstItems = initial.plan!.filter((item) =>
       item.sourceFlowNode?.nodeId.startsWith(a + '/'),

--- a/packages/database/src/models/acceptance.ts
+++ b/packages/database/src/models/acceptance.ts
@@ -1,4 +1,8 @@
-import type { AcceptanceStatus, AcceptanceSubjectType } from '@lobechat/types';
+import type {
+  AcceptanceCheckGroup,
+  AcceptanceStatus,
+  AcceptanceSubjectType,
+} from '@lobechat/types';
 import { and, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
 
 import type { AcceptanceItem, NewAcceptance } from '../schemas/verify';
@@ -51,6 +55,27 @@ export class AcceptanceModel {
 
   private ownership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, acceptances);
+
+  /** Presentation-only write: never starts a round or rewrites evidence-bearing snapshots. */
+  setCheckGroups = async (id: string, groups: AcceptanceCheckGroup[], expectedVersion: number) => {
+    return this.db.transaction(async (tx) => {
+      const [row] = await tx
+        .select()
+        .from(acceptances)
+        .where(and(eq(acceptances.id, id), this.ownership()))
+        .for('update');
+      if (!row) throw new Error('Acceptance not found');
+      const version = row.metadata?.checkGrouping?.version ?? 0;
+      if (version !== expectedVersion)
+        throw new Error('Check grouping changed; reload before editing');
+      const checkGrouping = { groups, version: version + 1 };
+      await tx
+        .update(acceptances)
+        .set({ metadata: { ...row.metadata, checkGrouping } })
+        .where(eq(acceptances.id, id));
+      return checkGrouping;
+    });
+  };
 
   /**
    * Scope-dependent visibility default: personal aggregates are link-shareable

--- a/packages/database/src/models/acceptanceFlow.ts
+++ b/packages/database/src/models/acceptanceFlow.ts
@@ -212,6 +212,28 @@ export class AcceptanceFlowModel {
       .where(eq(edges.flowId, flowId))
       .orderBy(asc(edges.id));
     const entry = nodeRows.find(({ node }) => node.isEntry)?.node.id;
+    // Read each journey from its entry, keeping a branch together. UUID order
+    // only breaks ties between sibling edges; it must not order the whole plan.
+    const rowsById = new Map(nodeRows.map((row) => [row.node.id, row]));
+    const outgoing = new Map<string, string[]>();
+    for (const edge of edgeRows) {
+      const targets = outgoing.get(edge.sourceNodeId) ?? [];
+      targets.push(edge.targetNodeId);
+      outgoing.set(edge.sourceNodeId, targets);
+    }
+    const orderedRows: typeof nodeRows = [];
+    const visited = new Set<string>();
+    const pending = entry ? [entry] : [];
+    while (pending.length) {
+      const id = pending.pop()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+      const row = rowsById.get(id);
+      if (!row) throw new Error('Unknown edge endpoint');
+      orderedRows.push(row);
+      pending.push(...(outgoing.get(id) ?? []).toReversed());
+    }
+    if (orderedRows.length !== nodeRows.length) throw new Error('Unreachable nodes');
     const plan: VerifyCheckItem[] = [];
     const snapshot: VerifyFlowSnapshot = {
       flowId,
@@ -223,7 +245,7 @@ export class AcceptanceFlowModel {
       })),
       nodes: [],
     };
-    for (const { node, asset } of nodeRows) {
+    for (const { node, asset } of orderedRows) {
       const branches: ((typeof edgeRows)[number] | undefined)[] = edgeRows.filter(
         (e) => e.targetNodeId === node.id,
       );
@@ -267,10 +289,10 @@ export class AcceptanceFlowModel {
             })),
           );
           plan.push(
-            ...child.plan.map((item) => ({
+            ...child.plan.map((item, index) => ({
               ...item,
               id: prefix + item.id,
-              index: plan.length,
+              index: plan.length + index,
               required: (node.overrides?.required ?? branch?.required ?? true) && item.required,
               onFail: node.overrides?.onFail ?? item.onFail,
               sourceFlowNode: {

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -158,9 +158,17 @@ export interface AcceptanceGroupFeedback {
 /** One group-scoped feedback entry as stored on a round's decision detail. */
 export type VerifyRunGroupFeedbackEntry = Omit<AcceptanceGroupFeedback, 'roundIndex'>;
 
+/** A presentation group of stable acceptance-union check IDs, independent of execution flows. */
+export interface AcceptanceCheckGroup {
+  checkItemIds: string[];
+  title: string;
+}
+
 /** Generic acceptance extension bag for cross-subject state we have not modeled yet. */
 export interface AcceptanceMetadata {
   [key: string]: unknown;
+  /** Current checklist organization; frozen plans, results and reviews keep their original IDs. */
+  checkGrouping?: { groups: AcceptanceCheckGroup[]; version: number };
   /** User-set display-title override for the acceptance (sidebar rename). */
   title?: string;
 }


### PR DESCRIPTION
Acceptance checklists could only use categories frozen into execution plans. Reorganizing an existing delivery through new flows or rounds could create new check identities or reset their current verification state. Flow-generated checklist order also followed node UUIDs, sometimes placing the entry after failure cases.

Add `lh acceptance regroup <idOrSubject> --file groups.json` and the authenticated `acceptance.regroupChecks` endpoint. Group membership is stored separately on the acceptance and keyed by stable union check IDs. The bundle projects the requested categories and group order while retaining check IDs, sequence numbers, results, evidence references, reviews, and history. No execution round or flow topology is changed. Empty groups restore the plan categories; unassigned checks keep their existing categories. Writes validate membership and use a locked version check to reject stale edits.

The PR also traverses flow plans from the entry, handles cycles and shared targets, and fixes consecutive indices for expanded subflows. Acceptance skill 0.4.2 explains business grouping, plan review, and presentation-only regrouping.

| Before | After |
| ------ | ----- |
| Reorganizing via new execution plans could reset a passed check | A passed check can change checklist category with the same identity and history |
| Node UUID order determines checklist order; the entry can appear last | Entry-first traversal follows the graph through each branch |

Existing round snapshots remain unchanged. Sibling edges still use UUID order as a deterministic tie-breaker because the schema does not persist authored sibling order. No database migration is required. The existing 26-check acceptance has not been changed in production; its regroup payload is prepared for after deployment. This command changes checklist organization, not the execution graph's structure.

Rebased onto canary at `45e923e302`. The two Settings test failures are now fixed upstream, so the duplicate test-fix commit has been removed. Both upstream Settings files passed all 30 tests and lint locally after rebase.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- Database flow tests: 12 passed.
- Grouping union/service tests: 18 passed; regression also failed against the pre-fix implementation.
- Acceptance model tests: 24 passed, including stale writes, user isolation, lifecycle and metadata preservation.
- CLI regroup command: 1 passed; actual command help also verified.
- Acceptance skill tests: 6 passed.
- Lint passed. Full-repository type-check is blocked by unrelated errors (including missing `BRANDING_PROVIDER` exports and `@lobechat/builtin-tool-auv`); after correcting the new fixture, no diagnostics remain in the changed files.

#### 🔗 Related Issue

Reported against the [PR #19080 acceptance plan](https://app.lobehub.com/acceptance/bd76c280-6069-45c1-8afa-39a4bb58cfab).

