### PR TITLE
chore: remove LOBE-XXX markers from code comments (2026-09-09)

### DIFF
--- a/src/features/EditorCanvas/InternalEditor.tsx
+++ b/src/features/EditorCanvas/InternalEditor.tsx
@@ -223,8 +223,9 @@ const InternalEditor = memo<InternalEditorProps>(
     }, [editor]);
 
     // Opt-in (comment editors): keep the caret out of the root node around
-    // block images by pushing an empty paragraph next to the image instead of
-    // showing Lexical's horizontal root-level caret (LOBE-13882).
+    // block images by pushing an empty paragraph next to the image. Otherwise
+    // pasting an image into a Documents body leaves a horizontal root-level
+    // caret that then snaps back to vertical.
     useEffect(() => {
       if (!editor || !blockImageCaretGuard) return;
       const unregister = registerBlockDecoratorCaretGuard(editor);

--- a/src/features/PageEditor/DocumentComments/styles.ts
+++ b/src/features/PageEditor/DocumentComments/styles.ts
@@ -121,7 +121,8 @@ export const styles = createStaticStyles(({ css }) => ({
 
     /* Only untouched images get the thumbnail treatment. Forcing width: auto
        on every image would beat the inline width the resize handles write, so
-       dragging would appear to do nothing (LOBE-13874). */
+       dragging would appear to do nothing and resizing in the comment editor
+       would silently break. */
     & [contenteditable='true'] img:not(${RESIZED_IMAGE}) {
       width: auto !important;
       max-height: ${COMMENT_EDITOR_IMAGE_MAX_HEIGHT}px;

--- a/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNodeMenuButton.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNodeMenuButton.tsx
@@ -17,9 +17,10 @@ interface HierarchyNodeMenuButtonProps {
 
 /**
  * Hover-revealed "..." on a tree row that opens the row's action menu. The
- * menu used to be reachable only through `onContextMenu`, which nobody finds
- * (LOBE-13884). Shares the `.hierarchy-node-actions` reveal rules with the
- * folder "+" (see styles.ts): hidden until hover, and kept visible while open.
+ * menu used to be reachable only through `onContextMenu` (right-click), which
+ * nobody discovers, so we surface an explicit affordance on hover. Shares the
+ * `.hierarchy-node-actions` reveal rules with the folder "+" (see styles.ts):
+ * hidden until hover, and kept visible while open.
  */
 const HierarchyNodeMenuButton = memo<HierarchyNodeMenuButtonProps>(({ menuItems }) => {
   const { t } = useTranslation('common');

--- a/src/features/Work/useRemoveWork.ts
+++ b/src/features/Work/useRemoveWork.ts
@@ -6,10 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { workService } from '@/services/work';
 
 /**
- * User-initiated removal of a Work card. Intended for orphaned Works (the
- * backing task / document is gone, so the user cannot clear the card by
- * deleting the resource itself — see LOBE-13917). Confirms first because the
- * delete cascades the Work's version history and any project pins.
+ * User-initiated removal of a Work card. Intended for orphaned Works: when the
+ * backing document is deleted the card stays clickable but opens a 404 and
+ * cannot be removed, because there is no resource left to delete. Confirms
+ * first because the delete cascades the Work's version history and any project
+ * pins.
  */
 export interface UseRemoveWorkOptions {
   /**

--- a/src/store/tree/actions.test.ts
+++ b/src/store/tree/actions.test.ts
@@ -614,8 +614,9 @@ describe('sortTreeItems', () => {
     toTreeItem({ createdAt, fileType: 'custom/document', id, name });
 
   it('puts a just-created page first instead of dropping it into the A-Z list', () => {
-    // LOBE-13814: creating a page inside a folder full of "<name> 周报 — 2026-Wxx"
-    // rows landed the new "Untitled" between "TC" and "xiaojie".
+    // A newly created page must sort first rather than falling into the A-Z
+    // list: inside a folder full of "<name> 周报 — 2026-Wxx" rows the new
+    // "Untitled" used to land between "TC" and "xiaojie".
     const rows = [
       doc('report-tc', 'TC 周报 — 2026-W35', '2026-08-28T02:00:00.000Z'),
       doc('untitled', 'Untitled', '2026-09-04T15:31:00.000Z'),


### PR DESCRIPTION
## Summary

Automated daily cleanup of `LOBE-XXX` markers left in code comments. The referenced Linear issues are all resolved, so their ticket references were replaced with the actual scenario each comment is guarding against.

## Changes

- `src/features/EditorCanvas/InternalEditor.tsx` — describe the horizontal root-level caret symptom that the caret guard prevents, instead of referencing a ticket.
- `src/features/PageEditor/DocumentComments/styles.ts` — clarify why forcing `width: auto` on every image would break comment-editor image resizing.
- `src/features/ResourceManager/components/LibraryHierarchy/HierarchyNodeMenuButton.tsx` — explain the hover affordance exists because the menu was previously only reachable via right-click.
- `src/features/Work/useRemoveWork.ts` — spell out the orphaned-Work scenario (card opens a 404 and cannot be removed).
- `src/store/tree/actions.test.ts` — document the just-created-page sort-first behavior in the test comment.

## Notes

- No behavioral changes; comment-only edits.
- Lint passes for all changed files.

Generated at 2026-09-09 (Asia/Shanghai).