### PR TITLE
fix: restore heartbeat tasks on server restart

### DIFF
--- a/apps/server/src/router-hono/standalone.ts
+++ b/apps/server/src/router-hono/standalone.ts
@@ -103,6 +103,12 @@ const startServer = async () => {
   server.listen(port, host, () => {
     console.info(`Hono runtime ready at http://${host}:${port}`);
   });
+
+  // Local queue mode: re-arm heartbeat ticks whose setTimeout timers died
+  // with the previous process. No-op in QStash mode (ticks persist there).
+  void import('@/server/services/taskRunner/heartbeatRecovery')
+    .then((m) => m.scheduleHeartbeatRecoveryOnce())
+    .catch((error) => console.error('[heartbeat-recovery] failed to start:', error));
 };
 
 void startServer().catch((error) => {

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -76,7 +76,7 @@ const isTerminal = (status: string) => TERMINAL_STATUSES.has(status);
 // transient upstream hiccup (429 / network / upstream 500) must NOT permanently
 // stop a recurring task — only this many *consecutive* failures do. Hardcoded
 // for now; move to task.config later if it needs to be tunable per-task.
-const AUTOMATION_FAILURE_FUSE = 3;
+export const AUTOMATION_FAILURE_FUSE = 3;
 
 // Terminal error codes whose fix lives in billing, not in a retry — running the
 // same task again just reproduces the same wall. For these the error brief leads

--- a/apps/server/src/services/taskRunner/heartbeatRecovery.test.ts
+++ b/apps/server/src/services/taskRunner/heartbeatRecovery.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { rehydrateHeartbeatTasks, scheduleHeartbeatRecoveryOnce } from './heartbeatRecovery';
+
+const {
+  mockBriefModelCtor,
+  mockFindRunnableHeartbeatTasks,
+  mockHasUnresolvedUrgent,
+  mockQueueMode,
+  mockScheduleNextTopic,
+  mockTaskModelCtor,
+  mockUpdateContext,
+} = vi.hoisted(() => ({
+  mockBriefModelCtor: vi.fn(),
+  mockFindRunnableHeartbeatTasks: vi.fn(),
+  mockHasUnresolvedUrgent: vi.fn(),
+  mockQueueMode: { enabled: false },
+  mockScheduleNextTopic: vi.fn(),
+  mockTaskModelCtor: vi.fn(),
+  mockUpdateContext: vi.fn(),
+}));
+
+vi.mock('@/database/models/brief', () => ({
+  BriefModel: mockBriefModelCtor,
+}));
+
+vi.mock('@/database/models/task', () => ({
+  TaskModel: Object.assign(mockTaskModelCtor, {
+    findRunnableHeartbeatTasks: mockFindRunnableHeartbeatTasks,
+  }),
+}));
+
+vi.mock('@/database/server', () => ({
+  getServerDB: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/envs/app', () => ({
+  appEnv: {
+    get enableQueueAgentRuntime() {
+      return mockQueueMode.enabled;
+    },
+  },
+}));
+
+vi.mock('@/server/services/taskLifecycle', () => ({
+  AUTOMATION_FAILURE_FUSE: 3,
+}));
+
+vi.mock('@/server/services/taskScheduler', () => ({
+  createTaskSchedulerModule: () => ({ scheduleNextTopic: mockScheduleNextTopic }),
+}));
+
+const globalForRecovery = globalThis as typeof globalThis & {
+  __lobeHeartbeatRecoveryStarted?: boolean;
+};
+
+const baseTask = (overrides: Record<string, unknown> = {}) => ({
+  automationMode: 'heartbeat',
+  context: {
+    scheduler: {
+      consecutiveFailures: 1,
+      scheduledAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      tickMessageId: 'msg-old',
+      tickToken: 'tok-old',
+    },
+  },
+  createdByUserId: 'user-1',
+  heartbeatInterval: 30,
+  id: 'task-1',
+  identifier: 'T-1',
+  status: 'scheduled',
+  workspaceId: null,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQueueMode.enabled = false;
+  mockTaskModelCtor.mockImplementation(() => ({ updateContext: mockUpdateContext }));
+  mockBriefModelCtor.mockImplementation(() => ({
+    hasUnresolvedUrgentByTask: mockHasUnresolvedUrgent,
+  }));
+  mockHasUnresolvedUrgent.mockResolvedValue(false);
+  mockUpdateContext.mockResolvedValue(null);
+  mockScheduleNextTopic.mockResolvedValue('tick-new');
+  mockFindRunnableHeartbeatTasks.mockResolvedValue([]);
+  delete globalForRecovery.__lobeHeartbeatRecoveryStarted;
+});
+
+describe('rehydrateHeartbeatTasks', () => {
+  it('is a no-op in QStash mode — ticks persist server-side there', async () => {
+    mockQueueMode.enabled = true;
+
+    await expect(rehydrateHeartbeatTasks()).resolves.toEqual({ rehydrated: 0 });
+
+    expect(mockFindRunnableHeartbeatTasks).not.toHaveBeenCalled();
+    expect(mockScheduleNextTopic).not.toHaveBeenCalled();
+  });
+
+  it('re-arms an overdue tick on the floor delay with a fresh generation', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([baseTask()]);
+
+    await expect(rehydrateHeartbeatTasks()).resolves.toEqual({ rehydrated: 1 });
+
+    expect(mockTaskModelCtor).toHaveBeenCalledWith({}, 'user-1', undefined);
+    expect(mockScheduleNextTopic).toHaveBeenCalledTimes(1);
+    const schedule = mockScheduleNextTopic.mock.calls[0][0];
+    expect(schedule).toMatchObject({ delay: 3, taskId: 'task-1', userId: 'user-1' });
+
+    // Token is written first (invalidate the dead generation), then the full
+    // scheduler context after the tick is scheduled.
+    expect(mockUpdateContext).toHaveBeenCalledTimes(2);
+    const [, tokenWrite] = mockUpdateContext.mock.calls[0];
+    expect(tokenWrite).toEqual({ scheduler: { tickToken: expect.any(String) } });
+    const [, fullWrite] = mockUpdateContext.mock.calls[1];
+    expect(fullWrite).toEqual({
+      scheduler: {
+        consecutiveFailures: 1,
+        scheduledAt: expect.any(String),
+        tickMessageId: 'tick-new',
+        tickToken: schedule.tickToken,
+      },
+    });
+  });
+
+  it('resumes the remaining wait for a tick still in the future', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([
+      baseTask({
+        context: { scheduler: { scheduledAt: new Date(Date.now() - 10_000).toISOString() } },
+        heartbeatInterval: 3600,
+      }),
+    ]);
+
+    await rehydrateHeartbeatTasks();
+
+    const { delay } = mockScheduleNextTopic.mock.calls[0][0];
+    // 3600s interval armed 10s ago → ~3590s remaining.
+    expect(delay).toBeGreaterThan(3585);
+    expect(delay).toBeLessThan(3595);
+  });
+
+  it('fires soon when the scheduler context carries no scheduledAt', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([baseTask({ context: { scheduler: {} } })]);
+
+    await rehydrateHeartbeatTasks();
+
+    expect(mockScheduleNextTopic.mock.calls[0][0].delay).toBe(3);
+  });
+
+  it('caps the delay at one interval', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([baseTask({ heartbeatInterval: 1 })]);
+
+    await rehydrateHeartbeatTasks();
+
+    expect(mockScheduleNextTopic.mock.calls[0][0].delay).toBe(1);
+  });
+
+  it('skips a task whose failure fuse has blown — recovery must not resurrect it', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([
+      baseTask({ context: { scheduler: { consecutiveFailures: 3 } } }),
+    ]);
+
+    await expect(rehydrateHeartbeatTasks()).resolves.toEqual({ rehydrated: 0 });
+
+    expect(mockScheduleNextTopic).not.toHaveBeenCalled();
+    expect(mockUpdateContext).not.toHaveBeenCalled();
+  });
+
+  it('skips a task with an unresolved urgent brief waiting on a human', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([baseTask()]);
+    mockHasUnresolvedUrgent.mockResolvedValue(true);
+
+    await expect(rehydrateHeartbeatTasks()).resolves.toEqual({ rehydrated: 0 });
+
+    expect(mockHasUnresolvedUrgent).toHaveBeenCalledWith('task-1', { excludeTypes: ['error'] });
+    expect(mockScheduleNextTopic).not.toHaveBeenCalled();
+  });
+
+  it('keeps the remaining tasks recoverable when one task fails', async () => {
+    mockFindRunnableHeartbeatTasks.mockResolvedValue([
+      baseTask({ id: 'task-1', identifier: 'T-1' }),
+      baseTask({ createdByUserId: 'user-2', id: 'task-2', identifier: 'T-2' }),
+    ]);
+    mockUpdateContext.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(rehydrateHeartbeatTasks()).resolves.toEqual({ rehydrated: 1 });
+
+    expect(mockScheduleNextTopic).toHaveBeenCalledTimes(1);
+    expect(mockScheduleNextTopic.mock.calls[0][0].taskId).toBe('task-2');
+  });
+
+  it('skips nothing extra for an empty sweep', async () => {
+    await expect(rehydrateHeartbeatTasks()).resolves.toEqual({ rehydrated: 0 });
+
+    expect(mockScheduleNextTopic).not.toHaveBeenCalled();
+    expect(mockUpdateContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('scheduleHeartbeatRecoveryOnce', () => {
+  it('runs the sweep at most once per process', async () => {
+    await scheduleHeartbeatRecoveryOnce();
+    await scheduleHeartbeatRecoveryOnce();
+
+    expect(mockFindRunnableHeartbeatTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the guard on failure so a later trigger can retry', async () => {
+    mockFindRunnableHeartbeatTasks.mockRejectedValueOnce(new Error('db not ready'));
+
+    await scheduleHeartbeatRecoveryOnce();
+    await scheduleHeartbeatRecoveryOnce();
+
+    expect(mockFindRunnableHeartbeatTasks).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/src/services/taskRunner/heartbeatRecovery.ts
+++ b/apps/server/src/services/taskRunner/heartbeatRecovery.ts
@@ -38,12 +38,13 @@ export interface HeartbeatRecoveryResult {
  * unaffected — its ticks are persisted server-side and re-deliver on their
  * own — so this sweep is a no-op there.
  *
- * For every runnable heartbeat task (`automationMode='heartbeat'`, positive
- * interval, not terminal/paused/running, fuse intact, no unresolved urgent
- * brief — the last two mirror `maybeRearmHeartbeat`'s gates, whose skip
- * leaves no pending tick at rest in QStash mode either) a fresh tick is
- * scheduled and the scheduler context is rewritten with a new `tickToken` /
- * `tickMessageId`:
+ * For every armed heartbeat task (`automationMode='heartbeat'`, status
+ * 'scheduled' — the only resting state a tick is ever published from, see
+ * {@link TaskModel.findRunnableHeartbeatTasks} — positive interval, fuse
+ * intact, no unresolved urgent brief; the last two mirror
+ * `maybeRearmHeartbeat`'s gates, whose skip leaves no pending tick at rest in
+ * QStash mode either) a fresh tick is scheduled and the scheduler context is
+ * rewritten with a new `tickToken` / `tickMessageId`:
  * - ticks that came due while the process was down fire after the floor delay;
  * - ticks still in the future keep their remaining wait, resuming the cadence
  *   where `scheduledAt + heartbeatInterval` says it left off.

--- a/apps/server/src/services/taskRunner/heartbeatRecovery.ts
+++ b/apps/server/src/services/taskRunner/heartbeatRecovery.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'node:crypto';
+
+import type { TaskContext, TaskSchedulerContext } from '@lobechat/types';
+import debug from 'debug';
+
+import { BriefModel } from '@/database/models/brief';
+import { TaskModel } from '@/database/models/task';
+import { getServerDB } from '@/database/server';
+import { appEnv } from '@/envs/app';
+import { AUTOMATION_FAILURE_FUSE } from '@/server/services/taskLifecycle';
+import { createTaskSchedulerModule } from '@/server/services/taskScheduler';
+
+const log = debug('task-runner:heartbeat-recovery');
+
+/**
+ * Floor under every rehydrated tick's delay, in seconds.
+ *
+ * Two reasons it exists:
+ * - `createTaskSchedulerModule` lazily dynamic-imports the heartbeat tick
+ *   runner to wire the execution callback; a delay-0 timer could fire before
+ *   that import resolves and the tick would be dropped with
+ *   "No execution callback set".
+ * - A restart storm (deploy loop, crash loop) should not stampede the DB and
+ *   the agent runtime the instant the process is up.
+ */
+const REHYDRATE_MIN_DELAY_SECONDS = 3;
+
+export interface HeartbeatRecoveryResult {
+  rehydrated: number;
+}
+
+/**
+ * Re-arm pending heartbeat ticks after a process restart in local queue mode.
+ *
+ * The LocalTaskScheduler holds ticks in in-memory `setTimeout` timers, so a
+ * restart (intentional or crash) loses every pending tick and the heartbeat
+ * chain stalls in its resting 'scheduled' state forever. QStash mode is
+ * unaffected — its ticks are persisted server-side and re-deliver on their
+ * own — so this sweep is a no-op there.
+ *
+ * For every runnable heartbeat task (`automationMode='heartbeat'`, positive
+ * interval, not terminal/paused/running, fuse intact, no unresolved urgent
+ * brief — the last two mirror `maybeRearmHeartbeat`'s gates, whose skip
+ * leaves no pending tick at rest in QStash mode either) a fresh tick is
+ * scheduled and the scheduler context is rewritten with a new `tickToken` /
+ * `tickMessageId`:
+ * - ticks that came due while the process was down fire after the floor delay;
+ * - ticks still in the future keep their remaining wait, resuming the cadence
+ *   where `scheduledAt + heartbeatInterval` says it left off.
+ *
+ * Safe to run redundantly: the fresh token invalidates any zombie timer (dev
+ * hot-reload keeps old module instances, and their timers, alive), and the
+ * tick runner re-validates all task state from the DB when it fires.
+ */
+export async function rehydrateHeartbeatTasks(): Promise<HeartbeatRecoveryResult> {
+  // QStash persists ticks server-side; they survive restarts without help.
+  if (appEnv.enableQueueAgentRuntime) return { rehydrated: 0 };
+
+  const db = await getServerDB();
+  const heartbeatTasks = await TaskModel.findRunnableHeartbeatTasks(db);
+  if (heartbeatTasks.length === 0) return { rehydrated: 0 };
+
+  log('rehydrating %d heartbeat task(s) after restart', heartbeatTasks.length);
+  const scheduler = createTaskSchedulerModule();
+
+  let rehydrated = 0;
+  for (const task of heartbeatTasks) {
+    try {
+      const interval = task.heartbeatInterval ?? 0;
+      if (interval <= 0) continue;
+
+      const sched =
+        ((task.context as TaskContext | null)?.scheduler as TaskSchedulerContext | undefined) ?? {};
+
+      // Mirror the re-arm gates in TaskLifecycleService.maybeRearmHeartbeat —
+      // both leave the task resting with NO pending tick in QStash mode, so
+      // recovery must not resurrect them either:
+      // - a blown failure fuse stops re-arming until a human resolves it;
+      // - an unresolved urgent brief means a human is already waiting.
+      if ((sched.consecutiveFailures ?? 0) >= AUTOMATION_FAILURE_FUSE) {
+        log('skip task=%s reason=fuse-blown', task.identifier);
+        continue;
+      }
+      const briefModel = new BriefModel(db, task.createdByUserId, task.workspaceId ?? undefined);
+      if (await briefModel.hasUnresolvedUrgentByTask(task.id, { excludeTypes: ['error'] })) {
+        log('skip task=%s reason=human-waiting', task.identifier);
+        continue;
+      }
+
+      const armedAt = sched.scheduledAt ? Date.parse(sched.scheduledAt) : Number.NaN;
+      const dueAt = Number.isFinite(armedAt) ? armedAt + interval * 1000 : Date.now();
+      const delay = Math.min(
+        Math.max((dueAt - Date.now()) / 1000, REHYDRATE_MIN_DELAY_SECONDS),
+        interval,
+      );
+
+      const taskModel = new TaskModel(db, task.createdByUserId, task.workspaceId ?? undefined);
+      const tickToken = randomUUID();
+
+      // Invalidate the dead tick generation before scheduling, mirroring the
+      // QStash race discipline in TaskService/TaskLifecycleService: a zombie
+      // delivery must lose to the replacement message.
+      await taskModel.updateContext(task.id, { scheduler: { tickToken } });
+      const tickMessageId = await scheduler.scheduleNextTopic({
+        delay,
+        taskId: task.id,
+        tickToken,
+        userId: task.createdByUserId,
+      });
+      await taskModel.updateContext(task.id, {
+        scheduler: {
+          consecutiveFailures: sched.consecutiveFailures ?? 0,
+          scheduledAt: new Date().toISOString(),
+          tickMessageId,
+          tickToken,
+        },
+      });
+
+      rehydrated += 1;
+      log(
+        'rehydrated task=%s delay=%ds messageId=%s',
+        task.identifier,
+        Math.round(delay),
+        tickMessageId,
+      );
+    } catch (error) {
+      // One broken task must not stall the sweep — the rest still recover.
+      console.error('[heartbeat-recovery] failed to rehydrate task %s:', task.id, error);
+    }
+  }
+
+  return { rehydrated };
+}
+
+const globalForHeartbeatRecovery = globalThis as typeof globalThis & {
+  __lobeHeartbeatRecoveryStarted?: boolean;
+};
+
+/**
+ * Startup wrapper around {@link rehydrateHeartbeatTasks}: runs the sweep at
+ * most once per process, fire-and-forget (callers never await it).
+ *
+ * Guard lives on `globalThis` so Next.js instrumentation, the standalone
+ * Hono bootstrap, and dev hot-reloads can all call it without double-running.
+ * A failed sweep releases the guard so a later trigger can retry.
+ */
+export const scheduleHeartbeatRecoveryOnce = (): Promise<void> => {
+  if (globalForHeartbeatRecovery.__lobeHeartbeatRecoveryStarted) return Promise.resolve();
+  globalForHeartbeatRecovery.__lobeHeartbeatRecoveryStarted = true;
+
+  return rehydrateHeartbeatTasks()
+    .then((result) => {
+      log('startup rehydration complete: %d task(s) re-armed', result.rehydrated);
+    })
+    .catch((error) => {
+      globalForHeartbeatRecovery.__lobeHeartbeatRecoveryStarted = false;
+      console.error('[heartbeat-recovery] startup rehydration failed:', error);
+    });
+};

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -2492,6 +2492,53 @@ describe('TaskModel', () => {
     });
   });
 
+  describe('static findRunnableHeartbeatTasks', () => {
+    it('returns only started (scheduled) heartbeat tasks with a positive interval', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const armed = await model.create({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 30,
+        instruction: 'Armed',
+        status: 'scheduled',
+      });
+      // Configured but never started: recovery must not auto-start it
+      const neverStarted = await model.create({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 30,
+        instruction: 'Never started',
+      });
+      // Paused requires user attention
+      const paused = await model.create({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 30,
+        instruction: 'Paused',
+        status: 'scheduled',
+      });
+      await model.updateStatus(paused.id, 'paused');
+      // Terminal
+      const done = await model.create({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 30,
+        instruction: 'Completed',
+        status: 'scheduled',
+      });
+      await model.updateStatus(done.id, 'completed', { completedAt: new Date() });
+      // No positive interval
+      await model.create({
+        automationMode: 'heartbeat',
+        instruction: 'No interval',
+        status: 'scheduled',
+      });
+
+      const result = await TaskModel.findRunnableHeartbeatTasks(serverDB);
+      const ids = result.map((t) => t.id);
+      expect(ids).toContain(armed.id);
+      expect(ids).not.toContain(neverStarted.id);
+      expect(ids).not.toContain(paused.id);
+      expect(ids).not.toContain(done.id);
+    });
+  });
+
   describe('updateComment', () => {
     it('should update comment content and editorData', async () => {
       const model = new TaskModel(serverDB, userId);

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -1480,6 +1480,27 @@ export class TaskModel {
       );
   }
 
+  // Heartbeat twin of {@link getScheduledTasks}: rows whose heartbeat loop
+  // should still be alive. `paused` requires user attention, `running` is
+  // already in flight (and `runTask` would CONFLICT anyway) — same exclusions
+  // as the schedule twin.
+  //
+  // Used by the local-queue startup sweep: a process restart wipes the
+  // LocalTaskScheduler's in-flight setTimeout timers, so every runnable
+  // heartbeat task must have its next tick re-armed from scratch.
+  static async findRunnableHeartbeatTasks(db: LobeChatDatabase): Promise<TaskItem[]> {
+    return db
+      .select()
+      .from(tasks)
+      .where(
+        and(
+          eq(tasks.automationMode, 'heartbeat'),
+          gt(tasks.heartbeatInterval, 0),
+          notInArray(tasks.status, ['canceled', 'completed', 'failed', 'paused', 'running']),
+        ),
+      );
+  }
+
   // Find stuck tasks (running but heartbeat timed out)
   // Only checks tasks that have both lastHeartbeatAt and heartbeatTimeout set
   static async findStuckTasks(db: LobeChatDatabase): Promise<TaskItem[]> {

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -1480,13 +1480,18 @@ export class TaskModel {
       );
   }
 
-  // Heartbeat twin of {@link getScheduledTasks}: rows whose heartbeat loop
-  // should still be alive. `paused` requires user attention, `running` is
-  // already in flight (and `runTask` would CONFLICT anyway) — same exclusions
-  // as the schedule twin.
+  // Heartbeat twin of {@link getScheduledTasks}, with a deliberate asymmetry:
+  // schedule mode dispatches any non-terminal/paused/running row whose cron
+  // pattern is set — configuring the pattern *is* arming it. Heartbeat loops
+  // are armed only by an explicit Start: the seed path in
+  // TaskService.updateStatus publishes the first tick exactly when the task
+  // transitions to 'scheduled', so 'scheduled' is the only resting state that
+  // legitimately carries a pending tick. A `backlog` row with heartbeat config
+  // was never started — selecting it here (and `runHeartbeatTick` does not
+  // reject backlog) would auto-start a task the user never ran.
   //
   // Used by the local-queue startup sweep: a process restart wipes the
-  // LocalTaskScheduler's in-flight setTimeout timers, so every runnable
+  // LocalTaskScheduler's in-flight setTimeout timers, so every armed
   // heartbeat task must have its next tick re-armed from scratch.
   static async findRunnableHeartbeatTasks(db: LobeChatDatabase): Promise<TaskItem[]> {
     return db
@@ -1495,8 +1500,8 @@ export class TaskModel {
       .where(
         and(
           eq(tasks.automationMode, 'heartbeat'),
+          eq(tasks.status, 'scheduled'),
           gt(tasks.heartbeatInterval, 0),
-          notInArray(tasks.status, ['canceled', 'completed', 'failed', 'paused', 'running']),
         ),
       );
   }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -42,6 +42,27 @@ export async function register() {
     });
   }
 
+  // Re-arm heartbeat ticks lost to a restart. In local queue mode the
+  // LocalTaskScheduler holds pending ticks in in-memory setTimeout timers,
+  // so a restart silently stalls every heartbeat loop; QStash deployments
+  // persist ticks server-side and are skipped inside the recovery module.
+  // Dynamic import: the recovery module pulls node-only DB code and this
+  // file is compiled for every Next runtime — same reason every other hook
+  // below defers its imports.
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.DATABASE_URL &&
+    !process.env.VERCEL_ENV
+  ) {
+    void (async () => {
+      const { scheduleHeartbeatRecoveryOnce } =
+        await import('@/server/services/taskRunner/heartbeatRecovery');
+      await scheduleHeartbeatRecoveryOnce();
+    })().catch((err) => {
+      console.error('[Instrumentation] Failed to rehydrate heartbeat tasks:', err);
+    });
+  }
+
   // Note: messenger system bot connections (Discord/Telegram) are managed
   // entirely from dc-center's System Bots admin — save / enable / forceReconnect
   // mutations call MessageGateway directly. The main app's only role here is


### PR DESCRIPTION
Reschedules heartbeat tasks that get lost on container/process restart when not using QStash.

No UI changes.

#### Test

Tested locally - set a heartbeat task for 10 minutes, wait for it to fire, then restart the container. Doing this before the change, it didn't fire, after the change it did.

- [X] Tested locally
- [X] Added/updated tests
- [ ] No tests needed

Fixes #19327 
