### PR TITLE
🐛 fix: surface sandbox recreation in tool results

### DIFF
--- a/apps/server/src/services/sandbox/__tests__/computerRuntime.test.ts
+++ b/apps/server/src/services/sandbox/__tests__/computerRuntime.test.ts
@@ -13,28 +13,33 @@ class TestComputerRuntime extends ComputerRuntime {
   }
 }
 
-describe.each(['runCommand', 'executeCode'] as const)('CloudSandbox %s recreation', (api) => {
-  it.each([true, false])('surfaces recreation with transport success %s', async (success) => {
-    const runtime = new CloudSandboxExecutionRuntime({
-      callTool: vi.fn().mockResolvedValue({
-        error: success ? undefined : { message: 'missing input file' },
-        result: { exitCode: success ? 0 : 1, output: 'partial output' },
-        sessionExpiredAndRecreated: true,
-        success,
-      }),
-      exportAndUploadFile: vi.fn(),
+describe.each(['runCommand', 'executeCode', 'getCommandOutput'] as const)(
+  'CloudSandbox %s recreation',
+  (api) => {
+    it.each([true, false])('surfaces recreation with transport success %s', async (success) => {
+      const runtime = new CloudSandboxExecutionRuntime({
+        callTool: vi.fn().mockResolvedValue({
+          error: success ? undefined : { message: 'missing input file' },
+          result: { exitCode: success ? 0 : 1, output: 'partial output' },
+          sessionExpiredAndRecreated: true,
+          success,
+        }),
+        exportAndUploadFile: vi.fn(),
+      });
+
+      const result =
+        api === 'runCommand'
+          ? await runtime.runCommand({ command: 'cat /tmp/input' })
+          : api === 'executeCode'
+            ? await runtime.executeCode({ code: 'print("output")' })
+            : await runtime.getCommandOutput({ commandId: 'task-1' });
+
+      expect(result.content).toContain('sandbox session expired and was recreated');
+      expect(result.content).toContain(success ? 'partial output' : 'missing input file');
+      expect(result.state).toMatchObject({ sessionExpiredAndRecreated: true, success });
     });
-
-    const result =
-      api === 'runCommand'
-        ? await runtime.runCommand({ command: 'cat /tmp/input' })
-        : await runtime.executeCode({ code: 'print("output")' });
-
-    expect(result.content).toContain('sandbox session expired and was recreated');
-    expect(result.content).toContain(success ? 'partial output' : 'missing input file');
-    expect(result.state).toMatchObject({ sessionExpiredAndRecreated: true, success });
-  });
-});
+  },
+);
 
 describe('ComputerRuntime command status mapping', () => {
   it('uses command result success when command transport succeeds with non-zero exit code', async () => {

--- a/apps/server/src/services/sandbox/__tests__/computerRuntime.test.ts
+++ b/apps/server/src/services/sandbox/__tests__/computerRuntime.test.ts
@@ -1,6 +1,7 @@
+import { CloudSandboxExecutionRuntime } from '@lobechat/builtin-tool-cloud-sandbox/executionRuntime';
 import type { ServiceResult } from '@lobechat/tool-runtime';
 import { ComputerRuntime } from '@lobechat/tool-runtime';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 class TestComputerRuntime extends ComputerRuntime {
   constructor(private readonly serviceResult: ServiceResult) {
@@ -11,6 +12,29 @@ class TestComputerRuntime extends ComputerRuntime {
     return this.serviceResult;
   }
 }
+
+describe.each(['runCommand', 'executeCode'] as const)('CloudSandbox %s recreation', (api) => {
+  it.each([true, false])('surfaces recreation with transport success %s', async (success) => {
+    const runtime = new CloudSandboxExecutionRuntime({
+      callTool: vi.fn().mockResolvedValue({
+        error: success ? undefined : { message: 'missing input file' },
+        result: { exitCode: success ? 0 : 1, output: 'partial output' },
+        sessionExpiredAndRecreated: true,
+        success,
+      }),
+      exportAndUploadFile: vi.fn(),
+    });
+
+    const result =
+      api === 'runCommand'
+        ? await runtime.runCommand({ command: 'cat /tmp/input' })
+        : await runtime.executeCode({ code: 'print("output")' });
+
+    expect(result.content).toContain('sandbox session expired and was recreated');
+    expect(result.content).toContain(success ? 'partial output' : 'missing input file');
+    expect(result.state).toMatchObject({ sessionExpiredAndRecreated: true, success });
+  });
+});
 
 describe('ComputerRuntime command status mapping', () => {
   it('uses command result success when command transport succeeds with non-zero exit code', async () => {

--- a/apps/server/src/services/sandbox/__tests__/service.test.ts
+++ b/apps/server/src/services/sandbox/__tests__/service.test.ts
@@ -5,6 +5,51 @@ import type { MarketService } from '@/server/services/market';
 
 import type { SandboxProvider } from '../types';
 
+describe('normalizeSandboxCommandResult', () => {
+  it('preserves recreation when the command fails inside a successful response', async () => {
+    const { normalizeSandboxCommandResult } = await import('../service');
+
+    expect(
+      normalizeSandboxCommandResult({
+        result: { exitCode: 1, stderr: 'missing input file', stdout: '' },
+        sessionExpiredAndRecreated: true,
+        success: true,
+      }),
+    ).toEqual({
+      exitCode: 1,
+      output: '',
+      sessionExpiredAndRecreated: true,
+      stderr: 'missing input file',
+      success: false,
+    });
+  });
+
+  it.each([undefined, false])('does not report recreation for flag %s', async (flag) => {
+    const { normalizeSandboxCommandResult } = await import('../service');
+
+    expect(
+      normalizeSandboxCommandResult({
+        result: { exitCode: 0, stdout: 'output' },
+        sessionExpiredAndRecreated: flag,
+        success: true,
+      }),
+    ).toEqual({ exitCode: 0, output: 'output', stderr: undefined, success: true });
+  });
+
+  it.each([true, false])('preserves recreation when transport success is %s', async (success) => {
+    const { normalizeSandboxCommandResult } = await import('../service');
+
+    expect(
+      normalizeSandboxCommandResult({
+        error: success ? undefined : { message: 'missing file' },
+        result: { exitCode: 0, stdout: 'output' },
+        sessionExpiredAndRecreated: true,
+        success,
+      }),
+    ).toMatchObject({ sessionExpiredAndRecreated: true, success });
+  });
+});
+
 describe('SandboxMiddlewareService', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/server/src/services/sandbox/service.ts
+++ b/apps/server/src/services/sandbox/service.ts
@@ -197,8 +197,12 @@ export class SandboxMiddlewareService implements SandboxService {
 export const normalizeSandboxCommandResult = (
   result: SandboxCallToolResult,
 ): SandboxCommandResult => {
+  const sessionState = result.sessionExpiredAndRecreated
+    ? { sessionExpiredAndRecreated: true }
+    : {};
   if (!result.success) {
     return {
+      ...sessionState,
       exitCode: 1,
       output: '',
       stderr: result.error?.message || 'Command execution failed',
@@ -214,6 +218,7 @@ export const normalizeSandboxCommandResult = (
   const success = typeof raw.success === 'boolean' ? raw.success : exitCode === 0;
 
   return {
+    ...sessionState,
     exitCode,
     output,
     stderr,

--- a/apps/server/src/services/sandbox/types.ts
+++ b/apps/server/src/services/sandbox/types.ts
@@ -72,6 +72,8 @@ export interface SandboxProviderFileExportResult {
 export interface SandboxCommandResult {
   exitCode: number;
   output: string;
+  /** The provider recreated the workspace before executing this command. */
+  sessionExpiredAndRecreated?: boolean;
   stderr?: string;
   success: boolean;
 }

--- a/packages/builtin-tool-cloud-sandbox/package.json
+++ b/packages/builtin-tool-cloud-sandbox/package.json
@@ -11,6 +11,7 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@lobechat/builtin-tool-local-system": "workspace:*",
+    "@lobechat/prompts": "workspace:*",
     "@lobechat/shared-tool-ui": "workspace:*",
     "@lobechat/tool-runtime": "workspace:*"
   },

--- a/packages/builtin-tool-cloud-sandbox/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/ExecutionRuntime/index.ts
@@ -1,3 +1,4 @@
+import { formatSandboxRecreation } from '@lobechat/prompts/fileSystem';
 import { ComputerRuntime } from '@lobechat/tool-runtime';
 import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
 
@@ -46,6 +47,7 @@ export class CloudSandboxExecutionRuntime extends ComputerRuntime {
       });
 
       const state: ExecuteCodeState = {
+        ...(result.sessionExpiredAndRecreated && { sessionExpiredAndRecreated: true }),
         error: result.result?.error,
         exitCode: result.result?.exitCode,
         language,
@@ -56,14 +58,20 @@ export class CloudSandboxExecutionRuntime extends ComputerRuntime {
 
       if (!result.success) {
         return {
-          content: result.error?.message || JSON.stringify(result.error),
+          content: formatSandboxRecreation(
+            result.error?.message || JSON.stringify(result.error),
+            result.sessionExpiredAndRecreated,
+          ),
           state,
           success: true,
         };
       }
 
       return {
-        content: JSON.stringify(result.result),
+        content: formatSandboxRecreation(
+          JSON.stringify(result.result),
+          result.sessionExpiredAndRecreated,
+        ),
         state,
         success: true,
       };

--- a/packages/builtin-tool-cloud-sandbox/src/systemRole.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/systemRole.ts
@@ -222,7 +222,7 @@ When generating PDFs with Chinese text, you MUST:
 <session_behavior>
 - Your sandbox session is automatically managed per conversation topic
 - If a session expires, it will be automatically recreated
-- Files from previous sessions may not persist; recreate them as needed
+- Files from previous sessions may not persist. Inform the user when the workspace is recreated, restore persistent checkpoints when available, and ask before repeating expensive generation. Do not silently regenerate previous work.
 - The sessionExpiredAndRecreated flag in responses indicates if this occurred
 </session_behavior>
 

--- a/packages/builtin-tool-cloud-sandbox/src/systemRole.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/systemRole.ts
@@ -222,7 +222,7 @@ When generating PDFs with Chinese text, you MUST:
 <session_behavior>
 - Your sandbox session is automatically managed per conversation topic
 - If a session expires, it will be automatically recreated
-- Files from previous sessions may not persist. Inform the user when the workspace is recreated, restore persistent checkpoints when available, and ask before repeating expensive generation. Do not silently regenerate previous work.
+- Files from previous sessions may not persist
 - The sessionExpiredAndRecreated flag in responses indicates if this occurred
 </session_behavior>
 

--- a/packages/builtin-tool-cloud-sandbox/src/types/state.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/types/state.ts
@@ -42,6 +42,8 @@ export interface ExecuteCodeState {
   language: 'javascript' | 'python' | 'typescript';
   /** Standard output from execution */
   output?: string;
+  /** The sandbox workspace was recreated before this code executed. */
+  sessionExpiredAndRecreated?: boolean;
   /** Standard error from execution */
   stderr?: string;
   /** Whether the execution was successful */

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -28,7 +28,7 @@ describe('SkillsExecutionRuntime', () => {
       const result = await runtime[api]({ command: 'cat /tmp/input', description: 'Read input' });
 
       expect(result.content).toContain('sandbox session expired and was recreated');
-      expect(result.content).toContain('Do not silently regenerate');
+      expect(result.content).toContain('Inform the user and ask before regenerating previous work');
       expect(result.content).toContain('command output');
       expect(result.state).toMatchObject({ sessionExpiredAndRecreated: true, success });
       expect(result.success).toBe(success);

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -12,6 +12,29 @@ const createMockService = (overrides?: Partial<SkillRuntimeService>): SkillRunti
 });
 
 describe('SkillsExecutionRuntime', () => {
+  describe.each(['runCommand', 'execScript'] as const)('%s sandbox recreation', (api) => {
+    it.each([true, false])('reports workspace loss when command success is %s', async (success) => {
+      const commandResult = {
+        exitCode: success ? 0 : 1,
+        output: 'command output',
+        sessionExpiredAndRecreated: true,
+        stderr: success ? undefined : 'missing input file',
+        success,
+      } satisfies CommandResult;
+      const runtime = new SkillsExecutionRuntime({
+        service: createMockService({ [api]: vi.fn().mockResolvedValue(commandResult) }),
+      });
+
+      const result = await runtime[api]({ command: 'cat /tmp/input', description: 'Read input' });
+
+      expect(result.content).toContain('sandbox session expired and was recreated');
+      expect(result.content).toContain('Do not silently regenerate');
+      expect(result.content).toContain('command output');
+      expect(result.state).toMatchObject({ sessionExpiredAndRecreated: true, success });
+      expect(result.success).toBe(success);
+    });
+  });
+
   describe('execScript', () => {
     const args = { command: 'echo hello', description: 'test command' };
 

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -1,5 +1,9 @@
 import { AGENT_SKILLS_IDENTIFIER_PREFIX } from '@lobechat/const';
-import { formatCommandResult, resourcesTreePrompt } from '@lobechat/prompts';
+import {
+  formatCommandResult,
+  formatSandboxRecreation,
+  resourcesTreePrompt,
+} from '@lobechat/prompts';
 import type {
   BuiltinServerRuntimeOutput,
   BuiltinSkill,
@@ -525,9 +529,10 @@ export class SkillsExecutionRuntime {
     });
 
     return {
-      content,
+      content: formatSandboxRecreation(content, result.sessionExpiredAndRecreated),
       state: {
         command,
+        ...(result.sessionExpiredAndRecreated && { sessionExpiredAndRecreated: true }),
         ...(result.executionEnv && { executionEnv: result.executionEnv }),
         exitCode: result.exitCode,
         ...(result.outputFiles && { outputFiles: result.outputFiles }),

--- a/packages/builtin-tool-skills/src/systemRole.ts
+++ b/packages/builtin-tool-skills/src/systemRole.ts
@@ -74,6 +74,7 @@ export const systemPrompt = `You have access to a Skills tool that can activate 
 - Only activate skills when the user's task clearly matches the skill's purpose
 - Follow the skill's instructions carefully once loaded
 - Use readReference only for files explicitly mentioned in the skill content
+- Sandbox files may not persist after session expiry. When a tool reports that the sandbox was recreated, inform the user, restore persistent checkpoints when available, and ask before repeating expensive generation. Do not silently regenerate previous work.
 - Use runCommand for CLI commands and general operations
 - Use execScript when the command needs skill-bundled resources
 - Use exportFile when the skill generates output files that need to be saved

--- a/packages/builtin-tool-skills/src/systemRole.ts
+++ b/packages/builtin-tool-skills/src/systemRole.ts
@@ -74,7 +74,6 @@ export const systemPrompt = `You have access to a Skills tool that can activate 
 - Only activate skills when the user's task clearly matches the skill's purpose
 - Follow the skill's instructions carefully once loaded
 - Use readReference only for files explicitly mentioned in the skill content
-- Sandbox files may not persist after session expiry. When a tool reports that the sandbox was recreated, inform the user, restore persistent checkpoints when available, and ask before repeating expensive generation. Do not silently regenerate previous work.
 - Use runCommand for CLI commands and general operations
 - Use execScript when the command needs skill-bundled resources
 - Use exportFile when the skill generates output files that need to be saved

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -54,6 +54,8 @@ export interface ExecScriptState {
    */
   exitCode?: number;
   outputFiles?: CommandResult['outputFiles'];
+  /** The sandbox workspace was recreated before this command. */
+  sessionExpiredAndRecreated?: boolean;
   /**
    * Shell handle for a still-running command, pollable via
    * `local-system.getCommandOutput`.
@@ -88,6 +90,8 @@ export interface CommandResult {
     stderr?: { path: string; size?: number; truncated?: boolean };
     stdout?: { path: string; size?: number; truncated?: boolean };
   };
+  /** The sandbox workspace was recreated before this command. */
+  sessionExpiredAndRecreated?: boolean;
   /**
    * Shell handle for a still-running command, pollable via
    * `local-system.getCommandOutput`.

--- a/packages/prompts/src/prompts/fileSystem/formatSandboxRecreation.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatSandboxRecreation.ts
@@ -1,0 +1,5 @@
+/** Keep workspace loss visible even when the command itself completed successfully. */
+export const formatSandboxRecreation = (content: string, recreated?: boolean): string =>
+  recreated
+    ? `Warning: The sandbox session expired and was recreated. Files from the previous session may have been lost. Do not silently regenerate previous work. Inform the user, restore from persistent checkpoints when available, and ask before repeating expensive generation.\n\n${content}`
+    : content;

--- a/packages/prompts/src/prompts/fileSystem/formatSandboxRecreation.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatSandboxRecreation.ts
@@ -1,5 +1,5 @@
 /** Keep workspace loss visible even when the command itself completed successfully. */
 export const formatSandboxRecreation = (content: string, recreated?: boolean): string =>
   recreated
-    ? `Warning: The sandbox session expired and was recreated. Files from the previous session may have been lost. Do not silently regenerate previous work. Inform the user, restore from persistent checkpoints when available, and ask before repeating expensive generation.\n\n${content}`
+    ? `Warning: The sandbox session expired and was recreated. Files from the previous session may have been lost. Inform the user and ask before regenerating previous work.\n\n${content}`
     : content;

--- a/packages/prompts/src/prompts/fileSystem/index.ts
+++ b/packages/prompts/src/prompts/fileSystem/index.ts
@@ -10,4 +10,5 @@ export * from './formatKillResult';
 export * from './formatMoveResults';
 export * from './formatMultipleFiles';
 export * from './formatRenameResult';
+export * from './formatSandboxRecreation';
 export * from './formatWriteResult';

--- a/packages/tool-runtime/src/ComputerRuntime.ts
+++ b/packages/tool-runtime/src/ComputerRuntime.ts
@@ -10,6 +10,7 @@ import {
   formatKillResult,
   formatMoveResults,
   formatRenameResult,
+  formatSandboxRecreation,
   formatWriteResult,
 } from '@lobechat/prompts/fileSystem';
 import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
@@ -322,9 +323,13 @@ export abstract class ComputerRuntime {
   async runCommand(args: RunCommandParams): Promise<BuiltinServerRuntimeOutput> {
     try {
       const result = await this.callService('runCommand', args);
+      const sessionState = result.sessionExpiredAndRecreated
+        ? { sessionExpiredAndRecreated: true }
+        : {};
 
       if (!result.success) {
-        return this.errorOutput(result, {
+        const output = this.errorOutput(result, {
+          ...sessionState,
           error: result.error?.message,
           exitCode: result.result?.exitCode ?? result.result?.exit_code,
           isBackground: args.background || false,
@@ -332,6 +337,10 @@ export abstract class ComputerRuntime {
           stdout: result.result?.stdout,
           success: false,
         });
+        return {
+          ...output,
+          content: formatSandboxRecreation(output.content, result.sessionExpiredAndRecreated),
+        };
       }
 
       const r = result.result || {};
@@ -339,6 +348,7 @@ export abstract class ComputerRuntime {
       const outputFiles = r.outputFiles ?? r.output_files;
 
       const state: RunCommandState = {
+        ...sessionState,
         commandId: r.commandId || r.shell_id,
         error: r.error,
         exitCode: r.exitCode ?? r.exit_code,
@@ -361,7 +371,11 @@ export abstract class ComputerRuntime {
         success: commandSuccess,
       });
 
-      return { content, state, success: true };
+      return {
+        content: formatSandboxRecreation(content, result.sessionExpiredAndRecreated),
+        state,
+        success: true,
+      };
     } catch (error) {
       return this.handleError(error);
     }

--- a/packages/tool-runtime/src/ComputerRuntime.ts
+++ b/packages/tool-runtime/src/ComputerRuntime.ts
@@ -384,12 +384,20 @@ export abstract class ComputerRuntime {
   async getCommandOutput(args: GetCommandOutputParams): Promise<BuiltinServerRuntimeOutput> {
     try {
       const result = await this.callService('getCommandOutput', args);
+      const sessionState = result.sessionExpiredAndRecreated
+        ? { sessionExpiredAndRecreated: true }
+        : {};
 
       if (!result.success) {
-        return this.errorOutput(result, {
+        const output = this.errorOutput(result, {
+          ...sessionState,
           error: result.error?.message,
           success: false,
         });
+        return {
+          ...output,
+          content: formatSandboxRecreation(output.content, result.sessionExpiredAndRecreated),
+        };
       }
 
       const r = result.result || {};
@@ -397,6 +405,7 @@ export abstract class ComputerRuntime {
       const outputFiles = r.outputFiles ?? r.output_files;
 
       const state: GetCommandOutputState = {
+        ...sessionState,
         durationMs: r.durationMs ?? r.duration_ms,
         error: r.error,
         exitCode: r.exitCode ?? r.exit_code,
@@ -418,7 +427,11 @@ export abstract class ComputerRuntime {
         success: outputSuccess,
       });
 
-      return { content, state, success: true };
+      return {
+        content: formatSandboxRecreation(content, result.sessionExpiredAndRecreated),
+        state,
+        success: true,
+      };
     } catch (error) {
       return this.handleError(error);
     }

--- a/packages/tool-runtime/src/types.ts
+++ b/packages/tool-runtime/src/types.ts
@@ -289,6 +289,8 @@ export interface GetCommandOutputState {
     stdout: { path: string; size: number; truncated: boolean };
   };
   running?: boolean;
+  /** The sandbox workspace was recreated before polling this command. */
+  sessionExpiredAndRecreated?: boolean;
   stderr?: string;
   stdout?: string;
   success: boolean;

--- a/packages/tool-runtime/src/types.ts
+++ b/packages/tool-runtime/src/types.ts
@@ -5,6 +5,8 @@
 export interface ServiceResult {
   error?: { message: string; name?: string };
   result: any;
+  /** The execution workspace was recreated before this call. */
+  sessionExpiredAndRecreated?: boolean;
   success: boolean;
 }
 
@@ -271,6 +273,8 @@ export interface RunCommandState {
    * Undefined when no sandbox was requested.
    */
   sandboxed?: boolean;
+  /** The execution workspace was recreated before this command. */
+  sessionExpiredAndRecreated?: boolean;
   stderr?: string;
   stdout?: string;
   success: boolean;

--- a/src/store/tool/slices/builtin/executors/__tests__/lobe-skills.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/lobe-skills.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cloudSandboxService } from '@/services/cloudSandbox';
+
+import { skillsExecutor } from '../lobe-skills';
+
+vi.mock('@lobechat/builtin-skills', () => ({ builtinSkills: [] }));
+vi.mock('@/helpers/skillFilters', () => ({ filterBuiltinSkills: () => [] }));
+vi.mock('@/services/cloudSandbox', () => ({ cloudSandboxService: { callTool: vi.fn() } }));
+vi.mock('@/services/skill', () => ({ agentSkillService: {} }));
+vi.mock('@/store/chat', () => ({
+  useChatStore: { getState: () => ({ activeTopicId: 'test-topic' }) },
+}));
+
+describe.each(['runCommand', 'execScript'] as const)('Web Skills %s recreation', (api) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([true, false])('warns when sandbox transport success is %s', async (success) => {
+    vi.mocked(cloudSandboxService.callTool).mockResolvedValue({
+      error: success ? undefined : { message: 'missing input file' },
+      result: { exitCode: success ? 0 : 1, stdout: 'command output' },
+      sessionExpiredAndRecreated: true,
+      success,
+    });
+
+    const result = await skillsExecutor.invoke(
+      api,
+      { command: 'cat /tmp/input', description: 'Read input' },
+      { messageId: 'test-message', operationId: 'test-operation' },
+    );
+
+    expect(result.content).toContain('sandbox session expired and was recreated');
+    expect(result.content).toContain(success ? 'command output' : 'missing input file');
+    expect(result.success).toBe(success);
+    if (success) expect(result.state).toMatchObject({ sessionExpiredAndRecreated: true });
+  });
+});

--- a/src/store/tool/slices/builtin/executors/lobe-skills.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-skills.ts
@@ -42,6 +42,7 @@ const runtime = new SkillsExecutionRuntime({
             executionEnv: 'sandbox' as const,
             exitCode: 1,
             output: '',
+            ...(result.sessionExpiredAndRecreated && { sessionExpiredAndRecreated: true }),
             stderr: result.error?.message || 'Command execution failed',
             success: false,
           };
@@ -57,6 +58,7 @@ const runtime = new SkillsExecutionRuntime({
           executionEnv: 'sandbox' as const,
           exitCode: sandboxResult.exitCode ?? (result.success ? 0 : 1),
           output: sandboxResult.stdout || sandboxResult.output || '',
+          ...(result.sessionExpiredAndRecreated && { sessionExpiredAndRecreated: true }),
           stderr: sandboxResult.stderr || '',
           success:
             result.success &&
@@ -124,6 +126,7 @@ const runtime = new SkillsExecutionRuntime({
             executionEnv: 'sandbox' as const,
             exitCode: 1,
             output: '',
+            ...(result.sessionExpiredAndRecreated && { sessionExpiredAndRecreated: true }),
             stderr: result.error?.message || 'Command execution failed',
             success: false,
           };
@@ -136,6 +139,7 @@ const runtime = new SkillsExecutionRuntime({
           executionEnv: 'sandbox' as const,
           exitCode: sandboxResult.exitCode ?? (result.success ? 0 : 1),
           output: sandboxResult.stdout || sandboxResult.output || '',
+          ...(result.sessionExpiredAndRecreated && { sessionExpiredAndRecreated: true }),
           stderr: sandboxResult.stderr || '',
           success:
             result.success &&


### PR DESCRIPTION
When a sandbox expires and is recreated, command normalization and tool formatting can discard the recreation signal. The agent then sees an ordinary result without knowing that previous workspace files may be gone.

Preserve `sessionExpiredAndRecreated` through command results, including the web Skills adapters, and expose it in tool state and model-visible output for skills commands/scripts and sandbox commands/code/background polling. Only when the flag is true, append a short warning that previous files may be lost and ask the agent to inform the user and confirm before regenerating previous work. Existing tool output remains unchanged when the flag is absent or false.

#### Key Decisions / Non-goals

- Keep the provider's existing signal; do not infer workspace loss from command errors.
- Surface recreation on both successful and failed commands.
- The web Skills executor retains its existing failure envelope: failed calls expose the warning through content/error text, but do not expose structured state. Structured failure-state consistency is deferred.
- Keep behavioral guidance in the conditional tool result. Do not add standing recovery instructions to system prompts; only remove the existing sandbox instruction to recreate lost files as needed, which would conflict with the warning.
- This is notification and recovery guidance, not file persistence, session keepalive, an enforced spending limit, or a fix for unrelated execution interruptions.
- Providers that do not emit this signal and recreation first triggered through other file tools remain outside this change.

#### Test

- [x] Added/updated regression tests for normalization and command/code/skill execution, including success and failure cases.
- Added regression coverage through the web Skills executor and for background polling, both with successful and failed sandbox responses. Local execution of these tests is blocked by missing Vitest; syntax and diff checks pass.
- Before migration and the subsequent prompt simplification, the earlier patch passed `bun run check`: 16 files, clean lint, 42 passing tests; six regression cases failed before the fix. This is not a test result for the latest PR head.
- Current worktree: `bun run check` is blocked by missing ESLint/dependencies. Dependencies were not installed for this PR.
- After prompt simplification, direct Bun checks of the formatter pass for true, false, and absent flags, including preservation of the original output. `git diff --check` passes. The existing skills regression assertion was updated for the shorter warning.
- Previous full type-check was blocked by unresolved `@lobechat/builtin-tool-auv` imports outside the changed files. No application or live sandbox acceptance has been performed.
