### PR TITLE
✨ feat(desktop): point the default cloud instance at the apex domain

### DIFF
--- a/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
@@ -574,7 +574,7 @@ export default class RemoteServerConfigCtr extends ControllerModule {
     const session = electronSession.fromPartition(partition);
 
     session.webRequest.onBeforeSendHeaders(
-      { urls: [`https://*.lobehub.com/*`] },
+      { urls: [`https://lobehub.com/*`, `https://*.lobehub.com/*`] },
       async (details, callback) => {
         const requestHeaders = { ...details.requestHeaders };
 

--- a/apps/desktop/src/main/env.ts
+++ b/apps/desktop/src/main/env.ts
@@ -1,4 +1,4 @@
-import { OFFICIAL_URL } from '@lobechat/const/url';
+import { OFFICIAL_CLOUD_URL } from '@lobechat/const/url';
 import { createEnv } from '@t3-oss/env-core';
 import { memoize } from 'es-toolkit';
 import { z } from 'zod';
@@ -101,7 +101,7 @@ export const getDesktopEnv = memoize(() =>
       NODE_ENV: z.enum(['development', 'production', 'test']).optional(),
 
       // cloud server url (can be overridden for selfhost/dev)
-      OFFICIAL_CLOUD_SERVER: z.string().optional().default(OFFICIAL_URL),
+      OFFICIAL_CLOUD_SERVER: z.string().optional().default(OFFICIAL_CLOUD_URL),
 
       // updater
       // process.env.xxx will replace in build stage

--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -4,6 +4,8 @@ export const OFFICIAL_URL = 'https://app.lobehub.com';
 export const OFFICIAL_SITE = 'https://lobehub.com';
 export const OFFICIAL_DOMAIN = 'lobehub.com';
 
+export const OFFICIAL_CLOUD_URL = OFFICIAL_SITE;
+
 export const isOfficialCloudServer = (url?: string): boolean => {
   if (!url) return false;
   try {


### PR DESCRIPTION
Cloud is moving from `app.lobehub.com` to the apex `lobehub.com`, and the gateway already serves the app backend there. This switches the Electron default cloud server over.

- `OFFICIAL_CLOUD_URL` (new, `= OFFICIAL_SITE`) backs the desktop `OFFICIAL_CLOUD_SERVER` default.
- `OFFICIAL_URL` is deliberately left at `app.lobehub.com` — web canonical/OG metadata, the CLI default server and branding links migrate on their own schedule.
- The subscription webview's `Oidc-Auth` injection filter gains `https://lobehub.com/*`; `https://*.lobehub.com/*` does not match the bare apex.

#### Test

Verified against a dev Electron build talking to production cloud:

| probe | result |
| --- | --- |
| `dist/main` bundle | no `app.lobehub.com` left; only `OFFICIAL_SITE = "https://lobehub.com"` |
| `remoteServer.getRemoteServerConfig` over IPC | `{ storageMode: "cloud", active: true }` |
| proxied `GET /trpc/lambda/device.listDevices` | **200**, `x-matched-path: /trpc/lambda/[trpc]` (authenticated round-trip) |
| proxied `GET /onboarding`, `GET /chat` | 404 — the apex signature (`app.` returns 302 / 200), confirming the host actually in use |

Gateway parity was checked endpoint by endpoint for every path desktop touches (`/trpc`, `/webapi`, `/api/auth`, `/market`, `/oidc/*`) — apex behaves identically to `app.`.

OIDC is already prepared server-side: `src/libs/oidc-provider/config.ts` lists `https://lobehub.com` in `cloudAppOrigins`, so `https://lobehub.com/oidc/callback/desktop` is a registered `redirect_uri`.

Not covered: a cold sign-in. The runtime check reused an existing token, so the full `/oidc/auth` → consent → callback round-trip on the apex is unverified. The redirect URI is registered, but worth one manual login before release.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

<!-- none -->

https://claude.ai/code/session_01HkdNNBVJRFvhr9PmqZYe6e