### PR TITLE
chore: remove LOBE-XXX markers from code comments

### DIFF
--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -437,7 +437,7 @@ describe('formatErrorForState', () => {
 
 // The cost-admission gate attaches `budget` to the thrown payload, and
 // `formatErrorForState` copies it onto `body` verbatim — `body` is `any`, so
-// reading it back has to narrow rather than cast (LOBE-13726).
+// reading it back has to narrow rather than cast.
 describe('readErrorBudgetContext', () => {
   it('reads the budget context an admission gate attached', () => {
     const formatted = formatErrorForState({

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -461,7 +461,7 @@ describe('CompletionLifecycle.buildLifecycleEvent', () => {
   it('carries the budget context of an exhausted allowance onto the event', () => {
     // Without this the bot reply can only say "not enough credits": which
     // allowance ran out, and by how much, lived in the error body and stopped
-    // at the lifecycle boundary (LOBE-13726).
+    // at the lifecycle boundary.
     const state = {
       error: {
         budget: {

--- a/apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
+++ b/apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
@@ -204,7 +204,7 @@ describe('AgentBridgeService', () => {
     expect(mockExecAgent.mock.calls[0][0].toolModeOverride).toBeUndefined();
   });
 
-  describe('current-conversation injection (LOBE-13803)', () => {
+  describe('current-conversation injection', () => {
     it('injects the platform + channelId the message tool needs into botPlatformContext', async () => {
       const service = new AgentBridgeService(FAKE_DB, USER_ID);
       const thread = createThread();

--- a/apps/server/src/services/bot/__tests__/replyTemplate.test.ts
+++ b/apps/server/src/services/bot/__tests__/replyTemplate.test.ts
@@ -416,7 +416,7 @@ describe('replyTemplate', () => {
 
     // The admission gate emits one of three codes for the same "the allowance
     // can't cover this" outcome; the plan-limit pair used to fall to the `user`
-    // tier and tell the user to check their input (LOBE-13726).
+    // tier and tell the user to check their input.
     it('gives every budget-exhaustion code its own credits copy, not "check your input"', () => {
       const expected: Record<string, string> = {
         FreePlanLimit: 'Free plan limit reached',
@@ -449,7 +449,7 @@ describe('replyTemplate', () => {
       }
     });
 
-    // LOBE-13726: a workspace member's own allowance ran out and the reply told
+    // A workspace member's own allowance ran out and the reply told
     // them to top up — which does nothing for that allowance — while the numbers
     // that would have identified the real fault stayed in the trace.
     describe('budget scope', () => {

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptanceStateRow.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptanceStateRow.tsx
@@ -34,7 +34,7 @@ import { useOpenAcceptanceInPanel } from './useOpenAcceptanceInPanel';
  * task — the same destination the checklist and run tags use. The standalone
  * `/acceptance/:id` page is a public, workspace-less route: navigating there
  * from a workspace task drops the slug from the URL and flips the whole app
- * back to personal scope (LOBE-13898).
+ * back to personal scope.
  *
  * `delivered` alone cannot be rendered honestly: a converged delivery and a
  * budget-exhausted one both land there. The latest round's verdict (shipped

--- a/src/features/AgentTasks/AgentTaskDetail/useOpenAcceptanceInPanel.test.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/useOpenAcceptanceInPanel.test.ts
@@ -10,8 +10,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 // The hook must NOT route anywhere: `/acceptance/:id` is a public,
-// workspace-less page and navigating there drops the workspace slug
-// (LOBE-13898). The navigate hook is mocked only to prove it stays unused.
+// workspace-less page and navigating there drops the workspace slug.
+// The navigate hook is mocked only to prove it stays unused.
 vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
   useWorkspaceAwareNavigate: () => mocks.navigate,
 }));

--- a/src/features/AgentTasks/AgentTaskDetail/useOpenAcceptanceInPanel.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/useOpenAcceptanceInPanel.ts
@@ -10,7 +10,7 @@ import { useGlobalStore } from '@/store/global';
  * Deliberately not a route change: the standalone `/acceptance/:id` page is a
  * public, workspace-less route, and navigating there from a workspace task
  * drops the slug from the URL so `useWorkspaceUrlSync` flips the whole app
- * back to the personal scope (LOBE-13898).
+ * back to the personal scope.
  */
 export const useOpenAcceptanceInPanel = () => {
   const openAcceptance = useChatStore((state) => state.openAcceptance);

--- a/src/features/EditorCanvas/InternalEditor.tsx
+++ b/src/features/EditorCanvas/InternalEditor.tsx
@@ -224,7 +224,7 @@ const InternalEditor = memo<InternalEditorProps>(
 
     // Opt-in (comment editors): keep the caret out of the root node around
     // block images by pushing an empty paragraph next to the image instead of
-    // showing Lexical's horizontal root-level caret (LOBE-13882).
+    // showing Lexical's horizontal root-level caret.
     useEffect(() => {
       if (!editor || !blockImageCaretGuard) return;
       const unregister = registerBlockDecoratorCaretGuard(editor);

--- a/src/features/PageEditor/DocumentComments/styles.ts
+++ b/src/features/PageEditor/DocumentComments/styles.ts
@@ -121,7 +121,7 @@ export const styles = createStaticStyles(({ css }) => ({
 
     /* Only untouched images get the thumbnail treatment. Forcing width: auto
        on every image would beat the inline width the resize handles write, so
-       dragging would appear to do nothing (LOBE-13874). */
+       dragging would appear to do nothing. */
     & [contenteditable='true'] img:not(${RESIZED_IMAGE}) {
       width: auto !important;
       max-height: ${COMMENT_EDITOR_IMAGE_MAX_HEIGHT}px;

--- a/src/features/ResourceHome/Home/RecentWorks.test.tsx
+++ b/src/features/ResourceHome/Home/RecentWorks.test.tsx
@@ -48,7 +48,7 @@ describe('RecentWorks', () => {
     expect(screen.queryByTestId('card-wk_4')).toBeNull();
 
     // The global Work refresh in `useRemoveWork` skips `useSWRInfinite` keys,
-    // so the card has to be handed this list's own `reload` (LOBE-13961).
+    // so the card has to be handed this list's own `reload`.
     fireEvent.click(screen.getByTestId('card-wk_1'));
     expect(mocks.reload).toHaveBeenCalledTimes(1);
   });

--- a/src/features/ResourceHome/Home/RecentWorks.tsx
+++ b/src/features/ResourceHome/Home/RecentWorks.tsx
@@ -48,7 +48,7 @@ const RecentWorks = memo(() => {
           {recent.map((item) => (
             // `onRemoved` is required here: this list is `useSWRInfinite`-backed,
             // and `useRemoveWork`'s global refresh skips `$inf$` keys, so without
-            // it a removed orphan card lingers until a page reload (LOBE-13961).
+            // it a removed orphan card lingers until a page reload.
             <WorkPreviewCard item={item} key={item.id} onOpen={openWork} onRemoved={reload} />
           ))}
         </div>

--- a/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNodeMenuButton.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNodeMenuButton.tsx
@@ -17,8 +17,8 @@ interface HierarchyNodeMenuButtonProps {
 
 /**
  * Hover-revealed "..." on a tree row that opens the row's action menu. The
- * menu used to be reachable only through `onContextMenu`, which nobody finds
- * (LOBE-13884). Shares the `.hierarchy-node-actions` reveal rules with the
+ * menu used to be reachable only through `onContextMenu`, which nobody finds.
+ * Shares the `.hierarchy-node-actions` reveal rules with the
  * folder "+" (see styles.ts): hidden until hover, and kept visible while open.
  */
 const HierarchyNodeMenuButton = memo<HierarchyNodeMenuButtonProps>(({ menuItems }) => {

--- a/src/features/Work/useRemoveWork.ts
+++ b/src/features/Work/useRemoveWork.ts
@@ -8,7 +8,7 @@ import { workService } from '@/services/work';
 /**
  * User-initiated removal of a Work card. Intended for orphaned Works (the
  * backing task / document is gone, so the user cannot clear the card by
- * deleting the resource itself — see LOBE-13917). Confirms first because the
+ * deleting the resource itself). Confirms first because the
  * delete cascades the Work's version history and any project pins.
  */
 export interface UseRemoveWorkOptions {

--- a/src/store/tree/actions.test.ts
+++ b/src/store/tree/actions.test.ts
@@ -614,7 +614,7 @@ describe('sortTreeItems', () => {
     toTreeItem({ createdAt, fileType: 'custom/document', id, name });
 
   it('puts a just-created page first instead of dropping it into the A-Z list', () => {
-    // LOBE-13814: creating a page inside a folder full of "<name> 周报 — 2026-Wxx"
+    // creating a page inside a folder full of "<name> 周报 — 2026-Wxx"
     // rows landed the new "Untitled" between "TC" and "xiaojie".
     const rows = [
       doc('report-tc', 'TC 周报 — 2026-W35', '2026-08-28T02:00:00.000Z'),


### PR DESCRIPTION
## Summary

Daily scan of the `canary` branch for `LOBE-XXX` markers left in code comments. This PR removes the numeric markers while keeping the surrounding context intact, since the project is open source and the markers should not remain in the codebase.

Each marker was cross-referenced against its Linear issue and the explanatory scenario was already written inline, so only the `LOBE-XXX` reference itself is dropped. No code semantics changed.

## Changed files

```
apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
apps/server/src/services/bot/__tests__/AgentBridgeService.test.ts
apps/server/src/services/bot/__tests__/replyTemplate.test.ts
src/features/AgentTasks/AgentTaskDetail/TaskAcceptanceStateRow.tsx
src/features/AgentTasks/AgentTaskDetail/useOpenAcceptanceInPanel.test.ts
src/features/AgentTasks/AgentTaskDetail/useOpenAcceptanceInPanel.ts
src/features/EditorCanvas/InternalEditor.tsx
src/features/PageEditor/DocumentComments/styles.ts
src/features/ResourceHome/Home/RecentWorks.test.tsx
src/features/ResourceHome/Home/RecentWorks.tsx
src/features/ResourceManager/components/LibraryHierarchy/HierarchyNodeMenuButton.tsx
src/features/Work/useRemoveWork.ts
src/store/tree/actions.test.ts
```

## Notes

- Preserved: i18n user-facing strings (e.g. "Used as the task prefix, for example LOBE-123.") and the `LOBE-321` task-identifier test fixture in `apps/cli/src/commands/task.test.ts`, which are legitimate content rather than code comments.