### PR TITLE
🐛 fix: support Serverless indices without internal UUIDs

### DIFF
--- a/apps/server/src/services/ftsSearch/elasticsearch.test.ts
+++ b/apps/server/src/services/ftsSearch/elasticsearch.test.ts
@@ -604,6 +604,35 @@ describe('ElasticsearchFtsSearchHttpClient', () => {
     });
   });
 
+  it('allows sync when Serverless omits the internal index UUID', async () => {
+    const index = identityIndex('agents', 'unused', { schema_fingerprint: undefined });
+    const { uuid: _uuid, ...settings } = index.settings.index;
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation(async (url: URL) =>
+          Response.json(
+            url.pathname.startsWith('/_alias/')
+              ? { 'lobehub-agents-v1': { aliases: { 'lobehub-agents': {} } } }
+              : { 'lobehub-agents-v1': { ...index, settings: { index: settings } } },
+          ),
+        ),
+    );
+    const client = new ElasticsearchFtsSearchHttpClient({
+      apiKey: 'test-api-key',
+      indexNamespace: 'lobehub',
+      url: 'https://search.example.com',
+    });
+
+    await expect(client.assertFtsSearchSyncAliases(['lobehub-agents'])).resolves.toBeUndefined();
+    await expect(client.getFtsSearchSyncIndexIdentities(['lobehub-agents'])).resolves.toMatchObject(
+      {
+        'lobehub-agents': { indexUuid: null, schemaFingerprint: null, schemaVersion: 1 },
+      },
+    );
+  });
+
   it('rejects a runtime identity response with missing reindex metadata', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/server/src/services/ftsSearch/elasticsearch.ts
+++ b/apps/server/src/services/ftsSearch/elasticsearch.ts
@@ -97,7 +97,9 @@ const indexIdentityResponseSchema = z.record(
       index: z
         .object({
           analysis: z.record(z.string(), z.unknown()),
-          uuid: z.string().trim().min(1),
+          // Serverless omits internal settings; sync still validates the stamped generation below.
+          // https://www.elastic.co/docs/reference/elasticsearch/index-settings/serverless
+          uuid: z.string().trim().min(1).optional(),
         })
         .passthrough(),
     }),
@@ -126,7 +128,8 @@ export interface ElasticsearchFtsSearchHttpClientOptions {
 }
 
 export interface ElasticsearchFtsSearchSyncIndexIdentity {
-  indexUuid: string;
+  /** Null when the deployment does not expose its internal index UUID. */
+  indexUuid: string | null;
   mappingSha256: string;
   physicalIndex: string;
   reindexRunId: string;
@@ -584,7 +587,7 @@ export class ElasticsearchFtsSearchHttpClient implements ElasticsearchFtsSearchC
       }
 
       identities.set(alias, {
-        indexUuid: index.settings.index.uuid,
+        indexUuid: index.settings.index.uuid ?? null,
         mappingSha256: sha256Json(index.mappings),
         physicalIndex,
         reindexRunId: index.mappings._meta.reindex_run_id,


### PR DESCRIPTION
Elasticsearch Serverless can omit `settings.index.uuid`. Requiring it during sync readiness rejects otherwise valid indices before incremental synchronization can start.

Allow an omitted UUID and represent it as `null`. Keep reindex metadata, generation, fingerprint (when present), and tombstone validation intact; reject invalid UUID values when provided. No index migration is required.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- The regression failed before the fix; focused checks passed (54 tests across the client and dependent validation code).
- Real Serverless read-only comparison: the baseline fails with `invalid shape`; the candidate passes readiness and returns `indexUuid: null`. All requests were GET.
- Acceptance: https://app.lobehub.com/acceptance/075f6f20-9ff9-4e2a-a9bc-23ce59eb924d
- Post-deploy: verify successful incremental sync and newly indexed content. Queue draining and end-user search recovery were not exercised by the read-only check.

#### 🔗 Related Issue

- [Elasticsearch Serverless index settings](https://www.elastic.co/docs/reference/elasticsearch/index-settings/serverless)
