### PR TITLE
📝 docs(acceptance): keep checklist explanations concise

### DIFF
--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -277,6 +277,21 @@ sufficient description. This also applies when a text file is stored inline.
 Shared rules for every artifact — media types, provenance, file vs inline,
 safety — are in [evidence.md](references/evidence.md).
 
+## Keep checklist explanations brief
+
+Write each check's `observation` and inline explanation in the user's language,
+usually 1–3 short sentences: what was done, what happened, and any limitation
+needed to judge that outcome. Do not paste the execution report into the check.
+Omit repeated titles, verdict labels, SHA/port/ID headers, environment boilerplate,
+and round-history explanations. Put shared setup and revision details once in
+the round report; keep commands, traces, raw output, and detailed reasoning in
+separate evidence attachments. Briefly disclose a limitation in the check when
+it changes the verdict; concision must not hide missing verification.
+
+Example: “转派后，新 Agent 收到原对话上下文并创建了独立话题。刷新后消息仍保留。”
+For a failure, name the unmet outcome directly, without recounting the debugging
+process. Keep required evidence complete; shorten its presentation, not the work.
+
 ## Final handoff (mandatory)
 
 Before declaring the task done, prove coverage: for each check with

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -128,6 +128,9 @@ supersedes? }`.
    (`{ id, name, category, surface, status, observation, evidence }`), reusing
    the plan item's `id`. `status`: `pass` / `fail` / `blocked` (couldn't run —
    a blocked case is not a pass).
+   Keep `observation` brief and reviewer-facing; follow
+   [checklist explanation guidance](../SKILL.md#keep-checklist-explanations-brief).
+   Detailed reasoning and execution records belong in evidence attachments.
 4. **Set `title` and `summary.verdict`** (`pass` / `fail` / `partial`) — without
    them the run lists as "未命名验证" with a permanent amber "?" glyph. Write the
    one-paragraph verdict into `summary.conclusion`.


### PR DESCRIPTION
Acceptance checklist explanations can become hard to review when they repeat revision IDs, environment setup, and execution history. Guide each observation toward 1–3 short sentences describing the action, observed outcome, and any material limitation.

Keep shared setup in the round report and detailed reasoning, commands, and traces in evidence attachments. Required verification and evidence remain unchanged. The report-writing guide links to the new rule.

#### Test

- [x] `bun run check --lint packages/builtin-skills/src/acceptance/SKILL.md packages/builtin-skills/src/acceptance/references/report.md`
- [x] `git diff --check`
- [x] No runtime tests needed (documentation only)
