### PR TITLE
🐛 fix(vite): stop assuming node_modules sits at the repo root

### DIFF
--- a/apps/desktop/pnpm-workspace.yaml
+++ b/apps/desktop/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ packages:
   - '../../packages/tool-runtime'
   - '../../packages/prompts'
   - '../../packages/ssrf-safe-fetch'
-  - './stubs/business-const'
+  - 'stubs/business-const'
   - '../../packages/types'
   - '../../packages/model-bank'
   - '../../packages/utils'

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "@lobehub/analytics": "^1.6.4",
     "@lobehub/charts": "^5.4.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^4.26.1",
+    "@lobehub/editor": "^4.27.0",
     "@lobehub/icons": "^5.18.0",
     "@lobehub/market-sdk": "0.41.0",
     "@lobehub/tts": "^5.1.2",

--- a/plugins/vite/lobeUiImports.ts
+++ b/plugins/vite/lobeUiImports.ts
@@ -1,6 +1,6 @@
 import { readFileSync, realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import transformImports from '@rolldown/plugin-transform-imports';
 import type { Plugin, PluginOption } from 'vite';
@@ -54,10 +54,10 @@ export const parseBarrel = (code: string, barrelDir: string): BarrelMap => {
 };
 
 const loadBarrelMaps = () => {
+  // Resolve through the package rather than a path into node_modules: overlay
+  // builds mount this repo as a submodule and hoist the install above it.
   // realpath so bare specifiers resolve from pnpm's isolated store, not the root symlink
-  const esRoot = realpathSync(
-    path.resolve(fileURLToPath(import.meta.url), '../../../node_modules/@lobehub/ui/es'),
-  );
+  const esRoot = realpathSync(path.dirname(createRequire(import.meta.url).resolve('@lobehub/ui')));
   const maps: Record<string, Barrel> = {};
   for (const barrel of BARRELS) {
     const barrelDir = barrel ? `${barrel}/` : '';

--- a/plugins/vite/sharedRendererConfig.test.ts
+++ b/plugins/vite/sharedRendererConfig.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   __testing,
@@ -21,14 +21,8 @@ describe('sharedRendererPlugins', () => {
   });
 });
 
-describe('lobe-editor-provider', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  const resolveProvider = async (entryId: string) => {
-    vi.stubEnv('NODE_ENV', 'production');
-
+describe('lobe-dev-editor-provider', () => {
+  it('sends the provider entry back to the one prebundled editor bundle', async () => {
     const plugin = sharedRendererPlugins({ platform: 'web' })
       .flat(Number.POSITIVE_INFINITY)
       .find(
@@ -37,26 +31,20 @@ describe('lobe-editor-provider', () => {
         ): item is { name: string; resolveId: (source: string, importer: string) => unknown } =>
           Boolean(item) &&
           typeof item === 'object' &&
-          (item as any).name === 'lobe-editor-provider',
+          (item as { name?: string }).name === 'lobe-dev-editor-provider',
       );
 
-    return plugin!.resolveId.call(
-      { resolve: async () => ({ id: entryId }) },
-      '@lobehub/editor/es/react/EditorProvider',
-      '/repo/src/layout/GlobalProvider/Editor.tsx',
-    );
-  };
+    const resolve = async (source: string) =>
+      plugin!.resolveId.call(
+        { resolve: async (id: string) => ({ id }) },
+        source,
+        '/repo/src/layout/GlobalProvider/Editor.tsx',
+      );
 
-  it('resolves the provider next to the package entry, wherever node_modules lives', async () => {
-    await expect(
-      resolveProvider('/overlay/node_modules/@lobehub/editor/es/react.js'),
-    ).resolves.toBe('/overlay/node_modules/@lobehub/editor/es/react/EditorProvider/index.js');
-  });
-
-  it('falls back to the package entry when it is prebundled', async () => {
-    await expect(resolveProvider('/repo/node_modules/.vite/deps/editor.js')).resolves.toEqual({
-      id: '/repo/node_modules/.vite/deps/editor.js',
+    await expect(resolve('@lobehub/editor/react/EditorProvider')).resolves.toEqual({
+      id: '@lobehub/editor/react',
     });
+    await expect(resolve('@lobehub/editor/react')).resolves.toBeNull();
   });
 });
 

--- a/plugins/vite/sharedRendererConfig.test.ts
+++ b/plugins/vite/sharedRendererConfig.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   __testing,
@@ -18,6 +18,45 @@ describe('sharedRendererPlugins', () => {
   it('keeps the icon barrel transform out of the Electron renderer', () => {
     expect(getPluginNames('desktop')).not.toContain('lobe-icon-named-export-proxy');
     expect(getPluginNames('web')).toContain('lobe-icon-named-export-proxy');
+  });
+});
+
+describe('lobe-editor-provider', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const resolveProvider = async (entryId: string) => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const plugin = sharedRendererPlugins({ platform: 'web' })
+      .flat(Number.POSITIVE_INFINITY)
+      .find(
+        (
+          item,
+        ): item is { name: string; resolveId: (source: string, importer: string) => unknown } =>
+          Boolean(item) &&
+          typeof item === 'object' &&
+          (item as any).name === 'lobe-editor-provider',
+      );
+
+    return plugin!.resolveId.call(
+      { resolve: async () => ({ id: entryId }) },
+      '@lobehub/editor/es/react/EditorProvider',
+      '/repo/src/layout/GlobalProvider/Editor.tsx',
+    );
+  };
+
+  it('resolves the provider next to the package entry, wherever node_modules lives', async () => {
+    await expect(
+      resolveProvider('/overlay/node_modules/@lobehub/editor/es/react.js'),
+    ).resolves.toBe('/overlay/node_modules/@lobehub/editor/es/react/EditorProvider/index.js');
+  });
+
+  it('falls back to the package entry when it is prebundled', async () => {
+    await expect(resolveProvider('/repo/node_modules/.vite/deps/editor.js')).resolves.toEqual({
+      id: '/repo/node_modules/.vite/deps/editor.js',
+    });
   });
 });
 

--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -408,20 +408,27 @@ export function sharedRendererPlugins(options: SharedRendererOptions) {
     viteNodeModuleStub(),
     vitePlatformResolve(options.platform),
 
-    // GlobalProvider/Editor.tsx reaches @lobehub/editor's provider by file path
-    // (the export map has no provider-only entry) so the editor runtime stays
-    // off the first screen. In dev that path is served raw while the editors
-    // use the prebundled @lobehub/editor/react, which would create a second
-    // EditorContext; point the dev import back at the bundle.
-    isDev &&
-      ({
-        enforce: 'pre',
-        name: 'lobe-dev-editor-provider',
-        resolveId(source, importer) {
-          if (!source.includes('@lobehub/editor/es/react/EditorProvider')) return null;
-          return this.resolve('@lobehub/editor/react', importer, { skipSelf: true });
-        },
-      } satisfies Plugin),
+    // GlobalProvider/Editor.tsx imports @lobehub/editor's provider module
+    // directly (the export map has no provider-only entry) so the editor
+    // runtime stays off the first screen. The subpath is unresolvable on its
+    // own, and node_modules may sit above the repo (business overlay builds),
+    // so derive it from the resolved package entry. In dev the editors use the
+    // prebundled @lobehub/editor/react and a raw second copy would create a
+    // second EditorContext; point dev at the bundle instead.
+    {
+      enforce: 'pre',
+      name: 'lobe-editor-provider',
+      async resolveId(source, importer) {
+        if (!source.includes('@lobehub/editor/es/react/EditorProvider')) return null;
+
+        const entry = await this.resolve('@lobehub/editor/react', importer, { skipSelf: true });
+        if (!entry || process.env.NODE_ENV !== 'production') return entry;
+
+        const provider = entry.id.replace(/es[/\\]react\.js$/, 'es/react/EditorProvider/index.js');
+
+        return provider === entry.id ? entry : provider;
+      },
+    } satisfies Plugin,
 
     isDev && {
       name: 'lobe-dev-strip-manifest',

--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -408,27 +408,19 @@ export function sharedRendererPlugins(options: SharedRendererOptions) {
     viteNodeModuleStub(),
     vitePlatformResolve(options.platform),
 
-    // GlobalProvider/Editor.tsx imports @lobehub/editor's provider module
-    // directly (the export map has no provider-only entry) so the editor
-    // runtime stays off the first screen. The subpath is unresolvable on its
-    // own, and node_modules may sit above the repo (business overlay builds),
-    // so derive it from the resolved package entry. In dev the editors use the
-    // prebundled @lobehub/editor/react and a raw second copy would create a
-    // second EditorContext; point dev at the bundle instead.
-    {
-      enforce: 'pre',
-      name: 'lobe-editor-provider',
-      async resolveId(source, importer) {
-        if (!source.includes('@lobehub/editor/es/react/EditorProvider')) return null;
-
-        const entry = await this.resolve('@lobehub/editor/react', importer, { skipSelf: true });
-        if (!entry || process.env.NODE_ENV !== 'production') return entry;
-
-        const provider = entry.id.replace(/es[/\\]react\.js$/, 'es/react/EditorProvider/index.js');
-
-        return provider === entry.id ? entry : provider;
-      },
-    } satisfies Plugin,
+    // Editor.tsx takes the provider-only entry so the editor runtime stays off
+    // the first screen. In dev that entry is prebundled separately from
+    // @lobehub/editor/react, which the editors use, giving the app a second
+    // EditorContext; point the dev import back at the one bundle.
+    isDev &&
+      ({
+        enforce: 'pre',
+        name: 'lobe-dev-editor-provider',
+        resolveId(source, importer) {
+          if (source !== '@lobehub/editor/react/EditorProvider') return null;
+          return this.resolve('@lobehub/editor/react', importer, { skipSelf: true });
+        },
+      } satisfies Plugin),
 
     isDev && {
       name: 'lobe-dev-strip-manifest',

--- a/src/layout/GlobalProvider/Editor.tsx
+++ b/src/layout/GlobalProvider/Editor.tsx
@@ -1,13 +1,13 @@
 'use client';
 
+// @lobehub/editor/react re-exports the whole editor runtime (lexical, yjs,
+// fuse) and rolldown does not shake it down to the provider, so reach the
+// context module directly until the package exposes a provider-only entry.
+// The export map has no such subpath; sharedRendererPlugins resolves it.
+import { EditorProvider } from '@lobehub/editor/es/react/EditorProvider';
 import { type PropsWithChildren } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-
-// @lobehub/editor/react re-exports the whole editor runtime (lexical, yjs,
-// fuse) and rolldown does not shake it down to the provider, so reach the
-// context module by path until the package exposes a provider-only entry.
-import { EditorProvider } from '../../../node_modules/@lobehub/editor/es/react/EditorProvider';
 
 const Editor = memo<PropsWithChildren>(({ children }) => {
   const {

--- a/src/layout/GlobalProvider/Editor.tsx
+++ b/src/layout/GlobalProvider/Editor.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 // @lobehub/editor/react re-exports the whole editor runtime (lexical, yjs,
-// fuse) and rolldown does not shake it down to the provider, so reach the
-// context module directly until the package exposes a provider-only entry.
-// The export map has no such subpath; sharedRendererPlugins resolves it.
-import { EditorProvider } from '@lobehub/editor/es/react/EditorProvider';
+// fuse) and rolldown does not shake it down to the provider, so take the
+// provider-only entry to keep that runtime off the first screen.
+import { EditorProvider } from '@lobehub/editor/react/EditorProvider';
 import { type PropsWithChildren } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/types/shim-lobe-editor.d.ts
+++ b/src/types/shim-lobe-editor.d.ts
@@ -1,0 +1,3 @@
+declare module '@lobehub/editor/es/react/EditorProvider' {
+  export { EditorProvider } from '@lobehub/editor/react';
+}

--- a/src/types/shim-lobe-editor.d.ts
+++ b/src/types/shim-lobe-editor.d.ts
@@ -1,3 +1,0 @@
-declare module '@lobehub/editor/es/react/EditorProvider' {
-  export { EditorProvider } from '@lobehub/editor/react';
-}


### PR DESCRIPTION
Desktop canary builds have been failing on every platform since #19294 ([run](https://github.com/lobehub/lobehub/actions/runs/34312261865)):

```
[UNRESOLVED_IMPORT] Could not resolve '../../../node_modules/@lobehub/editor/es/react/EditorProvider'
  in ../../src/layout/GlobalProvider/Editor.tsx
```

`.github/actions/business-overlay` mounts this repo as the overlay root's `lobehub/` submodule, so the install hoists one level **above** the checkout. Any path spelled relative to `node_modules` breaks there. OSS-only builds have a root `node_modules`, which is why this only broke the overlay job.

Two places made that assumption:

**1. `GlobalProvider/Editor.tsx`** reached `@lobehub/editor`'s provider by relative path, because the provider was not in the package's export map. It now is — lobehub/lobe-editor#211 shipped in **4.27.0** — so this takes the real `@lobehub/editor/react/EditorProvider` entry and the workaround is gone, ambient shim included. The first-screen win from #19294 is unchanged: the editor runtime stays off the boot path.

The **dev** redirect stays. Vite prebundles the provider entry separately from `@lobehub/editor/react`, which the editors use, and the app would end up with two `EditorContext`s.

**2. `plugins/vite/lobeUiImports.ts`** read the `@lobehub/ui` barrels from `../../../node_modules/@lobehub/ui/es`, where `realpathSync` would throw before the plugin could load. It now resolves the package entry. This never surfaced because the plugin is not loaded on the desktop platform, but the overlay share build runs it.

While verifying the desktop build locally I also hit a third one, unrelated to the regression but in the way of testing it: pnpm does not match the `./stubs/business-const` entry in `apps/desktop/pnpm-workspace.yaml`, so an OSS install from `apps/desktop` cannot resolve `@lobechat/business-const` and the desktop build cannot be run locally at all. Dropping the `./` fixes it. Cloud builds resolve the real package from the overlay, and the renderer redirects the module to `@cloud/business-const` either way, so nothing changes for them.

#### Test

- `apps/desktop$ npm run build:main` (main + preload + renderer) passes — the step that was failing in CI
- desktop renderer first-screen closure is byte-for-byte what `canary` produces: 201 files / 4013 KB gzip on both
- `bun run build:spa` and `bun run build:spa:share` pass
- entry-graph gate unchanged: `dist/desktop` 14 chunks / 1.41 MB
- `bunx vitest run plugins/vite/sharedRendererConfig.test.ts plugins/vite/lobeUiImports.test.ts` — 18 passed, including a regression test that the dev resolver folds the provider entry back into the one prebundled editor bundle

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up to #19294 · needs `@lobehub/editor` >= 4.27.0 (lobehub/lobe-editor#211)

https://claude.ai/code/session_01LNsSw6SDv3UEGNfBEwPa8S