### PR TITLE
🐛 fix(work): refresh the resource home works section after removing a card

### DIFF
--- a/src/features/ResourceHome/Home/RecentWorks.test.tsx
+++ b/src/features/ResourceHome/Home/RecentWorks.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import RecentWorks from './RecentWorks';
+
+const mocks = vi.hoisted(() => ({
+  openWork: vi.fn(),
+  reload: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/WorkGallery/hooks', () => ({
+  useWorkspaceWorksInfinite: () => ({
+    error: undefined,
+    isLoadingInitial: false,
+    items: [{ id: 'wk_1' }, { id: 'wk_2' }, { id: 'wk_3' }, { id: 'wk_4' }],
+    reload: mocks.reload,
+  }),
+}));
+
+vi.mock('@/features/WorkGallery/useOpenWork', () => ({
+  useOpenWork: () => mocks.openWork,
+}));
+
+vi.mock('@/features/WorkGallery/WorkPreviewCard', () => ({
+  default: ({ item, onRemoved }: { item: { id: string }; onRemoved?: () => void }) => (
+    <button data-testid={`card-${item.id}`} type="button" onClick={() => onRemoved?.()}>
+      {item.id}
+    </button>
+  ),
+}));
+
+vi.mock('./SectionTitle', () => ({
+  default: () => null,
+}));
+
+describe('RecentWorks', () => {
+  it('refreshes its own infinite list after a card is removed', () => {
+    render(<RecentWorks />);
+
+    // Only the freshest three are shown on the dashboard.
+    expect(screen.queryByTestId('card-wk_4')).toBeNull();
+
+    // The global Work refresh in `useRemoveWork` skips `useSWRInfinite` keys,
+    // so the card has to be handed this list's own `reload` (LOBE-13961).
+    fireEvent.click(screen.getByTestId('card-wk_1'));
+    expect(mocks.reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/ResourceHome/Home/RecentWorks.tsx
+++ b/src/features/ResourceHome/Home/RecentWorks.tsx
@@ -46,7 +46,10 @@ const RecentWorks = memo(() => {
       ) : (
         <div className={styles.grid}>
           {recent.map((item) => (
-            <WorkPreviewCard item={item} key={item.id} onOpen={openWork} />
+            // `onRemoved` is required here: this list is `useSWRInfinite`-backed,
+            // and `useRemoveWork`'s global refresh skips `$inf$` keys, so without
+            // it a removed orphan card lingers until a page reload (LOBE-13961).
+            <WorkPreviewCard item={item} key={item.id} onOpen={openWork} onRemoved={reload} />
           ))}
         </div>
       )}


### PR DESCRIPTION
Follow-up to #19275. The resource home (`/resource`) "Works" section renders `WorkPreviewCard` from the same `useSWRInfinite`-backed list as the full gallery, but never passed `onRemoved`. `useRemoveWork`'s global refresh skips `$inf$` keys, so removing an orphaned card from the home page left it on screen until a reload. The full gallery at `/resource/works` already passes `onRemoved={reload}` and behaves correctly.

This wires `onRemoved={reload}` in `ResourceHome/Home/RecentWorks.tsx`, mirroring the gallery.

| Before | After |
| ------ | ----- |
| Removing an orphan card on `/resource` leaves it on screen until a page reload | Card disappears in place and the section backfills the next freshest Work |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`RecentWorks.test.tsx` renders the section with a stubbed card, clicks the card's `onRemoved`, and asserts the list's own `reload` is called. Verified failing against the parent commit's component (reload never called) and passing on HEAD.

#### Key Decisions / Non-goals

- The repo's testing guidance discourages new React component tests, but AGENTS.md requires a regression test for every bug fix and this fix is purely a prop wiring with no logic to extract into a hook. A component test is the only assertion that can regress-guard it, so it stays.
- Orphan detection, dialog copy, and `deleteWork` gating are LOBE-13917 and already covered by its acceptance; not re-verified here.

- Acceptance: https://app.lobehub.com/acceptance/d02ec3c4-90df-41df-a752-c6a81d621ada?r=1 — 2/2 checks on the managed dev runtime: removing an orphan card on `/resource` disappears in place and backfills the 4th Work without a reload (network: `work.deleteWork` then `work.listByWorkspace`; DB rows gone), and the `/resource/works` gallery path shows no regression.

#### 🔗 Related Issue

Linear: [LOBE-13961](https://linear.app/lobehub/issue/LOBE-13961)
