### PR TITLE
💄 style(local-system): show only the image when a read returns one

### DIFF
--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/ReadFileView.tsx
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/ReadFileView.tsx
@@ -51,6 +51,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   header: css`
     cursor: pointer;
   `,
+  image: css`
+    border-radius: ${cssVar.borderRadiusLG};
+  `,
+  imageList: css`
+    flex-wrap: wrap;
+  `,
   lineCount: css`
     color: ${cssVar.colorTextQuaternary};
   `,
@@ -103,6 +109,28 @@ const ReadFileView = memo<ReadFileState>(
     const { t } = useTranslation('tool');
     const { openFile, openFolder, displayRelativePath } = useToolRenderCapabilities();
     const filename = filenameProp || path.split('/').pop() || path;
+
+    // Reading an image is best shown as the image itself: no card, no header, no path.
+    if (images && images.length > 0) {
+      return (
+        <PreviewGroup>
+          <Flexbox horizontal align={'flex-start'} className={styles.imageList} gap={8}>
+            {images.map((image, index) => (
+              <Image
+                alt={filename || image.mediaType || ''}
+                className={styles.image}
+                key={image.url || index}
+                maxHeight={600}
+                objectFit={'contain'}
+                src={image.url}
+                variant={'borderless'}
+              />
+            ))}
+          </Flexbox>
+        </PreviewGroup>
+      );
+    }
+
     const isHtml = isHtmlFile({ fileName: filename, fileType, path });
 
     const handleOpenFile = openFile
@@ -200,20 +228,7 @@ const ReadFileView = memo<ReadFileState>(
           className={styles.previewBox}
           style={{ height: isHtml ? 240 : undefined, maxHeight: 240 }}
         >
-          {images && images.length > 0 ? (
-            <PreviewGroup>
-              <Flexbox horizontal gap={8} style={{ flexWrap: 'wrap', padding: 8 }}>
-                {images.map((image, index) => (
-                  <Image
-                    alt={filename || image.mediaType || ''}
-                    key={image.url || index}
-                    src={image.url}
-                    style={{ borderRadius: 8, maxHeight: 224, objectFit: 'contain' }}
-                  />
-                ))}
-              </Flexbox>
-            </PreviewGroup>
-          ) : isHtml ? (
+          {isHtml ? (
             <InlineHtmlPreview content={content} />
           ) : fileType === 'md' ? (
             <Markdown style={{ overflow: 'auto' }}>{content}</Markdown>

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/ReadFileView.tsx
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/ReadFileView.tsx
@@ -1,9 +1,9 @@
 import { useToolRenderCapabilities } from '@lobechat/shared-tool-ui';
 import type { ReadFileState } from '@lobechat/tool-runtime';
-import { Flexbox, Icon, Image, Markdown, PreviewGroup } from '@lobehub/ui';
+import { Flexbox, Image, Markdown, PreviewGroup } from '@lobehub/ui';
 import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
-import { AlignLeft, Asterisk, ExternalLink, FolderOpen } from 'lucide-react';
+import { ExternalLink, FolderOpen } from 'lucide-react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,23 +20,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
     justify-content: space-between;
 
-    padding: 8px;
-    border-radius: ${cssVar.borderRadiusLG};
-
-    background: ${cssVar.colorFillQuaternary};
-
-    transition: all 0.2s ${cssVar.motionEaseInOut};
-
     .local-file-actions {
       opacity: 0;
     }
 
-    &:hover {
-      border-color: ${cssVar.colorBorder};
-
-      .local-file-actions {
-        opacity: 1;
-      }
+    &:hover .local-file-actions {
+      opacity: 1;
     }
   `,
   fileName: css`
@@ -56,13 +45,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   imageList: css`
     flex-wrap: wrap;
-  `,
-  lineCount: css`
-    color: ${cssVar.colorTextQuaternary};
-  `,
-  meta: css`
-    font-size: 12px;
-    color: ${cssVar.colorTextTertiary};
   `,
   path: css`
     margin-block-start: 4px;
@@ -95,17 +77,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 const ReadFileView = memo<ReadFileState>(
-  ({
-    filename: filenameProp,
-    path,
-    fileType,
-    charCount,
-    content,
-    images,
-    totalLines,
-    totalCharCount,
-    loc,
-  }) => {
+  ({ filename: filenameProp, path, fileType, content, images }) => {
     const { t } = useTranslation('tool');
     const { openFile, openFolder, displayRelativePath } = useToolRenderCapabilities();
     const filename = filenameProp || path.split('/').pop() || path;
@@ -123,7 +95,7 @@ const ReadFileView = memo<ReadFileState>(
                 maxHeight={600}
                 objectFit={'contain'}
                 src={image.url}
-                variant={'borderless'}
+                variant={'outlined'}
               />
             ))}
           </Flexbox>
@@ -150,7 +122,7 @@ const ReadFileView = memo<ReadFileState>(
     const displayPath = displayRelativePath ? displayRelativePath(path) : path;
 
     return (
-      <Flexbox className={styles.container} gap={12}>
+      <Flexbox className={styles.container} gap={8}>
         <Flexbox>
           <Flexbox
             horizontal
@@ -166,7 +138,12 @@ const ReadFileView = memo<ReadFileState>(
                   {filename}
                 </Text>
                 {(handleOpenFile || handleOpenFolder) && (
-                  <Flexbox horizontal className={styles.actions} gap={2} style={{ marginLeft: 8 }}>
+                  <Flexbox
+                    horizontal
+                    className={`${styles.actions} local-file-actions`}
+                    gap={2}
+                    style={{ marginLeft: 8 }}
+                  >
                     {handleOpenFile && (
                       <ActionIcon
                         icon={ExternalLink}
@@ -186,36 +163,6 @@ const ReadFileView = memo<ReadFileState>(
                   </Flexbox>
                 )}
               </Flexbox>
-            </Flexbox>
-            <Flexbox horizontal align={'center'} className={styles.meta} gap={16}>
-              {charCount !== undefined && (
-                <Flexbox horizontal align={'center'} gap={4}>
-                  <Icon icon={Asterisk} size={'small'} />
-                  <span>
-                    {charCount}
-                    {totalCharCount !== undefined && (
-                      <>
-                        {' '}
-                        / <span className={styles.lineCount}>{totalCharCount}</span>
-                      </>
-                    )}
-                  </span>
-                </Flexbox>
-              )}
-              {loc && (
-                <Flexbox horizontal align={'center'} gap={4}>
-                  <Icon icon={AlignLeft} size={'small'} />
-                  <span>
-                    L{loc[0]}-{loc[1]}
-                    {totalLines !== undefined && (
-                      <>
-                        {' '}
-                        / <span className={styles.lineCount}>{totalLines}</span>
-                      </>
-                    )}
-                  </span>
-                </Flexbox>
-              )}
             </Flexbox>
           </Flexbox>
 


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] style

### 🔀 变更说明 | Description of Change

Reading a file with the local-system `readFile` tool rendered everything inside the card built for text reads: a filled container, a header row with the file icon, filename, open-file actions and char count, a relative path line, and an inset grey preview box. An image ended up as a small thumbnail inside a full-width grey box.

- **Image reads** now render the images alone: outlined, rounded, capped at 600px tall, click-to-zoom preserved. This matches the Claude Code adapter's `Read` render.
- **Text reads** lose the filled outer container and the right-hand char-count / line-range column. Filename, path and the content preview stay; the line range is already shown on the tool row above.
- The open-file / open-folder buttons now carry the `local-file-actions` class the hover rule targets, so they are no longer permanently invisible.

Markdown and HTML reads keep their existing preview behaviour.

### 📝 补充信息 | Additional Information

Verified twice in the desktop app against real conversations, reading a 640x1138 image, a 1280x676 image and a text file through the device tools. Both before/after pairs were captured on the same message by toggling only this file, and the border change is backed by the computed style going from `0px none` to `1px solid`.

Acceptance: https://app.lobehub.com/acceptance/339d1c3a-d096-483f-9e0f-8bdcdb6c2fe8?r=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)