### PR TITLE
🐛 fix: prevent stale heterogeneous finish snapshot rollback

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -440,7 +440,7 @@ export class HeterogeneousPersistenceHandler {
    * - The operation state was created by ingest or can be bootstrapped from the topic marker.
    *
    * Returns:
-   * - A promise that resolves after final message state is flushed and released.
+   * - A promise that resolves after any finish-only error is projected and state is released.
    */
   async finish(params: {
     assistantMessageId?: string;
@@ -485,7 +485,7 @@ export class HeterogeneousPersistenceHandler {
     if (!state) return;
 
     try {
-      await this.flushFinalState(state, params.error, params.result);
+      if (params.error) await this.persistFinishError(state, params.error);
     } finally {
       operationStates.delete(params.operationId);
     }
@@ -1471,40 +1471,36 @@ export class HeterogeneousPersistenceHandler {
     return update;
   }
 
-  /** Final safety flush triggered by `heteroFinish`. */
-  private async flushFinalState(
+  /**
+   * Persist an error supplied only by `heteroFinish` without rewriting streamed content.
+   *
+   * `heteroIngest` is the single writer for content and reasoning. A finish request can
+   * reach a warm serverless replica whose accumulator predates a newer snapshot written
+   * by another replica; replaying that accumulator here would roll the final answer back.
+   */
+  private async persistFinishError(
     state: OperationState,
-    error: { body?: Record<string, unknown>; message: string; type: string } | undefined,
-    result: 'success' | 'error' | 'cancelled',
+    error: { body?: Record<string, unknown>; message: string; type: string },
   ) {
-    if (!state.main.accContent && !state.main.accReasoning && !error && result !== 'error') {
-      // Nothing pending — terminal event already flushed in-stream.
-      return;
-    }
-
     const updateValue: Record<string, any> = {};
-    if (state.main.accContent) updateValue.content = state.main.accContent;
-    if (state.main.accReasoning) updateValue.reasoning = { content: state.main.accReasoning };
-    if (error) {
-      if (error.body?.clearEchoedContent === true) updateValue.content = '';
-      // Same canonical normalization as the in-stream `setError` path — the CLI's
-      // free-form `{ message, type }` runs through formatErrorForState so the
-      // terminal flush and the in-stream write produce one classified error shape.
-      // A structured `body` (status-guide error: agentType + code) passes
-      // through untouched — the client's guide UI gates on it.
-      //
-      // Never DOWNGRADE, though: the in-stream `setError` path may already have
-      // persisted the adapter's classified status-guide error on this assistant,
-      // while older CLIs flatten the finish error to a bare `{ message }`.
-      // Overwriting would demote the client from the dedicated guide card to
-      // the generic error alert — keep the richer persisted error instead.
-      const overwritesGuideError =
-        !isHeteroStatusGuideErrorData(error.body) &&
-        isHeteroStatusGuideErrorData(
-          (await this.deps.messageModel.findById(state.main.currentAssistantId))?.error?.body,
-        );
-      if (!overwritesGuideError) updateValue.error = formatErrorForState(error);
-    }
+    if (error.body?.clearEchoedContent === true) updateValue.content = '';
+    // Same canonical normalization as the in-stream `setError` path — the CLI's
+    // free-form `{ message, type }` runs through formatErrorForState so the
+    // finish-only write and the in-stream write produce one classified error shape.
+    // A structured `body` (status-guide error: agentType + code) passes
+    // through untouched — the client's guide UI gates on it.
+    //
+    // Never DOWNGRADE, though: the in-stream `setError` path may already have
+    // persisted the adapter's classified status-guide error on this assistant,
+    // while older CLIs flatten the finish error to a bare `{ message }`.
+    // Overwriting would demote the client from the dedicated guide card to
+    // the generic error alert — keep the richer persisted error instead.
+    const overwritesGuideError =
+      !isHeteroStatusGuideErrorData(error.body) &&
+      isHeteroStatusGuideErrorData(
+        (await this.deps.messageModel.findById(state.main.currentAssistantId))?.error?.body,
+      );
+    if (!overwritesGuideError) updateValue.error = formatErrorForState(error);
 
     if (Object.keys(updateValue).length > 0) {
       await this.deps.messageModel.update(state.main.currentAssistantId, updateValue);

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -1388,6 +1388,57 @@ describe('HeterogeneousPersistenceHandler', () => {
       expect(asst.content).toBe('final answer');
     });
 
+    /**
+     * @example A finish request on a stale replica preserves the final snapshot written elsewhere.
+     */
+    it('does not let a stale finish overwrite a newer assistant snapshot', async () => {
+      // ROOT CAUSE:
+      //
+      // A warm serverless replica can retain an older per-operation accumulator
+      // while another replica persists a newer text snapshot to the shared DB.
+      // Before the fix, heteroFinish flushed the stale accumulator and replaced
+      // the final answer with the preceding progress message.
+      //
+      // We fixed this by making heteroIngest the only content/reasoning writer;
+      // a successful finish now releases operation state without rewriting text.
+      const h = createHarness({
+        assistantMessageId: 'asst-1',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      await h.handler.ingest({
+        events: [
+          buildEvent('stream_chunk', 0, {
+            chunkType: 'text',
+            content: 'progress',
+            snapshotMode: 'replace',
+            snapshotSeq: 4,
+          }),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      // Simulate a newer snapshot committed by another Lambda replica.
+      h.messages.set('asst-1', {
+        ...h.messages.get('asst-1')!,
+        content: 'progress\n\nfinal answer',
+        metadata: { heteroTextSnapshotSeq: 5 },
+      });
+
+      await h.handler.finish({
+        operationId: 'op-1',
+        result: 'success',
+        topicId: 'topic-1',
+      });
+
+      expect(h.messages.get('asst-1')).toMatchObject({
+        content: 'progress\n\nfinal answer',
+        metadata: { heteroTextSnapshotSeq: 5 },
+      });
+    });
+
     it('writes error onto the assistant when terminal event is error', async () => {
       const h = createHarness({
         assistantMessageId: 'asst-1',


### PR DESCRIPTION
## Brief and heads-up

Prevent `heteroFinish` from replaying stale in-memory content over a newer assistant snapshot persisted by another server instance.

`heteroIngest` is now the single writer for streamed content and reasoning. Finish callbacks only project finish-only errors, while preserving the existing `clearEchoedContent` behavior for explicit error payloads.

## Key Decisions / Non-goals

- Keep snapshot ordering in the ingest path instead of adding a second conflict-resolution rule to finish.
- Preserve structured status-guide errors and avoid downgrading them when older clients send a flatter finish error.
- This PR prevents future rollback; it does not introduce repair or replay for previously affected messages.

#### Test

- [x] Tested locally
- [x] Added/updated tests

```bash
bunx vitest run --silent='passed-only' 'apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts'
bunx eslint 'apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts' 'apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts'
```

The regression suite passes 43/43 cases, including a cross-replica scenario where a warm instance holds snapshot sequence 4 while the database already contains sequence 5.

#### 🔗 Related Issue

N/A
