### PR TITLE
🐛 fix: restore Work anchors after tool execution

### DIFF
--- a/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
@@ -1,3 +1,4 @@
+import { type Message, parse } from '@lobechat/conversation-flow';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AgentRuntime } from '../core/runtime';
@@ -439,6 +440,131 @@ describe('callLlmFinalizer', () => {
     });
     const [, plainUpdate] = vi.mocked(plainMessages.update).mock.calls[0];
     expect(plainUpdate.metadata ?? {}).not.toHaveProperty('work');
+  });
+
+  describe('Work anchors after message rehydration', () => {
+    const tool = {
+      apiName: 'createTask',
+      arguments: '{}',
+      id: 'call-1',
+      identifier: 'tasks',
+      type: 'default' as const,
+    };
+    const rows: Message[] = [
+      { content: 'Create a task', createdAt: 1, id: 'user-1', role: 'user' },
+      {
+        content: '',
+        createdAt: 2,
+        id: 'assistant-0',
+        parentId: 'user-1',
+        role: 'assistant',
+        tools: [tool],
+      },
+      {
+        content: 'created',
+        createdAt: 3,
+        id: 'tool-1',
+        parentId: 'assistant-0',
+        role: 'tool',
+        tool_call_id: 'call-1',
+      },
+      {
+        content: 'Continue',
+        createdAt: 4,
+        id: 'assistant-1',
+        parentId: 'tool-1',
+        role: 'assistant',
+      },
+    ];
+
+    const finalize = async (
+      messages: Message[],
+      sourceMessageId: string,
+      output = createOutput(),
+    ) => {
+      const transport = createMessageTransport();
+      await finalizeCallLlmTurn({
+        assistantMessageId: 'final',
+        events: [],
+        host: createHost(transport),
+        model: 'gpt-4',
+        output,
+        provider: 'openai',
+        shouldReplayAssistantReasoning: false,
+        state: AgentRuntime.createInitialState({
+          messages,
+          metadata: { sourceMessageId },
+          operationId: 'operation-1',
+        }),
+      });
+      return vi.mocked(transport.update).mock.calls[0][1].metadata?.work;
+    };
+
+    it.each(['assistantGroup', 'supervisor'] as const)(
+      'finds tools inside %s children',
+      async (role) => {
+        const parsed = parse(rows).flatList;
+        expect(parsed[1].role).toBe('assistantGroup');
+        const messages = [parsed[0], { ...parsed[1], role }];
+        expect(await finalize(messages, 'user-1')).toEqual({
+          rootOperationId: 'operation-1',
+          userMessageId: 'user-1',
+        });
+      },
+    );
+
+    it('preserves the source boundary inside compressed conversation messages', async () => {
+      const messages: Message[] = [
+        {
+          compressedMessages: parse(rows).flatList,
+          content: 'Summary',
+          createdAt: 5,
+          id: 'compressed-1',
+          role: 'compressedGroup',
+        },
+      ];
+      expect(await finalize(messages, 'user-1')).toEqual({
+        rootOperationId: 'operation-1',
+        userMessageId: 'user-1',
+      });
+      expect(await finalize(messages, 'assistant-1')).toBeUndefined();
+    });
+
+    it('finds a source assistant inside a parsed group', async () => {
+      expect(await finalize(parse(rows).flatList, 'assistant-0')).toEqual({
+        rootOperationId: 'operation-1',
+        userMessageId: 'assistant-0',
+      });
+    });
+
+    it('finds a source tool result before a later tool call in the same group', async () => {
+      const withLaterTool = rows.map((row) =>
+        row.id === 'assistant-1' ? { ...row, tools: [{ ...tool, id: 'call-2' }] } : row,
+      );
+      expect(await finalize(parse(withLaterTool).flatList, 'tool-1')).toEqual({
+        rootOperationId: 'operation-1',
+        userMessageId: 'tool-1',
+      });
+    });
+
+    it('does not count tools before a nested source or from a previous turn', async () => {
+      expect(await finalize(parse(rows).flatList, 'assistant-1')).toBeUndefined();
+      const nextTurn: Message = {
+        content: 'Hi',
+        createdAt: 5,
+        id: 'user-2',
+        parentId: 'assistant-1',
+        role: 'user',
+      };
+      expect(await finalize(parse([...rows, nextTurn]).flatList, 'user-2')).toBeUndefined();
+      expect(await finalize(parse(rows).flatList, 'missing')).toBeUndefined();
+    });
+
+    it('does not anchor an intermediate tool-calling response', async () => {
+      expect(
+        await finalize(parse(rows).flatList, 'user-1', createOutput({ toolsCalling: [tool] })),
+      ).toBeUndefined();
+    });
   });
 
   it('serializes multimodal parts and keeps the null grounding sentinel', async () => {

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.ts
@@ -128,14 +128,45 @@ const sanitizeStateToolCalls = (toolCalls: MessageToolCall[]) => {
   return sanitizedToolCalls.length > 0 ? sanitizedToolCalls : undefined;
 };
 
+interface WorkAnchorMessage {
+  children?: WorkAnchorMessage[];
+  compressedMessages?: WorkAnchorMessage[];
+  id?: string;
+  role?: string;
+  tool_calls?: unknown[];
+  tools?: { result?: { id?: string }; result_msg_id?: string }[];
+}
+
 /**
- * Work display anchor: Work cards render on the FINAL assistant message of a
- * turn (stable across the two-round tool flow), so stamp `metadata.work` only
- * when this LLM step ends the turn — i.e. it emits no new tool calls AND at
- * least one tool ran earlier in this operation (messages after
- * sourceMessageId, the triggering user message). Without the prior-tool check
- * every plain answer would get a work anchor; without the slice the scan
- * would see other turns' tool messages.
+ * Rehydration folds assistant/tool rows into groups. Visit their original IDs
+ * in conversation order so a nested source still excludes earlier tool calls.
+ * Group-level fields are summaries and must not count as new interactions.
+ */
+function* visitWorkAnchorMessages(
+  messages: WorkAnchorMessage[],
+): Generator<{ hasToolInteraction: boolean; id?: string }> {
+  for (const message of messages) {
+    const members = message.children ?? message.compressedMessages;
+    yield {
+      hasToolInteraction:
+        !members &&
+        (message.role === 'tool' || !!message.tool_calls?.length || !!message.tools?.length),
+      id: message.id,
+    };
+    if (members) {
+      yield* visitWorkAnchorMessages(members);
+    } else {
+      for (const tool of message.tools ?? []) {
+        const id = tool.result?.id ?? tool.result_msg_id;
+        if (id) yield { hasToolInteraction: true, id };
+      }
+    }
+  }
+}
+
+/**
+ * Stamp only the final assistant response after tool interaction in this turn.
+ * The source boundary prevents historical tools from anchoring plain answers.
  */
 const buildWorkAnchor = ({
   operationId,
@@ -149,22 +180,22 @@ const buildWorkAnchor = ({
   if (output.toolsCalling.length > 0 || output.toolCalls.length > 0) return undefined;
 
   const sourceMessageId = state.metadata?.sourceMessageId;
-  const sourceMessageIndex =
-    typeof sourceMessageId === 'string'
-      ? state.messages.findIndex((message) => message.id === sourceMessageId)
-      : -1;
-  const currentOperationMessages =
-    sourceMessageIndex >= 0 ? state.messages.slice(sourceMessageIndex + 1) : [];
-  const hasPriorToolInteraction = currentOperationMessages.some(
-    (message) =>
-      message.role === 'tool' ||
-      (Array.isArray(message.tool_calls) && message.tool_calls.length > 0),
-  );
+  if (typeof sourceMessageId !== 'string') return undefined;
+
+  let sourceFound = false;
+  let hasPriorToolInteraction = false;
+  for (const message of visitWorkAnchorMessages(state.messages)) {
+    if (sourceFound && message.hasToolInteraction) {
+      hasPriorToolInteraction = true;
+      break;
+    }
+    if (message.id === sourceMessageId) sourceFound = true;
+  }
   if (!hasPriorToolInteraction) return undefined;
 
   return {
     rootOperationId: operationId,
-    ...(typeof sourceMessageId === 'string' && { userMessageId: sourceMessageId }),
+    userMessageId: sourceMessageId,
   };
 };
 

--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -1009,6 +1009,37 @@ describe('StreamingExecutor actions', () => {
     });
   });
 
+  describe('Work source message', () => {
+    it.each([
+      { expected: 'parent', operationSource: undefined, restoredSource: undefined },
+      { expected: 'trigger', operationSource: 'trigger', restoredSource: undefined },
+      { expected: 'original', operationSource: 'trigger', restoredSource: 'original' },
+    ])(
+      'preserves the Work source as $expected',
+      ({ expected, operationSource, restoredSource }) => {
+        const store = useChatStore.getState();
+        const { operationId } = store.startOperation({
+          context: { agentId: TEST_IDS.SESSION_ID, messageId: operationSource },
+          type: 'execAgentRuntime',
+        });
+        const { state } = store.internal_createAgentState({
+          agentId: TEST_IDS.SESSION_ID,
+          initialState: restoredSource
+            ? agentRuntime.AgentRuntime.createInitialState({
+                metadata: { sourceMessageId: restoredSource },
+                operationId,
+              })
+            : undefined,
+          messages: [],
+          operationId,
+          parentMessageId: 'parent',
+        });
+
+        expect(state.metadata?.sourceMessageId).toBe(expected);
+      },
+    );
+  });
+
   describe('initialContext preservation', () => {
     it('should preserve initialContext through multiple steps in agent runtime loop', async () => {
       act(() => {

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -376,6 +376,9 @@ export class StreamingExecutorActionImpl {
         agentId,
         groupId,
         scope,
+        // Resuming changes the parent message, but Works still belong to the original turn.
+        sourceMessageId:
+          baseState.metadata?.sourceMessageId ?? operation?.context.messageId ?? parentMessageId,
         subAgentId: paramSubAgentId,
         threadId,
         topicId,


### PR DESCRIPTION
Work cards could be missing below a completed assistant response even when the produced resources were registered. The finalizer only inspected top-level messages, so rehydrated assistant groups hid tool interactions; client runs also omitted the source message ID used to identify the current turn.

Visit grouped assistant blocks, nested tool results, and compressed messages in conversation order when building the Work anchor. Initialize the client source from the operation or parent message while preserving the original source when resuming a run.

#### Key Decisions / Non-goals

- Keep the fix scoped to Work anchors and client source initialization; preserve the existing runtime message representation.
- Exclude tool interactions before the source boundary and keep intermediate tool-calling responses unanchored.
- Existing persisted messages are not backfilled.

#### Test

- [x] Tested locally: targeted `bun run check` passed lint and all 68 related tests.
- [x] Added/updated tests: four grouped-message cases and two client initialization cases failed before the fix and passed afterward.
- Coverage includes real `parse().flatList` grouping, supervisor-shaped groups, nested assistant/tool sources, compressed messages, historical-tool isolation, intermediate tool calls, flat messages, and resumed client sources.
- Browser end-to-end verification was not performed.
