### PR TITLE
💄 style(shared-tool-ui): sync shiny text rest color with sibling labels

### DIFF
--- a/packages/shared-tool-ui/src/styles.ts
+++ b/packages/shared-tool-ui/src/styles.ts
@@ -65,7 +65,14 @@ export const highlightTextStyles = createStaticStyles(({ css, cssVar }) => {
  */
 const shinyToneStyles = createStaticStyles(({ css, cssVar }) => ({
   secondary: css`
-    --shiny-color: ${cssVar.colorTextSecondary};
+    /* The upstream rest color is a 28% mix of --shiny-color, which reads far
+     * weaker than the static labels next to it. Pin the rest color to the
+     * neighbouring text color and let the sweep peak at full colorText. */
+    &&& {
+      --shiny-color: ${cssVar.colorText};
+
+      color: ${cssVar.colorTextSecondary};
+    }
   `,
 }));
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 💄 style

#### 🔀 变更说明 | Description of Change

Shimmering loading labels (`shinyTextStyles.shinyText`) rendered far weaker than the static text sitting right next to them — e.g. the `10 skill uses` headline in a streaming workflow row vs. the tool rows below it.

Cause: `@lobehub/ui`'s `textStyles.shiny` derives its **rest** color from the sweep peak — `color: color-mix(in srgb, var(--shiny-color) 28%, transparent)`. Our local tone override set `--shiny-color: colorTextSecondary`, which lowered the peak *and* pushed the rest color down to 28% of an already-light gray, so the label read as nearly invisible between sweeps.

Fix: pin the rest color to `colorTextSecondary` (matching the neighbouring static labels) and let the sweep peak at full `colorText`. The `&&&` also outranks the upstream single-class rule, so the result no longer depends on stylesheet injection order between the library and local static styles.

Audited every consumer of `shinyText` (workflow headline, tool inspectors, builtin-tool-memory inspectors, thinking title, todo progress, op status tray, agent goal/domain generation): only `TodoProgress`'s header co-applied a class that set its own `color`, and it now deterministically dims to secondary while shimmering instead of depending on class order.

#### 📝 补充信息 | Additional Information

Visual-only change; no behavioural surface to assert on beyond stylesheet source strings, so no regression test added.

https://claude.ai/code/session_011fuwi9TRSnm5nLkccFjBv4