### PR TITLE
🐛 fix(acceptance): order check occurrences along flow paths

### DIFF
--- a/packages/database/src/models/__tests__/acceptanceFlow.test.ts
+++ b/packages/database/src/models/__tests__/acceptanceFlow.test.ts
@@ -113,14 +113,56 @@ describe('check assets and round snapshots', () => {
     expect(round.flowSnapshots?.[0].nodes.map((node) => node.id)).toEqual(ids);
     expect(round.plan?.map((item) => item.title)).toEqual([
       titles[0],
-      titles[0],
       titles[1],
       titles[2],
-      titles[2],
+      titles[0],
       titles[3],
+      titles[2],
+    ]);
+    expect(round.plan?.map((item) => item.sourceFlowNode?.incomingEdgeId)).toEqual([
+      undefined,
+      journey.edges[0].id,
+      journey.edges[1].id,
+      journey.edges[3].id,
+      journey.edges[2].id,
+      journey.edges[4].id,
     ]);
     expect(round.plan?.map((item) => item.index)).toEqual([0, 1, 2, 3, 4, 5]);
     const replay = await model.start(acceptanceId, flowId, undefined, run.id);
+    expect((await roundPlan(replay.id)).plan).toEqual(round.plan);
+  });
+
+  it('keeps expanded subflow checks together at each traversed occurrence', async () => {
+    const child = await model.publish(acceptanceId, definition);
+    const a = randomUUID();
+    const b = randomUUID();
+    const forward = randomUUID();
+    const back = randomUUID();
+    const parent = await model.publish(acceptanceId, {
+      title: 'Retry journey',
+      entryNodeId: a,
+      nodes: [
+        { id: a, subFlowId: child.flowId },
+        { id: b, subFlowId: child.flowId },
+      ],
+      edges: [
+        { id: forward, sourceNodeId: a, targetNodeId: b, trigger: 'Continue', required: true },
+        { id: back, sourceNodeId: b, targetNodeId: a, trigger: 'Retry', required: true },
+      ],
+    });
+    const run = await model.start(acceptanceId, parent.flowId);
+    const round = await roundPlan(run.id);
+    const childRun = await model.start(acceptanceId, child.flowId);
+    const childPlan = (await roundPlan(childRun.id)).plan!;
+    const expectedIds = [`${a}/entry/`, `${b}/${forward}/`, `${a}/${back}/`].flatMap((prefix) =>
+      childPlan.map((item) => prefix + item.id),
+    );
+    expect(round.plan).toHaveLength(expectedIds.length);
+    expect(round.plan!.map((item) => item.id.slice(0, item.id.lastIndexOf(':')))).toEqual(
+      expectedIds,
+    );
+    expect(round.plan!.map((item) => item.index)).toEqual(expectedIds.map((_, index) => index));
+    const replay = await model.start(acceptanceId, parent.flowId, undefined, run.id);
     expect((await roundPlan(replay.id)).plan).toEqual(round.plan);
   });
 

--- a/packages/database/src/models/acceptanceFlow.ts
+++ b/packages/database/src/models/acceptanceFlow.ts
@@ -215,26 +215,34 @@ export class AcceptanceFlowModel {
     // Read each journey from its entry, keeping a branch together. UUID order
     // only breaks ties between sibling edges; it must not order the whole plan.
     const rowsById = new Map(nodeRows.map((row) => [row.node.id, row]));
-    const outgoing = new Map<string, string[]>();
+    const outgoing = new Map<string, typeof edgeRows>();
     for (const edge of edgeRows) {
       const targets = outgoing.get(edge.sourceNodeId) ?? [];
-      targets.push(edge.targetNodeId);
+      targets.push(edge);
       outgoing.set(edge.sourceNodeId, targets);
     }
     const orderedRows: typeof nodeRows = [];
     const visited = new Set<string>();
-    const pending = entry ? [entry] : [];
+    const occurrenceOrder: string[] = [];
+    const pending = entry ? [{ nodeId: entry, occurrenceId: 'entry' }] : [];
     while (pending.length) {
-      const id = pending.pop()!;
+      const { nodeId: id, occurrenceId } = pending.pop()!;
+      // Every incoming edge creates a check occurrence, including revisits.
+      // Expand a node's outgoing edges only once to terminate cycles.
+      occurrenceOrder.push(occurrenceId);
       if (visited.has(id)) continue;
       visited.add(id);
       const row = rowsById.get(id);
       if (!row) throw new Error('Unknown edge endpoint');
       orderedRows.push(row);
-      pending.push(...(outgoing.get(id) ?? []).toReversed());
+      pending.push(
+        ...(outgoing.get(id) ?? [])
+          .toReversed()
+          .map((edge) => ({ nodeId: edge.targetNodeId, occurrenceId: edge.id })),
+      );
     }
     if (orderedRows.length !== nodeRows.length) throw new Error('Unreachable nodes');
-    const plan: VerifyCheckItem[] = [];
+    const occurrencePlans = new Map<string, VerifyCheckItem[]>();
     const snapshot: VerifyFlowSnapshot = {
       flowId,
       title: flow.title,
@@ -288,11 +296,11 @@ export class AcceptanceFlowModel {
               targetNodeId: prefix + edge.targetNodeId,
             })),
           );
-          plan.push(
-            ...child.plan.map((item, index) => ({
+          occurrencePlans.set(
+            branch?.id ?? 'entry',
+            child.plan.map((item) => ({
               ...item,
               id: prefix + item.id,
-              index: plan.length + index,
               required: (node.overrides?.required ?? branch?.required ?? true) && item.required,
               onFail: node.overrides?.onFail ?? item.onFail,
               sourceFlowNode: {
@@ -339,27 +347,31 @@ export class AcceptanceFlowModel {
       for (const branch of branches) {
         const id = `${node.id}:${branch?.id ?? 'entry'}`;
         itemIds.push(id);
-        plan.push({
-          id,
-          index: plan.length,
-          title: asset.title,
-          description: asset.description ?? undefined,
-          category: flow.title,
-          sourceCriterionId: asset.id,
-          sourceFlowNode: { flowId, nodeId: node.id, incomingEdgeId: branch?.id },
-          definition: {
-            ...definition,
-            preconditions: [
-              ...(definition.preconditions ?? []),
-              ...(branch ? [branch.trigger, ...(branch.condition ? [branch.condition] : [])] : []),
-            ],
+        occurrencePlans.set(branch?.id ?? 'entry', [
+          {
+            id,
+            index: 0,
+            title: asset.title,
+            description: asset.description ?? undefined,
+            category: flow.title,
+            sourceCriterionId: asset.id,
+            sourceFlowNode: { flowId, nodeId: node.id, incomingEdgeId: branch?.id },
+            definition: {
+              ...definition,
+              preconditions: [
+                ...(definition.preconditions ?? []),
+                ...(branch
+                  ? [branch.trigger, ...(branch.condition ? [branch.condition] : [])]
+                  : []),
+              ],
+            },
+            documentId: asset.documentId,
+            verifierType: asset.verifierType,
+            verifierConfig: asset.verifierConfig ?? {},
+            onFail: node.overrides?.onFail ?? asset.onFail,
+            required: node.overrides?.required ?? branch?.required ?? true,
           },
-          documentId: asset.documentId,
-          verifierType: asset.verifierType,
-          verifierConfig: asset.verifierConfig ?? {},
-          onFail: node.overrides?.onFail ?? asset.onFail,
-          required: node.overrides?.required ?? branch?.required ?? true,
-        });
+        ]);
       }
       snapshot.nodes.push({
         id: node.id,
@@ -368,6 +380,9 @@ export class AcceptanceFlowModel {
         checkItemIds: itemIds,
       });
     }
+    const plan = occurrenceOrder
+      .flatMap((id) => occurrencePlans.get(id)!)
+      .map((item, index) => ({ ...item, index }));
     const acceptance = await this.owned(flow.acceptanceId, database);
     const frozen = await new VerifyCriterionModel(
       database,


### PR DESCRIPTION
Flow plans sorted nodes from the entry but emitted all incoming-edge checks together. With converging branches or cycles, this placed checks before their source path: `A→B→D`, `A→C→D`, `D→A` produced `A,A,B,D,D,C`.

Order check occurrences as their incoming edges are traversed, producing `A,B,D,A,C,D`. Expand outgoing edges once per node to terminate cycles, keep each subflow occurrence together, and assign consecutive plan indices. Check identity and frozen replay remain unchanged.

Validation: `bun run check` passed lint and 13 database flow tests. The corrected ordering regression failed before the fix; coverage includes convergence, cycles, subflow occurrences and replay.

Follow-up to #19306 and its ordering review comment.
