### PR TITLE
🐛 fix(bot): attach Markdown images from final replies

### DIFF
--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -924,7 +924,13 @@ export class CompletionLifecycle {
           metadata?.userId || this.userId,
           typeof metadata?.topicId === 'string' ? metadata.topicId : undefined,
         );
-        if (recovered) event.lastAssistantContent = recovered;
+        if (recovered) {
+          event.lastAssistantContent = recovered;
+          const attachments = extractOutboundAttachments([
+            { content: recovered, role: 'assistant' },
+          ]);
+          event.attachments = attachments.length > 0 ? attachments : undefined;
+        }
       }
 
       await hookDispatcher.dispatch(operationId, 'onComplete', event, metadata._hooks);

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -29,6 +29,7 @@ import { registerWorksForOperation } from '@/server/services/workRegistration';
 import { after } from '@/server/utils/scheduleAfterResponse';
 
 import { buildRuntimeInterventionNotification } from './agentInterventionNotification';
+import { extractFinalReplyImageUrls } from './finalReplyImages';
 import { CriticalHookDeliveryError, hookDispatcher, type SerializedHook } from './hooks';
 
 const log = debug('lobe-server:completion-lifecycle');
@@ -1445,8 +1446,18 @@ const extractOutboundAttachments = (messages: any[]): OutboundAttachment[] => {
 
     if (role === 'assistant') {
       if (!crossedFinalAssistant) {
-        // The final assistant turn: harvest its multimodal parts.
-        collected.push(...extractAttachmentsFromContent(content));
+        // Only the final reply's Markdown expresses an intent to send images.
+        // Do not promote generation state or intermediate tool Markdown.
+        const attachments: OutboundAttachment[] = [];
+        const text = extractTextFromMessageContent(content);
+        if (text) {
+          for (const url of extractFinalReplyImageUrls(text)) {
+            const attachment = buildAttachmentFromUrl(url, 'image');
+            if (attachment) attachments.push(attachment);
+          }
+        }
+        attachments.push(...extractAttachmentsFromContent(content));
+        collected.unshift(...attachments);
         crossedFinalAssistant = true;
         continue;
       }
@@ -1457,12 +1468,11 @@ const extractOutboundAttachments = (messages: any[]): OutboundAttachment[] => {
 
     if (role === 'tool') {
       // Tool results between the previous assistant turn and the final one.
-      collected.push(...extractAttachmentsFromContent(content));
+      collected.unshift(...extractAttachmentsFromContent(content));
     }
   }
 
-  // Reverse so message-order (older first) is preserved, then dedupe.
-  collected.reverse();
+  // Prepending each message preserves both message and within-message order.
   const seen = new Set<string>();
   const result: OutboundAttachment[] = [];
   for (const att of collected) {

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -1271,6 +1271,27 @@ describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery
     );
   });
 
+  it('extracts final Markdown images when the reply is recovered from the database', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const content = '![Result](https://cdn.example.com/recovered.png)';
+    (lifecycle as any).messageModel = {
+      findById: vi.fn().mockResolvedValue({ content, id: 'msg-assistant' }),
+    };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({
+        attachments: [{ fetchUrl: 'https://cdn.example.com/recovered.png', type: 'image' }],
+        lastAssistantContent: content,
+      }),
+      [],
+    );
+  });
+
   it('recovers by the final assistantGroup child id when grouped state carries no text', async () => {
     const lifecycle = buildLifecycle();
     const dispatchSpy = setupSpies(lifecycle);

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -171,6 +171,78 @@ describe('CompletionLifecycle.buildLifecycleEvent', () => {
   const callBuild = (state: unknown, reason = 'completed') =>
     (buildLifecycle() as any).buildLifecycleEvent('op-1', state, reason);
 
+  it('attaches Markdown images explicitly included in the final reply without changing its text', () => {
+    const url = 'https://cdn.example.com/f/file_image';
+    const content = `Here is the result: ![Result](${url})`;
+    const { event } = callBuild({ messages: [{ role: 'assistant', content }] });
+    expect(event.attachments).toEqual([{ fetchUrl: url, type: 'image' }]);
+    expect(event.lastAssistantContent).toBe(content);
+  });
+
+  it('preserves the order of distinct final-reply images', () => {
+    const { event } = callBuild({
+      messages: [
+        {
+          role: 'assistant',
+          content:
+            '![Before](https://cdn.example.com/before.png) ![After](https://cdn.example.com/after.png)',
+        },
+      ],
+    });
+    expect(event.attachments?.map((attachment: any) => attachment.fetchUrl)).toEqual([
+      'https://cdn.example.com/before.png',
+      'https://cdn.example.com/after.png',
+    ]);
+  });
+
+  it('parses reference images in final text parts and deduplicates structured images', () => {
+    const url = 'https://cdn.example.com/result.png';
+    const { event } = callBuild({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: `![one][result] ![two](${url})\n\n[result]: ${url}` },
+            { type: 'image_url', image_url: { url } },
+          ],
+        },
+      ],
+    });
+    expect(event.attachments).toEqual([{ fetchUrl: url, type: 'image' }]);
+  });
+
+  it('does not promote tool state, tool Markdown, or an earlier reply to final attachments', () => {
+    const url = 'https://cdn.example.com/intermediate.png';
+    const { event } = callBuild({
+      messages: [
+        { role: 'assistant', content: `![earlier](${url})` },
+        { role: 'user', content: 'Analyze the result without sending an image.' },
+        { role: 'assistant', content: '', tools: [{ id: 'call-image' }] },
+        {
+          role: 'tool',
+          content: `![tool result](${url})`,
+          state: { generations: [{ asset: { url, type: 'image' } }] },
+        },
+        { role: 'assistant', content: 'The composition is balanced.' },
+      ],
+    });
+    expect(event.attachments).toBeUndefined();
+  });
+
+  it('does not treat ordinary links, code, escaped syntax or unsafe schemes as images', () => {
+    const content = [
+      'https://cdn.example.com/plain.png',
+      '[download](https://cdn.example.com/download.png)',
+      '`![inline](https://cdn.example.com/inline.png)`',
+      '```md\n![fenced](https://cdn.example.com/fenced.png)\n```',
+      '\\![escaped](https://cdn.example.com/escaped.png)',
+      '![unsafe](file:///tmp/image.png)',
+      '![unsafe](javascript:alert)',
+    ].join('\n\n');
+    const { event } = callBuild({ messages: [{ role: 'assistant', content }] });
+    expect(event.attachments).toBeUndefined();
+  });
+
   it('extracts text content from a plain-string final assistant turn', () => {
     const state = {
       messages: [

--- a/apps/server/src/services/agentRuntime/finalReplyImages.ts
+++ b/apps/server/src/services/agentRuntime/finalReplyImages.ts
@@ -1,0 +1,23 @@
+import { parseMarkdown } from 'chat';
+import { visit } from 'unist-util-visit';
+
+/** Read explicit image references, never ordinary links or code examples. */
+export const extractFinalReplyImageUrls = (text: string): string[] => {
+  const tree = parseMarkdown(text);
+  const definitions = new Map<string, string>();
+  visit(tree, 'definition', (node) => {
+    const id = node.identifier.toUpperCase();
+    // CommonMark resolves duplicate definitions to the first definition.
+    if (!definitions.has(id)) definitions.set(id, node.url);
+  });
+
+  const urls: string[] = [];
+  visit(tree, (node) => {
+    if (node.type === 'image') urls.push(node.url);
+    if (node.type === 'imageReference') {
+      const url = definitions.get(node.identifier.toUpperCase());
+      if (url) urls.push(url);
+    }
+  });
+  return urls;
+};


### PR DESCRIPTION
## What changes

Final bot replies such as `![Result](https://example.com/result.png)` now produce image attachments through the shared completion event. Previously the extractor only recognized structured content arrays, so the image-generation tool's Markdown result was sent as text.

Parse explicit image nodes and reference definitions with the existing Chat SDK Markdown parser. Only the final assistant reply's text is parsed; tool state, intermediate tool Markdown, ordinary links and code examples do not become attachments. Handle final text recovered from the database as well. Preserve the reply text as a fallback and reuse existing URL handling and platform senders. Deduplicate attachments while preserving within-message image order. Existing structured tool-result handling remains unchanged.

Fixes #19382. Distinct from #19318 (explicit sendMessage failure reporting).

## Validation

- Confirmed the new Markdown and image-order regressions fail on the base revision.
- `bun run check` on the three changed files: lint clean, 86 tests passed; full type check passed.
- Real iPhone WeChat verification on ninglu OPS: a final Markdown image arrives as a native image; a text-only response sends no image; two references to the same image send one image. No explicit sendMessage call and no new image generation were used in these checks.
- Acceptance: https://app.lobehub.com/acceptance/cccbaa8f-b722-4639-abba-97e81caac797 — 3/3 checks, screenshots and text evidence uploaded and coverage verified.
- Deployment is an equivalent artifact patch layered on the existing PDF/QStash image, not a full canary rebuild. Receipt screenshots cover the normal path in r1/r2; final r3 additionally covers database-recovered replies in regression tests and removes diagnostic logging. Other platforms were not tested end to end.
- Vercel preview is blocked by upstream team authorization, independent of the local checks.


## Rebase validation (2026-09-21)

Rebased without conflicts onto canary `add06349cd`; the patch remains three files with unchanged behavior. Targeted `bun run check` passed: lint clean, 87 tests passed, and the full repository type check passed. GitHub CI app, server, database, packages, desktop, Windows shell, and Web E2E tests passed. Vercel preview remains blocked by team authorization. An independent light review found no blocking defects. The linked 3/3 iPhone acceptance remains historical evidence for the unchanged image extraction and sending behavior; the rebased release has not been rerun end to end on WeChat, and database-recovered replies remain covered by regression tests. Upstream runtime origin/host and messaging replay changes are not claimed as freshly accepted by that historical report.
