### PR TITLE
💄 style: align internal link labels with surrounding text

### DIFF
--- a/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityLink.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityLink.tsx
@@ -30,10 +30,14 @@ import {
 } from './InternalEntityPreview';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  icon: css`
+    margin-inline-end: 4px;
+    color: ${cssVar.colorTextSecondary};
+    vertical-align: -0.15em;
+  `,
   link: css`
-    display: inline-flex;
-    gap: 4px;
-    align-items: center;
+    /* Keep the label on the surrounding text baseline instead of the icon's flex baseline. */
+    display: inline;
 
     color: ${cssVar.colorText} !important;
 
@@ -58,11 +62,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       border-radius: 2px;
       outline: 2px solid ${cssVar.colorPrimaryBorder};
       outline-offset: 2px;
-    }
-
-    > svg {
-      flex: none;
-      color: ${cssVar.colorTextSecondary};
     }
   `,
 }));
@@ -223,7 +222,7 @@ export const InternalEntityLink = memo<InternalEntityLinkProps>(({ href, label, 
       target="_blank"
       onClick={handleClick}
     >
-      {icon && <Icon icon={icon} size={14} />}
+      {icon && <Icon className={styles.icon} icon={icon} size={14} />}
       {displayLabel}
     </a>
   );


### PR DESCRIPTION
Internal entity links could render their labels above the surrounding message text because the leading icon determined the baseline of an inline flex container. Keep the link in normal inline flow and align the icon separately, following the existing external-link pattern.

The shared fix covers document, agent, task, acceptance, and verification links. It also applies the existing secondary icon color to the Icon wrapper instead of an unmatched direct SVG selector.

| Before | After |
| ------ | ----- |
| In an isolated browser reproduction, the document label was 2 px above adjacent text. | The same reproduction measured a 0 px offset. |

#### Test

- [x] [Web acceptance](https://app.lobehub.com/acceptance/e40ac82b-cec4-40b0-a8b7-1ccdc817eb7b?r=1): all 3 criteria passed with 4 screenshots and independent evidence review. The real chat reproduced a 2.1875 px label offset before the fix and 0 px after it; long-label wrapping at a 700 px viewport and opening the correct document also passed. Electron and native mobile were not exercised.
- [x] Installed worktree dependencies and ran `bun run check lobehub/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityLink.tsx lobehub/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx` on PR head `dacc5aa1c9f627f07a90dcc191869cd5c697ad15`: lint clean, all 27 existing link-rendering tests passed. No source changes were needed after installation.
- [x] No new unit tests: the change is CSS-only, and DOM-only assertions would not verify browser baseline layout.
