### PR TITLE
🔧 chore(skills): teach cleanup-git-worktrees to prove merges and survive broken registrations

### DIFF
--- a/.agents/skills/cleanup-git-worktrees/SKILL.md
+++ b/.agents/skills/cleanup-git-worktrees/SKILL.md
@@ -5,61 +5,92 @@ description: 'Use for stale-worktree, Git registration and branch audits. Manage
 
 # Cleanup Git Worktrees
 
-Use the bundled script to make classification deterministic. Treat cleanup as a destructive action: audit first, show the exact candidates, and obtain explicit user approval before applying deletion unless the user's current request already names the exact targets.
+Use the bundled script to make classification deterministic. Treat cleanup as a destructive action: audit first, show the exact candidates grouped by why they are deletable, and obtain one explicit approval before applying deletion unless the user's current request already names the exact targets. Aim for a single approval round-trip, not a per-item Q&A.
 
 ## Workflow
 
 1. Run the audit from any worktree in the repository:
 
    ```bash
-   bash .agents/skills/cleanup-git-worktrees/scripts/cleanup.sh audit --fetch --base origin/canary
+   bash .agents/skills/cleanup-git-worktrees/scripts/cleanup.sh audit --fetch --gh --stale-days 15 --base origin/canary
    ```
 
-   Omit `--fetch` only when network access is unavailable; disclose that remote state may be stale.
+   - `--fetch`: prune the remote first. Omit only when offline and say so.
+   - `--gh`: look up each branch's PR (number, state, head SHA) with the `gh` CLI. This is what turns `[gone]` into a verified merge; use it whenever `gh` is authenticated. It costs roughly one second per branch, so run it in the background on large repos.
+   - `--stale-days N`: mark clean branches idle longer than N days with nothing unpushed as `candidate-stale`. The repository default the user has approved is 15 days.
+   - `--noise REGEX`: untracked paths that never count as dirt (default `node_modules|\.goal-tracing/`).
 
 2. Interpret classifications:
 
-   - `protect-dirty`: preserve; it has modified or untracked files.
-   - `protect-current`: preserve; never remove the worktree running the command.
-   - `candidate-merged`: clean and fully contained in the base branch.
-   - `candidate-gone`: clean and its configured upstream was pruned. This is stale, but not proof of merge after squash/rebase.
-   - `review-no-upstream`: clean but lacks an upstream and is not contained in the base.
-   - `active`: retain unless the user explicitly identifies it as finished.
-   - `protected-branch`: never delete `main`, `canary`, or the base branch.
+   | Classification | Meaning | Action |
+   | --- | --- | --- |
+   | `protected-branch` | `main`, `canary`, or the base ref | never |
+   | `protect-current` | the worktree running the command | never |
+   | `protect-dirty` | tracked modifications, or untracked files outside the noise regex | keep; list the files |
+   | `candidate-merged` | tip is an ancestor of the base | delete |
+   | `candidate-pr-merged` | PR state MERGED and local tip == PR head SHA | delete |
+   | `candidate-pr-closed` | PR CLOSED and tip == PR head or nothing unpushed | delete |
+   | `candidate-gone` | upstream pruned and nothing unpushed | delete after confirming PR state |
+   | `candidate-stale` | older than `--stale-days`, clean, nothing unpushed | delete |
+   | `review-pr-merged-ahead` | PR merged but local tip has extra commits | check the extra commits by subject (below) |
+   | `review-gone-unpushed` | upstream pruned but local-only commits exist | keep; deleting loses work |
+   | `review-no-upstream` | no upstream, not merged | keep unless the user names it |
+   | `review-detached` | detached HEAD worktree | keep; show its dirty files |
+   | `broken-registration(...)` | registration whose gitdir is gone | see below |
+   | `active` | everything else | keep |
 
-3. Present a compact table containing path, branch, dirty count, upstream state, base containment, and classification. Keep `candidate-merged` separate from `candidate-gone`; do not describe `[gone]` as proof of merge.
+   Columns worth reading: `dirty` (real dirt), `noise` (ignorable untracked), `age_days`, `unpushed` (commits no remote ref reaches), `pr` / `pr_state` / `tip_eq_pr`.
 
-4. After approval, use the repository's worktree lifecycle workflow when it manages
-   services or other resources alongside a checkout. The Git-only cleanup script
-   does not tear those resources down. For plain Git worktrees, pass exact branch
-   names to cleanup:
+3. Present one compact table split into three groups: deletable now (all `candidate-*`), needs a manual check (`review-*`), and protected. Keep `candidate-merged` separate from `candidate-gone`, and never describe `[gone]` alone as proof of merge.
+
+4. After approval, use the repository's worktree lifecycle workflow when it manages services or other resources alongside a checkout; the Git-only script does not tear those down. For plain Git worktrees, pass exact branch names and the same classification flags used for the audit:
 
    ```bash
    bash .agents/skills/cleanup-git-worktrees/scripts/cleanup.sh clean \
-     --base origin/canary \
+     --gh --stale-days 15 --base origin/canary \
      --branch feat/example \
      --branch fix/example \
      --apply
    ```
 
-   Without `--apply`, cleanup is a dry run. The script re-audits every target immediately before deletion.
+   Without `--apply`, cleanup is a dry run. The script re-classifies every target immediately before deletion and refuses anything that is not `candidate-*`. Worktrees whose only dirt is noise are removed with `git worktree remove --force`; everything else uses the plain, refusing form.
+
+   Removing a worktree that still holds `node_modules` can take several minutes each. Run large batches in the background and report progress rather than waiting on a single foreground call.
 
 5. Run the audit again and report:
 
-   - removed worktrees and branches;
-   - retained dirty/current targets;
+   - removed worktrees and branches, with the SHA each branch pointed at (the script prints it; reflog keeps it for 90 days);
+   - retained dirty / unpushed / detached targets and why;
    - remaining worktree and local-branch counts;
    - any partial deletion or Git error.
 
+## Proving a merge
+
+Squash and rebase merges leave no ancestry, so `git merge-base --is-ancestor` and `git cherry` say "not merged" for branches whose PR landed. Use this ladder instead:
+
+1. `--gh` reports `pr_state=MERGED` and `tip_eq_pr=eq`: the local tip is exactly what GitHub merged. Done.
+2. `review-pr-merged-ahead` (tip moved past the PR head): list the extra commits with `git log <pr-head>..<branch>` and search the base for each subject: `git log origin/canary --oneline -F --grep="<subject>"`. A hit on the PR's squash commit means the commit was part of the PR. A miss means the commit is unmerged; check which live branch still contains it with `git branch --contains <sha>` before deleting.
+3. Branches named after a PR (`pr-18412`, `codex/pr-18497-fix`) are local review copies; verify the PR by number with `gh pr view N --json state,headRefOid` and compare subjects as above.
+4. Do not judge by `git diff origin/canary <branch> -- <files>`: on an old branch the diff is dominated by later changes on the base.
+
+Zero `unpushed` means every local commit is reachable from some remote ref, so deleting the local branch loses nothing even when the PR is still OPEN; the user has approved deleting such branches once they pass the stale threshold.
+
+## Broken registrations
+
+`git worktree list --porcelain` marks an entry `prunable` when its gitdir file points nowhere (typically after a partial removal). The audit reports these as `broken-registration(directory-present|missing; reason)` instead of crashing on them.
+
+- `git worktree prune` drops only the registration. It never touches the directory or the branch, so it is safe to run before re-auditing.
+- A leftover directory has no `.git`, so its dirty state cannot be checked. Show its size and file count and ask before deleting it with `rm -rf`; that is the one place recursive deletion is acceptable, and only on a path the user named.
+
 ## Safety rules
 
-- Never discard dirty worktrees merely because their branch is merged or `[gone]`.
-- Never use recursive deletion to bypass `git worktree remove`. If Git partially removes a directory, stop and inspect the exact path before deciding how to recover.
-- Never force-delete a branch that is neither contained in the base nor `[gone]` through this script.
-- A deleted upstream indicates staleness, not necessarily merge. Use GitHub PR state when the distinction matters.
-- Preserve unrelated user changes and concurrent worktrees.
-- Prefer `git fetch --prune origin` before classification and `git worktree prune` only for registrations whose directories are already missing.
+- Never discard dirty worktrees merely because their branch is merged, `[gone]`, or old. Noise-only dirt (the `--noise` regex) does not count.
+- Never delete a branch with `unpushed > 0` through this script; list it and let the user decide.
+- Never use recursive deletion on a registered worktree. If Git partially removes a directory, stop and inspect the exact path before deciding how to recover.
+- Never delete `main`, `canary`, or the base branch.
+- Preserve unrelated user changes and concurrent worktrees. The user's other sessions may be working in them.
+- When writing ad-hoc verification loops, run them under `bash`, not the interactive `zsh`: zsh does not word-split `$var` in `for`/argument positions, so file lists collapse into one argument and checks silently pass.
 
 ## Script
 
-Use `scripts/cleanup.sh`; do not recreate its parsing and guard logic ad hoc unless the repository layout makes it unusable.
+Use `scripts/cleanup.sh`; do not recreate its parsing and guard logic ad hoc unless the repository layout makes it unusable. It is `set -euo pipefail`; helper functions that pipe through `grep` wrap it in `|| true` so an empty match is "clean", not an abort.

--- a/.agents/skills/cleanup-git-worktrees/scripts/cleanup.sh
+++ b/.agents/skills/cleanup-git-worktrees/scripts/cleanup.sh
@@ -5,10 +5,23 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  cleanup.sh audit [--fetch] [--base <ref>]
-  cleanup.sh clean [--base <ref>] --branch <name> [--branch <name> ...] [--apply]
+  cleanup.sh audit [--fetch] [--gh] [--stale-days <n>] [--base <ref>] [--noise <regex>]
+  cleanup.sh clean [--gh] [--stale-days <n>] [--base <ref>] [--noise <regex>] \
+                   --branch <name> [--branch <name> ...] [--apply]
 
 Audit is read-only except for optional fetch/prune. Clean defaults to a dry run.
+
+  --fetch          git fetch --prune the base remote first.
+  --gh             Query GitHub PR state per branch (needs `gh`). Enables the
+                   candidate-pr-merged / candidate-pr-closed classifications.
+  --stale-days n   Treat a clean branch whose last commit is older than n days
+                   and which has no unpushed commits as candidate-stale.
+  --noise regex    Untracked paths matching this regex do not count as dirty
+                   (default: node_modules|\.goal-tracing/). They are removed
+                   together with the worktree.
+
+Pass the same --gh / --stale-days / --noise flags to clean that you used for
+audit, otherwise the pre-deletion re-classification will refuse the target.
 EOF
 }
 
@@ -30,6 +43,9 @@ shift
 
 base_ref=origin/canary
 fetch_remote=false
+use_gh=false
+stale_days=0
+noise_regex='node_modules|\.goal-tracing/'
 apply=false
 branches=()
 
@@ -53,6 +69,21 @@ while (($#)); do
       fetch_remote=true
       shift
       ;;
+    --gh)
+      use_gh=true
+      shift
+      ;;
+    --noise)
+      (($# >= 2)) || die '--noise requires a regex'
+      noise_regex=$2
+      shift 2
+      ;;
+    --stale-days)
+      (($# >= 2)) || die '--stale-days requires a number'
+      [[ "$2" =~ ^[0-9]+$ ]] || die '--stale-days must be an integer'
+      stale_days=$2
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -67,30 +98,57 @@ git show-ref --verify --quiet "refs/remotes/$base_ref" \
   || git show-ref --verify --quiet "refs/heads/$base_ref" \
   || die "base ref does not exist: $base_ref"
 
+remote=${base_ref%%/*}
+[[ "$remote" != "$base_ref" ]] || remote=origin
+
 if $fetch_remote; then
-  remote=${base_ref%%/*}
-  [[ "$remote" != "$base_ref" ]] || remote=origin
   git fetch --prune "$remote"
 fi
 
-branch_worktree() {
-  local target="branch refs/heads/$1"
-  git worktree list --porcelain | awk -v target="$target" '
+if $use_gh; then
+  command -v gh >/dev/null 2>&1 || die '--gh requires the gh CLI'
+fi
+
+now_epoch=$(date +%s)
+
+# ---------------------------------------------------------------------------
+# Worktree enumeration. Emits: path <TAB> branch <TAB> prunable-reason
+# Detached worktrees have an empty branch; broken registrations carry a reason.
+# ---------------------------------------------------------------------------
+list_worktrees() {
+  git worktree list --porcelain | awk '
     BEGIN { RS=""; FS="\n" }
     {
-      path=""
-      found=0
+      path=""; branch=""; prunable=""
       for (i=1; i<=NF; i++) {
         if ($i ~ /^worktree /) path=substr($i, 10)
-        if ($i == target) found=1
+        if ($i ~ /^branch refs\/heads\//) branch=substr($i, 19)
+        if ($i ~ /^prunable/) prunable=substr($i, 10)
       }
-      if (found) { print path; exit }
+      # Empty fields become "-" so consecutive tabs do not collapse under IFS.
+      if (path != "") print path "\t" (branch == "" ? "-" : branch) "\t" (prunable == "" ? "-" : prunable)
     }
   '
 }
 
+branch_worktree() {
+  list_worktrees | awk -F'\t' -v b="$1" '$2 == b { print $1; exit }'
+}
+
+worktree_is_usable() {
+  local path=$1
+  [[ -d "$path" ]] && git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# Real dirt: any tracked change, plus untracked paths that do not match the
+# noise regex. Noise: untracked paths that match it (safe to drop with --force).
 dirty_count() {
-  git -C "$1" status --porcelain | wc -l | tr -d ' '
+  # grep exits 1 when nothing survives the filter; that is "clean", not an error.
+  { git -C "$1" status --porcelain | grep -Ev "^\?\? .*(${noise_regex})" || true; } | wc -l | tr -d ' '
+}
+
+noise_count() {
+  { git -C "$1" status --porcelain | grep -E "^\?\? .*(${noise_regex})" || true; } | wc -l | tr -d ' '
 }
 
 upstream_track() {
@@ -105,16 +163,51 @@ is_merged() {
   git merge-base --is-ancestor "$1" "$base_ref"
 }
 
+age_days() {
+  local ct
+  ct=$(git log -1 --format=%ct "$1")
+  printf '%d' $(( (now_epoch - ct) / 86400 ))
+}
+
+# Commits on the branch that no ref on the remote can reach. Zero means every
+# local commit already lives on the remote, so deleting the branch loses nothing.
+unpushed_count() {
+  git rev-list --count "$1" --not --remotes="$remote"
+}
+
+# Emits: number <TAB> state <TAB> tip_eq_head (eq|ne) — or "-\t-\t-" without --gh.
+pr_info() {
+  local branch=$1
+  if ! $use_gh; then
+    printf -- '-\t-\t-\n'
+    return
+  fi
+  local raw number state head
+  raw=$(gh pr list --state all --head "$branch" --limit 1 \
+    --json number,state,headRefOid \
+    --jq '.[0] | "\(.number)\t\(.state)\t\(.headRefOid)"' 2>/dev/null || true)
+  if [[ -z "$raw" || "$raw" == $'null\tnull\tnull' ]]; then
+    printf -- '-\t-\t-\n'
+    return
+  fi
+  IFS=$'\t' read -r number state head <<<"$raw"
+  if [[ "$(git rev-parse "$branch")" == "$head" ]]; then
+    printf '%s\t%s\teq\n' "$number" "$state"
+  else
+    printf '%s\t%s\tne\n' "$number" "$state"
+  fi
+}
+
 is_protected_branch() {
   local branch=$1
   local base_short=${base_ref#*/}
   [[ "$branch" == main || "$branch" == canary || "$branch" == "$base_ref" || "$branch" == "$base_short" ]]
 }
 
+# classify <branch> <worktree> <dirty> <age> <unpushed> <pr_state> <tip_eq>
 classify() {
-  local branch=$1
-  local worktree=${2:-}
-  local dirty=${3:-0}
+  local branch=$1 worktree=${2:-} dirty=${3:-0} age=${4:-0} unpushed=${5:-0}
+  local pr_state=${6:--} tip_eq=${7:--}
   local track
   track=$(upstream_track "$branch")
 
@@ -126,8 +219,21 @@ classify() {
     printf 'protect-dirty'
   elif is_merged "$branch"; then
     printf 'candidate-merged'
-  elif [[ "$track" == '[gone]' ]]; then
+  elif [[ "$pr_state" == MERGED && "$tip_eq" == eq ]]; then
+    printf 'candidate-pr-merged'
+  elif [[ "$pr_state" == MERGED ]]; then
+    # Local tip moved past the PR head: check the extra commits by subject
+    # against the base log before deleting.
+    printf 'review-pr-merged-ahead'
+  elif [[ "$pr_state" == CLOSED && ( "$tip_eq" == eq || "$unpushed" == 0 ) ]]; then
+    printf 'candidate-pr-closed'
+  elif [[ "$track" == '[gone]' && "$unpushed" == 0 ]]; then
     printf 'candidate-gone'
+  elif [[ "$track" == '[gone]' ]]; then
+    # Upstream pruned but local commits exist that no remote ref reaches.
+    printf 'review-gone-unpushed'
+  elif ((stale_days > 0 && age > stale_days && unpushed == 0)); then
+    printf 'candidate-stale'
   elif [[ -z "$(upstream_name "$branch")" ]]; then
     printf 'review-no-upstream'
   else
@@ -135,77 +241,111 @@ classify() {
   fi
 }
 
+print_header() {
+  printf 'scope\tpath\tbranch\tdirty\tnoise\tage_days\tunpushed\tupstream\ttrack\tmerged_into_base\tpr\tpr_state\ttip_eq_pr\tclassification\n'
+}
+
+print_row() {
+  local scope=$1 path=$2 branch=$3
+  local dirty noise age unpushed upstream track merged pr_number pr_state tip_eq classification
+  local worktree=''
+  [[ "$scope" == worktree ]] && worktree=$path
+  dirty=0; noise=0
+  if [[ -n "$worktree" ]]; then
+    dirty=$(dirty_count "$worktree")
+    noise=$(noise_count "$worktree")
+  fi
+  age=$(age_days "$branch")
+  unpushed=$(unpushed_count "$branch")
+  upstream=$(upstream_name "$branch")
+  track=$(upstream_track "$branch")
+  if is_merged "$branch"; then merged=yes; else merged=no; fi
+  IFS=$'\t' read -r pr_number pr_state tip_eq < <(pr_info "$branch") || true
+  classification=$(classify "$branch" "$worktree" "$dirty" "$age" "$unpushed" "$pr_state" "$tip_eq")
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$scope" "$path" "$branch" "$dirty" "$noise" "$age" "$unpushed" \
+    "${upstream:-none}" "${track:-none}" "$merged" "$pr_number" "$pr_state" "$tip_eq" "$classification"
+}
+
 audit() {
-  printf 'scope\tpath\tbranch\tdirty\tupstream\ttrack\tmerged_into_base\tclassification\n'
+  print_header
 
   local bound_file
   bound_file=$(mktemp)
   trap 'rm -f "$bound_file"' RETURN
 
-  while IFS=$'\t' read -r worktree branch; do
-    [[ -n "$branch" ]] || continue
+  while IFS=$'\t' read -r worktree branch prunable; do
+    [[ -n "$worktree" ]] || continue
+    [[ "$branch" != - ]] || branch=''
+    [[ "$prunable" != - ]] || prunable=''
+    if [[ -n "$prunable" ]] || ! worktree_is_usable "$worktree"; then
+      # Registration points at a missing or gitdir-less directory. `git worktree
+      # prune` drops the registration only; any leftover directory is reported
+      # for the user to decide on.
+      local reason=${prunable:-directory is not a git worktree}
+      local present=missing
+      [[ -d "$worktree" ]] && present=directory-present
+      printf 'worktree\t%s\t%s\t?\t?\t-\t-\t-\t-\t-\t-\t-\t-\tbroken-registration(%s; %s)\n' \
+        "$worktree" "${branch:--}" "$present" "$reason"
+      [[ -n "$branch" ]] && printf '%s\n' "$branch" >> "$bound_file"
+      continue
+    fi
+    if [[ -z "$branch" ]]; then
+      local head dirty
+      head=$(git -C "$worktree" rev-parse --short HEAD)
+      dirty=$(dirty_count "$worktree")
+      printf 'worktree\t%s\t(detached %s)\t%s\t%s\t-\t-\t-\t-\t-\t-\t-\t-\treview-detached\n' \
+        "$worktree" "$head" "$dirty" "$(noise_count "$worktree")"
+      continue
+    fi
     printf '%s\n' "$branch" >> "$bound_file"
-    local dirty upstream track merged classification
-    dirty=$(dirty_count "$worktree")
-    upstream=$(upstream_name "$branch")
-    track=$(upstream_track "$branch")
-    if is_merged "$branch"; then merged=yes; else merged=no; fi
-    classification=$(classify "$branch" "$worktree" "$dirty")
-    printf 'worktree\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$worktree" "$branch" "$dirty" "${upstream:-none}" "${track:-none}" "$merged" "$classification"
-  done < <(
-    git worktree list --porcelain | awk '
-      BEGIN { RS=""; FS="\n" }
-      {
-        path=""; branch=""
-        for (i=1; i<=NF; i++) {
-          if ($i ~ /^worktree /) path=substr($i, 10)
-          if ($i ~ /^branch refs\/heads\//) branch=substr($i, 19)
-        }
-        if (branch != "") print path "\t" branch
-      }
-    '
-  )
+    print_row worktree "$worktree" "$branch"
+  done < <(list_worktrees)
 
   while IFS= read -r branch; do
     grep -Fxq "$branch" "$bound_file" && continue
-    local upstream track merged classification
-    upstream=$(upstream_name "$branch")
-    track=$(upstream_track "$branch")
-    if is_merged "$branch"; then merged=yes; else merged=no; fi
-    classification=$(classify "$branch" '' 0)
-    printf 'branch\t-\t%s\t0\t%s\t%s\t%s\t%s\n' \
-      "$branch" "${upstream:-none}" "${track:-none}" "$merged" "$classification"
+    print_row branch - "$branch"
   done < <(git for-each-ref refs/heads --format='%(refname:short)')
 }
 
 clean() {
   ((${#branches[@]} > 0)) || die 'clean requires at least one --branch'
 
-  local branch worktree dirty classification
+  local branch worktree dirty noise age unpushed pr_number pr_state tip_eq classification
   for branch in "${branches[@]}"; do
     git show-ref --verify --quiet "refs/heads/$branch" || die "local branch not found: $branch"
     worktree=$(branch_worktree "$branch")
-    dirty=0
-    [[ -z "$worktree" ]] || dirty=$(dirty_count "$worktree")
-    classification=$(classify "$branch" "$worktree" "$dirty")
+    dirty=0; noise=0
+    if [[ -n "$worktree" ]]; then
+      worktree_is_usable "$worktree" || die "$branch: worktree $worktree is a broken registration; run 'git worktree prune' and inspect the directory first"
+      dirty=$(dirty_count "$worktree")
+      noise=$(noise_count "$worktree")
+    fi
+    age=$(age_days "$branch")
+    unpushed=$(unpushed_count "$branch")
+    IFS=$'\t' read -r pr_number pr_state tip_eq < <(pr_info "$branch") || true
+    classification=$(classify "$branch" "$worktree" "$dirty" "$age" "$unpushed" "$pr_state" "$tip_eq")
 
     case "$classification" in
-      candidate-merged|candidate-gone) ;;
+      candidate-*) ;;
       *) die "$branch is $classification; refusing cleanup" ;;
     esac
 
     if ! $apply; then
-      printf 'DRY-RUN\t%s\t%s\t%s\n' "$branch" "${worktree:--}" "$classification"
+      printf 'DRY-RUN\t%s\t%s\t%s\tnoise=%s\n' "$branch" "${worktree:--}" "$classification" "$noise"
       continue
     fi
 
     if [[ -n "$worktree" ]]; then
-      git worktree remove "$worktree"
+      if ((noise > 0)); then
+        git worktree remove --force "$worktree"
+      else
+        git worktree remove "$worktree"
+      fi
       printf 'REMOVED-WORKTREE\t%s\n' "$worktree"
     fi
-    git branch -D "$branch"
-    printf 'REMOVED-BRANCH\t%s\n' "$branch"
+    printf 'REMOVED-BRANCH\t%s\t%s\t(was %s)\n' "$branch" "$classification" "$(git rev-parse --short "$branch")"
+    git branch -D "$branch" >/dev/null
   done
 }
 


### PR DESCRIPTION
## What

Updates the `cleanup-git-worktrees` skill and its `cleanup.sh` with the rules learned during a real 74 → 29 worktree cleanup.

### Script

- **Broken registrations no longer abort the audit.** Entries whose gitdir is gone (`prunable` in `git worktree list --porcelain`, or a directory without `.git`) are reported as `broken-registration(directory-present|missing; reason)`. Previously the first such entry killed the whole run with `fatal: not a git repository`.
- **Noise-only dirt is not dirt.** Untracked paths matching `--noise` (default `node_modules|\.goal-tracing/`) are counted separately; `clean` removes such worktrees with `git worktree remove --force`, everything else keeps the refusing form.
- **New signals per branch:** `age_days`, `unpushed` (commits no remote ref reaches), and with `--gh` the PR number, state and whether the local tip equals the PR head SHA.
- **New classifications:** `candidate-pr-merged`, `candidate-pr-closed`, `candidate-stale` (`--stale-days N`), `review-pr-merged-ahead`, `review-gone-unpushed`, `review-detached`. `candidate-gone` now additionally requires `unpushed == 0`.
- `clean` accepts any `candidate-*` when invoked with the same flags as the audit, and prints the SHA each deleted branch pointed at for reflog recovery.
- Fixed two `set -euo pipefail` traps: `grep -v` matching nothing and `read` on input without a trailing newline both aborted the script silently.

### SKILL.md

- A merge-proof ladder for squash/rebase merges (PR state + tip==head, then subject matching against the base log), since `merge-base --is-ancestor` and `git cherry` cannot see them.
- How to handle broken registrations (`git worktree prune` is metadata-only; leftover directories need a named `rm -rf`).
- Present candidates in three groups and collect one approval; run large removals in the background because `node_modules` worktrees take minutes each.
- Run ad-hoc verification loops under `bash`, not `zsh` (no word splitting → checks silently pass).

## Verification

Ran against the live repo (64 rows, exit 0): classifications match a manual audit done earlier the same day. Simulated a gitdir-less worktree (reported as `broken-registration`, pruned cleanly), a noise-dirty merged worktree through `audit` → `clean` dry run → `clean --apply`, and confirmed `clean` refuses `active` / `review-gone-unpushed` targets. `bash -n` and `prettier --check` pass.

No acceptance round: tooling-only change under `.agents/skills`, no user-visible product outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
