### PR TITLE
🐛 fix: support the canonical DeepSeek Flash model alias

### DIFF
--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -804,6 +804,7 @@
   "lobehub.claude-sonnet-4-6.description": "Claude Sonnet 4.6 is Anthropic's best combination of speed and intelligence.",
   "lobehub.claude-sonnet-5.description": "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
   "lobehub.dall-e-3.description": "The latest DALL·E model, released in November 2023, supports more realistic, accurate image generation with stronger detail.",
+  "lobehub.deepseek-flash.description": "Native vision and stronger agent performance than V4 Pro, with lower input and cache costs for long-running workflows.",
   "lobehub.deepseek-v4-flash-vision-exp.description": "DeepSeek V4 Flash Vision Exp is an experimental multimodal model that matches V4 Flash on text capabilities and adds image understanding for visual agent workflows.",
   "lobehub.deepseek-v4-flash.description": "DeepSeek V4 Flash balances fast responses with strong reasoning for latency-sensitive workflows.",
   "lobehub.deepseek-v4-pro.description": "DeepSeek V4 Pro is currently the most affordable model that still performs well on everyday agent tasks.",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -804,6 +804,7 @@
   "lobehub.claude-sonnet-4-6.description": "Claude Sonnet 4.6 是 Anthropic 最佳的速度与智能结合模型。",
   "lobehub.claude-sonnet-5.description": "Claude Sonnet 5 是 Anthropic 最具主动性的 Sonnet 模型，专为持续编码、工具使用和长上下文工作流程而设计，具有 Sonnet 级别的速度和效率。",
   "lobehub.dall-e-3.description": "最新的 DALL·E 模型，于 2023 年 11 月发布，支持更真实、准确的图像生成，细节更强。",
+  "lobehub.deepseek-flash.description": "原生支持看图，智能体表现超越 V4 Pro，以更低的输入和缓存成本完成长流程任务。",
   "lobehub.deepseek-v4-flash-vision-exp.description": "DeepSeek V4 Flash Vision Exp 是一款实验性多模态模型，文本能力与 V4 Flash 相当，并增加图像理解能力，适用于视觉智能代理工作流。",
   "lobehub.deepseek-v4-flash.description": "DeepSeek V4 Flash 在快速响应与强推理之间实现平衡，适用于低延迟工作流。",
   "lobehub.deepseek-v4-pro.description": "DeepSeek V4 Pro 是目前最实惠的模型，同时在日常智能代理任务中表现良好。",

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -30,6 +30,8 @@ export const lobeHubOnlineModelDescriptions = {
     "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
   'lobehub.dall-e-3.description':
     'The latest DALL·E model, released in November 2023, supports more realistic, accurate image generation with stronger detail.',
+  'lobehub.deepseek-flash.description':
+    'Native vision and stronger agent performance than V4 Pro, with lower input and cache costs for long-running workflows.',
   'lobehub.deepseek-v4-flash-vision-exp.description':
     'DeepSeek V4 Flash Vision Exp is an experimental multimodal model that matches V4 Flash on text capabilities and adds image understanding for visual agent workflows.',
   'lobehub.deepseek-v4-flash.description':

--- a/packages/model-runtime/src/providers/deepseek/__tests__/anthropic.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/anthropic.test.ts
@@ -30,21 +30,24 @@ describe('LobeDeepSeekAnthropicAI handlePayload', () => {
     vi.clearAllMocks();
   });
 
-  it('should enable thinking by default for deepseek-v4-pro', async () => {
-    await instance.chat({
-      messages: [{ content: 'Hello', role: 'user' }],
-      model: 'deepseek-v4-pro',
-      temperature: 0,
-    });
+  it.each(['deepseek-v4-pro', 'deepseek-flash'])(
+    'should enable thinking by default for %s',
+    async (model) => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model,
+        temperature: 0,
+      });
 
-    const payload = getLastRequestPayload();
+      const payload = getLastRequestPayload();
 
-    expect(payload.max_tokens).toBe(393_216);
-    expect(payload.thinking).toEqual({
-      budget_tokens: 1024,
-      type: 'enabled',
-    });
-  });
+      expect(payload.max_tokens).toBe(393_216);
+      expect(payload.thinking).toEqual({
+        budget_tokens: 1024,
+        type: 'enabled',
+      });
+    },
+  );
 
   it('should disable thinking when thinking.type is disabled', async () => {
     await instance.chat({

--- a/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AgentRuntimeErrorType } from '../../../types/error';
 import {
   LobeDeepSeekAI,
   LobeDeepSeekAnthropicAI,
@@ -166,6 +167,29 @@ describe('LobeDeepSeekAI', () => {
 });
 
 describe('LobeDeepSeekOpenAI', () => {
+  it('should reject oversized Flash alias prompts before calling the upstream API', async () => {
+    const runtime = new LobeDeepSeekOpenAI({ apiKey: 'test_api_key' });
+    const create = vi
+      .spyOn(runtime.client.chat.completions, 'create')
+      .mockRejectedValue(new Error('Unexpected upstream request'));
+
+    await expect(
+      runtime.chat({
+        messages: [{ content: 'lorem ipsum dolor '.repeat(400_000), role: 'user' }],
+        model: 'deepseek-flash',
+        temperature: 0,
+      }),
+    ).rejects.toMatchObject({
+      error: {
+        ctx: 1_000_000,
+        model: 'deepseek-flash',
+        type: 'context_exceeded_pre_flight',
+      },
+      errorType: AgentRuntimeErrorType.ExceededContextWindow,
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
   describe('init', () => {
     it('should correctly initialize with an API key', () => {
       const runtime = new LobeDeepSeekOpenAI({ apiKey: 'test_api_key' });

--- a/packages/model-runtime/src/providers/deepseek/__tests__/openaiPayload.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/openaiPayload.test.ts
@@ -10,6 +10,25 @@ import {
 } from './testUtils';
 
 describe('DeepSeek OpenAI-compatible chatCompletion.handlePayload', () => {
+  it('should preserve the thinking history contract for the canonical Flash alias', () => {
+    const result = openAIParams.chatCompletion!.handlePayload!({
+      messages: [
+        { content: 'Use the tool', role: 'user' },
+        {
+          content: '',
+          role: 'assistant',
+          tool_calls: [
+            { function: { arguments: '{}', name: 'lookup' }, id: 'call_1', type: 'function' },
+          ],
+        },
+        { content: 'done', role: 'tool', tool_call_id: 'call_1' },
+      ],
+      model: 'deepseek-flash',
+    });
+
+    expect(result.messages[1]).toHaveProperty('reasoning_content', '');
+  });
+
   it('should transform reasoning object to reasoning_content string', () => {
     const payload = {
       messages: [

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.ts
@@ -1,5 +1,5 @@
 import type Anthropic from '@anthropic-ai/sdk';
-import { deepseek as deepseekChatModels, ModelProvider } from 'model-bank';
+import { ModelProvider } from 'model-bank';
 import type OpenAI from 'openai';
 
 import { buildDefaultAnthropicPayload } from '../../core/anthropicCompatibleFactory';
@@ -8,6 +8,7 @@ import { getModelPropertyWithFallback } from '../../utils/getFallbackModelProper
 import { isDeepSeekV4FamilyModel } from '../../utils/modelParse';
 import { resolveSafeMaxTokens } from '../../utils/resolveSafeMaxTokens';
 import { sanitizeAnthropicThinkingParts } from '../../utils/sanitizeAnthropicThinkingParts';
+import { deepseekRuntimeModels } from './runtimeModels';
 import { sanitizeDeepSeekJsonPayload } from './sanitizePayload';
 
 export const isDeepSeekV4Model = (model: string | undefined) => isDeepSeekV4FamilyModel(model);
@@ -140,7 +141,7 @@ export const buildDeepSeekAnthropicPayload = async (
     // is more actionable (fork_topic / larger-ctx suggestions) than either a
     // doomed upstream 400 or a truncated stub completion. Estimate against the
     // messages we actually send (anthropic-normalized).
-    resolveSafeMaxTokens({ ...payload, messages: anthropicMessages }, deepseekChatModels) ??
+    resolveSafeMaxTokens({ ...payload, messages: anthropicMessages }, deepseekRuntimeModels) ??
     (await getModelPropertyWithFallback<number | undefined>(
       payload.model,
       'maxOutput',

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -1,4 +1,4 @@
-import { deepseek as deepseekChatModels, ModelProvider } from 'model-bank';
+import { ModelProvider } from 'model-bank';
 
 import {
   createAnthropicCompatibleParams,
@@ -14,6 +14,7 @@ import {
   createDeepSeekAnthropicGenerateObject,
 } from './generateObject';
 import { fetchDeepSeekModels } from './modelFetch';
+import { deepseekRuntimeModels } from './runtimeModels';
 
 const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 const DEFAULT_DEEPSEEK_ANTHROPIC_BASE_URL = 'https://api.deepseek.com/anthropic';
@@ -66,7 +67,7 @@ export const openAIParams = {
     // DeepSeek upstream rejects requests where input alone exceeds the
     // model context window with a 400 carrying `max_completion=0` in the
     // message. Fail fast before round-tripping. See .
-    contextPreFlight: { models: deepseekChatModels },
+    contextPreFlight: { models: deepseekRuntimeModels },
     handlePayload: buildDeepSeekOpenAIPayload,
   },
   debug: {

--- a/packages/model-runtime/src/providers/deepseek/runtimeModels.ts
+++ b/packages/model-runtime/src/providers/deepseek/runtimeModels.ts
@@ -1,0 +1,21 @@
+import { deepseek } from 'model-bank';
+
+/**
+ * The canonical Flash alias needs context safeguards before provider catalogs
+ * catch up with the release. This does not add a self-hosted model card.
+ * @see https://api-docs.deepseek.com/api/create-chat-completion/
+ * @see https://api-docs.deepseek.com/quick_start/pricing/
+ */
+export const deepseekRuntimeModels: typeof deepseek = [
+  ...deepseek,
+  ...(deepseek.some((model) => model.id === 'deepseek-flash')
+    ? []
+    : [
+        {
+          contextWindowTokens: 1_000_000,
+          id: 'deepseek-flash',
+          maxOutput: 393_216,
+          type: 'chat' as const,
+        },
+      ]),
+];

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -194,7 +194,9 @@ export const MODEL_OWNER_DETECTION_CONFIG = {
 } as const;
 
 export const isDeepSeekV4FamilyModel = (model: string | undefined): boolean =>
-  typeof model === 'string' && model.toLowerCase().includes('deepseek-v4');
+  typeof model === 'string' &&
+  (model.toLowerCase().includes('deepseek-v4') ||
+    model.toLowerCase().split('/').at(-1) === 'deepseek-flash');
 
 export const isDeepSeekThinkingEligibleModel = (model: string | undefined): boolean =>
   typeof model === 'string' &&


### PR DESCRIPTION
DeepSeek V4.1 Flash uses the canonical API ID `deepseek-flash`, which the existing V4 family check missed. Recognize the new alias so default thinking, assistant reasoning history and structured-output handling continue to work, and provide runtime context/output limits for both API adapters.

The provider catalog remains unchanged; runtime metadata covers the alias until the catalog includes it. Adds the new model description in English and Simplified Chinese.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- 119 related tests passed; type check and changed-file lint passed.
- New regression cases failed before the fix for default output/thinking handling and OpenAI assistant reasoning history.
- The provider-level oversized-input regression also verifies the canonical alias is rejected locally with a 1,000,000-token context limit before an upstream call. It fails when the alias preflight metadata is removed; all 19 provider entry-point tests pass with the metadata restored.
- [Acceptance](https://app.lobehub.com/acceptance/c6bb1237-3be4-4b5d-b1a1-d314095d459f): actual Anthropic-compatible text, image and thinking/tool round trip. Streaming conversion and deployed UI are outside that report's coverage.

#### Related references

- [Official release and canonical ID](https://x.com/deepseek_ai/status/2097930620680941732)
- [API parameters](https://api-docs.deepseek.com/api/create-chat-completion/)
- [Context/output limits](https://api-docs.deepseek.com/quick_start/pricing/)
