### PR TITLE
✨ feat(desktop): enable native scroll bounce in the app window

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -193,6 +193,7 @@ export default class Browser {
         contextIsolation: true,
         preload: path.join(preloadDir, 'index.js'),
         sandbox: false,
+        scrollBounce: true,
         webviewTag: true,
       },
       width: resolvedState.width,

--- a/src/layout/GlobalProvider/AppTheme.tsx
+++ b/src/layout/GlobalProvider/AppTheme.tsx
@@ -29,7 +29,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   app: css`
     position: relative;
 
-    overscroll-behavior: none;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
Turns on Electron's `scrollBounce` webPreference so macOS elastic overscroll works inside the desktop app, and removes a dead CSS rule that was shadowing the intent.

**Why this needed no CSS change to work.** `overscroll-behavior` is *not* an inherited property and its initial value is `auto`. The `overscroll-behavior: none` we declare at the root therefore never reached any inner scroll container — the message list, the sidebars, `#lobe-mobile-scroll-container`, and the `@lobehub/ui` `ScrollArea` viewport were all already `auto`. Flipping the Electron flag is enough for them to bounce.

**The removed rule.** `.app` in `AppTheme.tsx` carried its own `overscroll-behavior: none`, copied verbatim from `src/styles/global.ts` when that file was created in #13933. `.app` is a child of `#__next` and is not a scroller, so the rule did nothing there. Deleted as dead code.

**What deliberately stays.** The root rule in `src/styles/global.ts` (`html, body, #__next`) is *not* touched. It looks removable — the document never scrolls, since every level is clamped to `height: 100%; max-height: 100dvh` and mobile scrolls inside its own container — but the rule is not about scrolling the document. It suppresses Chrome Android's pull-to-refresh, which fires off the root scroller whether or not the root can actually scroll. Removing it would bring back "swipe down at the top of the chat list → the whole page reloads and your draft is gone" on mobile web/PWA. (`@lobehub/ui`'s own `GlobalStyle` also sets `html { overscroll-behavior: none }`, so removing ours alone would not even change behavior.)

The 12 `overscroll-behavior: contain` declarations elsewhere in `src/` are unrelated and correct as-is — they are all on popovers, dropdowns and modals, where stopping scroll chaining to the chat list behind them is the desired behavior.

| Before | After |
| ------ | ----- |
| Scrolling past the end of the message list / sidebars stops dead — no elastic bounce anywhere in the desktop app. | Inner scroll areas bounce like a native macOS app. |

#### Test

Verified statically, since the change is one webPreferences flag plus one dead-rule deletion:

- Confirmed `scrollBounce?: boolean` exists in `apps/desktop/node_modules/electron/electron.d.ts` (it is a macOS-only webPreference).
- Confirmed no scroll container in the app declares `overscroll-behavior`, so all of them resolve to `auto` and pick the flag up: `@lobehub/ui` `ScrollArea` viewport (and the underlying `@base-ui-components/react` ScrollArea) declare none; `MobileNavLayout` sets only `overflowY: auto`.
- `bun run check --lint --type` reports 0 errors for the two touched files.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Acceptance: **skipped.** No new UI, no new user flow and no new strings — the diff is one Electron `webPreferences` flag and the deletion of a CSS rule that had no effect on any element. There is nothing to drive or capture beyond the platform's own scroll physics, which is a Chromium behavior rather than product behavior. Reviewer sanity check if wanted: restart the desktop app (webPreferences are read at window creation) and scroll past the end of the message list.

#### 🔗 Related Issue

None.

https://claude.ai/code/session_01UfQZPkguhjsXwvuqdySHB2