### PR TITLE
🐛 fix(agent-tasks): let the task drawer yield its bottom edge to a toast

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -328,7 +328,10 @@ const TopicChatDrawer = memo(() => {
         body: { padding: 0 },
         panel: {
           background: cssVar.colorBgContainer,
-          maxHeight: 'calc(100dvh - 16px)',
+          // Leave room for whatever the panel reserves when it yields the
+          // bottom edge to a toast; the library's own cap assumes a 16px
+          // offset and this panel sits at 8.
+          maxHeight: 'calc(100dvh - 16px - var(--floating-panel-reserve-block-end, 0px))',
         },
         title: {
           boxSizing: 'border-box',


### PR DESCRIPTION
## What

`@lobehub/ui` 5.42.0 ([lobehub/lobe-ui#649](https://github.com/lobehub/lobe-ui/pull/649)) moves the bottom-right toast viewport out of an open `bottomRight` `FloatingPanel`'s way. The verdict is: shift the toast left → shift it up → narrow it to the lane that is left → and, when neither axis has room, have the panel yield by raising its own bottom edge. That last branch works through a cap on the panel's `max-height`.

This drawer overrode that cap outright, so the panel could not yield.

## Why not just delete the override

The override existed for a reason. The library's cap is `calc(100dvh - 32px - reserve)`, which assumes a 16px offset — this panel sits at the default 8, so the space actually available is `100dvh - 16px`. Accepting the library value would cost 16px of drawer height.

Subtracting the reserve from our own cap keeps both properties:

```ts
maxHeight: 'calc(100dvh - 16px - var(--floating-panel-reserve-block-end, 0px))',
```

The variable falls back to `0px`, so on any earlier `@lobehub/ui` this is a no-op.

## Verified

Measured in a harness passing this drawer's exact props, against the built package, at 1280×633:

| Panel state | Panel height | Toast | Gap |
| --- | --- | --- | --- |
| Default 640 | 609 (library cap alone would give 593) | beside, 360px wide | 12px, bottom edges aligned |
| Panel yields | 509 = `633 − 16 − 108` | below the panel, 360px wide | 12px, right edges aligned |

Without this change the yield branch leaves the panel at its full height, so raising its bottom edge pushes the top past the container and clips the header.

Full evidence for the library side, including a before/after against the published 5.41.0 build: https://app.lobehub.com/acceptance/0ef50725-9064-4d97-82e2-d8d499596b19

## Notes

- No dependency bump needed: `^5.40.3` already resolves to 5.42.0, and no lockfile is tracked.
- The reserve branch is only reachable below roughly 1256px of viewport width, since this drawer caps its expanded width at 960px. Above that the toast shifts left or narrows instead, both of which already work without this change.
- `FloatingChatPanel` (the Document copilot surface) uses `FloatingSheet`, which spans the whole bottom edge and does not dodge. Same user-visible problem, different component — out of scope here.

https://claude.ai/code/session_01X2C9jktiWMsyDXVQyYYEi3