### PR TITLE
🐛 fix(goal): recover pipeline failures instead of escalating them to a person

### DIFF
--- a/apps/server/src/services/aiAgent/helpers/heteroErrors.ts
+++ b/apps/server/src/services/aiAgent/helpers/heteroErrors.ts
@@ -9,7 +9,12 @@ import { ChatErrorType, type ErrorType } from '@lobechat/types';
  * caller keeps for non-web surfaces (IM bots) while retaining the raw code in
  * `detail` for diagnostics. Web clients localize via the mapped error type below.
  */
-const HETERO_DISPATCH_ERROR_HEADLINES: Record<string, string> = {
+/**
+ * Exported so a consumer that reads a persisted `task.error` can recognise the same
+ * failure it would have recognised from the raw code: dispatch failures reach storage
+ * as a code on one path and as this headline on another.
+ */
+export const HETERO_DISPATCH_ERROR_HEADLINES: Record<string, string> = {
   DEVICE_CHANNEL_UNAVAILABLE:
     "The device this agent runs on isn't reachable right now — it went offline, went to sleep, or is reconnecting. Check that the LobeHub desktop app (or the `lh` CLI) is running and connected, then try again.",
   DEVICE_GATEWAY_ERROR:

--- a/apps/server/src/services/goal/decideNextMove.test.ts
+++ b/apps/server/src/services/goal/decideNextMove.test.ts
@@ -10,6 +10,7 @@ import {
   needsBudget,
   needsMetricCriteria,
   selectFrontier,
+  VERIFICATION_ERRORED_ERROR,
   VERIFICATION_FAILED_ERROR,
 } from './decideNextMove';
 
@@ -176,6 +177,17 @@ describe('decideNextMove', () => {
           frontierTask: task({ error: VERIFICATION_FAILED_ERROR, status: 'paused' }),
         }).branch,
       ).toBe('recover_verification');
+
+      // A verifier that crashed never judged the delivery, so it recovers like a
+      // rejection instead of stopping the goal on a verdict nobody reached.
+      expect(
+        decide(snapshot, {
+          frontierTask: task({ error: VERIFICATION_ERRORED_ERROR, status: 'paused' }),
+        }),
+      ).toMatchObject({
+        branch: 'recover_verification',
+        message: 'Verification could not run for Task T-1',
+      });
 
       expect(
         decide(snapshot, { frontierTask: task({ error: 'Device offline', status: 'failed' }) }),

--- a/apps/server/src/services/goal/decideNextMove.ts
+++ b/apps/server/src/services/goal/decideNextMove.ts
@@ -5,7 +5,12 @@ import type {
   GoalTickBranch,
   GoalTickOutcome,
 } from '@lobechat/agent-tracing';
-import { GOAL_ACCEPTANCE_TASK_TITLE } from '@lobechat/const/goal';
+import {
+  GOAL_ACCEPTANCE_TASK_TITLE,
+  LEASE_EXPIRED_ERROR,
+  VERIFICATION_ERRORED_ERROR,
+  VERIFICATION_FAILED_ERROR,
+} from '@lobechat/const/goal';
 import type {
   GoalGraphNode,
   GoalGraphSnapshot,
@@ -17,8 +22,7 @@ import { toMetricScale } from '@lobechat/types';
 export { GOAL_ACCEPTANCE_TASK_TITLE } from '@lobechat/const/goal';
 
 /** Reason strings the recovery paths key off, written by the settle path. */
-export const LEASE_EXPIRED_ERROR = 'Goal Task operation lease expired.';
-export const VERIFICATION_FAILED_ERROR = 'Delivery did not pass verification.';
+export { LEASE_EXPIRED_ERROR, VERIFICATION_ERRORED_ERROR, VERIFICATION_FAILED_ERROR };
 
 export const TERMINAL_NODE_STATUSES = new Set(['resolved', 'rejected', 'retired']);
 
@@ -89,7 +93,11 @@ export const needsBudget = (task?: TaskItem | null): boolean => {
   if (task === null) return false;
   // A failure the coordinator can retry spends money too.
   if (task.status === 'paused') {
-    return task.error === LEASE_EXPIRED_ERROR || task.error === VERIFICATION_FAILED_ERROR;
+    return (
+      task.error === LEASE_EXPIRED_ERROR ||
+      task.error === VERIFICATION_FAILED_ERROR ||
+      task.error === VERIFICATION_ERRORED_ERROR
+    );
   }
   return !['completed', 'failed', 'canceled', 'running', 'scheduled'].includes(task.status);
 };
@@ -508,7 +516,9 @@ const decideForTask = (
     if (
       budget?.deadlinePassed &&
       task.status === 'paused' &&
-      (task.error === LEASE_EXPIRED_ERROR || task.error === VERIFICATION_FAILED_ERROR)
+      (task.error === LEASE_EXPIRED_ERROR ||
+        task.error === VERIFICATION_FAILED_ERROR ||
+        task.error === VERIFICATION_ERRORED_ERROR)
     ) {
       return {
         ...base,
@@ -526,12 +536,22 @@ const decideForTask = (
         outcome: 'waiting_external',
       };
     }
-    if (task.status === 'paused' && task.error === VERIFICATION_FAILED_ERROR) {
+    // A verifier that could not run never evaluated the delivery, so it is an
+    // infrastructure failure rather than a verdict. It recovers the same way a
+    // rejection does; without a branch it fell through to the human gate, which
+    // stopped the goal on a failure nobody needed to judge.
+    if (
+      task.status === 'paused' &&
+      (task.error === VERIFICATION_FAILED_ERROR || task.error === VERIFICATION_ERRORED_ERROR)
+    ) {
       if (!capacity) return 'needs-capacity';
       return {
         ...base,
         branch: 'recover_verification',
-        message: `Task ${task.identifier} did not pass verification`,
+        message:
+          task.error === VERIFICATION_ERRORED_ERROR
+            ? `Verification could not run for Task ${task.identifier}`
+            : `Task ${task.identifier} did not pass verification`,
         outcome: 'waiting_external',
       };
     }

--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -433,6 +433,34 @@ describe('GoalService', () => {
     expect((await taskModel.findById(created.taskId!))?.status).toBe(settledAs);
   });
 
+  it('does not restart a Task a person paused themselves', async () => {
+    const runSpy = vi.spyOn(TaskRunnerService.prototype, 'runTask').mockResolvedValue({} as never);
+    const service = new GoalService(serverDB, userId);
+    const taskModel = new TaskModel(serverDB, userId);
+    const graph = await service.create({
+      title: 'Actor paused during recovery',
+      tasks: ['Do not restart'],
+    });
+    const created = await service.tick(graph.goal.id);
+    await taskModel.updateStatus(created.taskId!, 'paused', { error: VERIFICATION_ERRORED_ERROR });
+    // A manual round trip keeps the routing error, because the status update replaces
+    // it only when a new one is supplied, so the final pause is the person's.
+    const taskService = new TaskService(serverDB, userId);
+    await taskService.updateStatus({ id: created.taskId!, status: 'failed' }, { userId });
+    await taskService.updateStatus({ id: created.taskId!, status: 'paused' }, { userId });
+    const stale = (await taskModel.findById(created.taskId!))!;
+    runSpy.mockClear();
+
+    const recovery = await new TaskRecoveryCoordinator(serverDB, userId).recover({
+      goal: (await service.graph(graph.goal.id)).goal,
+      task: stale,
+    });
+
+    expect(recovery.outcome).toBe('settled');
+    expect(runSpy).not.toHaveBeenCalled();
+    expect((await taskModel.findById(created.taskId!))?.status).toBe('paused');
+  });
+
   it('hands back a dispatch claim whose worker died before the run existed', async () => {
     // The claim is taken just before `runTask` creates the topic. If the worker
     // dies in that sliver the task is `running` with no operation to reclaim,

--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -402,36 +402,36 @@ describe('GoalService', () => {
     },
   );
 
-  it.each([LEASE_EXPIRED_ERROR, VERIFICATION_ERRORED_ERROR])(
-    'does not restart a Task settled while recovery for %s was being decided',
-    async (error) => {
-      const runSpy = vi
-        .spyOn(TaskRunnerService.prototype, 'runTask')
-        .mockResolvedValue({} as never);
-      const service = new GoalService(serverDB, userId);
-      const taskModel = new TaskModel(serverDB, userId);
-      const graph = await service.create({
-        title: `Settled during recovery ${error}`,
-        tasks: ['Do not restart'],
-      });
-      const created = await service.tick(graph.goal.id);
-      await taskModel.updateStatus(created.taskId!, 'paused', { error });
-      // The advance routed here holding the paused row; a person settled the Task
-      // before the claim, which is the row the coordinator now reads.
-      const stale = (await taskModel.findById(created.taskId!))!;
-      await taskModel.updateStatus(created.taskId!, 'completed', { error: null });
-      runSpy.mockClear();
+  it.each([
+    [LEASE_EXPIRED_ERROR, 'completed'],
+    [LEASE_EXPIRED_ERROR, 'failed'],
+    [VERIFICATION_ERRORED_ERROR, 'completed'],
+    [VERIFICATION_ERRORED_ERROR, 'canceled'],
+  ])('does not restart a Task settled during recovery (%s → %s)', async (error, settledAs) => {
+    const runSpy = vi.spyOn(TaskRunnerService.prototype, 'runTask').mockResolvedValue({} as never);
+    const service = new GoalService(serverDB, userId);
+    const taskModel = new TaskModel(serverDB, userId);
+    const graph = await service.create({
+      title: `Settled during recovery ${error} ${settledAs}`,
+      tasks: ['Do not restart'],
+    });
+    const created = await service.tick(graph.goal.id);
+    await taskModel.updateStatus(created.taskId!, 'paused', { error });
+    // The advance routed here holding the paused row; a person settled the Task
+    // before the claim, which is the row the coordinator now reads.
+    const stale = (await taskModel.findById(created.taskId!))!;
+    await taskModel.updateStatus(created.taskId!, settledAs, { error: null });
+    runSpy.mockClear();
 
-      const recovery = await new TaskRecoveryCoordinator(serverDB, userId).recover({
-        goal: (await service.graph(graph.goal.id)).goal,
-        task: stale,
-      });
+    const recovery = await new TaskRecoveryCoordinator(serverDB, userId).recover({
+      goal: (await service.graph(graph.goal.id)).goal,
+      task: stale,
+    });
 
-      expect(recovery.outcome).toBe('settled');
-      expect(runSpy).not.toHaveBeenCalled();
-      expect((await taskModel.findById(created.taskId!))?.status).toBe('completed');
-    },
-  );
+    expect(recovery.outcome).toBe('settled');
+    expect(runSpy).not.toHaveBeenCalled();
+    expect((await taskModel.findById(created.taskId!))?.status).toBe(settledAs);
+  });
 
   it('hands back a dispatch claim whose worker died before the run existed', async () => {
     // The claim is taken just before `runTask` creates the topic. If the worker

--- a/apps/server/src/services/goal/index.test.ts
+++ b/apps/server/src/services/goal/index.test.ts
@@ -35,10 +35,15 @@ import { TaskService } from '../task';
 import { TaskRunnerService } from '../taskRunner';
 import { VerifyPlanGeneratorService } from '../verify/planGenerator';
 import { GoalCriteriaGeneratorService } from './criteriaGenerator';
-import { LEASE_EXPIRED_ERROR, VERIFICATION_FAILED_ERROR } from './decideNextMove';
+import {
+  LEASE_EXPIRED_ERROR,
+  VERIFICATION_ERRORED_ERROR,
+  VERIFICATION_FAILED_ERROR,
+} from './decideNextMove';
 import { GoalExplorationPlanner } from './explorationPlanner';
 import { GoalService } from './index';
 import { VERIFY_SETTLE_GRACE_MS } from './recoveryPolicy';
+import { TaskRecoveryCoordinator } from './taskRecoveryCoordinator';
 import type { GoalTickObservation } from './traceObservation';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -394,6 +399,37 @@ describe('GoalService', () => {
       expect(runSpy).not.toHaveBeenCalled();
       expect(stopped).toMatchObject({ outcome: 'no_progress' });
       expect(stopped.message).toContain('Deadline passed');
+    },
+  );
+
+  it.each([LEASE_EXPIRED_ERROR, VERIFICATION_ERRORED_ERROR])(
+    'does not restart a Task settled while recovery for %s was being decided',
+    async (error) => {
+      const runSpy = vi
+        .spyOn(TaskRunnerService.prototype, 'runTask')
+        .mockResolvedValue({} as never);
+      const service = new GoalService(serverDB, userId);
+      const taskModel = new TaskModel(serverDB, userId);
+      const graph = await service.create({
+        title: `Settled during recovery ${error}`,
+        tasks: ['Do not restart'],
+      });
+      const created = await service.tick(graph.goal.id);
+      await taskModel.updateStatus(created.taskId!, 'paused', { error });
+      // The advance routed here holding the paused row; a person settled the Task
+      // before the claim, which is the row the coordinator now reads.
+      const stale = (await taskModel.findById(created.taskId!))!;
+      await taskModel.updateStatus(created.taskId!, 'completed', { error: null });
+      runSpy.mockClear();
+
+      const recovery = await new TaskRecoveryCoordinator(serverDB, userId).recover({
+        goal: (await service.graph(graph.goal.id)).goal,
+        task: stale,
+      });
+
+      expect(recovery.outcome).toBe('settled');
+      expect(runSpy).not.toHaveBeenCalled();
+      expect((await taskModel.findById(created.taskId!))?.status).toBe('completed');
     },
   );
 

--- a/apps/server/src/services/goal/index.ts
+++ b/apps/server/src/services/goal/index.ts
@@ -62,6 +62,7 @@ import {
   VERIFY_SETTLE_GRACE_MS,
 } from './recoveryPolicy';
 import { GoalSupervisorService } from './supervisor';
+import { claimGoalTask } from './taskClaim';
 import { TaskRecoveryCoordinator } from './taskRecoveryCoordinator';
 import {
   type GoalTickOptions,
@@ -1790,12 +1791,10 @@ export class GoalService {
       ).countRunningTasks(goalId);
       if (inFlight >= resolveMaxConcurrentTasks(graph.goal)) return 'at-capacity' as const;
 
-      return new TaskModel(tx, this.userId, this.workspaceId).updateStatusIfCurrent(
-        task.id,
-        task.status,
-        'running',
-        { error: null, startedAt: new Date() },
-      );
+      return claimGoalTask(new TaskModel(tx, this.userId, this.workspaceId), task, 'running', {
+        error: null,
+        startedAt: new Date(),
+      });
     });
 
     if (claimed === 'stopped')

--- a/apps/server/src/services/goal/index.ts
+++ b/apps/server/src/services/goal/index.ts
@@ -1715,6 +1715,17 @@ export class GoalService {
       };
     }
 
+    // Nothing failed: somebody settled the Task while this advance was deciding.
+    // Opening a gate would ask them to judge their own decision.
+    if (recovery.outcome === 'settled') {
+      return {
+        goalId: graph.goal.id,
+        message: `Task ${task.identifier} was settled while recovery was being decided`,
+        nodeId,
+        outcome: 'no_progress',
+        taskId: task.id,
+      };
+    }
     const exhaustedReason =
       recovery.outcome === 'exhausted-cost'
         ? 'Goal cost budget was exhausted'
@@ -1996,6 +2007,17 @@ export class GoalService {
       };
     }
 
+    // Nothing failed: somebody settled the Task while this advance was deciding.
+    // Opening a gate would ask them to judge their own decision.
+    if (recovery.outcome === 'settled') {
+      return {
+        goalId: graph.goal.id,
+        message: `Task ${task.identifier} was settled while recovery was being decided`,
+        nodeId,
+        outcome: 'no_progress',
+        taskId: task.id,
+      };
+    }
     const reason =
       recovery.outcome === 'exhausted-cost'
         ? 'Goal cost budget was exhausted after an operation was abandoned'

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -121,7 +121,10 @@ const failedGoal = async (enabled = true, error = 'fetch failed: ECONNRESET') =>
  * dropped, or verification could not run. The Task is left `paused`, not `failed`,
  * and its operation is `done`, not `error`.
  */
-const pipelineFailureGoal = async (error = 'Device offline', withRun = true) => {
+const pipelineFailureGoal = async (
+  error = '{"error":"DEVICE_OFFLINE","success":false}',
+  withRun = true,
+) => {
   const graph = await service().create({
     config: { supervision: { enabled: true } },
     tasks: ['Finish existing report'],

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -525,6 +525,28 @@ describe('Goal Supervisor integration', () => {
     expect((await taskModel.findById(taskId))?.status).toBe('failed');
   });
 
+  it('escalates a diagnosis persisted before the opening status was recorded', async () => {
+    const { goalId, taskId } = await pipelineFailureGoal();
+    expect((await service().tick(goalId)).outcome).toBe('waiting_external');
+    await diagnose(goalId);
+    // A rolling deploy leaves incidents from the previous version with no record of
+    // what they opened on, so they cannot prove the row is still theirs to claim.
+    const state = (await goalModel.findById(goalId))!.config!.supervisorState!;
+    await goalModel.updateSupervisorState(goalId, state.revision, {
+      ...state,
+      incidents: state.incidents.map(({ taskStatus: _drop, ...rest }) => rest),
+    });
+    expect(
+      (await goalModel.findById(goalId))!.config!.supervisorState!.incidents.at(-1)?.taskStatus,
+    ).toBeUndefined();
+
+    await service().tick(goalId);
+
+    expect((await taskModel.findById(taskId))?.status).toBe('paused');
+    const after = (await goalModel.findById(goalId))!.config!.supervisorState!;
+    expect(after.incidents.at(-1)?.status).toBe('escalated');
+  });
+
   it('without supervision the same transport failure opens a human Gate', async () => {
     const { goalId } = await failedGoal(false);
     expect((await service().tick(goalId)).outcome).toBe('waiting_human');

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -499,6 +499,16 @@ describe('Goal Supervisor integration', () => {
     expect(graph.goal.config?.supervisorState?.incidents.at(-1)?.status).not.toBe('escalated');
   });
 
+  it('does not overwrite a completion a person recorded during the diagnosis', async () => {
+    const { goalId, taskId } = await pipelineFailureGoal();
+    expect((await service().tick(goalId)).outcome).toBe('waiting_external');
+    await diagnose(goalId);
+    // The person settled the Task while the supervisor was still deciding.
+    await taskModel.update(taskId, { status: 'completed', error: null });
+    await service().tick(goalId);
+    expect((await taskModel.findById(taskId))?.status).toBe('completed');
+  });
+
   it('without supervision the same transport failure opens a human Gate', async () => {
     const { goalId } = await failedGoal(false);
     expect((await service().tick(goalId)).outcome).toBe('waiting_human');

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -26,6 +26,7 @@ import {
   users,
 } from '@/database/schemas';
 import { AiAgentService } from '@/server/services/aiAgent';
+import { TaskService } from '@/server/services/task';
 import { TaskRunnerService } from '@/server/services/taskRunner';
 
 import { GoalService } from '../index';
@@ -545,6 +546,20 @@ describe('Goal Supervisor integration', () => {
     expect((await taskModel.findById(taskId))?.status).toBe('paused');
     const after = (await goalModel.findById(goalId))!.config!.supervisorState!;
     expect(after.incidents.at(-1)?.status).toBe('escalated');
+  });
+
+  it('leaves a paused transport failure alone once a person marks it failed', async () => {
+    // The run errored with a recoverable transport error and the lifecycle paused the
+    // Task. A person then marks it failed without supplying a new error, so the
+    // transport text survives and only the transition's author tells them apart.
+    const { goalId, taskId } = await failedGoal();
+    await taskModel.update(taskId, { status: 'paused' });
+    await new TaskService(db, userId).updateStatus({ id: taskId, status: 'failed' }, { userId });
+
+    const move = await service().tick(goalId);
+
+    expect((await taskModel.findById(taskId))?.status).toBe('failed');
+    expect(move.outcome).not.toBe('waiting_external');
   });
 
   it('without supervision the same transport failure opens a human Gate', async () => {

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -512,6 +512,19 @@ describe('Goal Supervisor integration', () => {
     expect((await taskModel.findById(taskId))?.status).toBe('completed');
   });
 
+  it('loses the claim when the Task moved to another recoverable state mid-diagnosis', async () => {
+    // Routed as `paused`; a person then marks it `failed` without supplying a new
+    // error, so the run's transport reason survives and the policy still accepts it.
+    // Only claiming against the status the incident was opened on keeps this decision.
+    const { goalId, taskId } = await failedGoal(true, '{"error":"DEVICE_OFFLINE","success":false}');
+    await taskModel.update(taskId, { status: 'paused' });
+    expect((await service().tick(goalId)).outcome).toBe('waiting_external');
+    await diagnose(goalId);
+    await taskModel.update(taskId, { status: 'failed' });
+    await service().tick(goalId);
+    expect((await taskModel.findById(taskId))?.status).toBe('failed');
+  });
+
   it('without supervision the same transport failure opens a human Gate', async () => {
     const { goalId } = await failedGoal(false);
     expect((await service().tick(goalId)).outcome).toBe('waiting_human');

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -499,16 +499,6 @@ describe('Goal Supervisor integration', () => {
     expect(graph.goal.config?.supervisorState?.incidents.at(-1)?.status).not.toBe('escalated');
   });
 
-  it('supervises a dispatch that failed before it ever wrote a run', async () => {
-    const { goalId } = await pipelineFailureGoal('Kickoff failed before dispatch', false);
-    expect((await service().tick(goalId)).outcome).toBe('waiting_external');
-    const graph = await service().graph(goalId);
-    expect(graph.decisions).toHaveLength(0);
-    const incident = graph.goal.config?.supervisorState?.incidents.at(-1);
-    expect(incident?.eligible).toBe(true);
-    expect(incident?.failedOperationId).toMatch(/^dispatch:/);
-  });
-
   it('without supervision the same transport failure opens a human Gate', async () => {
     const { goalId } = await failedGoal(false);
     expect((await service().tick(goalId)).outcome).toBe('waiting_human');

--- a/apps/server/src/services/goal/supervisor/index.test.ts
+++ b/apps/server/src/services/goal/supervisor/index.test.ts
@@ -116,6 +116,36 @@ const failedGoal = async (enabled = true, error = 'fetch failed: ECONNRESET') =>
   return { goalId: graph.goal.id, nodeId: created.nodeId!, operationId, taskId };
 };
 
+/**
+ * The run itself settled cleanly and something around it broke: the device link
+ * dropped, or verification could not run. The Task is left `paused`, not `failed`,
+ * and its operation is `done`, not `error`.
+ */
+const pipelineFailureGoal = async (error = 'Device offline', withRun = true) => {
+  const graph = await service().create({
+    config: { supervision: { enabled: true } },
+    tasks: ['Finish existing report'],
+    title: 'Interrupted delivery',
+  });
+  const created = await service().tick(graph.goal.id);
+  const taskId = created.taskId!;
+  if (withRun) {
+    const topicId = `topic-pipeline-${++sequence}`;
+    const operationId = `op-pipeline-${sequence}`;
+    await db.insert(topics).values({ id: topicId, userId });
+    await operationModel.recordStart({ operationId, taskId, topicId });
+    await operationModel.recordCompletion(operationId, {
+      completionReason: 'done',
+      status: 'done',
+    });
+    await db
+      .insert(taskTopics)
+      .values({ operationId, seq: 1, status: 'completed', taskId, topicId, userId });
+  }
+  await taskModel.update(taskId, { status: 'paused', error, totalTopics: withRun ? 1 : 0 });
+  return { goalId: graph.goal.id, taskId };
+};
+
 const diagnose = async (goalId: string, action = 'retry') => {
   const state = (await goalModel.findById(goalId))!.config!.supervisorState!;
   const incident = state.incidents.at(-1)!;
@@ -454,6 +484,29 @@ describe('Goal Supervisor integration', () => {
     expect((await goalModel.findById(goalId))?.config?.supervisorState?.incidents[0]).toMatchObject(
       { recoveryOperationId: operationId, status: 'recovered' },
     );
+  });
+
+  it('recovers a paused pipeline failure instead of leaving it on the human Gate', async () => {
+    const { goalId, taskId } = await pipelineFailureGoal();
+    expect((await service().tick(goalId)).outcome).toBe('waiting_external');
+    expect((await service().graph(goalId)).decisions).toHaveLength(0);
+    await diagnose(goalId);
+    expect((await service().tick(goalId)).outcome).toBe('advanced');
+    // The Task holds `paused`, so a recovery that only accepted `failed` would
+    // silently do nothing here and escalate the incident.
+    expect((await taskModel.findById(taskId))?.status).toBe('backlog');
+    const graph = await service().graph(goalId);
+    expect(graph.goal.config?.supervisorState?.incidents.at(-1)?.status).not.toBe('escalated');
+  });
+
+  it('supervises a dispatch that failed before it ever wrote a run', async () => {
+    const { goalId } = await pipelineFailureGoal('Kickoff failed before dispatch', false);
+    expect((await service().tick(goalId)).outcome).toBe('waiting_external');
+    const graph = await service().graph(goalId);
+    expect(graph.decisions).toHaveLength(0);
+    const incident = graph.goal.config?.supervisorState?.incidents.at(-1);
+    expect(incident?.eligible).toBe(true);
+    expect(incident?.failedOperationId).toMatch(/^dispatch:/);
   });
 
   it('without supervision the same transport failure opens a human Gate', async () => {

--- a/apps/server/src/services/goal/supervisor/index.ts
+++ b/apps/server/src/services/goal/supervisor/index.ts
@@ -332,11 +332,16 @@ export class GoalSupervisorService {
       // opened on. Re-reading first and comparing against that would swap whatever
       // the person chose in the meantime.
       if (!RECOVERABLE_TASK_STATUSES.has(currentTask.status)) return false;
+      // An incident persisted before this field existed cannot say what it opened
+      // on, so it cannot show the row is unchanged. Claiming against a later read
+      // would restore the race this closes; a rolling deploy leaves at most the
+      // handful mid-diagnosis, and they escalate rather than retry silently.
+      if (!ownIncident.taskStatus) return false;
       const changed = await claimGoalTask(
         new TaskModel(tx, this.userId, this.workspaceId),
         // The status this incident opened on, so anything a person did across the
         // whole diagnosis wins the race rather than only a change since this tick.
-        { id: task.id, status: ownIncident.taskStatus ?? currentTask.status },
+        { id: task.id, status: ownIncident.taskStatus },
         'backlog',
         { error: null },
       );

--- a/apps/server/src/services/goal/supervisor/index.ts
+++ b/apps/server/src/services/goal/supervisor/index.ts
@@ -21,12 +21,7 @@ import { AiAgentService } from '@/server/services/aiAgent';
 
 import { resolveGoalModelConfig } from '../modelConfig';
 import { scheduleGoalAdvance } from '../scheduler';
-import {
-  dispatchFailureKey,
-  recoveryEligibility,
-  supervisionLimit,
-  SUPERVISOR_DIAGNOSIS_TIMEOUT_MS,
-} from './policy';
+import { recoveryEligibility, supervisionLimit, SUPERVISOR_DIAGNOSIS_TIMEOUT_MS } from './policy';
 
 /** Durable supervisor with a dedicated, incident-scoped tool set. */
 export class GoalSupervisorService {
@@ -133,15 +128,13 @@ export class GoalSupervisorService {
       task.id,
     );
     const latest = runs[0];
-    // A kickoff that threw before writing a run has no operation to key on, yet it
-    // is the failure least in need of a person. Fall back to a per-attempt key so
-    // the incident is still recorded, deduplicated and budgeted.
-    const failureKey = latest?.operationId ?? dispatchFailureKey(task);
-    const failedOperation = latest?.operationId
-      ? await operations.findById(latest.operationId)
-      : undefined;
+    // A kickoff that threw before writing a run has no operation to key an incident on,
+    // and settlement is anchored on that run's sequence. Supervising it needs incident
+    // identity and settlement redesigned, so it still reaches a person for now.
+    if (!latest?.operationId) return null;
+    const failedOperation = await operations.findById(latest.operationId);
     const state = graph.goal.config.supervisorState ?? (await this.initialize(graph));
-    let incident = state.incidents.find((item) => item.failedOperationId === failureKey);
+    let incident = state.incidents.find((item) => item.failedOperationId === latest.operationId);
     if (!incident) {
       if (state.incidents.some((item) => item.status === 'diagnosing'))
         return waiting('Another interruption is being diagnosed');
@@ -166,8 +159,8 @@ export class GoalSupervisorService {
       incident = {
         createdAt: new Date().toISOString(),
         eligible: eligibility.eligible,
-        failedOperationId: failureKey,
-        id: failureKey,
+        failedOperationId: latest.operationId,
+        id: latest.operationId,
         nodeId,
         reason: eligibility.reason,
         status: eligibility.eligible ? 'diagnosing' : 'escalated',
@@ -321,8 +314,7 @@ export class GoalSupervisorService {
         !currentGraph ||
         !currentTask ||
         ownIncident?.status !== 'diagnosing' ||
-        (currentRuns[0]?.operationId ?? dispatchFailureKey(currentTask)) !==
-          incident.failedOperationId ||
+        currentRuns[0]?.operationId !== incident.failedOperationId ||
         !recoveryEligibility(currentGraph, currentTask, failedOperation).eligible ||
         (await new GoalSupervisorService(tx, this.userId, this.workspaceId).budgetBlocked(
           currentGraph,

--- a/apps/server/src/services/goal/supervisor/index.ts
+++ b/apps/server/src/services/goal/supervisor/index.ts
@@ -21,6 +21,7 @@ import { AiAgentService } from '@/server/services/aiAgent';
 
 import { resolveGoalModelConfig } from '../modelConfig';
 import { scheduleGoalAdvance } from '../scheduler';
+import { claimGoalTask } from '../taskClaim';
 import {
   RECOVERABLE_TASK_STATUSES,
   recoveryEligibility,
@@ -170,6 +171,7 @@ export class GoalSupervisorService {
         reason: eligibility.reason,
         status: eligibility.eligible ? 'diagnosing' : 'escalated',
         taskId: task.id,
+        taskStatus: task.status,
       };
       const claimed = await new GoalModel(
         this.db,
@@ -326,14 +328,15 @@ export class GoalSupervisorService {
         ))
       )
         return false;
-      // Compare against the status this Task actually holds, because a pipeline
-      // failure leaves it `paused` and a fixed `failed` expectation would never
-      // match. Guard the set first: a completion recorded during the diagnosis must
-      // never be swapped back to `backlog` and rerun.
+      // A diagnosis takes minutes, so claim against the status the incident was
+      // opened on. Re-reading first and comparing against that would swap whatever
+      // the person chose in the meantime.
       if (!RECOVERABLE_TASK_STATUSES.has(currentTask.status)) return false;
-      const changed = await new TaskModel(tx, this.userId, this.workspaceId).updateStatusIfCurrent(
-        task.id,
-        currentTask.status,
+      const changed = await claimGoalTask(
+        new TaskModel(tx, this.userId, this.workspaceId),
+        // The status this incident opened on, so anything a person did across the
+        // whole diagnosis wins the race rather than only a change since this tick.
+        { id: task.id, status: ownIncident.taskStatus ?? currentTask.status },
         'backlog',
         { error: null },
       );

--- a/apps/server/src/services/goal/supervisor/index.ts
+++ b/apps/server/src/services/goal/supervisor/index.ts
@@ -21,7 +21,12 @@ import { AiAgentService } from '@/server/services/aiAgent';
 
 import { resolveGoalModelConfig } from '../modelConfig';
 import { scheduleGoalAdvance } from '../scheduler';
-import { recoveryEligibility, supervisionLimit, SUPERVISOR_DIAGNOSIS_TIMEOUT_MS } from './policy';
+import {
+  RECOVERABLE_TASK_STATUSES,
+  recoveryEligibility,
+  supervisionLimit,
+  SUPERVISOR_DIAGNOSIS_TIMEOUT_MS,
+} from './policy';
 
 /** Durable supervisor with a dedicated, incident-scoped tool set. */
 export class GoalSupervisorService {
@@ -321,9 +326,11 @@ export class GoalSupervisorService {
         ))
       )
         return false;
-      // Compare against the status this Task actually holds. A pipeline failure
-      // leaves it `paused`, so a fixed `failed` expectation would never match and
-      // every recovery would silently fall back to the human gate.
+      // Compare against the status this Task actually holds, because a pipeline
+      // failure leaves it `paused` and a fixed `failed` expectation would never
+      // match. Guard the set first: a completion recorded during the diagnosis must
+      // never be swapped back to `backlog` and rerun.
+      if (!RECOVERABLE_TASK_STATUSES.has(currentTask.status)) return false;
       const changed = await new TaskModel(tx, this.userId, this.workspaceId).updateStatusIfCurrent(
         task.id,
         currentTask.status,

--- a/apps/server/src/services/goal/supervisor/index.ts
+++ b/apps/server/src/services/goal/supervisor/index.ts
@@ -21,7 +21,12 @@ import { AiAgentService } from '@/server/services/aiAgent';
 
 import { resolveGoalModelConfig } from '../modelConfig';
 import { scheduleGoalAdvance } from '../scheduler';
-import { recoveryEligibility, supervisionLimit, SUPERVISOR_DIAGNOSIS_TIMEOUT_MS } from './policy';
+import {
+  dispatchFailureKey,
+  recoveryEligibility,
+  supervisionLimit,
+  SUPERVISOR_DIAGNOSIS_TIMEOUT_MS,
+} from './policy';
 
 /** Durable supervisor with a dedicated, incident-scoped tool set. */
 export class GoalSupervisorService {
@@ -128,10 +133,15 @@ export class GoalSupervisorService {
       task.id,
     );
     const latest = runs[0];
-    if (!latest?.operationId) return null;
-    const failedOperation = await operations.findById(latest.operationId);
+    // A kickoff that threw before writing a run has no operation to key on, yet it
+    // is the failure least in need of a person. Fall back to a per-attempt key so
+    // the incident is still recorded, deduplicated and budgeted.
+    const failureKey = latest?.operationId ?? dispatchFailureKey(task);
+    const failedOperation = latest?.operationId
+      ? await operations.findById(latest.operationId)
+      : undefined;
     const state = graph.goal.config.supervisorState ?? (await this.initialize(graph));
-    let incident = state.incidents.find((item) => item.failedOperationId === latest.operationId);
+    let incident = state.incidents.find((item) => item.failedOperationId === failureKey);
     if (!incident) {
       if (state.incidents.some((item) => item.status === 'diagnosing'))
         return waiting('Another interruption is being diagnosed');
@@ -156,8 +166,8 @@ export class GoalSupervisorService {
       incident = {
         createdAt: new Date().toISOString(),
         eligible: eligibility.eligible,
-        failedOperationId: latest.operationId,
-        id: latest.operationId,
+        failedOperationId: failureKey,
+        id: failureKey,
         nodeId,
         reason: eligibility.reason,
         status: eligibility.eligible ? 'diagnosing' : 'escalated',
@@ -311,16 +321,20 @@ export class GoalSupervisorService {
         !currentGraph ||
         !currentTask ||
         ownIncident?.status !== 'diagnosing' ||
-        currentRuns[0]?.operationId !== incident.failedOperationId ||
+        (currentRuns[0]?.operationId ?? dispatchFailureKey(currentTask)) !==
+          incident.failedOperationId ||
         !recoveryEligibility(currentGraph, currentTask, failedOperation).eligible ||
         (await new GoalSupervisorService(tx, this.userId, this.workspaceId).budgetBlocked(
           currentGraph,
         ))
       )
         return false;
+      // Compare against the status this Task actually holds. A pipeline failure
+      // leaves it `paused`, so a fixed `failed` expectation would never match and
+      // every recovery would silently fall back to the human gate.
       const changed = await new TaskModel(tx, this.userId, this.workspaceId).updateStatusIfCurrent(
         task.id,
-        'failed',
+        currentTask.status,
         'backlog',
         { error: null },
       );

--- a/apps/server/src/services/goal/supervisor/index.ts
+++ b/apps/server/src/services/goal/supervisor/index.ts
@@ -25,6 +25,7 @@ import { claimGoalTask } from '../taskClaim';
 import {
   RECOVERABLE_TASK_STATUSES,
   recoveryEligibility,
+  statusAuthoredByActor,
   supervisionLimit,
   SUPERVISOR_DIAGNOSIS_TIMEOUT_MS,
 } from './policy';
@@ -155,7 +156,13 @@ export class GoalSupervisorService {
         }
         return null;
       }
-      let eligibility = recoveryEligibility(graph, task, failedOperation);
+      const taskModel = new TaskModel(this.db, this.userId, this.workspaceId);
+      let eligibility = recoveryEligibility(
+        graph,
+        task,
+        failedOperation,
+        statusAuthoredByActor(await taskModel.getActivities(task.id, 20), task.status),
+      );
       if (eligibility.eligible && (await this.budgetBlocked(graph))) {
         eligibility = {
           eligible: false,
@@ -322,7 +329,15 @@ export class GoalSupervisorService {
         !currentTask ||
         ownIncident?.status !== 'diagnosing' ||
         currentRuns[0]?.operationId !== incident.failedOperationId ||
-        !recoveryEligibility(currentGraph, currentTask, failedOperation).eligible ||
+        !recoveryEligibility(
+          currentGraph,
+          currentTask,
+          failedOperation,
+          statusAuthoredByActor(
+            await new TaskModel(tx, this.userId, this.workspaceId).getActivities(task.id, 20),
+            currentTask.status,
+          ),
+        ).eligible ||
         (await new GoalSupervisorService(tx, this.userId, this.workspaceId).budgetBlocked(
           currentGraph,
         ))

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -76,11 +76,27 @@ describe('supervisor recovery authority', () => {
       ).toBe(true);
   });
 
+  it('reads an errored run as an agent failure even when the Task is left paused', () => {
+    // An ad-hoc run that fails is stored as `paused`, the same shape a pipeline
+    // failure leaves. Reading the Task instead of the operation would route real
+    // agent errors around the transport allowlist.
+    const paused = { ...task, error: 'TypeError: cannot read property', status: 'paused' };
+    const errored = { ...operation, error: { message: 'TypeError: cannot read property' } };
+    expect(recoveryEligibility(graph, paused, errored).eligible).toBe(false);
+    expect(
+      recoveryEligibility(graph, paused, { ...operation, error: { message: 'ECONNRESET' } })
+        .eligible,
+    ).toBe(true);
+  });
+
+  it('never restarts a Task a person already settled', () => {
+    const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
+    for (const status of ['completed', 'canceled', 'running'])
+      expect(recoveryEligibility(graph, { ...task, status }, settled).eligible).toBe(false);
+  });
+
   it('still refuses a pipeline failure that a person or a limit caused', () => {
     const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
-    expect(recoveryEligibility(graph, { ...task, status: 'canceled' }, settled).eligible).toBe(
-      false,
-    );
     expect(
       recoveryEligibility(
         graph,

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -3,6 +3,7 @@ import { summarizeGoalSupervision } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import type { AgentOperationItem } from '@/database/schemas/agentOperations';
+import { humanizeHeteroDispatchError } from '@/server/services/aiAgent/helpers/heteroErrors';
 
 import { recoveryEligibility } from './policy';
 
@@ -64,13 +65,16 @@ describe('supervisor recovery authority', () => {
 
   const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
 
-  it('recovers a dispatch the gateway says never started, without asking a person', () => {
+  it('recovers a dispatch the gateway says never started, in either stored shape', () => {
     // The run finished or never began and the device link broke around it, so there is
-    // no errored operation to read: the gateway code is the only evidence.
+    // no errored operation to read: the dispatch failure is the only evidence. It
+    // reaches storage as a raw code from the coordinator's dispatch and as the
+    // humanized headline once the runtime finalizes it.
     for (const error of [
       '{"error":"DEVICE_OFFLINE","success":false}',
-      'DEVICE_GATEWAY_UNREACHABLE',
       'DEVICE_GATEWAY_RATE_LIMITED',
+      humanizeHeteroDispatchError('DEVICE_OFFLINE'),
+      humanizeHeteroDispatchError('DEVICE_GATEWAY_UNREACHABLE'),
     ])
       expect(
         recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,
@@ -82,6 +86,8 @@ describe('supervisor recovery authority', () => {
       'DEVICE_GATEWAY_UNAUTHORIZED',
       'GATEWAY_NOT_CONFIGURED',
       'DEVICE_RESPONSE_TIMEOUT',
+      humanizeHeteroDispatchError('DEVICE_RESPONSE_TIMEOUT'),
+      humanizeHeteroDispatchError('GATEWAY_NOT_CONFIGURED'),
     ])
       expect(
         recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -105,6 +105,23 @@ describe('supervisor recovery authority', () => {
       recoveryEligibility(graph, { ...task, error: 'Superseded by a newer plan' }, settled)
         .eligible,
     ).toBe(false);
+    // The status update keeps the old error when none is supplied, so an actor can
+    // leave a Task `failed` still carrying the transport reason it was paused with.
+    expect(
+      recoveryEligibility(
+        graph,
+        { ...task, error: '{"error":"DEVICE_OFFLINE","success":false}' },
+        settled,
+      ).eligible,
+    ).toBe(false);
+    // The same text on a `paused` Task is the pipeline failure it looks like.
+    expect(
+      recoveryEligibility(
+        graph,
+        { ...task, error: '{"error":"DEVICE_OFFLINE","success":false}', status: 'paused' },
+        settled,
+      ).eligible,
+    ).toBe(true);
   });
 
   it('reads an errored run as an agent failure even when the Task is left paused', () => {

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -62,18 +62,40 @@ describe('supervisor recovery authority', () => {
     ).toBe(false);
   });
 
-  it('recovers a failure that happened outside the agent run without asking a person', () => {
-    // The run itself finished cleanly; the device link, the dispatch or the verifier
-    // broke around it, so there is no errored operation to pattern-match.
-    const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
+  const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
+
+  it('recovers a dispatch the gateway says never started, without asking a person', () => {
+    // The run finished or never began and the device link broke around it, so there is
+    // no errored operation to read: the gateway code is the only evidence.
     for (const error of [
-      'Verification could not run (internal error); the delivery was not evaluated.',
       '{"error":"DEVICE_OFFLINE","success":false}',
-      'Automatic recovery could not start the next attempt',
+      'DEVICE_GATEWAY_UNREACHABLE',
+      'DEVICE_GATEWAY_RATE_LIMITED',
     ])
       expect(
         recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,
       ).toBe(true);
+  });
+
+  it('keeps a dispatch failure a retry cannot fix, or whose outcome is unknown, with a person', () => {
+    for (const error of [
+      'DEVICE_GATEWAY_UNAUTHORIZED',
+      'GATEWAY_NOT_CONFIGURED',
+      'DEVICE_RESPONSE_TIMEOUT',
+    ])
+      expect(
+        recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,
+      ).toBe(false);
+  });
+
+  it('leaves a failure an actor authored to the actor', () => {
+    // A caller marking a Goal-linked Task failed after a clean run looks exactly like
+    // a dropped dispatch. Recovery must not reopen it and spend more paid work.
+    expect(recoveryEligibility(graph, { ...task, error: null }, settled).eligible).toBe(false);
+    expect(
+      recoveryEligibility(graph, { ...task, error: 'Superseded by a newer plan' }, settled)
+        .eligible,
+    ).toBe(false);
   });
 
   it('reads an errored run as an agent failure even when the Task is left paused', () => {
@@ -90,13 +112,11 @@ describe('supervisor recovery authority', () => {
   });
 
   it('never restarts a Task a person already settled', () => {
-    const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
     for (const status of ['completed', 'canceled', 'running'])
       expect(recoveryEligibility(graph, { ...task, status }, settled).eligible).toBe(false);
   });
 
   it('still refuses a pipeline failure that a person or a limit caused', () => {
-    const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
     expect(
       recoveryEligibility(
         graph,

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -74,9 +74,6 @@ describe('supervisor recovery authority', () => {
       expect(
         recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,
       ).toBe(true);
-    expect(recoveryEligibility(graph, { ...task, status: 'paused' }, undefined).eligible).toBe(
-      true,
-    );
   });
 
   it('still refuses a pipeline failure that a person or a limit caused', () => {

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -73,8 +73,11 @@ describe('supervisor recovery authority', () => {
     for (const error of [
       '{"error":"DEVICE_OFFLINE","success":false}',
       'DEVICE_GATEWAY_RATE_LIMITED',
+      // A gateway 500 lands here, outside the transport regex's 502-504.
+      'DEVICE_GATEWAY_ERROR (HTTP 500)',
       humanizeHeteroDispatchError('DEVICE_OFFLINE'),
       humanizeHeteroDispatchError('DEVICE_GATEWAY_UNREACHABLE'),
+      humanizeHeteroDispatchError('DEVICE_GATEWAY_ERROR'),
     ])
       expect(
         recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import type { AgentOperationItem } from '@/database/schemas/agentOperations';
 import { humanizeHeteroDispatchError } from '@/server/services/aiAgent/helpers/heteroErrors';
 
-import { recoveryEligibility } from './policy';
+import { recoveryEligibility, statusAuthoredByActor } from './policy';
 
 const graph = {
   decisions: [],
@@ -97,49 +97,19 @@ describe('supervisor recovery authority', () => {
       ).toBe(false);
   });
 
-  it('leaves a failure an actor authored to the actor', () => {
-    // A caller marking a Goal-linked Task failed after a clean run looks exactly like
-    // a dropped dispatch. Recovery must not reopen it and spend more paid work.
-    expect(recoveryEligibility(graph, { ...task, error: null }, settled).eligible).toBe(false);
-    expect(
-      recoveryEligibility(graph, { ...task, error: 'Superseded by a newer plan' }, settled)
-        .eligible,
-    ).toBe(false);
-    // The status update keeps the old error when none is supplied, so an actor can
-    // leave a Task `failed` still carrying the transport reason it was paused with.
-    expect(
-      recoveryEligibility(
-        graph,
-        { ...task, error: '{"error":"DEVICE_OFFLINE","success":false}' },
-        settled,
-      ).eligible,
-    ).toBe(false);
-    // The same text on a `paused` Task is the pipeline failure it looks like.
-    expect(
-      recoveryEligibility(
-        graph,
-        { ...task, error: '{"error":"DEVICE_OFFLINE","success":false}', status: 'paused' },
-        settled,
-      ).eligible,
-    ).toBe(true);
-  });
-
-  it('reads an errored run as an agent failure even when the Task is left paused', () => {
-    // An ad-hoc run that fails is stored as `paused`, the same shape a pipeline
-    // failure leaves. Reading the Task instead of the operation would route real
-    // agent errors around the transport allowlist.
-    const paused = { ...task, error: 'TypeError: cannot read property', status: 'paused' };
-    const errored = { ...operation, error: { message: 'TypeError: cannot read property' } };
-    expect(recoveryEligibility(graph, paused, errored).eligible).toBe(false);
-    expect(
-      recoveryEligibility(graph, paused, { ...operation, error: { message: 'ECONNRESET' } })
-        .eligible,
-    ).toBe(true);
-  });
-
-  it('never restarts a Task a person already settled', () => {
-    for (const status of ['completed', 'canceled', 'running'])
-      expect(recoveryEligibility(graph, { ...task, status }, settled).eligible).toBe(false);
+  it('leaves a status a person wrote to the person, whatever the error says', () => {
+    const errored = { ...operation, error: { message: 'ECONNRESET' } } as AgentOperationItem;
+    // The run genuinely errored and the Task was paused with recoverable text; a
+    // person then marked it failed without supplying a new error, so the text stayed.
+    // Only the transition's author separates this from the failure it looks like.
+    expect(recoveryEligibility(graph, task, errored, true).eligible).toBe(false);
+    expect(recoveryEligibility(graph, task, errored, false).eligible).toBe(true);
+    // Same for a dispatch failure a person closed out.
+    const stalled = { ...task, error: '{"error":"DEVICE_OFFLINE","success":false}' };
+    expect(recoveryEligibility(graph, stalled, settled, true).eligible).toBe(false);
+    expect(recoveryEligibility(graph, { ...stalled, status: 'paused' }, settled).eligible).toBe(
+      true,
+    );
   });
 
   it('still refuses a pipeline failure that a person or a limit caused', () => {
@@ -169,6 +139,37 @@ describe('supervisor recovery authority', () => {
         task,
         operation,
       ).eligible,
+    ).toBe(false);
+  });
+});
+
+describe('status provenance', () => {
+  const act = (over: Record<string, unknown> = {}) => ({
+    actorAgentId: null,
+    actorUserId: null,
+    payload: { to: 'failed' },
+    type: 'status',
+    ...over,
+  });
+
+  it('reads the author of the transition that produced the current status', () => {
+    expect(statusAuthoredByActor([act({ actorUserId: 'u1' })], 'failed')).toBe(true);
+    expect(statusAuthoredByActor([act({ actorAgentId: 'a1' })], 'failed')).toBe(true);
+    // The pipeline writes without an actor.
+    expect(statusAuthoredByActor([act()], 'failed')).toBe(false);
+    // A later pipeline transition supersedes an earlier authored one.
+    expect(
+      statusAuthoredByActor(
+        [act({ actorUserId: 'u1' }), act({ payload: { to: 'paused' } })],
+        'paused',
+      ),
+    ).toBe(false);
+    // An authored move somewhere else does not speak for this status.
+    expect(statusAuthoredByActor([act({ actorUserId: 'u1' })], 'paused')).toBe(false);
+    expect(statusAuthoredByActor([], 'failed')).toBe(false);
+    // Assignee changes are not status provenance.
+    expect(
+      statusAuthoredByActor([act({ actorUserId: 'u1', type: 'assignee_user' })], 'failed'),
     ).toBe(false);
   });
 });

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -171,6 +171,17 @@ describe('status provenance', () => {
     expect(
       statusAuthoredByActor([act({ actorUserId: 'u1', type: 'assignee_user' })], 'failed'),
     ).toBe(false);
+    // Deleting the actor clears the id columns, so "someone who is gone" would read
+    // as the system without the durable kind written beside them.
+    expect(
+      statusAuthoredByActor([act({ payload: { actorKind: 'agent', to: 'failed' } })], 'failed'),
+    ).toBe(true);
+    expect(
+      statusAuthoredByActor([act({ payload: { actorKind: 'user', to: 'failed' } })], 'failed'),
+    ).toBe(true);
+    expect(
+      statusAuthoredByActor([act({ payload: { actorKind: 'system', to: 'failed' } })], 'failed'),
+    ).toBe(false);
   });
 });
 

--- a/apps/server/src/services/goal/supervisor/policy.test.ts
+++ b/apps/server/src/services/goal/supervisor/policy.test.ts
@@ -62,6 +62,46 @@ describe('supervisor recovery authority', () => {
     ).toBe(false);
   });
 
+  it('recovers a failure that happened outside the agent run without asking a person', () => {
+    // The run itself finished cleanly; the device link, the dispatch or the verifier
+    // broke around it, so there is no errored operation to pattern-match.
+    const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
+    for (const error of [
+      'Verification could not run (internal error); the delivery was not evaluated.',
+      '{"error":"DEVICE_OFFLINE","success":false}',
+      'Automatic recovery could not start the next attempt',
+    ])
+      expect(
+        recoveryEligibility(graph, { ...task, error, status: 'paused' }, settled).eligible,
+      ).toBe(true);
+    expect(recoveryEligibility(graph, { ...task, status: 'paused' }, undefined).eligible).toBe(
+      true,
+    );
+  });
+
+  it('still refuses a pipeline failure that a person or a limit caused', () => {
+    const settled = { completionReason: 'done', status: 'done' } as AgentOperationItem;
+    expect(recoveryEligibility(graph, { ...task, status: 'canceled' }, settled).eligible).toBe(
+      false,
+    );
+    expect(
+      recoveryEligibility(
+        graph,
+        { ...task, error: 'device unauthorized', status: 'paused' },
+        settled,
+      ).eligible,
+    ).toBe(false);
+    expect(
+      recoveryEligibility(graph, { ...task, status: 'paused' }, {
+        ...settled,
+        completionReason: 'cost_limit',
+      } as AgentOperationItem).eligible,
+    ).toBe(false);
+    expect(
+      recoveryEligibility(graph, { ...task, totalTopics: 3, status: 'paused' }, settled).eligible,
+    ).toBe(false);
+  });
+
   it('respects attempt exhaustion and explicit manual decisions', () => {
     expect(recoveryEligibility(graph, { ...task, totalTopics: 3 }, operation).eligible).toBe(false);
     expect(

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -7,6 +7,7 @@ import type {
 } from '@lobechat/types';
 
 import type { AgentOperationItem } from '@/database/schemas/agentOperations';
+import { HETERO_DISPATCH_ERROR_HEADLINES } from '@/server/services/aiAgent/helpers/heteroErrors';
 
 import { resolveTaskAttemptBudget } from '../recoveryPolicy';
 
@@ -40,14 +41,31 @@ const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
 ]);
 
 /**
- * Gateway codes whose message states the run never started, so retrying cannot
- * duplicate committed work. `DEVICE_GATEWAY_UNAUTHORIZED` and
- * `GATEWAY_NOT_CONFIGURED` say retrying will not help, and
- * `DEVICE_RESPONSE_TIMEOUT` says whether the run started is unknown; those stay
- * with a person.
+ * Gateway codes whose own message states the run never started, so a retry cannot
+ * duplicate committed work. `DEVICE_GATEWAY_UNAUTHORIZED` and `GATEWAY_NOT_CONFIGURED`
+ * say retrying will not help, `DEVICE_RESPONSE_TIMEOUT` says whether the run started is
+ * unknown, and `DEVICE_NOT_FOUND` needs someone to reconnect or rebind; those stay with
+ * a person.
  */
-const RETRYABLE_DISPATCH_CODES =
-  /DEVICE_OFFLINE|DEVICE_CHANNEL_UNAVAILABLE|DEVICE_GATEWAY_UNREACHABLE|DEVICE_GATEWAY_RATE_LIMITED/i;
+const RETRYABLE_DISPATCH_CODES = [
+  'DEVICE_OFFLINE',
+  'DEVICE_CHANNEL_UNAVAILABLE',
+  'DEVICE_GATEWAY_UNREACHABLE',
+  'DEVICE_GATEWAY_RATE_LIMITED',
+];
+
+/**
+ * The same failure reaches `task.error` as a raw code when the coordinator's own
+ * dispatch fails, and as the humanized headline when the runtime finalizes it. Match
+ * both, off the one map, so neither storage shape decides whether a person is needed.
+ */
+const isRetryableDispatchFailure = (error: string) =>
+  RETRYABLE_DISPATCH_CODES.some(
+    (code) =>
+      error.includes(code) ||
+      (HETERO_DISPATCH_ERROR_HEADLINES[code] &&
+        error.includes(HETERO_DISPATCH_ERROR_HEADLINES[code])),
+  );
 
 export const recoveryEligibility = (
   graph: GoalGraphSnapshot,
@@ -91,7 +109,7 @@ export const recoveryEligibility = (
   // reopened — arrives looking exactly like a dropped dispatch. Recognising the
   // failures instead keeps an authored decision with the person who made it.
   if (
-    !RETRYABLE_DISPATCH_CODES.test(error) &&
+    !isRetryableDispatchFailure(error) &&
     !/ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|fetch failed|network error|socket hang up|service unavailable|bad gateway|gateway timeout|\b50[234]\b/i.test(
       error,
     )

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -91,6 +91,14 @@ export const recoveryEligibility = (
   if (!RECOVERABLE_TASK_STATUSES.has(task.status)) {
     return { eligible: false, reason: `A ${task.status} Task is not supervision's to restart` };
   }
+  // `TaskService.updateStatus` replaces `error` only when a new one is supplied, so an
+  // actor can move a pipeline-paused Task to `failed` and leave the transport text
+  // that paused it. The status log records assignee changes, not transitions, so the
+  // author is not readable; require the errored run instead. Nothing the system does
+  // writes `failed` with a recoverable error — its own is `Heartbeat timeout`.
+  if (task.status === 'failed' && operation?.status !== 'error') {
+    return { eligible: false, reason: 'A failed Task without an errored run is a decision' };
+  }
   if ((task.totalTopics ?? 0) >= resolveTaskAttemptBudget(graph.goal)) {
     return { eligible: false, reason: 'Task attempt budget exhausted' };
   }

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -1,4 +1,10 @@
-import type { GoalGraphSnapshot, GoalItem, TaskItem } from '@lobechat/types';
+import type {
+  AgentOperationCompletionReason,
+  AgentOperationStatus,
+  GoalGraphSnapshot,
+  GoalItem,
+  TaskItem,
+} from '@lobechat/types';
 
 import type { AgentOperationItem } from '@/database/schemas/agentOperations';
 
@@ -10,7 +16,37 @@ export const MAX_SUPERVISION_INCIDENTS = 100;
 export const supervisionLimit = (goal: GoalItem) =>
   Math.min(MAX_SUPERVISION_INCIDENTS, Math.max(1, goal.config?.supervision?.maxIncidents ?? 10));
 
-/** Recognised transport failures only. Unknown failures need a person in v1. */
+/** A limit or a person stopped the run, so continuing is not the supervisor's call. */
+const INTERVENTION_REASONS = new Set<AgentOperationCompletionReason>([
+  'cost_limit',
+  'interrupted',
+  'max_steps',
+  'waiting_for_human',
+]);
+
+/** The run has not settled yet; the lease reclaim owns it, not recovery. */
+const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
+  'idle',
+  'running',
+  'waiting_for_async_tool',
+  'waiting_for_human',
+]);
+
+/**
+ * Where the failure happened, which is what decides whether a person must be involved.
+ *
+ * `agent-run` is a run that started and errored, so its own error text says whether
+ * retrying is safe. `pipeline` is everything the coordinator routed here without such
+ * an error: the dispatch never reached the device, the device link dropped, or a
+ * post-run step like verification broke. Those never produce an errored operation, so
+ * demanding one used to escalate the entire class to a human — the failures least in
+ * need of a human judgement were the only ones that always got one.
+ */
+export type GoalFailureOrigin = 'agent-run' | 'pipeline';
+
+export const failureOrigin = (task: TaskItem, operation?: AgentOperationItem): GoalFailureOrigin =>
+  task.status === 'failed' && operation?.status === 'error' ? 'agent-run' : 'pipeline';
+
 export const recoveryEligibility = (
   graph: GoalGraphSnapshot,
   task: TaskItem,
@@ -21,19 +57,22 @@ export const recoveryEligibility = (
   if (graph.goal.status !== 'running' || graph.decisions.some((d) => d.status === 'pending')) {
     return { eligible: false, reason: 'Goal is stopped or has a pending decision' };
   }
-  if (task.status !== 'failed' || !operation || operation.status !== 'error') {
-    return { eligible: false, reason: 'Only a confirmed failed operation can be recovered' };
+  if (operation && IN_FLIGHT_STATUSES.has(operation.status)) {
+    return { eligible: false, reason: 'The operation has not settled yet' };
   }
   if (
-    operation.interruption ||
-    (operation.completionReason && operation.completionReason !== 'error')
+    operation?.interruption ||
+    (operation?.completionReason && INTERVENTION_REASONS.has(operation.completionReason))
   ) {
     return { eligible: false, reason: 'Operation stopped at an explicit intervention or limit' };
+  }
+  if (task.status === 'canceled') {
+    return { eligible: false, reason: 'A cancelled Task is a human decision' };
   }
   if ((task.totalTopics ?? 0) >= resolveTaskAttemptBudget(graph.goal)) {
     return { eligible: false, reason: 'Task attempt budget exhausted' };
   }
-  const error = `${operation.error?.type ?? ''} ${operation.error?.message ?? ''} ${task.error ?? ''}`;
+  const error = `${operation?.error?.type ?? ''} ${operation?.error?.message ?? ''} ${task.error ?? ''}`;
   if (
     /auth|credential|api.?key|permission|approv|forbidden|unauthor|usage.?limit|quota|billing|budget|cancel|用户|授权|凭据|额度/i.test(
       error,
@@ -42,6 +81,14 @@ export const recoveryEligibility = (
     return {
       eligible: false,
       reason: 'Credentials, permission, cancellation or spending requires user action',
+    };
+  }
+  // A pipeline failure has no run error to pattern-match, and retrying it re-runs a
+  // dispatch the goal already authorised rather than granting anything new.
+  if (failureOrigin(task, operation) === 'pipeline') {
+    return {
+      eligible: true,
+      reason: 'Failure outside the agent run; retrying uses the authority the goal already granted',
     };
   }
   if (

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -24,6 +24,13 @@ const INTERVENTION_REASONS = new Set<AgentOperationCompletionReason>([
   'waiting_for_human',
 ]);
 
+/**
+ * Only a Task the coordinator routed to recovery may be restarted. Anything else —
+ * a cancellation, or a completion a person recorded while the diagnosis ran — is a
+ * decision supervision must not overwrite.
+ */
+export const RECOVERABLE_TASK_STATUSES = new Set(['failed', 'paused']);
+
 /** The run has not settled yet; the lease reclaim owns it, not recovery. */
 const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
   'idle',
@@ -35,17 +42,20 @@ const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
 /**
  * Where the failure happened, which is what decides whether a person must be involved.
  *
- * `agent-run` is a run that started and errored, so its own error text says whether
- * retrying is safe. `pipeline` is everything the coordinator routed here without such
- * an error: the dispatch never reached the device, the device link dropped, or a
- * post-run step like verification broke. Those never produce an errored operation, so
- * demanding one used to escalate the entire class to a human — the failures least in
- * need of a human judgement were the only ones that always got one.
+ * `agent-run` is a run that errored, so its own error text says whether retrying is
+ * safe. The Task status cannot decide this: an ad-hoc run that fails is stored as
+ * `paused`, exactly like a pipeline failure, so reading the Task would route real
+ * agent errors around the credential and transport checks.
+ *
+ * `pipeline` is everything the coordinator routed here without an errored operation:
+ * the dispatch never reached the device, the device link dropped, or a post-run step
+ * like verification broke. Those never produce an error to inspect, so demanding one
+ * used to escalate the entire class to a human.
  */
 export type GoalFailureOrigin = 'agent-run' | 'pipeline';
 
-export const failureOrigin = (task: TaskItem, operation?: AgentOperationItem): GoalFailureOrigin =>
-  task.status === 'failed' && operation?.status === 'error' ? 'agent-run' : 'pipeline';
+export const failureOrigin = (operation?: AgentOperationItem): GoalFailureOrigin =>
+  operation?.status === 'error' ? 'agent-run' : 'pipeline';
 
 export const recoveryEligibility = (
   graph: GoalGraphSnapshot,
@@ -66,8 +76,8 @@ export const recoveryEligibility = (
   ) {
     return { eligible: false, reason: 'Operation stopped at an explicit intervention or limit' };
   }
-  if (task.status === 'canceled') {
-    return { eligible: false, reason: 'A cancelled Task is a human decision' };
+  if (!RECOVERABLE_TASK_STATUSES.has(task.status)) {
+    return { eligible: false, reason: `A ${task.status} Task is not supervision's to restart` };
   }
   if ((task.totalTopics ?? 0) >= resolveTaskAttemptBudget(graph.goal)) {
     return { eligible: false, reason: 'Task attempt budget exhausted' };
@@ -85,7 +95,7 @@ export const recoveryEligibility = (
   }
   // A pipeline failure has no run error to pattern-match, and retrying it re-runs a
   // dispatch the goal already authorised rather than granting anything new.
-  if (failureOrigin(task, operation) === 'pipeline') {
+  if (failureOrigin(operation) === 'pipeline') {
     return {
       eligible: true,
       reason: 'Failure outside the agent run; retrying uses the authority the goal already granted',

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -32,6 +32,26 @@ const INTERVENTION_REASONS = new Set<AgentOperationCompletionReason>([
  */
 export const RECOVERABLE_TASK_STATUSES = new Set(['failed', 'paused']);
 
+/**
+ * Whether the Task's current status was written by a person or an agent tool rather
+ * than by the pipeline. `updateWithLog` records an actor on every tracked transition,
+ * which is the only way to tell an authored `failed` from a run that failed into one:
+ * both can carry the same recoverable error text.
+ */
+export const statusAuthoredByActor = (
+  activities: {
+    actorAgentId?: string | null;
+    actorUserId?: string | null;
+    payload?: unknown;
+    type: string;
+  }[],
+  status: string,
+): boolean => {
+  const latest = [...activities].reverse().find((item) => item.type === 'status');
+  if (!latest || (latest.payload as { to?: string } | undefined)?.to !== status) return false;
+  return Boolean(latest.actorUserId || latest.actorAgentId);
+};
+
 /** The run has not settled yet; the lease reclaim owns it, not recovery. */
 const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
   'idle',
@@ -73,6 +93,8 @@ export const recoveryEligibility = (
   graph: GoalGraphSnapshot,
   task: TaskItem,
   operation?: AgentOperationItem,
+  /** Whether the Task's current status was written by a person or an agent tool. */
+  actorAuthoredStatus = false,
 ): { eligible: boolean; reason: string } => {
   if (!graph.goal.config?.supervision?.enabled && !graph.goal.config?.manager)
     return { eligible: false, reason: 'Supervision is disabled' };
@@ -91,13 +113,13 @@ export const recoveryEligibility = (
   if (!RECOVERABLE_TASK_STATUSES.has(task.status)) {
     return { eligible: false, reason: `A ${task.status} Task is not supervision's to restart` };
   }
-  // `TaskService.updateStatus` replaces `error` only when a new one is supplied, so an
-  // actor can move a pipeline-paused Task to `failed` and leave the transport text
-  // that paused it. The status log records assignee changes, not transitions, so the
-  // author is not readable; require the errored run instead. Nothing the system does
-  // writes `failed` with a recoverable error — its own is `Heartbeat timeout`.
-  if (task.status === 'failed' && operation?.status !== 'error') {
-    return { eligible: false, reason: 'A failed Task without an errored run is a decision' };
+  // `TaskService.updateStatus` replaces `error` only when a new one is supplied, so a
+  // person can move a Task the pipeline paused — or one whose run genuinely errored —
+  // to `failed` and leave the recoverable text behind. Reading the error cannot tell
+  // the two apart, so ask who wrote the status: `updateWithLog` records the actor on
+  // every tracked transition, and a transition somebody made is theirs to undo.
+  if (actorAuthoredStatus) {
+    return { eligible: false, reason: 'Someone set this status themselves' };
   }
   if ((task.totalTopics ?? 0) >= resolveTaskAttemptBudget(graph.goal)) {
     return { eligible: false, reason: 'Task attempt budget exhausted' };

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -48,7 +48,13 @@ export const statusAuthoredByActor = (
   status: string,
 ): boolean => {
   const latest = [...activities].reverse().find((item) => item.type === 'status');
-  if (!latest || (latest.payload as { to?: string } | undefined)?.to !== status) return false;
+  const payload = latest?.payload as { actorKind?: string; to?: string } | undefined;
+  if (!latest || payload?.to !== status) return false;
+  // The id columns are cleared when the actor is deleted, so a transition made by
+  // someone who has since left would read as the system's. `actorKind` is written
+  // beside them precisely so it survives that; fall back to the ids only for rows
+  // written before it existed.
+  if (payload?.actorKind) return payload.actorKind !== 'system';
   return Boolean(latest.actorUserId || latest.actorAgentId);
 };
 

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -44,14 +44,6 @@ const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
  */
 export type GoalFailureOrigin = 'agent-run' | 'pipeline';
 
-/**
- * Stable id for a failure that produced no operation, so a kickoff that threw
- * before writing a run can still be deduplicated and counted. Keyed per attempt:
- * a second failed dispatch is a second incident, not a silent reuse of the first.
- */
-export const dispatchFailureKey = (task: TaskItem) =>
-  `dispatch:${task.id}:${task.totalTopics ?? 0}`;
-
 export const failureOrigin = (task: TaskItem, operation?: AgentOperationItem): GoalFailureOrigin =>
   task.status === 'failed' && operation?.status === 'error' ? 'agent-run' : 'pipeline';
 

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -44,6 +44,14 @@ const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
  */
 export type GoalFailureOrigin = 'agent-run' | 'pipeline';
 
+/**
+ * Stable id for a failure that produced no operation, so a kickoff that threw
+ * before writing a run can still be deduplicated and counted. Keyed per attempt:
+ * a second failed dispatch is a second incident, not a silent reuse of the first.
+ */
+export const dispatchFailureKey = (task: TaskItem) =>
+  `dispatch:${task.id}:${task.totalTopics ?? 0}`;
+
 export const failureOrigin = (task: TaskItem, operation?: AgentOperationItem): GoalFailureOrigin =>
   task.status === 'failed' && operation?.status === 'error' ? 'agent-run' : 'pipeline';
 

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -40,22 +40,14 @@ const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
 ]);
 
 /**
- * Where the failure happened, which is what decides whether a person must be involved.
- *
- * `agent-run` is a run that errored, so its own error text says whether retrying is
- * safe. The Task status cannot decide this: an ad-hoc run that fails is stored as
- * `paused`, exactly like a pipeline failure, so reading the Task would route real
- * agent errors around the credential and transport checks.
- *
- * `pipeline` is everything the coordinator routed here without an errored operation:
- * the dispatch never reached the device, the device link dropped, or a post-run step
- * like verification broke. Those never produce an error to inspect, so demanding one
- * used to escalate the entire class to a human.
+ * Gateway codes whose message states the run never started, so retrying cannot
+ * duplicate committed work. `DEVICE_GATEWAY_UNAUTHORIZED` and
+ * `GATEWAY_NOT_CONFIGURED` say retrying will not help, and
+ * `DEVICE_RESPONSE_TIMEOUT` says whether the run started is unknown; those stay
+ * with a person.
  */
-export type GoalFailureOrigin = 'agent-run' | 'pipeline';
-
-export const failureOrigin = (operation?: AgentOperationItem): GoalFailureOrigin =>
-  operation?.status === 'error' ? 'agent-run' : 'pipeline';
+const RETRYABLE_DISPATCH_CODES =
+  /DEVICE_OFFLINE|DEVICE_CHANNEL_UNAVAILABLE|DEVICE_GATEWAY_UNREACHABLE|DEVICE_GATEWAY_RATE_LIMITED/i;
 
 export const recoveryEligibility = (
   graph: GoalGraphSnapshot,
@@ -93,15 +85,13 @@ export const recoveryEligibility = (
       reason: 'Credentials, permission, cancellation or spending requires user action',
     };
   }
-  // A pipeline failure has no run error to pattern-match, and retrying it re-runs a
-  // dispatch the goal already authorised rather than granting anything new.
-  if (failureOrigin(operation) === 'pipeline') {
-    return {
-      eligible: true,
-      reason: 'Failure outside the agent run; retrying uses the authority the goal already granted',
-    };
-  }
+  // One allowlist for both origins, read off whatever error text exists. Inferring a
+  // recoverable failure from the *absence* of a run error is an open set: every state
+  // an actor can author — a Task marked failed through the API, a settled run someone
+  // reopened — arrives looking exactly like a dropped dispatch. Recognising the
+  // failures instead keeps an authored decision with the person who made it.
   if (
+    !RETRYABLE_DISPATCH_CODES.test(error) &&
     !/ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|fetch failed|network error|socket hang up|service unavailable|bad gateway|gateway timeout|\b50[234]\b/i.test(
       error,
     )

--- a/apps/server/src/services/goal/supervisor/policy.ts
+++ b/apps/server/src/services/goal/supervisor/policy.ts
@@ -50,6 +50,8 @@ const IN_FLIGHT_STATUSES = new Set<AgentOperationStatus>([
 const RETRYABLE_DISPATCH_CODES = [
   'DEVICE_OFFLINE',
   'DEVICE_CHANNEL_UNAVAILABLE',
+  // Any gateway 5xx, so it covers the 500 the transport regex's 502-504 misses.
+  'DEVICE_GATEWAY_ERROR',
   'DEVICE_GATEWAY_UNREACHABLE',
   'DEVICE_GATEWAY_RATE_LIMITED',
 ];

--- a/apps/server/src/services/goal/taskClaim.ts
+++ b/apps/server/src/services/goal/taskClaim.ts
@@ -1,0 +1,21 @@
+import type { TaskModel } from '@/database/models/task';
+
+/**
+ * The one place a Goal moves a Task back into work.
+ *
+ * Every such write competes with a person. Between the tick that decided to act and
+ * the write that acts, someone can complete, cancel or fail the Task, and a
+ * supervisor diagnosis can sit in between for minutes. So the claim is conditioned on
+ * the status the decision was made against — never on a freshly re-read one, which
+ * would swap whatever the person just chose and start paid work over their decision.
+ *
+ * Losing the compare-and-set is the correct outcome, not an error: it means the row
+ * moved, so this decision is stale and belongs to whoever moved it.
+ */
+export const claimGoalTask = async (
+  taskModel: TaskModel,
+  /** The Task as the caller read it when it decided, not a fresh re-read. */
+  decidedOn: { id: string; status: string },
+  to: 'backlog' | 'running',
+  extra?: { error?: string | null; startedAt?: Date },
+) => taskModel.updateStatusIfCurrent(decidedOn.id, decidedOn.status, to, extra);

--- a/apps/server/src/services/goal/taskRecoveryCoordinator.ts
+++ b/apps/server/src/services/goal/taskRecoveryCoordinator.ts
@@ -7,6 +7,7 @@ import type { LobeChatDatabase } from '@/database/type';
 import { TaskRunnerService } from '@/server/services/taskRunner';
 
 import { resolveTaskAttemptBudget, resolveTaskMaxSteps } from './recoveryPolicy';
+import { claimGoalTask } from './taskClaim';
 
 const log = debug('lobe-server:goal-task-recovery');
 
@@ -87,7 +88,7 @@ export class TaskRecoveryCoordinator {
       );
       return { outcome: 'settled' };
     }
-    const claimed = await taskModel.updateStatusIfCurrent(task.id, 'paused', 'running', {
+    const claimed = await claimGoalTask(taskModel, { id: task.id, status: 'paused' }, 'running', {
       error: null,
       startedAt: new Date(),
     });

--- a/apps/server/src/services/goal/taskRecoveryCoordinator.ts
+++ b/apps/server/src/services/goal/taskRecoveryCoordinator.ts
@@ -7,6 +7,7 @@ import type { LobeChatDatabase } from '@/database/type';
 import { TaskRunnerService } from '@/server/services/taskRunner';
 
 import { resolveTaskAttemptBudget, resolveTaskMaxSteps } from './recoveryPolicy';
+import { RECOVERABLE_TASK_STATUSES } from './supervisor/policy';
 
 const log = debug('lobe-server:goal-task-recovery');
 
@@ -15,6 +16,8 @@ export type TaskRecoveryOutcome =
   | 'started'
   /** Another overlapping advance owns the retry; this one started nothing. */
   | 'already-running'
+  /** Someone settled the Task while this recovery was being decided. */
+  | 'settled'
   | 'exhausted-cost'
   | 'exhausted-rounds'
   | 'spawn-failed';
@@ -72,6 +75,13 @@ export class TaskRecoveryCoordinator {
     if (!current || current.status === 'running') {
       log('task %s recovery was already claimed by another advance', task.identifier);
       return { outcome: 'already-running' };
+    }
+    // The tick that routed here read the Task before it decided. Claiming whatever
+    // status it holds now would swap a completion or a cancellation to `running` and
+    // start a paid run against a decision somebody already made.
+    if (!RECOVERABLE_TASK_STATUSES.has(current.status)) {
+      log('task %s was settled as %s; leaving it alone', task.identifier, current.status);
+      return { outcome: 'settled' };
     }
     const claimed = await taskModel.updateStatusIfCurrent(task.id, current.status, 'running', {
       error: null,

--- a/apps/server/src/services/goal/taskRecoveryCoordinator.ts
+++ b/apps/server/src/services/goal/taskRecoveryCoordinator.ts
@@ -7,6 +7,7 @@ import type { LobeChatDatabase } from '@/database/type';
 import { TaskRunnerService } from '@/server/services/taskRunner';
 
 import { resolveTaskAttemptBudget, resolveTaskMaxSteps } from './recoveryPolicy';
+import { statusAuthoredByActor } from './supervisor/policy';
 import { claimGoalTask } from './taskClaim';
 
 const log = debug('lobe-server:goal-task-recovery');
@@ -86,6 +87,13 @@ export class TaskRecoveryCoordinator {
         task.identifier,
         current.status,
       );
+      return { outcome: 'settled' };
+    }
+    // A pause somebody made is theirs. The routing error survives a manual round trip
+    // through another status, because the status update keeps the old error when none
+    // is supplied, so the status alone cannot say whose pause this is.
+    if (statusAuthoredByActor(await taskModel.getActivities(task.id, 20), current.status)) {
+      log('task %s was paused by an actor; leaving it alone', task.identifier);
       return { outcome: 'settled' };
     }
     const claimed = await claimGoalTask(taskModel, { id: task.id, status: 'paused' }, 'running', {

--- a/apps/server/src/services/goal/taskRecoveryCoordinator.ts
+++ b/apps/server/src/services/goal/taskRecoveryCoordinator.ts
@@ -7,7 +7,6 @@ import type { LobeChatDatabase } from '@/database/type';
 import { TaskRunnerService } from '@/server/services/taskRunner';
 
 import { resolveTaskAttemptBudget, resolveTaskMaxSteps } from './recoveryPolicy';
-import { RECOVERABLE_TASK_STATUSES } from './supervisor/policy';
 
 const log = debug('lobe-server:goal-task-recovery');
 
@@ -76,14 +75,19 @@ export class TaskRecoveryCoordinator {
       log('task %s recovery was already claimed by another advance', task.identifier);
       return { outcome: 'already-running' };
     }
-    // The tick that routed here read the Task before it decided. Claiming whatever
-    // status it holds now would swap a completion or a cancellation to `running` and
-    // start a paid run against a decision somebody already made.
-    if (!RECOVERABLE_TASK_STATUSES.has(current.status)) {
-      log('task %s was settled as %s; leaving it alone', task.identifier, current.status);
+    // Both branches that route here require `paused`, so that is the only status this
+    // claim may take. The tick read the Task before it decided; claiming whatever it
+    // holds now would swap somebody's completion, cancellation or explicit failure to
+    // `running` and start a paid run over their decision.
+    if (current.status !== 'paused') {
+      log(
+        'task %s moved to %s before the claim; leaving it alone',
+        task.identifier,
+        current.status,
+      );
       return { outcome: 'settled' };
     }
-    const claimed = await taskModel.updateStatusIfCurrent(task.id, current.status, 'running', {
+    const claimed = await taskModel.updateStatusIfCurrent(task.id, 'paused', 'running', {
       error: null,
       startedAt: new Date(),
     });
@@ -104,7 +108,7 @@ export class TaskRecoveryCoordinator {
       log('task %s recovery spawn failed (non-fatal): %O', task.identifier, error);
       // We own the claim, so nothing else will put the task back.
       await taskModel
-        .updateStatusIfCurrent(task.id, 'running', current.status, { error: current.error })
+        .updateStatusIfCurrent(task.id, 'running', 'paused', { error: current.error })
         .catch((releaseError) => {
           log('task %s failed to release the recovery claim: %O', task.identifier, releaseError);
         });

--- a/apps/server/src/services/verify/settle.ts
+++ b/apps/server/src/services/verify/settle.ts
@@ -1,3 +1,4 @@
+import { VERIFICATION_ERRORED_ERROR, VERIFICATION_FAILED_ERROR } from '@lobechat/const/goal';
 import debug from 'debug';
 
 import { AgentOperationModel } from '@/database/models/agentOperation';
@@ -137,12 +138,11 @@ export const driveTaskFromVerify = async (
       //   evaluated, so we must not claim it "did not pass".
       const isErrored = outcome === 'errored';
 
-      // `Delivery did not pass verification.` is a contract string, not just
-      // copy: the Goal coordinator matches on it to decide whether a paused
-      // Goal Task should start another attempt or open a decision gate.
-      const pauseSummary = isErrored
-        ? 'Verification could not run (internal error); the delivery was not evaluated.'
-        : 'Delivery did not pass verification.';
+      // Both summaries are contract strings, not copy: the Goal coordinator
+      // matches on them to decide whether a paused Goal Task starts another
+      // attempt or opens a decision gate. They live in `@lobechat/const/goal`
+      // so the writer and the reader cannot drift apart.
+      const pauseSummary = isErrored ? VERIFICATION_ERRORED_ERROR : VERIFICATION_FAILED_ERROR;
       if (task.automationMode) {
         // Mirror of the pass branch: verify judges THIS tick, not the lifetime
         // schedule. Pausing here would permanently disarm the cron (the

--- a/packages/const/src/goal.ts
+++ b/packages/const/src/goal.ts
@@ -49,3 +49,18 @@ export const GOAL_COORDINATOR_ACTOR_ID = 'goal-coordinator';
  * recognize it and render the localized copy (`goalProcess.node.terminalAcceptance`).
  */
 export const GOAL_ACCEPTANCE_TASK_TITLE = 'Complete full Goal acceptance';
+
+/**
+ * Task error strings the Goal coordinator matches on to route a paused Task.
+ *
+ * These are a contract between whoever pauses a Task and the coordinator that
+ * reads it back, not user-facing copy. A string with no branch here falls
+ * through to the human decision gate, so an unmatched infrastructure failure
+ * stops a long-horizon goal until a person clicks retry.
+ */
+export const LEASE_EXPIRED_ERROR = 'Goal Task operation lease expired.';
+/** The verifier ran and judged the delivery short of the criteria. */
+export const VERIFICATION_FAILED_ERROR = 'Delivery did not pass verification.';
+/** The verifier itself could not run, so the delivery was never evaluated. */
+export const VERIFICATION_ERRORED_ERROR =
+  'Verification could not run (internal error); the delivery was not evaluated.';

--- a/packages/types/src/goal.ts
+++ b/packages/types/src/goal.ts
@@ -165,6 +165,12 @@ export interface GoalSupervisionIncident {
   status: 'diagnosing' | 'retrying' | 'recovered' | 'escalated' | 'unsuccessful' | 'human_resumed';
   supervisorOperationId?: string;
   taskId: string;
+  /**
+   * Status the Task held when this incident opened. A diagnosis runs for minutes, so
+   * the recovery claims against this rather than a later read: anything a person did
+   * in between must win, not be swapped back into work.
+   */
+  taskStatus?: string;
 }
 
 /** Server-owned state; never accepted as client configuration. */


### PR DESCRIPTION
## Why

Supervision's first gate was:

```ts
if (task.status !== 'failed' || !operation || operation.status !== 'error')
  return { eligible: false, reason: 'Only a confirmed failed operation can be recovered' };
```

It demands a failure that has already produced an errored operation. Three real failure modes never take that shape, because the run either never started or finished cleanly and something around it broke:

| What broke | Task | Operation |
|---|---|---|
| Dispatch never reached the device | `paused` | `done` |
| Device link dropped | `paused` | `done` |
| Verifier crashed after the run | `paused` | `done` |

So the entire class escalated to a human decision gate. In a live goal these were the only three interruptions, all recorded as `Only a confirmed failed operation can be recovered`, `eligible: false`. Each stopped a long-horizon goal until someone clicked retry — and the recommended option was always `retry`, so no judgement was being asked for.

The policy's own comment says "recognised transport failures only", and transport failures are precisely the ones that never produce an operation to inspect.

A second, narrower cause sat underneath. `settle.ts` deliberately keeps two summaries apart so infra never reads as a rejected delivery, but only one of them had a coordinator branch:

| Task error | Branch |
|---|---|
| `Goal Task operation lease expired.` | `recover_lease` |
| `Delivery did not pass verification.` | `recover_verification` |
| `Verification could not run (internal error); …` | none → human gate |

A delivery genuinely judged short recovered automatically; a verifier that crashed stopped the goal.

## What

- **Classify by where the failure happened.** `failureOrigin` returns `agent-run` for a run that started and errored — still judged by its own error text — and `pipeline` for everything else the coordinator routed to recovery. A pipeline failure is eligible without a transport pattern match, because retrying re-runs a dispatch the goal already authorised rather than granting anything new.
- **Keep the gates that carry a real decision**: an explicit interruption, a limit stop (`cost_limit`, `max_steps`, `waiting_for_human`), a cancelled Task, exhausted attempts, and anything reading as credentials, permission, cancellation or spend. An operation that has not settled is left to the lease reclaim.
- **Route the errored verification** to `recover_verification`, with its own message so the two outcomes stay distinguishable in the ledger.
- **Move the three contract strings to `@lobechat/const/goal`.** They are a contract between whoever pauses a Task and the coordinator that matches on it; keeping the literal in two files is how the third one drifted out of the routing in the first place.

## Testing

`bun run check` — lint clean, tests pass. Full-repo `--type` shows no new errors in the changed files. All 51 pre-existing policy and `decideNextMove` tests pass unchanged, which is the main evidence that agent-run failures keep their old contract.

New coverage: a settled-clean run with a device-offline, dispatch or verifier error recovers without a person; the same shape stays ineligible when a person cancelled it, when credentials are implicated, when a limit stopped the operation, or when attempts are exhausted; an errored verification routes to `recover_verification` rather than the gate.

## Acceptance

Not published. The change is a coordinator policy with no surface of its own — what a user sees is a gate that no longer appears. Covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)