### PR TITLE
🐛 fix(bot): opt in to serialized QStash runs on persistent hosts

### DIFF
--- a/apps/server/src/services/bot/AgentBridgeService.ts
+++ b/apps/server/src/services/bot/AgentBridgeService.ts
@@ -19,6 +19,7 @@ import { SystemAgentService } from '@/server/services/systemAgent';
 
 import { createBotCompletionWebhook } from './createBotCompletionHook';
 import { formatPrompt as formatPromptUtil } from './formatPrompt';
+import { isPersistentBotQueueEnabled, waitForBotOperation } from './persistentBotQueue';
 import type { BotReplyLocale, PlatformClient } from './platforms';
 import {
   getBotReplyLocale,
@@ -1217,6 +1218,17 @@ export class AgentBridgeService {
           );
         }
       }
+    }
+
+    if (result.operationId && isPersistentBotQueueEnabled()) {
+      // Keep the Chat SDK handler (and its Redis lease) open until the run settles.
+      // Otherwise a follow-up starts before the topic is available and is rejected
+      // before its user message is persisted.
+      const topicModel = new TopicModel(this.db, this.userId, this.workspaceId);
+      await waitForBotOperation(async () => {
+        const topic = await topicModel.findById(result.topicId);
+        return topic?.metadata?.runningOperation?.operationId === result.operationId;
+      });
     }
 
     return { reply: '', topicId: result.topicId };

--- a/apps/server/src/services/bot/BotMessageRouter.ts
+++ b/apps/server/src/services/bot/BotMessageRouter.ts
@@ -27,6 +27,11 @@ import {
 } from './dmPairingStore';
 import { submitBotFeedback } from './feedbackSubmit';
 import {
+  BOT_QUEUE_RETENTION_MS,
+  configurePersistentBotState,
+  isPersistentBotQueueEnabled,
+} from './persistentBotQueue';
+import {
   type BotPlatformRuntimeContext,
   type BotReplyLocale,
   buildRuntimeKey,
@@ -560,6 +565,10 @@ export class BotMessageRouter {
       userName: `lobehub-bot-${label}`,
     };
 
+    if (isPersistentBotQueueEnabled()) {
+      config.concurrency = { strategy: 'queue', queueEntryTtlMs: BOT_QUEUE_RETENTION_MS };
+    }
+
     const redisClient = getAgentRuntimeRedisClient();
     if (redisClient) {
       config.state = createIoRedisState({
@@ -567,6 +576,7 @@ export class BotMessageRouter {
         keyPrefix: `chat-sdk:${label}`,
         logger: new ConsoleLogger(),
       });
+      if (isPersistentBotQueueEnabled()) configurePersistentBotState(config.state);
     }
 
     return new Chat(config);

--- a/apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
+++ b/apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
@@ -131,6 +131,45 @@ describe('AgentBridgeService', () => {
     });
   });
 
+  it('keeps the subscribed handler open while its queued operation is running beyond 90 seconds', async () => {
+    vi.stubEnv('BOT_QUEUE_WAIT_FOR_COMPLETION', '1');
+    vi.stubEnv('VERCEL', '');
+    vi.useFakeTimers();
+    try {
+      mockTopicFindById.mockResolvedValue({
+        agentId: 'agent-1',
+        id: 'topic-1',
+        updatedAt: new Date(),
+        metadata: { runningOperation: { operationId: 'op-1' } },
+      });
+      mockExecAgent.mockResolvedValue({ success: true, operationId: 'op-1', topicId: 'topic-1' });
+      let finished = false;
+      const service = new AgentBridgeService(FAKE_DB, USER_ID);
+      const pending = service
+        .handleSubscribedMessage(createThread({ topicId: 'topic-1' }), createMessage(), {
+          agentId: 'agent-1',
+          client: createClient(),
+        })
+        .then(() => {
+          finished = true;
+        });
+      await vi.advanceTimersByTimeAsync(95_000);
+      expect(mockExecAgent).toHaveBeenCalledTimes(1);
+      expect(finished).toBe(false);
+      mockTopicFindById.mockResolvedValue({
+        agentId: 'agent-1',
+        id: 'topic-1',
+        metadata: { runningOperation: null },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await pending;
+      expect(finished).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('calls execAgent with hooks in queue mode for mention', async () => {
     const service = new AgentBridgeService(FAKE_DB, USER_ID);
     const thread = createThread();

--- a/apps/server/src/services/bot/persistentBotQueue.test.ts
+++ b/apps/server/src/services/bot/persistentBotQueue.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BOT_QUEUE_RETENTION_MS,
+  configurePersistentBotState,
+  isPersistentBotQueueEnabled,
+} from './persistentBotQueue';
+
+afterEach(() => vi.unstubAllEnvs());
+describe('persistent bot queue', () => {
+  it('is opt-in and disabled on Vercel', () => {
+    vi.stubEnv('BOT_QUEUE_WAIT_FOR_COMPLETION', '1');
+    vi.stubEnv('VERCEL', '');
+    expect(isPersistentBotQueueEnabled()).toBe(true);
+    vi.stubEnv('VERCEL', '1');
+    expect(isPersistentBotQueueEnabled()).toBe(false);
+  });
+  it('keeps a second receiver excluded beyond the SDK 30-second lease', async () => {
+    let now = 0;
+    let until = 0;
+    const state = {
+      async acquireLock(id: string, ttl: number) {
+        if (until > now) return null;
+        until = now + ttl;
+        return { threadId: id, token: 'owner' };
+      },
+      async extendLock(_lock: unknown, ttl: number) {
+        until = now + ttl;
+        return true;
+      },
+    };
+    configurePersistentBotState(state as any);
+    const owner = await state.acquireLock('thread', 30_000);
+    now = 120_000;
+    expect(await state.acquireLock('thread', 30_000)).toBeNull();
+    await state.extendLock(owner, 30_000);
+    now += 120_000;
+    expect(await state.acquireLock('thread', 30_000)).toBeNull();
+    expect(BOT_QUEUE_RETENTION_MS).toBeGreaterThan(now);
+  });
+});

--- a/apps/server/src/services/bot/persistentBotQueue.ts
+++ b/apps/server/src/services/bot/persistentBotQueue.ts
@@ -1,0 +1,25 @@
+import type { StateAdapter } from 'chat';
+
+// Opt-in for a continuously running server, never a serverless request lifecycle.
+export const isPersistentBotQueueEnabled = () =>
+  process.env.BOT_QUEUE_WAIT_FOR_COMPLETION === '1' && !process.env.VERCEL;
+
+export const BOT_OPERATION_WAIT_MS = 30 * 60 * 1000;
+export const BOT_QUEUE_RETENTION_MS = 60 * 60 * 1000;
+
+/** Keep Chat SDK's 30-second lease alive for the bounded handler lifetime. */
+export const configurePersistentBotState = (state: StateAdapter): void => {
+  const acquire = state.acquireLock.bind(state);
+  const extend = state.extendLock.bind(state);
+  const leaseMs = BOT_OPERATION_WAIT_MS + 60_000;
+  state.acquireLock = (id, ttl) => acquire(id, Math.max(ttl, leaseMs));
+  state.extendLock = (lock, ttl) => extend(lock, Math.max(ttl, leaseMs));
+};
+
+export const waitForBotOperation = async (isRunning: () => Promise<boolean>): Promise<void> => {
+  const deadline = Date.now() + BOT_OPERATION_WAIT_MS;
+  while (await isRunning()) {
+    if (Date.now() >= deadline) throw new Error('Bot operation exceeded the 30-minute queue wait');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+};


### PR DESCRIPTION
QStash submission currently finishes the bot handler while the topic's agent operation is still running. A follow-up can then enter `execAgent` and fail at the topic reservation guard before its message is persisted.

This draft proposes an opt-in mitigation for continuously running self-hosted servers. With `BOT_QUEUE_WAIT_FOR_COMPLETION=1` and no `VERCEL` environment flag, keep the handler pending until its operation marker clears, extend the receiver lease, and retain pending queue entries longer.

| Before | After (opt-in persistent hosts) |
| ------ | ----- |
| Handler returns at QStash submission; follow-up hits the running-topic guard | Handler waits for completion; follow-up drains afterward |

**Maintainer decision requested:** whether this bounded persistent-host mitigation belongs upstream, or should be replaced by a durable inbox/dispatcher design. It is not a serverless solution.

Limits: 30-minute operation wait, 31-minute receiver lease, one-hour queue retention, existing SDK queue capacity/overflow unchanged. No restart recovery guarantee; a process death can leave the longer lease until expiry. The bridge polls the topic once per second while waiting. Defaults remain unchanged, and Vercel is excluded explicitly; other non-persistent environments must not enable it.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- Latest canary rebase: targeted checks passed, 148 tests, lint clean.
- Regression tests cover pending operation/lease lifetime and opt-in gating.
- Self-hosted Docker with QStash Dev: real WeChat follow-up input stayed queued through a running task and executed afterward. Tests included a roughly 176-second wait and shorter video/audio tool tasks; provider failure itself was not the queue acceptance criterion.
- Live acceptance used targeted compiled patches on canary.11. Later rounds also include a separate PDF extraction fix, excluded from this PR. QStash Dev usage is test evidence, not a durability endorsement.
- Acceptance: https://app.lobehub.com/acceptance/b48a7162-2f9c-4f93-8f7b-ec276abcc486?r=6

#### 🔗 Related Issue

Fixes #19368
Related to #19253; this only mitigates queue retention under the opt-in mode and does not fully resolve durable delivery/recovery.
