### PR TITLE
⚡️ perf: reduce idle rendering and defer cold tab routers

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,6 @@ resolutionMode: highest
 dedupePeerDependents: true
 ignoreWorkspaceRootCheck: true
 enablePrePostScripts: true
-# ponytail: serialize builds while editor instances patch shared Lexical files; remove once upstream writes atomically.
-childConcurrency: 1
 
 publicHoistPattern:
   - '*@umijs/lint*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ resolutionMode: highest
 dedupePeerDependents: true
 ignoreWorkspaceRootCheck: true
 enablePrePostScripts: true
+# ponytail: serialize builds while editor instances patch shared Lexical files; remove once upstream writes atomically.
+childConcurrency: 1
 
 publicHoistPattern:
   - '*@umijs/lint*'

--- a/src/features/Electron/TabHost/TabHost.test.ts
+++ b/src/features/Electron/TabHost/TabHost.test.ts
@@ -100,6 +100,26 @@ afterEach(() => {
 });
 
 describe('TabHost', () => {
+  it('creates only the visible router when restoring many persisted tabs', async () => {
+    setStore(
+      Array.from({ length: 14 }, (_, i) => ({
+        id: `t${i}`,
+        lastVisited: i,
+        url: `/item/t${i}`,
+      })),
+      't0',
+    );
+    renderHost();
+    expect(await screen.findByTestId('param-t0')).toBeVisible();
+    expect(created.map(({ url }) => url)).toEqual(['/item/t0']);
+    act(() => useElectronStore.setState({ activeTabId: 't1' }));
+    expect(await screen.findByTestId('param-t1')).toBeVisible();
+    expect(created.map(({ url }) => url)).toEqual(['/item/t0', '/item/t1']);
+    act(() => useElectronStore.setState({ activeTabId: 't0' }));
+    expect(screen.getByTestId('param-t0')).toBeVisible();
+    expect(created).toHaveLength(2);
+  });
+
   it('mounts per-tab routers inside an outer data router without tripping the nested-Router invariant', async () => {
     setStore(
       [
@@ -122,6 +142,8 @@ describe('TabHost', () => {
     render(React.createElement(RouterProvider, { router: outerRouter }));
 
     expect(await screen.findByTestId('param-a')).toHaveTextContent('a');
+    expect(screen.queryByTestId('param-b')).not.toBeInTheDocument();
+    act(() => useElectronStore.setState({ activeTabId: 'b' }));
     expect(await screen.findByTestId('param-b')).toHaveTextContent('b');
   });
 
@@ -137,6 +159,8 @@ describe('TabHost', () => {
     renderHost();
 
     expect(await screen.findByTestId('param-a')).toHaveTextContent('a');
+    expect(screen.queryByTestId('param-b')).not.toBeInTheDocument();
+    act(() => useElectronStore.setState({ activeTabId: 'b' }));
     expect(await screen.findByTestId('param-b')).toHaveTextContent('b');
   });
 
@@ -152,7 +176,10 @@ describe('TabHost', () => {
     renderHost();
 
     const slotA = (await screen.findByTestId('param-a')).parentElement!;
+    expect(screen.queryByTestId('param-b')).not.toBeInTheDocument();
+    act(() => useElectronStore.setState({ activeTabId: 'b' }));
     const slotB = (await screen.findByTestId('param-b')).parentElement!;
+    act(() => useElectronStore.setState({ activeTabId: 'a' }));
 
     expect(slotA.style.display).toBe('');
     expect(slotB.style.display).toBe('none');
@@ -224,7 +251,7 @@ describe('TabHost', () => {
     renderHost();
 
     expect(await screen.findByTestId('param-a')).toBeVisible();
-    expect(screen.getByTestId('param-b').parentElement).toHaveStyle({ display: 'none' });
+    expect(screen.queryByTestId('param-b')).not.toBeInTheDocument();
     await waitFor(() => expect(useElectronStore.getState().splitView).toBeNull());
   });
 
@@ -239,7 +266,10 @@ describe('TabHost', () => {
     setStore(baseTabs, 't0');
     renderHost();
 
-    await screen.findByTestId(`param-${oldest.id}`);
+    for (const tab of baseTabs) {
+      act(() => useElectronStore.setState({ activeTabId: tab.id }));
+      await screen.findByTestId(`param-${tab.id}`);
+    }
     expect(created).toHaveLength(MAX_LIVE_TAB_ROUTERS);
 
     const withEvictor: TabItem[] = [
@@ -298,6 +328,10 @@ describe('TabHost', () => {
     act(() => {
       useElectronStore.setState({ activeTabId: 'f0', tabs: evicted });
     });
+    for (const tab of fillers.slice(1, MAX_LIVE_TAB_ROUTERS)) {
+      act(() => useElectronStore.setState({ activeTabId: tab.id }));
+      await screen.findByTestId(`param-${tab.id}`);
+    }
 
     const targetEntry = created.find((entry) => entry.url === '/agent/orig')!;
     await vi.waitFor(() => expect(targetEntry.dispose).toHaveBeenCalled());
@@ -322,13 +356,17 @@ describe('TabHost', () => {
       url: `/item/f${index}`,
     }));
 
-    // The newest filler is active; `target` is hidden but live. `createTestRouter`
+    // Visit the target and fillers so `target` is hidden but live. `createTestRouter`
     // mounts no reporter, mirroring the real hidden tab whose reporter effect is
     // torn down.
-    setStore([target, ...fillers], fillers.at(-1)!.id);
+    setStore([target, ...fillers], target.id);
     renderHost();
 
     await screen.findByTestId('param-target');
+    for (const tab of fillers) {
+      act(() => useElectronStore.setState({ activeTabId: tab.id }));
+      await screen.findByTestId(`param-${tab.id}`);
+    }
 
     const targetRouter = created.find((entry) => entry.url === '/item/target')!.router;
     await act(async () => {
@@ -340,7 +378,7 @@ describe('TabHost', () => {
       '/item/target',
     );
 
-    // A newly active sixth tab pushes the oldest (`target`) out of the live set.
+    // A newly active tab pushes the oldest (`target`) out of the live set.
     const withEvictor: TabItem[] = [
       ...useElectronStore.getState().tabs,
       { id: 'evictor', lastVisited: 100, url: '/item/evictor' },
@@ -381,6 +419,8 @@ describe('TabHost', () => {
 
     render(React.createElement(TabHost, { createRouter: createScopedRouter }));
 
+    act(() => useElectronStore.setState({ activeTabId: 'b' }));
+    act(() => useElectronStore.setState({ activeTabId: 'a' }));
     await vi.waitFor(() => {
       expect(getTabRouter('a')).toBeDefined();
       expect(getTabRouter('b')).toBeDefined();
@@ -422,7 +462,9 @@ describe('TabHost', () => {
 
     render(React.createElement(TabHost, { createRouter: createReporterRouter }));
 
+    act(() => useElectronStore.setState({ activeTabId: 'b' }));
     await screen.findByTestId('param-b');
+    act(() => useElectronStore.setState({ activeTabId: 'a' }));
 
     const hiddenRouter = created.find((entry) => entry.url === '/agent/b')!.router;
     await act(async () => {

--- a/src/features/Electron/TabHost/TabHost.tsx
+++ b/src/features/Electron/TabHost/TabHost.tsx
@@ -155,7 +155,14 @@ const TabHost = ({ createRouter = createTabRouter }: TabHostProps) => {
   }, [closeSplitView, isPreferenceInit, splitView, splitViewEnabled]);
 
   const liveIds = useMemo(
-    () => resolveLiveTabIds(tabs, activeTabId, MAX_LIVE_TAB_ROUTERS, visibleTabIds),
+    () =>
+      resolveLiveTabIds(
+        // Persisted tabs are cold until first shown; only retain already-created routers.
+        tabs.filter((tab) => visibleTabIds.includes(tab.id) || getTabRouter(tab.id)),
+        activeTabId,
+        MAX_LIVE_TAB_ROUTERS,
+        visibleTabIds,
+      ),
     [tabs, activeTabId, visibleTabIds],
   );
 

--- a/src/features/NavPanel/index.test.tsx
+++ b/src/features/NavPanel/index.test.tsx
@@ -1,11 +1,17 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import NavPanel from './index';
 import { NavPanelPortal } from './NavPanelPortal';
-import { clearNavPanelRegistry } from './registry';
+import {
+  clearNavPanelRegistry,
+  registerNavPanelContent,
+  unregisterNavPanelContent,
+} from './registry';
 import NavPanelShell from './Shell';
+
+const panelRender = vi.fn();
 
 let pathname = '/lobe-team/settings/general';
 
@@ -37,11 +43,14 @@ vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
 }));
 
 vi.mock('./components/NavPanelDraggable', () => ({
-  NavPanelDraggable: ({ activeContent }: NavPanelDraggableMockProps) => (
-    <div data-nav-key={activeContent.key} data-testid="nav-panel">
-      {activeContent.node}
-    </div>
-  ),
+  NavPanelDraggable: ({ activeContent }: NavPanelDraggableMockProps) => {
+    panelRender();
+    return (
+      <div data-nav-key={activeContent.key} data-testid="nav-panel">
+        {activeContent.node}
+      </div>
+    );
+  },
 }));
 
 vi.mock('@/features/HomeSidebar/Content', () => ({
@@ -53,6 +62,27 @@ describe('NavPanel', () => {
     pathname = '/lobe-team/settings/general';
     clearNavPanelRegistry();
   });
+
+  it.each([false, true])(
+    'ignores unrelated registrations with active content present: %s',
+    (registered) => {
+      pathname = '/tasks';
+      const owner = Symbol('home');
+      if (registered) registerNavPanelContent('home', owner, <div>Original</div>);
+      render(<NavPanel />);
+      const before = panelRender.mock.calls.length;
+      const otherOwner = Symbol('discover');
+
+      act(() => registerNavPanelContent('discover', otherOwner, <div>Discover</div>));
+      act(() => unregisterNavPanelContent('discover', otherOwner));
+      expect(panelRender).toHaveBeenCalledTimes(before);
+
+      act(() => registerNavPanelContent('home', owner, <div>Updated</div>));
+      expect(screen.getByText('Updated')).toBeInTheDocument();
+      act(() => unregisterNavPanelContent('home', owner));
+      expect(screen.getByTestId('nav-sidebar-skeleton')).toBeInTheDocument();
+    },
+  );
 
   it('selects the route-owned entry instead of a concurrently registered Home entry', async () => {
     render(

--- a/src/features/NavPanel/index.tsx
+++ b/src/features/NavPanel/index.tsx
@@ -18,12 +18,12 @@ const NavPanelFallback = memo<{ navKey: string }>(({ navKey }) => (
 
 const NavPanel = memo(() => {
   const activeNavKey = useActiveNavKey();
-  const registry = useSyncExternalStore(
+  const getActiveContent = () => getNavPanelRegistrySnapshot().get(activeNavKey);
+  const registeredContent = useSyncExternalStore(
     subscribeNavPanelRegistry,
-    getNavPanelRegistrySnapshot,
-    getNavPanelRegistrySnapshot,
+    getActiveContent,
+    getActiveContent,
   );
-  const registeredContent = registry.get(activeNavKey);
   const activeContent = registeredContent
     ? { key: activeNavKey, node: registeredContent.node }
     : { key: `pending:${activeNavKey}`, node: <NavPanelFallback navKey={activeNavKey} /> };

--- a/src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx
+++ b/src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx
@@ -8,6 +8,8 @@ import * as THREE from 'three';
 import { type QueryTagsResult } from '@/database/models/userMemory';
 import UserAvatar from '@/features/User/UserAvatar';
 
+import { retainActiveConnections } from './retainActiveConnections';
+
 // Configuration constants
 const CONFIG = {
   // Connection line count ratio (actual count = tag count * ratio)
@@ -267,7 +269,8 @@ const ConnectionLine = memo<ConnectionLineProps>(
   },
 );
 
-const CenterAvatar = () => {
+// Connection animation updates must not rerender the DOM avatar mounted through Html.
+const CenterAvatar = memo(() => {
   return (
     <Html
       center
@@ -280,7 +283,7 @@ const CenterAvatar = () => {
       <UserAvatar shape={'circle'} size={80} />
     </Html>
   );
-};
+});
 
 interface CloudProps {
   radius?: number;
@@ -411,7 +414,7 @@ const Cloud = memo<CloudProps>(({ tags, radius = 20 }) => {
 
       setConnections((prev) => {
         // Filter out expired connections
-        const active = prev.filter((conn) => time - conn.birthTime < conn.duration);
+        const active = retainActiveConnections(prev, time);
 
         // If there are not enough connections, randomly add new ones
         const needed = connectionCount - active.length;

--- a/src/routes/(main)/memory/(home)/features/RoleTagCloud/retainActiveConnections.test.ts
+++ b/src/routes/(main)/memory/(home)/features/RoleTagCloud/retainActiveConnections.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { retainActiveConnections } from './retainActiveConnections';
+
+describe('retainActiveConnections', () => {
+  it('keeps idle ticks referentially stable, including an empty cloud', () => {
+    const connections = [{ birthTime: 1, duration: 2 }];
+    expect(retainActiveConnections(connections, 2)).toBe(connections);
+    const empty: typeof connections = [];
+    expect(retainActiveConnections(empty, 10)).toBe(empty);
+  });
+
+  it('expires connections at their deadline without replacing survivors or mutating state', () => {
+    const expired = { birthTime: 1, duration: 2 };
+    const survivor = { birthTime: 2, duration: 4 };
+    const connections = [expired, survivor];
+    const active = retainActiveConnections(connections, 3);
+    expect(active).toEqual([survivor]);
+    expect(active[0]).toBe(survivor);
+    expect(connections).toEqual([expired, survivor]);
+    expect(retainActiveConnections(active, 6)).toEqual([]);
+  });
+});

--- a/src/routes/(main)/memory/(home)/features/RoleTagCloud/retainActiveConnections.ts
+++ b/src/routes/(main)/memory/(home)/features/RoleTagCloud/retainActiveConnections.ts
@@ -1,0 +1,9 @@
+export const retainActiveConnections = <T extends { birthTime: number; duration: number }>(
+  connections: T[],
+  time: number,
+): T[] => {
+  const active = connections.filter(
+    (connection) => time - connection.birthTime < connection.duration,
+  );
+  return active.length === connections.length ? connections : active;
+};


### PR DESCRIPTION
Avoid unnecessary work when restoring desktop tabs and while navigation panels and the memory tag cloud are idle.

- Subscribe NavPanel to its active registry entry so unrelated registrations do not rerender the panel chrome.
- Preserve the connection array on unchanged animation ticks and memoize the DOM avatar boundary.
- Create persisted tab routers on first visibility, while retaining the existing three-router LRU cache and both visible split panes.

#### Key Decisions / Non-goals

This is a fresh, focused implementation of applicable ideas from #19121 against current canary. It does not include the previous PR's application-wide router-store migration. Existing tab URL snapshots, eviction, and navigation-history behavior are retained. The benchmark below measures the three targeted work reductions; it does not establish whole-app startup or production FPS improvements.

#### Test

- [x] Added/updated tests
- [x] Tested locally in real Electron with paired benchmarks and functional acceptance

Targeted `bun run check`: 24 tests passed; lint clean. `git diff --check` passed. The new NavPanel and cold-restore regressions were observed failing before the fixes. Coverage includes 14 persisted tabs, lazy creation/reuse, split panes, LRU eviction, URL restoration, registry updates, and connection expiry.

#### Local benchmark

Five paired trials, alternating AB/BA, comparing parent `20f16ef4cd` with `3eab706ffa`. Real Electron development renderer on Apple M4 Max / 128 GiB / macOS 26.4.1, same foreground viewport (1526 × 1000 CSS px), profile, dependencies and instrumentation. Only the three changed component modules were replaced with their parent versions for baseline; runtime source markers verify each trial.

| Metric | Before median (range), n=5 | After median (range), n=5 |
| --- | --- | --- |
| Routers created/live after restoring 14 tabs | 3 (3–3) | 1 (1–1) |
| NavPanel calls per 40 unrelated registry mutations | 40 (40–40) | 0 (0–0) |
| Panel chrome calls per 40 unrelated registry mutations | 40 (40–40) | 0 (0–0) |
| TagCloud calls in 20 seconds idle | 182 (174–185) | 134 (119–143) |
| CenterAvatar calls in 20 seconds idle | 182 (174–185) | 0 (0–0) |

Each restore recreates renderer/router state and observes an approximately 20-second window (20.039–20.961 seconds observed); this is not a cold disk/network startup measurement. The registry experiment uses 20 register/unregister cycles separated by animation frames. The real Memory route uses 24 local synthetic roles, settles for 2.5 seconds, then samples 20 seconds with its random animation intact. Counts are component function invocations, not DOM updates. Identical React Scan instrumentation is enabled in both variants.

Renderer scripting time during the cloud sample was 2075.8 ms (1727.7–2828.0) before and 2006.6 ms (1820.1–2294.3) after; the ranges overlap substantially, so no general CPU speedup is claimed. Uncontrolled-GC heap snapshots and aggregate startup render counts are retained as raw context only.

Functional checks cover both cold split panes, focus, the three-router cache cap, eviction and latest-URL/history restoration, active navigation replacement/fallback/restoration, and continued cloud rotation/connection animation. Existing user data and server records were preserved.

Acceptance: https://app.lobehub.com/acceptance/31676c2c-15d5-4723-9c19-8e6fb75d165b?r=1 — includes all 10 sample records, raw fiber observations, methods/drivers, before/after screenshots, functional states and an animation clip. The PR remains a draft for human review.

#### CI installation fix

`60b8beb52f` serializes dependency build scripts with pnpm's `childConcurrency: 1`. Multiple editor installations patch the same Lexical files; concurrent non-atomic writes can leave another patcher reading an incomplete file and failing before tests start. The published postinstall scripts in editor 4.26.2, 4.27.0 and 4.27.1 are identical.

Reproduction using those three published scripts against pristine shared Lexical 0.42.0 / Yjs 0.42.0 files: 5 of 20 parallel batches failed with the same patch mismatch; all 20 sequential batches passed. A pnpm 12.3.4 install fixture also confirmed sequential execution and successful idempotent skips. Focused configuration lint passed. All patch validation remains enabled; dependency builds may take longer until the upstream patcher writes atomically.

This follow-up changes installation configuration only; the rendering benchmark above remains tied to `3eab706ffa`. Fresh full CI is running for the follow-up commit.

#### 🔗 Related Issue

Related to #19121.

