### PR TITLE
🐛 fix(bot): preserve original messages when extracting queued attachments

### DIFF
--- a/apps/server/src/services/bot/AgentBridgeService.ts
+++ b/apps/server/src/services/bot/AgentBridgeService.ts
@@ -1770,6 +1770,14 @@ export class AgentBridgeService {
     }>;
     warnings?: string[];
   }> {
+    const sources = (message as Message & { sourceMessages?: Message[] }).sourceMessages;
+    if (sources?.length) {
+      const results = [];
+      for (const source of sources) results.push(await this.resolveFiles(source, client));
+      const files = results.flatMap((result) => result.files ?? []);
+      const warnings = results.flatMap((result) => result.warnings ?? []);
+      return { files, warnings: warnings.length ? warnings : undefined };
+    }
     const result = await client?.extractFiles?.(message);
     if (!result) return {};
     if (Array.isArray(result)) return { files: result };

--- a/apps/server/src/services/bot/BotMessageRouter.ts
+++ b/apps/server/src/services/bot/BotMessageRouter.ts
@@ -593,6 +593,8 @@ export class BotMessageRouter {
 
     return Object.assign(Object.create(Object.getPrototypeOf(message)), message, {
       attachments: mergedAttachments,
+      // Platform extractors need each original raw payload after Redis drops buffers.
+      sourceMessages: allMessages,
       text: mergedText,
     });
   }

--- a/apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
+++ b/apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
@@ -649,6 +649,18 @@ describe('AgentBridgeService', () => {
       >;
     }
 
+    it('extracts queued files from each original message and preserves warnings', async () => {
+      const pdf = { id: 'pdf', raw: { item_list: [{ type: 4 }] } };
+      const text = { id: 'text', raw: { item_list: [{ type: 1 }] } };
+      const file = { buffer: Buffer.from('%PDF-fixture'), name: 'queued.pdf' };
+      const extractFiles = vi.fn(async (message) =>
+        message === pdf ? { files: [file], warnings: ['other file unavailable'] } : undefined,
+      );
+      const result = await callResolve({ ...text, sourceMessages: [pdf, text] }, { extractFiles });
+      expect(extractFiles.mock.calls.map(([message]) => message)).toEqual([pdf, text]);
+      expect(result).toEqual({ files: [file], warnings: ['other file unavailable'] });
+    });
+
     it('delegates to client.extractFiles when the client implements it', async () => {
       const clientResult = [
         { buffer: Buffer.from('via-client'), mimeType: 'image/jpeg', name: 'pic.jpg' },

--- a/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
+++ b/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
@@ -3319,3 +3319,24 @@ describe('BotMessageRouter', () => {
     });
   });
 });
+
+describe('queued attachment source preservation', () => {
+  it('keeps original PDF and text messages for platform extraction without changing latest raw', () => {
+    const pdf = {
+      id: 'pdf',
+      text: '[file: queued.pdf]',
+      raw: { item_list: [{ type: 4 }] },
+      attachments: [{ name: 'queued.pdf' }],
+    };
+    const text = {
+      id: 'text',
+      text: 'read it',
+      raw: { item_list: [{ type: 1 }] },
+      attachments: [],
+    };
+    const merged = (BotMessageRouter as any).mergeSkippedMessages(text, { skipped: [pdf] });
+    expect(merged.sourceMessages).toEqual([pdf, text]);
+    expect(merged.raw).toBe(text.raw);
+    expect(merged.attachments).toEqual(pdf.attachments);
+  });
+});


### PR DESCRIPTION
When a queued PDF is followed by text, merging retained only the text message's raw payload. WeChat's extractor therefore saw no downloadable media even though the merged attachment list contained the PDF.

Preserve the original messages on the merged object and resolve each through the existing platform extractor, combining files and warnings. No queue schema or platform download implementation changes.

| Before | After |
| ------ | ----- |
| PDF + text drain with `mergedAttachments=1` but `files=0` | Each original payload is extracted; the new user message references the PDF |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- Latest canary rebase: targeted checks passed, 147 tests, lint clean.
- Both added regressions failed before the fix. Independent review of the original source patch found no blocking defects.
- Real self-hosted WeChat scenario: start a video/tool request, send a PDF and then a reading instruction during execution. The new message referenced a new file record; all 44,403,719 bytes were downloaded and their SHA-256 matched storage metadata; the agent returned the page count and first-page title.
- Live acceptance used a targeted compiled patch on canary.11 alongside a separate persistent QStash serialization mitigation. This PR contains only the independent attachment-source fix, rebased onto current canary. Final reply delivery was confirmed in server logs; the final native UI was obscured.
- Acceptance: https://app.lobehub.com/acceptance/b48a7162-2f9c-4f93-8f7b-ec276abcc486?r=6

#### 🔗 Related Issue

Fixes #19367
Related to #19253 (separate queue-expiry failure).
