### PR TITLE
✅ test(settings): fix skill fixture and API key scope interaction

### DIFF
--- a/src/features/Settings/apikey/features/ApiKey.test.tsx
+++ b/src/features/Settings/apikey/features/ApiKey.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -459,20 +460,22 @@ describe('ApiKey', () => {
   });
 
   it('edits a key scope in place and refreshes the list', async () => {
+    const user = userEvent.setup();
     hoisted.trpc.getApiKeys.mockResolvedValue([makeItem({ scopes: ['agent:read'] })]);
     renderPage();
     await screen.findByText('My Key');
 
     const dialog = await openDetail('My Key');
     fireEvent.click(within(dialog).getByRole('button', { name: 'apikey.detail.permissions.edit' }));
-    const toggleScope = (groupKey: string) => {
+    const toggleScope = async (groupKey: string, checked: boolean) => {
       const group = within(dialog).getByText(`apikey.scopes.groups.${groupKey}`).parentElement!;
       const checkbox = within(group).getByRole('checkbox', { name: 'apikey.scopes.read' });
-      fireEvent.keyDown(checkbox, { key: ' ' });
-      fireEvent.keyUp(checkbox, { key: ' ' });
+      await user.click(checkbox);
+      if (checked) expect(checkbox).toBeChecked();
+      else expect(checkbox).not.toBeChecked();
     };
-    toggleScope('agent');
-    toggleScope('chat');
+    await toggleScope('agent', false);
+    await toggleScope('chat', true);
     fireEvent.click(within(dialog).getByRole('button', { name: 'apikey.detail.permissions.save' }));
 
     await waitFor(() =>

--- a/src/features/Settings/skill/features/SkillDetail/localization.test.ts
+++ b/src/features/Settings/skill/features/SkillDetail/localization.test.ts
@@ -21,7 +21,6 @@ describe('SkillDetail localization helpers', () => {
     (translations, title) => {
       const result = getLocalizedBuiltinSkillDetail(
         {
-          content: AuvManifest.meta.readme ?? '',
           description: AuvManifest.meta.description ?? '',
           identifier: AuvManifest.identifier,
           name: AuvManifest.meta.title,


### PR DESCRIPTION
Two existing Settings tests block canary-based CI: the skill localization fixture passes `content`, which was removed from `BuiltinSkillManifest`, and the API key scope edit test can submit the original scope when raw keyboard events do not activate the checkbox in CI.

Remove the obsolete fixture field. Use `userEvent.click` for scope changes and assert both checkbox states before saving, while retaining the assertions for the exact updated scopes and list refresh. Production behavior is unchanged.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- `bun run check src/features/Settings/apikey/features/ApiKey.test.tsx src/features/Settings/skill/features/SkillDetail/localization.test.ts`: lint clean, 30 tests passed.
- Failure evidence: [canary-based CI run](https://github.com/lobehub/lobehub/actions/runs/34298927146). The original keyboard-only test passed locally; a raw click also failed the new state assertion locally. Full user interaction passes both state and submission assertions.

#### 🔗 Related Issue

Unblocks the Settings failures observed in #19306.
