### PR TITLE
💄 style(acceptance): flatten the focused flow group, indent the outline and tidy the acceptance page

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -20,87 +20,88 @@ rg -n '^#{2,4} ' "$P"     # every heading, to find the next bound
 gateway / hetero / any (the agent runtime the recipe depends on); **phase** = env / auth / fixture /
 drive / probe / capture / publish. Skip a row only when its surface AND runtime both miss yours.
 
-| id  | surface       | runtime         | phase          | situation                                                                                                                     |
-| --- | ------------- | --------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| P01 | any           | any             | probe          | `window.__LOBE_STORES.<name>()` returns state only; add a dev action instead of HMR `setState` patches                        |
-| P02 | web, electron | any             | probe          | `goto` / `location.assign` full-reload wipes fetch wrappers; change route via `history.pushState` + `popstate`                |
-| P03 | any           | client, gateway | probe          | Prove which runtime ran with a server-only artifact (operation row, queue step, server log)                                   |
-| P04 | web, electron | any             | probe          | A top-level `const` in a second `agent-browser eval` collides; wrap payloads in an IIFE                                       |
-| P05 | web           | any             | drive          | `lobehub-dev` is shared across runs; use a run-specific session and check `location.origin` / script src first                |
-| P06 | electron      | any             | probe          | After adding or moving a module the renderer may keep the old graph; `goto`, then confirm a structural signal                 |
-| P07 | web           | any             | env            | `_dangerous_local_dev_proxy` in a signed-out automation context sits on the loading shell; use the isolated local stack       |
-| P08 | web           | any             | env            | Workspace `packages/*` dynamic imports fail cross-origin through the proxy; A/B at HEAD, use Electron for settled state       |
-| P09 | any           | client, gateway | fixture        | The stub must answer `stream:false` chat/completions with a plain JSON completion, never SSE                                  |
-| P10 | web           | gateway         | fixture        | `review_predict` is pinned to Gemini; pin the constants, allow private IPs, return schema JSON from the stub                  |
-| P11 | any           | gateway         | fixture        | `generateObject` via the deepseek stub crashes; route through the openai `/v1/responses` stub                                 |
-| P12 | web           | gateway         | fixture        | Backdate node and op rows past the client's 15-minute lease, not the server's 5                                               |
-| P13 | web, cli      | any             | fixture        | `lh topic create` rows have NULL trigger/status and drop out of the paged view; set both, then `goto`                         |
-| P14 | web, electron | hetero          | fixture        | Seed `agency_config.heterogeneousProvider` with SQL, then cold-load; the store write drops it                                 |
-| P15 | web           | any             | fixture        | Derive day boundaries from the browser's `resolvedOptions().timeZone`, never an assumed zone                                  |
-| P16 | web, electron | any             | fixture        | Clear cache tiers in the NEW document via `addScriptToEvaluateOnNewDocument`; the outgoing page re-flushes on reload          |
-| P17 | web           | any             | drive          | Goals live at `/agent/:aid/goals` behind the Labs toggle `enableTopicAcceptance`                                              |
-| P18 | electron      | hetero          | fixture        | Local-execution CC agent plus a four-table ledger fixture keyed to the live CLI identity                                      |
-| P19 | web           | any             | auth           | Seed a second user and sign in from inside a run-specific session; a signed-out context hits `/signin`                        |
-| P20 | cli           | any             | fixture        | Strip ambient topic/agent/operation ids for a LOCAL ingest; keep them for the production publish                              |
-| P21 | web           | any             | drive          | Upload through the Add-menu input, poll `dockUploadFileList`, A/B the hashing worker with `window.Worker = undefined`         |
-| P22 | web, electron | any             | drive          | `keyboard type` emits no keydown; fire `/` (and any menu trigger) with `press`                                                |
-| P23 | web, electron | any             | drive          | Tag `svg.lucide-<rendered-name>` and click through agent-browser; `el.click()` on the wrapper does nothing                    |
-| P24 | web, electron | any             | drive          | Re-query elements after every re-render; one assertion per eval                                                               |
-| P25 | web, electron | any             | capture        | Anchor on `#nav-panel-drawer`'s aside sibling; tell skeleton states apart by testid, not row count                            |
-| P26 | web           | any             | capture        | Park the route's own tRPC call with `park-request.cjs`; a broad `*trpc*` pattern stalls the shell                             |
-| P27 | web           | any             | drive          | `SWRConfig` only affects hooks below it; move the hooks into a child component                                                |
-| P28 | electron      | any             | capture        | Raw CDP `Fetch.enable` on the layout chunk holds the sidebar fallback; name the layout module only                            |
-| P29 | web, electron | any             | fixture, drive | Seed via `mkdirDocumentByPath` / `writeDocumentByPath`; rows live in pierre's shadow DOM; hetero agents have no Documents tab |
-| P30 | web, electron | any             | drive          | pierre's focus-visible and truncation-mask contracts when restyling the tree                                                  |
-| P31 | web           | any             | drive          | Row-shape bugs need the real account: foreground the MCP tab, zero-write clicks, in-page event ring buffer                    |
-| P32 | web, electron | hetero          | fixture        | Dispatch a temp assistant message and attach an `AgentRuntimeError` guide code                                                |
-| P33 | web, electron | any             | fixture        | Backfill `pluginState` from each tool message's result after Agent Mock playback                                              |
-| P34 | web, electron | any             | fixture        | Dispatch an assistant+tool pair into an empty conversation; truncate args to reach the Streaming render                       |
-| P35 | web           | gateway         | probe          | Step-boundary `uiMessages` snapshots overwrite the bucket; record `replaceMessages` stacks, A/B with `disableGatewayMode`     |
-| P36 | web           | gateway         | env            | Run the JWT handshake probe after every gateway restart; `/health` 200 proves nothing                                         |
-| P37 | any           | gateway         | env            | QStash / s3rver on fixed ports may belong to a sibling session; read the start log before stopping anything                   |
-| P38 | web           | any             | fixture        | Call the real load-more store action when the fixture is too short for the observer                                           |
-| P39 | web, electron | any             | fixture        | Replace the react-query `mutationFn` with a rejection via HMR so no network call ever fires                                   |
-| P40 | web, electron | any             | drive          | Remount the DevDock panel after a reload; pre-seed `LOBE_DEV_DOCK_UI` to land on it                                           |
-| P41 | web           | client          | fixture, drive | openai speaks `/v1/responses`; the model must be in `enabledAiModels`; set approval `auto-run`                                |
-| P42 | web           | hetero          | fixture, drive | In-page IPC mock feeding stream-json through the real `ClaudeCodeAdapter`, no Electron needed                                 |
-| P43 | web, electron | any             | capture        | Focus and read in one eval, wait past the transition, assert an untransitioned property too                                   |
-| P44 | web, electron | any             | capture        | Inject `html > canvas { display: none }` at capture time and disclose it                                                      |
-| P45 | web           | any             | capture        | Gate on `checkVisibility`, match own text nodes, assert both columns in one pass                                              |
-| P46 | web, electron | any             | capture        | Sample in-page (`addScriptToEvaluateOnNewDocument` or an entry injection), record the max tick gap, mirror the timer          |
-| P47 | web, electron | any             | capture        | Sample opacity in-page at 8 ms and use `Page.startScreencast`; `data-ending-style` is never set                               |
-| P48 | web           | any             | capture        | `localStorage.theme` + reload; assert `dataset.theme`; restore before stopping the server                                     |
-| P49 | electron      | any             | capture        | Prove the hosted URL (curl + open it), not the in-app preview                                                                 |
-| P50 | any           | any             | publish        | Re-running `ingest` mints a duplicate round; re-read with `run list` / `run get` / `view`                                     |
-| P51 | electron      | any             | probe          | Read the loaded entry script per run; never assume `entry.desktop.tsx`                                                        |
-| P52 | electron      | any             | capture        | `DESKTOP_RENDERER_STATIC=1` pool instance; prove the build via modulepreload hashes                                           |
-| P53 | electron      | any             | drive          | Open via `openTopicInNewWindow` and attach raw CDP to the popup target                                                        |
-| P54 | electron      | any             | drive          | `activateTab` alone is a no-op on the single-router shell; click the TabItem element and assert the pathname                  |
-| P55 | electron      | any             | drive          | `addTab` activates; enter the route with `goto` and assert tab / pathname / activeTopicId agree                               |
-| P56 | electron      | any             | capture        | Classify hidden slots on both sides of the switch and use the intersection                                                    |
-| P57 | electron      | any             | capture        | The renderer tracks OS appearance; `themeMode` never applies; mark the dark case untested                                     |
-| P58 | electron      | any             | probe          | i18next stays English until `switchLocale`; decide language from the DOM, not `status.language`                               |
-| P59 | electron      | any             | drive          | `addTab('/')` first; `goto /` alone keeps the restored tab                                                                    |
-| P60 | electron      | any             | auth, env      | Read `dataSyncConfig` first; `storageMode: cloud` means the run must stay read-only                                           |
-| P61 | web, electron | any             | capture        | Stall `indexedDB.open` only on web; it kills the Electron renderer                                                            |
-| P62 | electron      | any             | env            | Keep locale tests out of `packages/locales/src/default/` or the renderer imports vitest                                       |
-| P63 | cli           | gateway         | auth           | `lh task run --follow` needs OIDC; poll with `task view`; use internal ids for `--subject task:`                              |
-| P64 | web           | any             | auth           | No seeded session for the debug proxy; drive the user's Chrome and add DOM measurements                                       |
-| P65 | electron      | any             | auth, env      | Start the server on the snapshot's port with `SERVER_PORT=`; inject a better-auth cookie over CDP                             |
-| P66 | electron      | any             | auth           | `safeStorage` cannot decrypt the copied token; fall back to the legacy single instance                                        |
-| P67 | electron      | any             | auth, env      | Read the port from `/tmp/electron-dev.log`, mint a session, `Network.setCookie`                                               |
-| P68 | electron      | any             | auth, env      | Pool logs are `instance-<id>.log`; fix the port and start the server before Electron                                          |
-| P69 | electron      | any             | fixture        | Snapshot `dist/renderer` before building so the manifest differs from the local tree                                          |
-| P70 | any           | any             | env            | `.records/runtime/` holds the owned server's PID and ports; poll that port                                                    |
-| P71 | web           | any             | env            | `lsof` the listener, kill only the run-owned tree, restart, reseed auth                                                       |
-| P72 | web, electron | any             | env            | Two copies of a dep produce context errors; `pnpm dedupe`; local-only, never a branch defect                                  |
-| P73 | web           | any             | env            | Install without `--ignore-scripts` and `rm -rf .next`; turbo-tasks panics are disposable cache                                |
-| P74 | electron      | any             | env            | The desktop install duplicates `@types/react`; intersect errors with changed files, A/B after evidence                        |
-| P75 | electron      | any             | env            | Run the Model B desktop command in a long-lived PTY                                                                           |
-| P76 | any           | any             | env            | Prefix git and check commands with `cd <worktree>`; read the diffstat before pushing                                          |
-| P77 | web, cli      | gateway         | probe          | Read `llm_generation_tracing.prompt_version` after one call; restart the server if stale                                      |
-| P78 | web, cli      | gateway         | env            | `SSRF_ALLOW_PRIVATE_IP_ADDRESS=1` so the server can read local s3rver URLs                                                    |
-| P79 | web, cli      | client, gateway | env            | Local SearXNG with `SEARCH_PROVIDERS=searxng`; the on-disk search1api keys are dead                                           |
+| id  | surface       | runtime         | phase          | situation                                                                                                                                      |
+| --- | ------------- | --------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| P01 | any           | any             | probe          | `window.__LOBE_STORES.<name>()` returns state only; add a dev action instead of HMR `setState` patches                                         |
+| P02 | web, electron | any             | probe          | `goto` / `location.assign` full-reload wipes fetch wrappers; change route via `history.pushState` + `popstate`                                 |
+| P03 | any           | client, gateway | probe          | Prove which runtime ran with a server-only artifact (operation row, queue step, server log)                                                    |
+| P04 | web, electron | any             | probe          | A top-level `const` in a second `agent-browser eval` collides; wrap payloads in an IIFE                                                        |
+| P05 | web           | any             | drive          | `lobehub-dev` is shared across runs; use a run-specific session and check `location.origin` / script src first                                 |
+| P06 | electron      | any             | probe          | After adding or moving a module the renderer may keep the old graph; `goto`, then confirm a structural signal                                  |
+| P07 | web           | any             | env            | `_dangerous_local_dev_proxy` in a signed-out automation context sits on the loading shell; use the isolated local stack                        |
+| P08 | web           | any             | env            | Workspace `packages/*` dynamic imports fail cross-origin through the proxy; A/B at HEAD, use Electron for settled state                        |
+| P09 | any           | client, gateway | fixture        | The stub must answer `stream:false` chat/completions with a plain JSON completion, never SSE                                                   |
+| P10 | web           | gateway         | fixture        | `review_predict` is pinned to Gemini; pin the constants, allow private IPs, return schema JSON from the stub                                   |
+| P11 | any           | gateway         | fixture        | `generateObject` via the deepseek stub crashes; route through the openai `/v1/responses` stub                                                  |
+| P12 | web           | gateway         | fixture        | Backdate node and op rows past the client's 15-minute lease, not the server's 5                                                                |
+| P13 | web, cli      | any             | fixture        | `lh topic create` rows have NULL trigger/status and drop out of the paged view; set both, then `goto`                                          |
+| P14 | web, electron | hetero          | fixture        | Seed `agency_config.heterogeneousProvider` with SQL, then cold-load; the store write drops it                                                  |
+| P15 | web           | any             | fixture        | Derive day boundaries from the browser's `resolvedOptions().timeZone`, never an assumed zone                                                   |
+| P16 | web, electron | any             | fixture        | Clear cache tiers in the NEW document via `addScriptToEvaluateOnNewDocument`; the outgoing page re-flushes on reload                           |
+| P17 | web           | any             | drive          | Goals live at `/agent/:aid/goals` behind the Labs toggle `enableTopicAcceptance`                                                               |
+| P18 | electron      | hetero          | fixture        | Local-execution CC agent plus a four-table ledger fixture keyed to the live CLI identity                                                       |
+| P19 | web           | any             | auth           | Seed a second user and sign in from inside a run-specific session; a signed-out context hits `/signin`                                         |
+| P20 | cli           | any             | fixture        | Strip ambient topic/agent/operation ids for a LOCAL ingest; keep them for the production publish                                               |
+| P21 | web           | any             | drive          | Upload through the Add-menu input, poll `dockUploadFileList`, A/B the hashing worker with `window.Worker = undefined`                          |
+| P22 | web, electron | any             | drive          | `keyboard type` emits no keydown; fire `/` (and any menu trigger) with `press`                                                                 |
+| P23 | web, electron | any             | drive          | Tag `svg.lucide-<rendered-name>` and click through agent-browser; `el.click()` on the wrapper does nothing                                     |
+| P24 | web, electron | any             | drive          | Re-query elements after every re-render; one assertion per eval                                                                                |
+| P25 | web, electron | any             | capture        | Anchor on `#nav-panel-drawer`'s aside sibling; tell skeleton states apart by testid, not row count                                             |
+| P26 | web           | any             | capture        | Park the route's own tRPC call with `park-request.cjs`; a broad `*trpc*` pattern stalls the shell                                              |
+| P27 | web           | any             | drive          | `SWRConfig` only affects hooks below it; move the hooks into a child component                                                                 |
+| P28 | electron      | any             | capture        | Raw CDP `Fetch.enable` on the layout chunk holds the sidebar fallback; name the layout module only                                             |
+| P29 | web, electron | any             | fixture, drive | Seed via `mkdirDocumentByPath` / `writeDocumentByPath`; rows live in pierre's shadow DOM; hetero agents have no Documents tab                  |
+| P30 | web, electron | any             | drive          | pierre's focus-visible and truncation-mask contracts when restyling the tree                                                                   |
+| P31 | web           | any             | drive          | Row-shape bugs need the real account: foreground the MCP tab, zero-write clicks, in-page event ring buffer                                     |
+| P32 | web, electron | hetero          | fixture        | Dispatch a temp assistant message and attach an `AgentRuntimeError` guide code                                                                 |
+| P33 | web, electron | any             | fixture        | Backfill `pluginState` from each tool message's result after Agent Mock playback                                                               |
+| P34 | web, electron | any             | fixture        | Dispatch an assistant+tool pair into an empty conversation; truncate args to reach the Streaming render                                        |
+| P35 | web           | gateway         | probe          | Step-boundary `uiMessages` snapshots overwrite the bucket; record `replaceMessages` stacks, A/B with `disableGatewayMode`                      |
+| P36 | web           | gateway         | env            | Run the JWT handshake probe after every gateway restart; `/health` 200 proves nothing                                                          |
+| P37 | any           | gateway         | env            | QStash / s3rver on fixed ports may belong to a sibling session; read the start log before stopping anything                                    |
+| P38 | web           | any             | fixture        | Call the real load-more store action when the fixture is too short for the observer                                                            |
+| P39 | web, electron | any             | fixture        | Replace the react-query `mutationFn` with a rejection via HMR so no network call ever fires                                                    |
+| P40 | web           | any             | drive          | Acceptance flow canvas through the production debug proxy: anonymous shared link, one uninterrupted script, canvas controls for clipped groups |
+| P40 | web, electron | any             | drive          | Remount the DevDock panel after a reload; pre-seed `LOBE_DEV_DOCK_UI` to land on it                                                            |
+| P41 | web           | client          | fixture, drive | openai speaks `/v1/responses`; the model must be in `enabledAiModels`; set approval `auto-run`                                                 |
+| P42 | web           | hetero          | fixture, drive | In-page IPC mock feeding stream-json through the real `ClaudeCodeAdapter`, no Electron needed                                                  |
+| P43 | web, electron | any             | capture        | Focus and read in one eval, wait past the transition, assert an untransitioned property too                                                    |
+| P44 | web, electron | any             | capture        | Inject `html > canvas { display: none }` at capture time and disclose it                                                                       |
+| P45 | web           | any             | capture        | Gate on `checkVisibility`, match own text nodes, assert both columns in one pass                                                               |
+| P46 | web, electron | any             | capture        | Sample in-page (`addScriptToEvaluateOnNewDocument` or an entry injection), record the max tick gap, mirror the timer                           |
+| P47 | web, electron | any             | capture        | Sample opacity in-page at 8 ms and use `Page.startScreencast`; `data-ending-style` is never set                                                |
+| P48 | web           | any             | capture        | `localStorage.theme` + reload; assert `dataset.theme`; restore before stopping the server                                                      |
+| P49 | electron      | any             | capture        | Prove the hosted URL (curl + open it), not the in-app preview                                                                                  |
+| P50 | any           | any             | publish        | Re-running `ingest` mints a duplicate round; re-read with `run list` / `run get` / `view`                                                      |
+| P51 | electron      | any             | probe          | Read the loaded entry script per run; never assume `entry.desktop.tsx`                                                                         |
+| P52 | electron      | any             | capture        | `DESKTOP_RENDERER_STATIC=1` pool instance; prove the build via modulepreload hashes                                                            |
+| P53 | electron      | any             | drive          | Open via `openTopicInNewWindow` and attach raw CDP to the popup target                                                                         |
+| P54 | electron      | any             | drive          | `activateTab` alone is a no-op on the single-router shell; click the TabItem element and assert the pathname                                   |
+| P55 | electron      | any             | drive          | `addTab` activates; enter the route with `goto` and assert tab / pathname / activeTopicId agree                                                |
+| P56 | electron      | any             | capture        | Classify hidden slots on both sides of the switch and use the intersection                                                                     |
+| P57 | electron      | any             | capture        | The renderer tracks OS appearance; `themeMode` never applies; mark the dark case untested                                                      |
+| P58 | electron      | any             | probe          | i18next stays English until `switchLocale`; decide language from the DOM, not `status.language`                                                |
+| P59 | electron      | any             | drive          | `addTab('/')` first; `goto /` alone keeps the restored tab                                                                                     |
+| P60 | electron      | any             | auth, env      | Read `dataSyncConfig` first; `storageMode: cloud` means the run must stay read-only                                                            |
+| P61 | web, electron | any             | capture        | Stall `indexedDB.open` only on web; it kills the Electron renderer                                                                             |
+| P62 | electron      | any             | env            | Keep locale tests out of `packages/locales/src/default/` or the renderer imports vitest                                                        |
+| P63 | cli           | gateway         | auth           | `lh task run --follow` needs OIDC; poll with `task view`; use internal ids for `--subject task:`                                               |
+| P64 | web           | any             | auth           | No seeded session for the debug proxy; drive the user's Chrome and add DOM measurements                                                        |
+| P65 | electron      | any             | auth, env      | Start the server on the snapshot's port with `SERVER_PORT=`; inject a better-auth cookie over CDP                                              |
+| P66 | electron      | any             | auth           | `safeStorage` cannot decrypt the copied token; fall back to the legacy single instance                                                         |
+| P67 | electron      | any             | auth, env      | Read the port from `/tmp/electron-dev.log`, mint a session, `Network.setCookie`                                                                |
+| P68 | electron      | any             | auth, env      | Pool logs are `instance-<id>.log`; fix the port and start the server before Electron                                                           |
+| P69 | electron      | any             | fixture        | Snapshot `dist/renderer` before building so the manifest differs from the local tree                                                           |
+| P70 | any           | any             | env            | `.records/runtime/` holds the owned server's PID and ports; poll that port                                                                     |
+| P71 | web           | any             | env            | `lsof` the listener, kill only the run-owned tree, restart, reseed auth                                                                        |
+| P72 | web, electron | any             | env            | Two copies of a dep produce context errors; `pnpm dedupe`; local-only, never a branch defect                                                   |
+| P73 | web           | any             | env            | Install without `--ignore-scripts` and `rm -rf .next`; turbo-tasks panics are disposable cache                                                 |
+| P74 | electron      | any             | env            | The desktop install duplicates `@types/react`; intersect errors with changed files, A/B after evidence                                         |
+| P75 | electron      | any             | env            | Run the Model B desktop command in a long-lived PTY                                                                                            |
+| P76 | any           | any             | env            | Prefix git and check commands with `cd <worktree>`; read the diffstat before pushing                                                           |
+| P77 | web, cli      | gateway         | probe          | Read `llm_generation_tracing.prompt_version` after one call; restart the server if stale                                                       |
+| P78 | web, cli      | gateway         | env            | `SSRF_ALLOW_PRIVATE_IP_ADDRESS=1` so the server can read local s3rver URLs                                                                     |
+| P79 | web, cli      | client, gateway | env            | Local SearXNG with `SEARCH_PROVIDERS=searxng`; the on-disk search1api keys are dead                                                            |
 
 ## Choose the least invasive mechanism
 
@@ -1374,6 +1375,38 @@ the bubble shows "Claude Code is running…", and the topic persists user → as
 tool → assistant(text) rows. Capture mid-turn by polling the top-level `[data-index]` rows,
 not `body.innerText`, and key turn-2 captures on the store/DOM state you assert rather than a
 fixed sleep.
+
+#### P40 · Acceptance flow canvas through the production debug proxy: anonymous shared link, one uninterrupted script, canvas controls for clipped groups
+
+**applies-to:** surface=web · runtime=any · phase=drive
+
+**Situation:** verifying the acceptance flow graph (`src/features/Acceptance/Viewer/Flow`)
+with local worktree code against production data through
+`/_dangerous_local_dev_proxy/acceptance/<id>?debug-host=http://localhost:<port>`, using a
+publicly shared acceptance so no production login is injected.
+
+**Doesn't work:**
+
+- Idle gaps between `agent-browser` commands. The anonymous context is redirected to
+  `/signin?reason=sessionExpired` within roughly a minute, so a later screenshot silently
+  becomes the login page and reads as "the group frame is gone".
+- `focus @ref` + `press Enter` on a group button after the flow's fullscreen toggle was
+  used. `AcceptanceFlow.tsx` refocuses the fullscreen `ActionIcon` when fullscreen exits, so
+  the Enter re-enters fullscreen while the group action also fires.
+- Trusting the default `fitView`. `FlowCanvas` fits with `minZoom: 0.65`, so on a
+  1440×1800 viewport a 26-node group does not fit and the wrapper's title row is clipped
+  out of the canvas; collapsing a group does not refit, so the collapsed card can sit
+  outside the viewport. Both are pre-existing and identical on production.
+
+**Works:** one bash script that opens the URL, waits for the `验收流程` tab, and performs
+every click and screenshot back to back; log `get url` before each screenshot and skip any
+that is not on the acceptance route. Click `.react-flow__controls-zoomout` twice before the
+root/focused screenshots and `.react-flow__controls-fitview` after collapsing; drive group
+buttons with `click @ref` (focus+Enter only as fallback) and take the fullscreen shot last.
+Assert structure with `get count '.react-flow__node-flowGroup'` /
+`'.react-flow__node-state'`, capture `before` from the same route on production and `after`
+from the proxy in the same session and viewport, and rely on a top-bar string that exists
+only in the worktree as the visible identity marker of every `after` screenshot.
 
 ### Capturing and publishing evidence
 

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -61,7 +61,6 @@ drive / probe / capture / publish. Skip a row only when its surface AND runtime 
 | P37 | any           | gateway         | env            | QStash / s3rver on fixed ports may belong to a sibling session; read the start log before stopping anything                                    |
 | P38 | web           | any             | fixture        | Call the real load-more store action when the fixture is too short for the observer                                                            |
 | P39 | web, electron | any             | fixture        | Replace the react-query `mutationFn` with a rejection via HMR so no network call ever fires                                                    |
-| P40 | web           | any             | drive          | Acceptance flow canvas through the production debug proxy: anonymous shared link, one uninterrupted script, canvas controls for clipped groups |
 | P40 | web, electron | any             | drive          | Remount the DevDock panel after a reload; pre-seed `LOBE_DEV_DOCK_UI` to land on it                                                            |
 | P41 | web           | client          | fixture, drive | openai speaks `/v1/responses`; the model must be in `enabledAiModels`; set approval `auto-run`                                                 |
 | P42 | web           | hetero          | fixture, drive | In-page IPC mock feeding stream-json through the real `ClaudeCodeAdapter`, no Electron needed                                                  |
@@ -102,6 +101,7 @@ drive / probe / capture / publish. Skip a row only when its surface AND runtime 
 | P77 | web, cli      | gateway         | probe          | Read `llm_generation_tracing.prompt_version` after one call; restart the server if stale                                                       |
 | P78 | web, cli      | gateway         | env            | `SSRF_ALLOW_PRIVATE_IP_ADDRESS=1` so the server can read local s3rver URLs                                                                     |
 | P79 | web, cli      | client, gateway | env            | Local SearXNG with `SEARCH_PROVIDERS=searxng`; the on-disk search1api keys are dead                                                            |
+| P82 | web           | any             | drive          | Acceptance flow canvas through the production debug proxy: anonymous shared link, one uninterrupted script, canvas controls for clipped groups |
 
 ## Choose the least invasive mechanism
 
@@ -1376,7 +1376,7 @@ tool → assistant(text) rows. Capture mid-turn by polling the top-level `[data-
 not `body.innerText`, and key turn-2 captures on the store/DOM state you assert rather than a
 fixed sleep.
 
-#### P40 · Acceptance flow canvas through the production debug proxy: anonymous shared link, one uninterrupted script, canvas controls for clipped groups
+#### P82 · Acceptance flow canvas through the production debug proxy: anonymous shared link, one uninterrupted script, canvas controls for clipped groups
 
 **applies-to:** surface=web · runtime=any · phase=drive
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -21,6 +21,7 @@ user-invocable: true
 - `git log --oneline origin/canary..HEAD` — unpushed commits
 - `gh pr list --head "$(git branch --show-current)" --json number,title,state,url` — existing PR
 - `git diff --stat --stat-count=20 origin/canary..HEAD` — change summary
+- `env -u LOBEHUB_SERVER -u LOBE_API_KEY -u LOBEHUB_CLI_API_KEY -u LOBEHUB_CLI_HOME lh acceptance run list --json` — the published acceptance round for this branch (match on `branch`)
 
 ### 2. Handle uncommitted changes on default branch
 
@@ -46,15 +47,20 @@ If current branch is `canary`/`main` but there are NO uncommitted changes and no
 - Only link issues with matching scope (avoid large umbrella issues)
 - Skip if no matching issue found
 
-### 5. Create PR with `gh pr create --base canary`
+### 5. Acceptance gate
+
+A feature or fix needs a published acceptance round before the PR is opened (AGENTS.md → Acceptance). If step 1 found none for this branch, run the `acceptance` skill first and come back with its `https://app.lobehub.com/acceptance/<id>` link. Pure refactors or tooling changes with no user-visible outcome may skip it — state that in the PR body instead of leaving the line out.
+
+### 6. Create PR with `gh pr create --base canary`
 
 - Title: `<gitmoji> <type>(<scope>): <description>`
 - Body: based on PR template (`.github/PULL_REQUEST_TEMPLATE.md`), fill checkboxes
 - Link related GitHub issues using magic keywords (`Fixes #123`, `Closes #123`)
 - Link Linear issues if applicable (`Fixes LOBE-xxx`)
+- Put the acceptance link (or the explicit skip reason) under **Test**
 - Use HEREDOC for body to preserve formatting
 
-### 6. Open in browser
+### 7. Open in browser
 
 `gh pr view --web`
 
@@ -66,6 +72,7 @@ Use `.github/PULL_REQUEST_TEMPLATE.md` as the body structure. Key sections:
 - **Related Issue**: Link GitHub/Linear issues with magic keywords
 - **Description of Change**: Summarize what and why
 - **How to Test**: Describe test approach, check relevant boxes
+- **Acceptance**: the published `https://app.lobehub.com/acceptance/<id>` link, or why the change has no user-visible outcome
 
 ## Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,10 @@
 - [ ] Added/updated tests
 - [ ] No tests needed
 
+<!-- Acceptance round for user-visible changes (AGENTS.md → Acceptance); or state why none is needed -->
+
+- Acceptance: ...
+
 #### 🔗 Related Issue
 
 <!-- Link to the issue that is fixed by this PR -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,10 @@ Use `bun run check [changed-files...]`.
 - Lint autofixes files: review the emitted diff. Tests use the nearest owning Vitest config. `--type` checks the full repo. Never run `bun run test`, which runs the full suite.
 - For a manual package test, run from the owning package: `cd packages/database && bunx vitest run --silent='passed-only' '[file-path]'`.
 
+### Acceptance
+
+Finishing a feature or fix means proving it on the real product, not only passing the gates above. Before a PR is opened or marked ready, run the `acceptance` skill: drive the change on the surface it reaches (CLI / Web / Electron), capture visually confirmed evidence, and publish a round with `lh acceptance run ingest`. Put the published `https://app.lobehub.com/acceptance/<id>` link in the PR body. Tests, lint, and type-check are gates, never acceptance checks; a change without a published round is not done. Skip only for pure refactors or tooling changes with no user-visible outcome, and say so explicitly in the PR.
+
 ### i18n
 
 - Add keys to a namespace file under `packages/locales/src/default/` (e.g. `agent.ts`, `auth.ts`)

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -384,7 +384,7 @@
   "acceptance.workspace.searchScope": "已在载入的 {{count}} 条中搜索。",
   "acceptance.workspace.statusError": "状态更新失败",
   "acceptance.workspace.statusSuccess": "状态已更新",
-  "acceptance.workspace.title": "交付",
+  "acceptance.workspace.title": "验收",
   "actions.backToApp": "返回 {{name}}",
   "actions.cancel": "取消",
   "actions.delete": "删除",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -226,7 +226,7 @@
   "acceptance.sharedNotice.title": "来自他人的分享",
   "acceptance.sharedNotice.titleWithName": "来自 {{name}} 的分享",
   "acceptance.shell.back": "返回",
-  "acceptance.shell.menu": "查看交付列表",
+  "acceptance.shell.menu": "查看验收列表",
   "acceptance.stats.failed": "{{count}} 失败",
   "acceptance.stats.notExecuted": "{{count}} 未执行",
   "acceptance.stats.passed": "{{count}} 通过",

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acceptance
-version: 0.4.2
+version: 0.4.3
 description: >
   End-to-end verification and self-evidence for a delivery in any repository,
   with or without a preconfigured verify plan. Discover an existing plan when
@@ -309,7 +309,7 @@ chat reply.
 Write the link as a plain-text line, never inside a fenced or inline code block — the
 chat client only linkifies plain text, and a code block makes it unclickable:
 
-Acceptance: <https://app.lobehub.com/acceptance/><acceptanceId>
+Acceptance: <https://app.lobehub.com/acceptance/ACCEPTANCE_ID> (the placeholder is the id ingest printed; it stays inside the URL)
 Coverage: 2/2 criteria, all required evidence uploaded
 
 ## Portability rules

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -306,10 +306,11 @@ surface; append `?r=<roundIndex>` for this round's fixed snapshot.
 Put no images, local paths, local file links, or internal run-page paths in the
 chat reply.
 
-```text
-Acceptance:   https://app.lobehub.com/acceptance/<acceptanceId>
+Write the link as a plain-text line, never inside a fenced or inline code block — the
+chat client only linkifies plain text, and a code block makes it unclickable:
+
+Acceptance: <https://app.lobehub.com/acceptance/><acceptanceId>
 Coverage: 2/2 criteria, all required evidence uploaded
-```
 
 ## Portability rules
 

--- a/src/features/Acceptance/Viewer/AcceptanceOverview.tsx
+++ b/src/features/Acceptance/Viewer/AcceptanceOverview.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
+import { createStaticStyles, useResponsive } from 'antd-style';
 import { useState } from 'react';
 
 import { useAcceptanceScope } from './AcceptanceScope';
@@ -40,7 +40,6 @@ const styles = createStaticStyles(({ css }) => ({
   headerBand: css`
     flex: none;
     padding-block: 20px 0;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
 }));
 interface AcceptancePageProps {
@@ -48,8 +47,9 @@ interface AcceptancePageProps {
 }
 
 /**
- * The record's own body: an identity band that ends in the full-width rule,
- * then whichever face of the delivery the tabs select.
+ * The record's own body: an identity band that ends in the tabs, then whichever
+ * face of the delivery the tabs select. The tabs' own active underline is the
+ * only separator; a full-width rule under them read as a stray line.
  */
 export const AcceptanceOverview = ({
   onDraftToComposer,

--- a/src/features/Acceptance/Viewer/AcceptanceOverview.tsx
+++ b/src/features/Acceptance/Viewer/AcceptanceOverview.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { createStaticStyles, useResponsive } from 'antd-style';
+import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
 import { useState } from 'react';
 
 import { useAcceptanceScope } from './AcceptanceScope';
@@ -40,6 +40,7 @@ const styles = createStaticStyles(({ css }) => ({
   headerBand: css`
     flex: none;
     padding-block: 20px 0;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
 }));
 interface AcceptancePageProps {
@@ -47,9 +48,9 @@ interface AcceptancePageProps {
 }
 
 /**
- * The record's own body: an identity band that ends in the tabs, then whichever
- * face of the delivery the tabs select. The tabs' own active underline is the
- * only separator; a full-width rule under them read as a stray line.
+ * The record's own body: an identity band that ends in the full-width rule,
+ * then whichever face of the delivery the tabs select. The rule is the band's;
+ * the tabs draw no line of their own, so the two never double up.
  */
 export const AcceptanceOverview = ({
   onDraftToComposer,

--- a/src/features/Acceptance/Viewer/Evidence/attachments.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/attachments.tsx
@@ -4,7 +4,7 @@ import type { AcceptanceAttachment } from '@lobechat/types';
 import { Flexbox, Icon, Image } from '@lobehub/ui';
 import { Button, toast } from '@lobehub/ui/base-ui';
 import { Upload } from 'antd';
-import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { createStaticStyles, cssVar, cx, useResponsive } from 'antd-style';
 import { ImagePlus, Loader2, X } from 'lucide-react';
 import { type ClipboardEvent, memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -224,6 +224,8 @@ interface AttachmentUploadButtonProps {
 /** The "attach screenshot" trigger — a picker button that hands files back for upload. */
 export const AttachmentUploadButton = memo<AttachmentUploadButtonProps>(({ disabled, onFiles }) => {
   const { t } = useTranslation('verify');
+  // A 44px target is for thumbs; on a pointer device it towers over the field above it.
+  const { md = true } = useResponsive();
   return (
     <Upload
       multiple
@@ -240,7 +242,7 @@ export const AttachmentUploadButton = memo<AttachmentUploadButtonProps>(({ disab
       <Button
         disabled={disabled}
         icon={<Icon icon={ImagePlus} />}
-        style={{ minHeight: 44, alignSelf: 'flex-start' }}
+        style={{ alignSelf: 'flex-start', minHeight: md ? undefined : 44 }}
         type={'text'}
       >
         {t('acceptance.review.attach')}

--- a/src/features/Acceptance/Viewer/Flow/AcceptanceFlow.tsx
+++ b/src/features/Acceptance/Viewer/Flow/AcceptanceFlow.tsx
@@ -58,6 +58,16 @@ const styles = createStaticStyles(({ css }) => ({
     max-width: ${acceptanceContentLayout.maxWidth - 2 * acceptanceContentLayout.paddingInline}px;
     margin-inline: auto;
   `,
+  // The outline is reading material, so it keeps the page's text measure while
+  // the canvas next to it is allowed the full width.
+  outline: css`
+    overflow: auto;
+
+    width: 100%;
+    min-width: 0;
+    max-width: ${acceptanceContentLayout.maxWidth - 2 * acceptanceContentLayout.paddingInline}px;
+    margin-inline: auto;
+  `,
 }));
 const nodeTypes = { state: FlowNode, flowGroup: FlowGroup };
 
@@ -227,7 +237,7 @@ export function AcceptanceFlow() {
       </Flexbox>
       <Flexbox horizontal className={styles.workspace} flex={fullscreen ? 1 : undefined}>
         {showOutline ? (
-          <Flexbox flex={1} style={{ minWidth: 0, overflow: 'auto' }}>
+          <Flexbox className={styles.outline} flex={1}>
             <FlowOutline edges={graphEdges} nodes={graph.nodes} onSelect={setSelected} />
           </Flexbox>
         ) : (

--- a/src/features/Acceptance/Viewer/Flow/FlowGroup.tsx
+++ b/src/features/Acceptance/Viewer/Flow/FlowGroup.tsx
@@ -16,7 +16,7 @@ import {
 import { useTranslation } from 'react-i18next';
 
 import type { FlowGraphData } from './flowGraph';
-import { flowStateColor } from './FlowNode';
+import { flowStateBackground, flowStateColor } from './FlowNode';
 
 const styles = createStaticStyles(({ css }) => ({
   group: css`
@@ -33,6 +33,36 @@ const styles = createStaticStyles(({ css }) => ({
     height: 36px;
     padding-inline: 16px;
     background: transparent;
+  `,
+  collapsed: css`
+    height: 100%;
+    padding-block: 12px;
+    padding-inline: 12px;
+  `,
+  glyph: css`
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    width: 36px;
+    height: 36px;
+    border-radius: ${cssVar.borderRadius};
+  `,
+  title: css`
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.4;
+  `,
+  summary: css`
+    font-size: 11px;
+    line-height: 16px;
+    color: ${cssVar.colorTextTertiary};
   `,
   handle: css`
     width: 1px;
@@ -63,55 +93,100 @@ export function FlowGroup({ data }: { data: FlowGraphData }) {
     <>
       <Handle className={styles.handle} id="in" position={Position.Left} type="target" />
       <div className={styles.group}>
-        <Flexbox horizontal align="center" className={styles.header} gap={8}>
-          {data.onToggle && (
-            <Button
-              className="nodrag nopan"
-              size="small"
-              type="text"
-              aria-label={t(data.collapsed ? 'flow.expandGroup' : 'flow.collapseGroup', {
-                title: data.title,
-              })}
-              onClick={(e) => {
-                e.stopPropagation();
-                data.onToggle?.();
+        {data.collapsed ? (
+          <Flexbox horizontal align="flex-start" className={styles.collapsed} gap={10}>
+            <div
+              aria-label={t(`flow.state.${data.state ?? 'pending'}`)}
+              className={styles.glyph}
+              role="img"
+              style={{
+                background: flowStateBackground(data.state),
+                color: flowStateColor(data.state),
               }}
             >
-              <Icon icon={data.collapsed ? ChevronRight : ChevronDown} size={16} />
-            </Button>
-          )}
-          <Icon icon={statusIcon} size={18} style={{ color: flowStateColor(data.state) }} />
-          <Text ellipsis fontSize={13} style={{ flex: 1 }}>
-            {data.title}
-          </Text>
-          <Text fontSize={12} type="secondary">
-            {`${data.passed}/${data.total}`}
-          </Text>
-          {Boolean(data.reviewed) && (
-            <Text fontSize={12} type="secondary">
-              {t('flow.groupReviewed', { count: data.reviewed })}
+              <Icon icon={statusIcon} size={24} />
+            </div>
+            <Flexbox flex={1} gap={3} style={{ minWidth: 0 }}>
+              <span className={styles.title}>{data.title}</span>
+              <span className={styles.summary}>
+                {`${data.passed}/${data.total} · ${t(`flow.state.${data.state ?? 'pending'}`)}`}
+                {Boolean(data.reviewed) &&
+                  ` · ${t('flow.groupReviewed', { count: data.reviewed })}`}
+              </span>
+            </Flexbox>
+            <Flexbox horizontal align="center" gap={2} style={{ flex: 'none' }}>
+              {data.onToggle && (
+                <Button
+                  aria-label={t('flow.expandGroup', { title: data.title })}
+                  className="nodrag nopan"
+                  size="small"
+                  type="text"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    data.onToggle?.();
+                  }}
+                >
+                  <Icon icon={ChevronRight} size={16} />
+                </Button>
+              )}
+              {data.onEnter && (
+                <Button
+                  aria-label={t('flow.enterGroup', { title: data.title })}
+                  className="nodrag nopan"
+                  size="small"
+                  type="text"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    data.onEnter?.();
+                  }}
+                >
+                  <Icon icon={Maximize2} size={14} />
+                </Button>
+              )}
+            </Flexbox>
+          </Flexbox>
+        ) : (
+          <Flexbox horizontal align="center" className={styles.header} gap={8}>
+            {data.onToggle && (
+              <Button
+                aria-label={t('flow.collapseGroup', { title: data.title })}
+                className="nodrag nopan"
+                size="small"
+                type="text"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  data.onToggle?.();
+                }}
+              >
+                <Icon icon={ChevronDown} size={16} />
+              </Button>
+            )}
+            <Icon icon={statusIcon} size={18} style={{ color: flowStateColor(data.state) }} />
+            <Text ellipsis fontSize={13} style={{ flex: 1 }}>
+              {data.title}
             </Text>
-          )}
-          {data.onEnter && (
-            <Button
-              aria-label={t('flow.enterGroup', { title: data.title })}
-              className="nodrag nopan"
-              size="small"
-              type="text"
-              onClick={(e) => {
-                e.stopPropagation();
-                data.onEnter?.();
-              }}
-            >
-              <Icon icon={Maximize2} size={14} />
-            </Button>
-          )}
-        </Flexbox>
-        {data.collapsed && (
-          <Flexbox style={{ padding: '10px 16px' }}>
             <Text fontSize={12} type="secondary">
-              {t(`flow.state.${data.state ?? 'pending'}`)}
+              {`${data.passed}/${data.total}`}
             </Text>
+            {Boolean(data.reviewed) && (
+              <Text fontSize={12} type="secondary">
+                {t('flow.groupReviewed', { count: data.reviewed })}
+              </Text>
+            )}
+            {data.onEnter && (
+              <Button
+                aria-label={t('flow.enterGroup', { title: data.title })}
+                className="nodrag nopan"
+                size="small"
+                type="text"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  data.onEnter?.();
+                }}
+              >
+                <Icon icon={Maximize2} size={14} />
+              </Button>
+            )}
           </Flexbox>
         )}
       </div>

--- a/src/features/Acceptance/Viewer/Flow/FlowNode.tsx
+++ b/src/features/Acceptance/Viewer/Flow/FlowNode.tsx
@@ -25,6 +25,15 @@ export interface FlowNodeData extends Record<string, unknown> {
   title: string;
 }
 
+export const flowStateBackground = (state?: string) =>
+  state === 'passed'
+    ? cssVar.colorSuccessBg
+    : state === 'failed'
+      ? cssVar.colorErrorBg
+      : state
+        ? cssVar.colorWarningBg
+        : cssVar.colorFillTertiary;
+
 export const flowStateColor = (state?: string) =>
   state === 'passed'
     ? cssVar.colorSuccess
@@ -36,6 +45,7 @@ export const flowStateColor = (state?: string) =>
 
 const styles = createStaticStyles(({ css }) => ({
   card: css`
+    overflow: hidden;
     display: flex;
     flex-direction: column;
 
@@ -77,6 +87,11 @@ const styles = createStaticStyles(({ css }) => ({
     background: ${cssVar.colorFillTertiary};
   `,
   title: css`
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+
     font-size: 13px;
     font-weight: 500;
     line-height: 1.4;
@@ -136,15 +151,8 @@ export function FlowNode({ data }: { data: FlowNodeData }) {
             className={styles.glyph}
             role="img"
             style={{
+              background: flowStateBackground(data.state),
               color: flowStateColor(data.state),
-              background:
-                data.state === 'passed'
-                  ? cssVar.colorSuccessBg
-                  : data.state === 'failed'
-                    ? cssVar.colorErrorBg
-                    : data.state
-                      ? cssVar.colorWarningBg
-                      : cssVar.colorFillTertiary,
             }}
           >
             <Icon icon={statusIcon} size={24} />

--- a/src/features/Acceptance/Viewer/Flow/FlowOutline.tsx
+++ b/src/features/Acceptance/Viewer/Flow/FlowOutline.tsx
@@ -12,11 +12,13 @@ import {
   CircleHelp,
   CirclePause,
   CircleX,
+  CornerDownRight,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import type { FlowGraphData } from './flowGraph';
 import { flowStateColor } from './FlowNode';
+import { buildOutlineTree, type OutlineBranch, type OutlineStep } from './flowOutlineTree';
 
 const styles = createStaticStyles(({ css }) => ({
   item: css`
@@ -34,21 +36,22 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     height: auto;
-    min-height: 44px;
-    padding-block: 8px;
+    min-height: 36px;
+    padding-block: 6px;
     padding-inline: 12px;
 
     color: ${cssVar.colorTextSecondary};
     text-align: start;
     white-space: normal;
   `,
-  group: css`
+  nested: css`
+    margin-inline-start: 18px;
     padding-inline-start: 8px;
     border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
 }));
 
-/** A readable traversal of the same graph, including every branch and its target. */
+/** A readable traversal of the same graph: dependent steps are indented under the branch that leads to them. */
 export function FlowOutline({
   nodes,
   edges,
@@ -59,7 +62,7 @@ export function FlowOutline({
   onSelect: (id: string) => void;
 }) {
   const { t } = useTranslation('verify');
-  const renderNode = (node: Node<FlowGraphData>) => {
+  const renderItem = (node: Node<FlowGraphData>) => {
     const { data } = node;
     const group = node.type === 'flowGroup';
     const glyph =
@@ -75,65 +78,95 @@ export function FlowOutline({
                 ? CircleDot
                 : CircleDashed;
     return (
-      <Flexbox gap={4} key={node.id}>
-        <Button
-          aria-expanded={group ? !data.collapsed : undefined}
-          className={styles.item}
-          type={data.selected ? 'default' : 'text'}
-          onClick={() => (group ? data.onToggle?.() : onSelect(node.id))}
-        >
-          <Flexbox horizontal align="center" gap={10} width="100%">
-            {group && <Icon icon={data.collapsed ? ChevronRight : ChevronDown} size={14} />}
-            <Icon
-              aria-label={t(`flow.state.${data.state ?? 'pending'}`)}
-              icon={glyph}
-              size={18}
-              style={{ color: flowStateColor(data.state), flex: 'none' }}
-            />
-            <Flexbox flex={1} gap={4} style={{ minWidth: 0 }}>
-              <Text strong={group} style={{ overflowWrap: 'anywhere' }}>
-                {data.title}
+      <Button
+        aria-expanded={group ? !data.collapsed : undefined}
+        className={styles.item}
+        type={data.selected ? 'default' : 'text'}
+        onClick={() => (group ? data.onToggle?.() : onSelect(node.id))}
+      >
+        <Flexbox horizontal align="center" gap={10} width="100%">
+          {group && <Icon icon={data.collapsed ? ChevronRight : ChevronDown} size={14} />}
+          <Icon
+            aria-label={t(`flow.state.${data.state ?? 'pending'}`)}
+            icon={glyph}
+            size={18}
+            style={{ color: flowStateColor(data.state), flex: 'none' }}
+          />
+          <Flexbox flex={1} gap={4} style={{ minWidth: 0 }}>
+            <Text strong={group} style={{ overflowWrap: 'anywhere' }}>
+              {data.title}
+            </Text>
+            {!group && (
+              <Text fontSize={13} style={{ overflowWrap: 'anywhere' }} type="secondary">
+                {String(data.expected ?? '')}
               </Text>
-              {!group && (
-                <Text fontSize={13} style={{ overflowWrap: 'anywhere' }} type="secondary">
-                  {String(data.expected ?? '')}
-                </Text>
-              )}
-            </Flexbox>
-            {group ? (
-              <Text fontSize={12} type="secondary">
-                {data.passed}/{data.total}
-              </Text>
-            ) : (
-              <Icon icon={ChevronRight} size={16} />
             )}
           </Flexbox>
-        </Button>
-        {group && !data.collapsed && (
-          <Flexbox className={styles.group} gap={12}>
-            {nodes.filter((child) => child.parentId === node.id).map(renderNode)}
-          </Flexbox>
-        )}
-        {edges
-          .filter((edge) => edge.source === node.id)
-          .map((edge) => (
-            <Button
-              className={styles.branch}
-              key={edge.id}
-              type="text"
-              onClick={() => onSelect(edge.id)}
-            >
-              <Flexbox horizontal align="center" gap={8}>
-                <Icon icon={ArrowRight} size={14} style={{ flex: 'none' }} />
-                <span>
-                  {String(edge.label ?? '')} →{' '}
-                  {nodes.find((target) => target.id === edge.target)?.data.title}
-                </span>
-              </Flexbox>
-            </Button>
-          ))}
-      </Flexbox>
+          {group ? (
+            <Text fontSize={12} type="secondary">
+              {data.passed}/{data.total}
+            </Text>
+          ) : (
+            <Icon icon={ChevronRight} size={16} />
+          )}
+        </Flexbox>
+      </Button>
     );
   };
-  return <Flexbox gap={24}>{nodes.filter((node) => !node.parentId).map(renderNode)}</Flexbox>;
+  const renderBranchLabel = (branch: OutlineBranch, reference: boolean) => {
+    const label = String(branch.edge.label ?? '');
+    // A trigger that merely repeats the next step's title adds nothing above that step.
+    if (!reference && (!label || label === branch.target.data.title)) return null;
+    return (
+      <Button
+        className={styles.branch}
+        key={branch.edge.id}
+        type="text"
+        onClick={() => onSelect(branch.edge.id)}
+      >
+        <Flexbox horizontal align="center" gap={8}>
+          <Icon
+            icon={reference ? ArrowRight : CornerDownRight}
+            size={14}
+            style={{ flex: 'none' }}
+          />
+          <span>{reference ? `${label} → ${branch.target.data.title}` : label}</span>
+        </Flexbox>
+      </Button>
+    );
+  };
+  // A single continuation stays at the same level; a fork indents each path under its branch.
+  const renderSequence = (step: OutlineStep): React.ReactNode[] => {
+    const out: React.ReactNode[] = [
+      <Flexbox gap={4} key={step.node.id}>
+        {renderItem(step.node)}
+        {step.node.type === 'flowGroup' && !step.node.data.collapsed && (
+          <Flexbox className={styles.nested} gap={12}>
+            {step.members.flatMap(renderSequence)}
+          </Flexbox>
+        )}
+      </Flexbox>,
+    ];
+    const expanded = step.branches.filter((branch) => branch.step);
+    for (const branch of step.branches) {
+      const label = renderBranchLabel(branch, !branch.step);
+      if (!branch.step) {
+        if (label) out.push(label);
+        continue;
+      }
+      const steps = renderSequence(branch.step);
+      if (expanded.length === 1) out.push(label, ...steps);
+      else
+        out.push(
+          <Flexbox gap={4} key={`branch:${branch.edge.id}`}>
+            {label}
+            <Flexbox className={styles.nested} gap={4}>
+              {steps}
+            </Flexbox>
+          </Flexbox>,
+        );
+    }
+    return out;
+  };
+  return <Flexbox gap={24}>{buildOutlineTree(nodes, edges).flatMap(renderSequence)}</Flexbox>;
 }

--- a/src/features/Acceptance/Viewer/Flow/FlowOutline.tsx
+++ b/src/features/Acceptance/Viewer/Flow/FlowOutline.tsx
@@ -24,8 +24,8 @@ const styles = createStaticStyles(({ css }) => ({
   item: css`
     width: 100%;
     height: auto;
-    min-height: 44px;
-    padding-block: 10px;
+    min-height: 36px;
+    padding-block: 6px;
     padding-inline: 12px;
 
     text-align: start;
@@ -36,8 +36,8 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     height: auto;
-    min-height: 36px;
-    padding-block: 6px;
+    min-height: 32px;
+    padding-block: 4px;
     padding-inline: 12px;
 
     color: ${cssVar.colorTextSecondary};
@@ -131,10 +131,10 @@ export function FlowOutline({
   // A single continuation stays at the same level; a fork indents each path under its branch.
   const renderSequence = (step: OutlineStep): React.ReactNode[] => {
     const out: React.ReactNode[] = [
-      <Flexbox gap={4} key={step.node.id}>
+      <Flexbox gap={2} key={step.node.id}>
         {renderItem(step.node)}
         {step.node.type === 'flowGroup' && !step.node.data.collapsed && (
-          <Flexbox className={styles.nested} gap={12}>
+          <Flexbox className={styles.nested} gap={2}>
             {step.members.flatMap(renderSequence)}
           </Flexbox>
         )}
@@ -151,9 +151,9 @@ export function FlowOutline({
       if (expanded.length === 1) out.push(label, ...steps);
       else
         out.push(
-          <Flexbox gap={4} key={`branch:${branch.edge.id}`}>
+          <Flexbox gap={2} key={`branch:${branch.edge.id}`}>
             {label}
-            <Flexbox className={styles.nested} gap={4}>
+            <Flexbox className={styles.nested} gap={2}>
               {steps}
             </Flexbox>
           </Flexbox>,
@@ -161,5 +161,5 @@ export function FlowOutline({
     }
     return out;
   };
-  return <Flexbox gap={24}>{buildOutlineTree(nodes, edges).flatMap(renderSequence)}</Flexbox>;
+  return <Flexbox gap={2}>{buildOutlineTree(nodes, edges).flatMap(renderSequence)}</Flexbox>;
 }

--- a/src/features/Acceptance/Viewer/Flow/FlowOutline.tsx
+++ b/src/features/Acceptance/Viewer/Flow/FlowOutline.tsx
@@ -92,16 +92,9 @@ export function FlowOutline({
             size={18}
             style={{ color: flowStateColor(data.state), flex: 'none' }}
           />
-          <Flexbox flex={1} gap={4} style={{ minWidth: 0 }}>
-            <Text strong={group} style={{ overflowWrap: 'anywhere' }}>
-              {data.title}
-            </Text>
-            {!group && (
-              <Text fontSize={13} style={{ overflowWrap: 'anywhere' }} type="secondary">
-                {String(data.expected ?? '')}
-              </Text>
-            )}
-          </Flexbox>
+          <Text strong={group} style={{ flex: 1, minWidth: 0, overflowWrap: 'anywhere' }}>
+            {data.title}
+          </Text>
           {group ? (
             <Text fontSize={12} type="secondary">
               {data.passed}/{data.total}

--- a/src/features/Acceptance/Viewer/Flow/flowGraph.test.ts
+++ b/src/features/Acceptance/Viewer/Flow/flowGraph.test.ts
@@ -116,7 +116,8 @@ describe('grouped acceptance canvas', () => {
     expect(collapsed.nodes.some((node) => node.id === 'send/a')).toBe(false);
     expect(collapsed.nodes.some((node) => node.id === 'switch/a')).toBe(true);
     const focused = build(views, new Set(['send']), 'send');
-    expect(focused.nodes.map((node) => node.id)).toEqual(['send', 'send/a', 'send/b']);
+    expect(focused.nodes.map((node) => node.id)).toEqual(['send/a', 'send/b']);
+    expect(focused.nodes.every((node) => !node.parentId)).toBe(true);
     expect(focused.checks.has('switch/a')).toBe(false);
     expect(collapsed.checks.has('send/a')).toBe(false);
     expect(build(views).nodes).toHaveLength(6);
@@ -191,9 +192,8 @@ describe('grouped acceptance canvas', () => {
     expect(graph.nodes.find((n) => n.id === 'root/g2')?.data.state).toBeUndefined();
     expect(graph.nodes.find((n) => n.id === 'root/two')?.data.state).toBeUndefined();
     expect(graph.edges[0]).toMatchObject({ source: 'root/g1', target: 'root/g2' });
-    expect(build([parent], new Set(), 'root/g2').nodes.map((n) => n.id)).toEqual([
-      'root/g2',
-      'root/two',
-    ]);
+    const drilled = build([parent], new Set(), 'root/g2');
+    expect(drilled.nodes.map((n) => n.id)).toEqual(['root/two']);
+    expect(drilled.nodes[0].parentId).toBeUndefined();
   });
 });

--- a/src/features/Acceptance/Viewer/Flow/flowGraph.ts
+++ b/src/features/Acceptance/Viewer/Flow/flowGraph.ts
@@ -224,12 +224,21 @@ export function buildFlowGraph(
     );
     if (focus && focus !== view.id && !focusedNode) continue;
     const id = focus ?? view.id;
-    const child = collapsed.has(id) && !focus ? undefined : layout(view, focusedNode?.id, id);
+    // Inside a focused group the breadcrumb already names it, so render its members
+    // directly on the canvas instead of wrapping them in the group container.
+    if (focus) {
+      const focused = layout(view, focusedNode?.id, id);
+      for (const node of focused.nodes)
+        nodes.push(node.parentId === id ? { ...node, parentId: undefined } : node);
+      edges.push(...focused.edges);
+      continue;
+    }
+    const child = collapsed.has(id) ? undefined : layout(view, undefined, id);
     const leafNodes = view.version.nodes.filter((node) => !node.subFlowId);
     const summary = aggregate(
       view,
-      focusedNode?.checkItemIds ?? leafNodes.flatMap((n) => n.checkItemIds),
-      focusedNode?.requiredCheckItemIds ?? leafNodes.flatMap((n) => n.requiredCheckItemIds),
+      leafNodes.flatMap((n) => n.checkItemIds),
+      leafNodes.flatMap((n) => n.requiredCheckItemIds),
     );
     const height = child?.height ?? 96;
     nodes.push({
@@ -240,11 +249,11 @@ export function buildFlowGraph(
       height,
       style: { width: child?.width ?? 360, height },
       data: {
-        title: focusedNode?.title ?? view.version.title,
+        title: view.version.title,
         ...summary,
         collapsed: !child,
-        onToggle: focus ? undefined : () => onToggle(id),
-        onEnter: focus ? undefined : () => onEnter(id),
+        onToggle: () => onToggle(id),
+        onEnter: () => onEnter(id),
       },
     });
     if (child) {

--- a/src/features/Acceptance/Viewer/Flow/flowGraph.ts
+++ b/src/features/Acceptance/Viewer/Flow/flowGraph.ts
@@ -128,7 +128,8 @@ export function buildFlowGraph(
     if (stacked) for (const node of siblings) depths.set(node.id, 0);
     const parts = orderedSiblings.map((node) => {
       const id = graphId(view, node.id);
-      if (!node.subFlowId) return { node, id, width: 260, height: 116 };
+      // Two title lines, two expected lines and the footer; the card clamps to this box.
+      if (!node.subFlowId) return { node, id, width: 260, height: 132 };
       const child = collapsed.has(id) ? undefined : layout(view, node.id, id);
       return { node, id, child, width: child?.width ?? 320, height: child?.height ?? 96 };
     });

--- a/src/features/Acceptance/Viewer/Flow/flowOutlineTree.test.ts
+++ b/src/features/Acceptance/Viewer/Flow/flowOutlineTree.test.ts
@@ -1,0 +1,67 @@
+import type { Edge, Node } from '@xyflow/react';
+import { describe, expect, it } from 'vitest';
+
+import type { FlowGraphData } from './flowGraph';
+import { buildOutlineTree } from './flowOutlineTree';
+
+const node = (id: string, extra: Partial<Node<FlowGraphData>> = {}): Node<FlowGraphData> => ({
+  data: { title: id },
+  id,
+  position: { x: 0, y: 0 },
+  type: 'state',
+  ...extra,
+});
+const edge = (source: string, target: string): Edge => ({
+  id: `${source}-${target}`,
+  label: `${source}→${target}`,
+  source,
+  target,
+});
+const titles = (steps: ReturnType<typeof buildOutlineTree>): unknown =>
+  steps.map((step) => [
+    step.node.id,
+    step.branches.map((b) => (b.step ? titles([b.step]) : `ref:${b.target.id}`)),
+  ]);
+
+describe('buildOutlineTree', () => {
+  it('starts at the entry and hangs dependent steps under their branches', () => {
+    const steps = buildOutlineTree(
+      [node('c'), node('a'), node('b')],
+      [edge('a', 'b'), edge('b', 'c')],
+    );
+    expect(titles(steps)).toEqual([['a', [[['b', [[['c', []]]]]]]]]);
+  });
+
+  it('lists a merged step once and turns the other path into a reference', () => {
+    const steps = buildOutlineTree(
+      [node('a'), node('b'), node('c'), node('d')],
+      [edge('a', 'b'), edge('a', 'c'), edge('b', 'd'), edge('c', 'd')],
+    );
+    expect(titles(steps)).toEqual([['a', [[['b', [[['d', []]]]]], [['c', ['ref:d']]]]]]);
+  });
+
+  it('keeps cycles finite and still lists every step, including detached ones', () => {
+    const steps = buildOutlineTree(
+      [node('a'), node('b'), node('lone')],
+      [edge('a', 'b'), edge('b', 'a')],
+    );
+    // Steps nobody depends on are entries and come first; the cycle is listed after them.
+    expect(titles(steps)).toEqual([
+      ['lone', []],
+      ['a', [[['b', ['ref:a']]]]],
+    ]);
+  });
+
+  it('nests group members under their group and keeps sibling edges inside the group', () => {
+    const steps = buildOutlineTree(
+      [
+        node('g', { type: 'flowGroup' }),
+        node('g/a', { parentId: 'g' }),
+        node('g/b', { parentId: 'g' }),
+      ],
+      [edge('g/a', 'g/b')],
+    );
+    expect(steps).toHaveLength(1);
+    expect(titles(steps[0].members)).toEqual([['g/a', [[['g/b', []]]]]]);
+  });
+});

--- a/src/features/Acceptance/Viewer/Flow/flowOutlineTree.ts
+++ b/src/features/Acceptance/Viewer/Flow/flowOutlineTree.ts
@@ -1,0 +1,54 @@
+import type { Edge, Node } from '@xyflow/react';
+
+import type { FlowGraphData } from './flowGraph';
+
+export interface OutlineBranch {
+  edge: Edge;
+  /** The step listed under this branch; null when the target is already listed elsewhere. */
+  step: OutlineStep | null;
+  target: Node<FlowGraphData>;
+}
+
+export interface OutlineStep {
+  branches: OutlineBranch[];
+  /** Members of a group node, in reading order. */
+  members: OutlineStep[];
+  node: Node<FlowGraphData>;
+}
+
+/**
+ * Turns the flat canvas graph into a reading order: every check is listed once, the
+ * first time a path from an entry reaches it, and the steps that depend on it hang
+ * beneath its branches. Later paths to an already listed step become references.
+ */
+export function buildOutlineTree(
+  nodes: Node<FlowGraphData>[],
+  edges: Edge[],
+  parentId?: string,
+): OutlineStep[] {
+  const siblings = nodes.filter((node) => (node.parentId ?? undefined) === parentId);
+  const byId = new Map(siblings.map((node) => [node.id, node]));
+  const links = edges.filter((edge) => byId.has(edge.source) && byId.has(edge.target));
+  const incoming = new Set(links.map((edge) => edge.target));
+  const visited = new Set<string>();
+  const build = (node: Node<FlowGraphData>): OutlineStep => {
+    visited.add(node.id);
+    const branches: OutlineBranch[] = [];
+    for (const edge of links) {
+      if (edge.source !== node.id) continue;
+      const target = byId.get(edge.target)!;
+      branches.push({ edge, step: visited.has(target.id) ? null : build(target), target });
+    }
+    return {
+      branches,
+      members: node.type === 'flowGroup' ? buildOutlineTree(nodes, edges, node.id) : [],
+      node,
+    };
+  };
+  const roots: OutlineStep[] = [];
+  const entries = siblings.filter((node) => !incoming.has(node.id));
+  for (const node of entries.length ? entries : siblings)
+    if (!visited.has(node.id)) roots.push(build(node));
+  for (const node of siblings) if (!visited.has(node.id)) roots.push(build(node));
+  return roots;
+}

--- a/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
+++ b/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
@@ -2,10 +2,21 @@
 
 import { Flexbox, Icon } from '@lobehub/ui';
 import { Tabs, Tag } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
 import { ListChecks, Paperclip, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 export type AcceptanceTabKey = 'checks' | 'resources' | 'flow';
+
+const styles = createStaticStyles(({ css }) => ({
+  // The square variant underlines its whole list; the band below already draws
+  // the full-width rule, so the list's own line would sit on top of it.
+  list: css`
+    && {
+      box-shadow: none;
+    }
+  `,
+}));
 
 interface AcceptanceTabsProps {
   active: AcceptanceTabKey;
@@ -47,6 +58,7 @@ const AcceptanceTabs = ({
   return (
     <Tabs
       activeKey={active}
+      classNames={{ list: styles.list }}
       style={{ minWidth: 0, overflowX: 'auto' }}
       variant={'square'}
       items={tabs

--- a/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
+++ b/src/features/Acceptance/Viewer/Header/AcceptanceTabs.tsx
@@ -17,8 +17,8 @@ interface AcceptanceTabsProps {
 
 /**
  * The delivery's two faces: the checks a person judges, and the artefacts the
- * rounds produced. They sit above the full-width rule so the rule reads as the
- * boundary between "what this delivery is" and "what you are looking at".
+ * rounds produced. They close the identity band; the active tab's underline is
+ * the boundary between "what this delivery is" and "what you are looking at".
  */
 const AcceptanceTabs = ({
   active,


### PR DESCRIPTION
Polish pass on the acceptance flow viewer and page chrome, driven by seven review rounds on the linked acceptance.

**Flow canvas**

- Drilling into a group now lays its members straight onto the canvas; the group's own frame and title row are gone (the breadcrumb already names it). Root view, collapse and enter behaviour are unchanged, and a collapsed group keeps its state across enter/back.
- A collapsed group renders as a compact status card (state glyph, two-line title, `passed/total · state`, expand + enter actions) instead of a truncated 36px header over an empty box.
- Check cards clamp to a fixed 132px box (two title lines, two expected lines, footer); a two-line title no longer pushes the footer below its neighbours.

**Outline (步骤) view**

- New `buildOutlineTree` turns the graph into a reading order: start at the entry, keep a single continuation at the same level, indent each fork's path under its branch, and list a merged step once (later paths become references). A trigger that merely repeats the target title is not shown as its own row.
- Rows show the title only, at the page text measure, with tight spacing.

**Page chrome**

- The tab list's own underline is removed; the header band's full-width rule stays.
- Standalone workspace title and list-menu label in zh-CN read 「验收」 / 「查看验收列表」 (en source was already "Acceptance").
- The 44px "add screenshot" button in the reject form keeps its touch height only below `md`.

**Docs**

- `AGENTS.md`, the `pr` skill and the PR template now require a published acceptance round before a PR is opened.
- Acceptance skill: final link is plain text (a fenced block made it unclickable); project probe log gains P40 (debug-proxy flow-canvas capture recipe).

| Before | After |
| ------ | ----- |
| Focused group wrapped in its own frame; flat outline with `X → X` branch rows; tab list double underline | See the acceptance rounds below (before = production canary, after = this branch via debug proxy / local full stack) |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`buildFlowGraph` and `buildOutlineTree` unit tests (12 passing); lint clean.

- Acceptance: https://app.lobehub.com/acceptance/85af248a-ecf7-4d6a-970c-97a494013cb0 (7 rounds, every review comment addressed; latest snapshot `?r=7`)

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)