### PR TITLE
🐛 fix(security): replace rm blacklist regex with semantic shell predicates

### DIFF
--- a/packages/agent-runtime/src/audit/defaultSecurityBlacklist.ts
+++ b/packages/agent-runtime/src/audit/defaultSecurityBlacklist.ts
@@ -11,31 +11,35 @@ import { type SecurityBlacklistConfig } from '@lobechat/types';
  */
 export const DEFAULT_SECURITY_BLACKLIST: SecurityBlacklistConfig = [
   // ==================== File System Dangers ====================
+  //
+  // rm rules use `semanticShell` predicates evaluated against the PARSED
+  // command (segmented on ; | && with quote awareness, wrappers like
+  // sudo/env/nohup unwrapped, targets classified) instead of raw-string
+  // regex. Regex forms like `rm.*-r.*/\s*$` catastrophically false-positive:
+  // `ls .../terminal-bench-regex-log/` matched because "term**rm**inal"
+  // supplied `rm`, "-**r**egex" supplied `-r`, and the trailing `/` supplied
+  // the root target — three harmless fragments spanning unrelated commands.
+  //
+  // The semantic predicates require: the resolved command IS `rm`, a
+  // recursive flag is active, AND a target actually resolves to '/' or a
+  // home directory. Note quoting cannot hide danger (`rm '-rf' /` is still
+  // caught) because the shell strips quotes before argv.
   {
     description: 'securityBlacklist.rmHomeDir',
     match: {
-      command: {
-        pattern: 'rm.*-r.*(~|\\$HOME|/Users/[^/]+|/home/[^/]+)/?\\s*$',
-        type: 'regex',
-      },
+      command: { type: 'semanticShell', predicate: 'rmRecursiveHomeTarget' },
     },
   },
   {
     description: 'securityBlacklist.rmRootDir',
     match: {
-      command: {
-        pattern: 'rm.*-r.*/\\s*$',
-        type: 'regex',
-      },
+      command: { type: 'semanticShell', predicate: 'rmRecursiveRootTarget' },
     },
   },
   {
     description: 'securityBlacklist.rmForceRecursive',
     match: {
-      command: {
-        pattern: 'rm\\s+-rf\\s+[~./]\\s*$',
-        type: 'regex',
-      },
+      command: { type: 'semanticShell', predicate: 'rmForceDotTarget' },
     },
   },
 

--- a/packages/agent-runtime/src/core/InterventionChecker.ts
+++ b/packages/agent-runtime/src/core/InterventionChecker.ts
@@ -1,4 +1,4 @@
-import  {
+import {
   type ArgumentMatcher,
   type HumanInterventionPolicy,
   type HumanInterventionRule,
@@ -7,6 +7,7 @@ import  {
 } from '@lobechat/types';
 
 import { DEFAULT_SECURITY_BLACKLIST } from '../audit/defaultSecurityBlacklist';
+import { matchSemanticShellPredicate } from './semanticShellPredicates';
 
 /**
  * Result of security blacklist check
@@ -158,6 +159,16 @@ export class InterventionChecker {
    * @returns true if matches
    */
   private static matchesArgument(matcher: ArgumentMatcher, value: any): boolean {
+    // Semantic shell matcher: evaluate parsed-command predicates
+    if (
+      typeof matcher === 'object' &&
+      'type' in matcher &&
+      matcher.type === 'semanticShell' &&
+      'predicate' in matcher
+    ) {
+      return matchSemanticShellPredicate(matcher.predicate, String(value));
+    }
+
     const strValue = String(value);
 
     // Simple string matcher

--- a/packages/agent-runtime/src/core/__tests__/InterventionChecker.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/InterventionChecker.test.ts
@@ -304,6 +304,59 @@ describe('InterventionChecker', () => {
         expect(result.blocked).toBe(false);
       });
 
+      // Regression: the old `rm.*-r.*/\s*$` regex matched this READ-ONLY
+      // command because "te|rm|inal" supplied `rm`, "-|r|egex" supplied `-r`
+      // and the trailing `/` of the ls path supplied the root target.
+      it('should allow read-only jq+ls compound command (original false-positive report)', () => {
+        const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
+          command:
+            "jq '.trial // . | {status, error, runner_command}' /Users/arvinxx/CodeProjects/frontierharness/eval/runs/2026-09-10-lobe-smoke/trials/terminal-bench-regex-log/trial.json 2>/dev/null; ls /Users/arvinxx/CodeProjects/frontierharness/eval/runs/2026-09-10-lobe-smoke/trials/terminal-bench-regex-log/",
+        });
+        expect(result.blocked).toBe(false);
+      });
+
+      it('should allow recursive grep over user directories', () => {
+        const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
+          command: 'grep -r pattern /Users/alice/notes',
+        });
+        expect(result.blocked).toBe(false);
+      });
+
+      it('should allow recursive deletes inside the home tree', () => {
+        const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
+          command: 'rm -rf ~/.cache/some-tool',
+        });
+        expect(result.blocked).toBe(false);
+      });
+
+      it('should still block rm -rf via wrapper commands', () => {
+        for (const command of [
+          'sudo rm -rf /',
+          'sudo -u alice rm -rf ~',
+          'env rm -rf /',
+          'nohup rm -rf ~',
+        ]) {
+          const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
+            command,
+          });
+          expect(result.blocked).toBe(true);
+        }
+      });
+
+      it('should block rm -rf with quoted flags (shell strips quotes before argv)', () => {
+        const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
+          command: "rm '-rf' /",
+        });
+        expect(result.blocked).toBe(true);
+      });
+
+      it('should block compound commands containing a real rm -rf / segment', () => {
+        const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
+          command: 'echo start && rm -rf /',
+        });
+        expect(result.blocked).toBe(true);
+      });
+
       it('should block fork bomb', () => {
         const result = InterventionChecker.checkSecurityBlacklist(DEFAULT_SECURITY_BLACKLIST, {
           command: ':(){ :|:& };:',

--- a/packages/agent-runtime/src/core/semanticShellPredicates.test.ts
+++ b/packages/agent-runtime/src/core/semanticShellPredicates.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchSemanticShellPredicate } from './semanticShellPredicates';
+
+describe('matchSemanticShellPredicate', () => {
+  describe('rmRecursiveRootTarget', () => {
+    it.each([
+      'rm -rf /',
+      'rm -r /',
+      'rm --recursive /',
+      'rm -fr /',
+      'rm -rf //',
+      'rm -rf /./',
+      'sudo rm -rf /',
+      'sudo -u alice rm -rf /',
+      'env rm -rf /',
+      'nohup rm -rf /',
+      'FOO=bar rm -rf /',
+      "rm '-rf' /", // shell strips quotes before argv — must stay blocked
+      'rm -rf / ; echo done',
+      'echo start && rm -rf /',
+      'cd /tmp && sudo rm -rf /',
+    ])('blocks: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', command)).toBe(true);
+    });
+
+    it.each([
+      // The original false-positive class: read-only commands whose SUBSTRINGS
+      // used to satisfy the old `rm.*-r.*/\s*$` regex.
+      "jq '.trial // . | {status, error, runner_command}' /Users/arvinxx/CodeProjects/frontierharness/eval/runs/2026-09-10-lobe-smoke/trials/terminal-bench-regex-log/trial.json 2>/dev/null; ls /Users/arvinxx/CodeProjects/frontierharness/eval/runs/2026-09-10-lobe-smoke/trials/terminal-bench-regex-log/",
+      'ls /Users/arvinxx/CodeProjects/terminal/',
+      'ls /',
+      'cd /',
+      'cat firmware/README.md | grep -r term',
+      'npm run build --prefix ./packages/app/',
+      'terraform -chdir=infra/ plan',
+      'rm -rf /tmp/build-cache',
+      'rm -rf ./dist',
+      'rm file.txt',
+      'rm -f file.txt',
+      'rm -rf dir',
+      'grep -r pattern /Users/arvinxx/notes',
+      'grep -ri todo /home/dev/project/',
+      'du -sh /Users/arvinxx/',
+      'find /Users/arvinxx -name "*.log"',
+      'ls -la /usr/local/bin/',
+      // Unknown predicate must never match (forward compatibility).
+    ])('allows: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', command)).toBe(false);
+    });
+
+    it('returns false for unknown predicate names (fail-open)', () => {
+      expect(matchSemanticShellPredicate('timeTravelAndDeleteEverything', 'rm -rf /')).toBe(false);
+    });
+
+    it('returns false for non-string-ish input', () => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', '')).toBe(false);
+    });
+  });
+
+  describe('rmRecursiveHomeTarget', () => {
+    it.each([
+      'rm -rf ~',
+      'rm -rf ~/',
+      'rm -r ~',
+      'rm --recursive ~',
+      'sudo rm -rf ~',
+      'rm -rf $HOME',
+      'rm -rf $HOME/',
+      'rm -rf /Users/alice',
+      'rm -rf /Users/alice/',
+      'rm -rf /home/bob',
+      "rm '-r' ~",
+      'echo x; rm -rf ~/',
+    ])('blocks: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmRecursiveHomeTarget', command)).toBe(true);
+    });
+
+    it.each([
+      // Deletes INSIDE the home tree are routine agent work — must not block.
+      'rm -rf ~/notes/old',
+      'rm -rf ~/.cache',
+      'rm -r ~/.config/some-app',
+      'rm -rf /Users/alice/projects/sandbox',
+      'rm -rf /home/bob/tmp/build',
+      // Not rm at all.
+      'ls ~',
+      'du -sh /Users/arvinxx/',
+      'grep -r pattern /Users/arvinxx/notes',
+      'cat ~/.zshrc',
+    ])('allows: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmRecursiveHomeTarget', command)).toBe(false);
+    });
+  });
+
+  describe('rmForceDotTarget', () => {
+    it.each(['rm -rf .', 'rm -rf ./', 'rm -Rf .', 'sudo rm -rf .'])('blocks: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmForceDotTarget', command)).toBe(true);
+    });
+
+    it.each(['rm -r .', 'rm -f .', 'rm -rf ./dist', 'rm file'])('allows: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmForceDotTarget', command)).toBe(false);
+    });
+  });
+
+  describe('command substitution containment', () => {
+    // Substitution bodies stay embedded inside words rather than splitting the
+    // outer command. The predicates above only fire on `rm` as the RESOLVED
+    // command of a segment, so `echo $(rm -rf /)` does not fire rmRecursiveRootTarget.
+    // This is deliberate: execution-level protections are the exec sandbox's
+    // job; the blacklist targets unambiguous direct invocations. What matters
+    // for regression safety is that read-only commands are never flagged.
+    it('does not flag substitution content as a direct rm invocation', () => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', 'echo $(rm -rf /)')).toBe(false);
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', 'echo `rm -rf /`')).toBe(false);
+    });
+
+    it('still catches the direct command sharing a line with a substitution', () => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', 'echo $(date) && rm -rf /')).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/packages/agent-runtime/src/core/semanticShellPredicates.test.ts
+++ b/packages/agent-runtime/src/core/semanticShellPredicates.test.ts
@@ -191,6 +191,73 @@ describe('matchSemanticShellPredicate', () => {
     });
   });
 
+  describe('independent review regressions (SEC-1/SEC-2 hardening)', () => {
+    it.each([
+      // Value-taking sudo options the old whitelist missed — the flag's VALUE
+      // used to resolve as the command, letting real rm slip through.
+      'sudo -p password: rm -rf /',
+      'sudo -R /chroot rm -rf /',
+      'sudo -r sys_t rm -rf /',
+      'sudo -T 10 rm -rf /',
+      'env -u FOO rm -rf /',
+      // Positional wrapper values (timeout DURATION, flock LOCKFILE).
+      'timeout 30 rm -rf /',
+      'timeout 30 rm -rf ~',
+      'flock /tmp/lock rm -rf /',
+      // Option values that ARE the payload (ambiguous-shape fallback).
+      'env -S rm -rf /',
+      'bash -c rm -rf /',
+      'bash -c "rm -rf /"',
+      'sh -c rm -rf ~',
+      // Embedded option values (stdbuf -o0 style, no '=' present).
+      'stdbuf -o0 rm -rf /',
+      // Exec-prefix wrappers previously unwrapped nowhere (SEC-2).
+      'exec rm -rf /',
+      'exec rm -rf ~',
+      'xargs rm -rf /',
+      'nice rm -rf /',
+      'setsid rm -rf /',
+      'ionice rm -rf /',
+      'strace rm -rf /',
+      'time rm -rf /',
+      // Compounds and multi-line shapes sharing these wrappers.
+      'echo ok\nxargs rm -rf /',
+      'find . | xargs rm -rf /',
+    ])('blocks review-found bypass: %s', (command) => {
+      expect(
+        matchSemanticShellPredicate('rmRecursiveRootTarget', command) ||
+          matchSemanticShellPredicate('rmRecursiveHomeTarget', command) ||
+          matchSemanticShellPredicate('rmForceDotTarget', command),
+      ).toBe(true);
+    });
+
+    it.each([
+      // Value-free whitelist flags must NOT over-consume: rm stays resolvable
+      // and the (safe) target decides the verdict.
+      'sudo -n rm -rf /tmp/build',
+      'sudo -v && echo ok',
+      'sudo -l',
+      'sudo -A rm -rf /tmp/build-cache',
+      'env -i ls /',
+      'command -v rm',
+      'time ls /',
+      'nice -n 10 ls /',
+      'timeout 30 ls /',
+      'flock /tmp/lock ls /',
+      'stdbuf -o0 ls /',
+      // Quoted/argument rm strings under confident non-rm commands stay
+      // allowed — no re-creation of the substring false-positive class.
+      "echo 'rm -rf /'",
+      'echo $(date) && ls /',
+    ])('allows legitimate usage: %s', (command) => {
+      expect(
+        matchSemanticShellPredicate('rmRecursiveRootTarget', command) ||
+          matchSemanticShellPredicate('rmRecursiveHomeTarget', command) ||
+          matchSemanticShellPredicate('rmForceDotTarget', command),
+      ).toBe(false);
+    });
+  });
+
   describe('command substitution containment', () => {
     // Substitution bodies stay embedded inside words rather than splitting the
     // outer command. The predicates above only fire on `rm` as the RESOLVED

--- a/packages/agent-runtime/src/core/semanticShellPredicates.test.ts
+++ b/packages/agent-runtime/src/core/semanticShellPredicates.test.ts
@@ -103,6 +103,94 @@ describe('matchSemanticShellPredicate', () => {
     });
   });
 
+  describe('codex review regressions (bypass hardening)', () => {
+    it.each([
+      // #1 Unescaped newlines are command separators — second line must resolve.
+      'echo ok\nrm -rf /',
+      'echo ok\r\nrm -rf /',
+      'echo ok\nsudo rm -rf /',
+    ])('blocks multi-line root bypass: %s', (command) => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', command)).toBe(true);
+    });
+
+    it.each(['echo ok;\necho hi\nrm -rf ~', 'echo ok\nrm -rf ~'])(
+      'blocks multi-line home bypass: %s',
+      (command) => {
+        expect(matchSemanticShellPredicate('rmRecursiveHomeTarget', command)).toBe(true);
+      },
+    );
+
+    it('keeps newlines inside quotes inert (not a separator)', () => {
+      const command = "printf 'line1\nline2' | cat";
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', command)).toBe(false);
+    });
+
+    it.each([
+      // #2 Value-free wrapper options must not swallow the command.
+      'sudo -n rm -rf /',
+      'env -i rm -rf /',
+      'sudo -n rm -rf ~',
+      // Value-TAKING wrapper options still consume their value…
+      'sudo -u alice rm -rf /',
+      // …including their value hiding further flags.
+      'sudo -u alice rm -rf ~',
+      // Long forms embed the value and consume nothing extra.
+      'sudo --user=alice rm -rf /',
+      // Combined wrapper flags with an embedded value-free flag.
+      'sudo -ln rm -rf /',
+    ])('blocks wrapper-option bypass: %s', (command) => {
+      expect(
+        matchSemanticShellPredicate('rmRecursiveRootTarget', command) ||
+          matchSemanticShellPredicate('rmRecursiveHomeTarget', command),
+      ).toBe(true);
+    });
+
+    it('still blocks plain value-taking wrapper usage (no regression)', () => {
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', 'sudo -u alice rm -rf /')).toBe(
+        true,
+      );
+    });
+
+    it.each([
+      // #3 Path-qualified executables normalize to basename.
+      '/bin/rm -rf /',
+      '/usr/bin/rm -rf ~',
+      './rm -rf /',
+      '/bin/rm -rf / ; ls ok',
+    ])('blocks path-qualified bypass: %s', (command) => {
+      expect(
+        matchSemanticShellPredicate('rmRecursiveRootTarget', command) ||
+          matchSemanticShellPredicate('rmRecursiveHomeTarget', command),
+      ).toBe(true);
+    });
+
+    it('keeps root path as a target, not a command basename', () => {
+      // `rm -rf /` — the standalone `/` is the TARGET; resolvedCommand is rm.
+      const command = 'rm -rf /';
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', command)).toBe(true);
+    });
+
+    it.each([
+      // #4 bash `command` builtin executes its argument directly.
+      'command rm -rf /',
+      'command rm -rf ~',
+      'command -p rm -rf /',
+      'sudo command rm -rf /',
+    ])('blocks command-builtin bypass: %s', (command) => {
+      expect(
+        matchSemanticShellPredicate('rmRecursiveRootTarget', command) ||
+          matchSemanticShellPredicate('rmRecursiveHomeTarget', command),
+      ).toBe(true);
+    });
+
+    it('command -v/-V describe mode is not a rm execution (fails open safely)', () => {
+      // `command -v rm` only PRINTS the path; no deletion happens. The
+      // unwrapping stops at `-v`'s value `rm`, resolvedCommand becomes `rm`
+      // with no recursive flag — predicate needs flag+target, so no block.
+      expect(matchSemanticShellPredicate('rmRecursiveRootTarget', 'command -v rm')).toBe(false);
+    });
+  });
+
   describe('command substitution containment', () => {
     // Substitution bodies stay embedded inside words rather than splitting the
     // outer command. The predicates above only fire on `rm` as the RESOLVED

--- a/packages/agent-runtime/src/core/semanticShellPredicates.ts
+++ b/packages/agent-runtime/src/core/semanticShellPredicates.ts
@@ -5,9 +5,10 @@ import { analyzeShellCommand } from './shellCommand';
  * Semantic shell predicates for security rules.
  *
  * Unlike string regex matching on the raw command, these evaluate the PARSED
- * command: segments are split on `;` `&&` `|` respecting quotes, wrappers
- * (sudo/env/nohup) are unwrapped to the real command, and targets are
- * classified (trailing-slash paths, home-resolved paths).
+ * command: segments are split on `;` `&&` `|` and unescaped newlines,
+ * respecting quotes; exec-prefix wrappers (sudo/env/nohup/command/exec/
+ * xargs/timeout/…) are unwrapped to the real command; targets are classified
+ * (trailing-slash paths, home-resolved paths).
  *
  * Design principle for the security context: over-detection is acceptable,
  * under-detection is not. Quoting must NOT hide danger (`rm '-rf' /` is a real
@@ -15,9 +16,83 @@ import { analyzeShellCommand } from './shellCommand';
  */
 
 /**
- * True when the segment invokes rm with a recursive flag on a target that
- * resolves to the filesystem root '/'.
+ * Ambiguity fallback (defense in depth).
+ *
+ * Some wrapper shapes hide the real command from unwrapping: the dangerous
+ * `rm` ends up as a wrapper OPTION VALUE whose semantics the resolver cannot
+ * know (`env -S 'rm -rf /'`, `bash -c rm -rf /`), or as a POSITIONAL wrapper
+ * argument (`timeout 30 rm -rf ~`, `flock /tmp/l rm -rf /`). After
+ * unwrapping, resolvedCommand is null/`bash`/`timeout`… — not `rm` — so a
+ * plain predicate would pass. Per the module's own principle
+ * (over-detection acceptable, under-detection is not), when a segment that
+ * did NOT resolve to a confident rm invocation nevertheless CONTAINS an rm
+ * word plus a recursive flag plus a dangerous target, treat it as dangerous.
+ *
+ * The over-detection cost is bounded: this only fires when rm + recursive
+ * flag + root/home target co-occur in one segment — a shape that essentially
+ * only appears in real attack payloads or adversarial test strings.
  */
+const hasAmbiguousRmShape = (segment: ShellSegment): boolean => {
+  // Confident rm resolution is handled by the precise predicates; here we
+  // catch segments where the command slot is NOT a confidently-parsed rm.
+  if (segment.resolvedCommand === 'rm') return false;
+  if (segment.resolvedCommand !== null && !AMBIGUOUS_COMMAND_HINTS.has(segment.resolvedCommand)) {
+    // Resolved to an unrelated confident command (echo, ls, …) — the rm word
+    // (if any) belongs to a quoted string or argument of THAT command; the
+    // segment-level fallback would just re-create the original substring
+    // false-positive class. Only ambiguous command slots fall through.
+    return false;
+  }
+  const words = segment.words;
+  const rmIndex = words.findIndex((word) => word === 'rm' || /\/rm$/.test(word));
+  if (rmIndex < 0) {
+    // Quoted payload form: the interpreter's -c value arrives as ONE word
+    // after quote stripping (`bash -c "rm -rf /"` → word `rm -rf /`). Treat a
+    // word that STARTS with `rm ` as an embedded rm invocation.
+    return words.some((word) => /^rm\s+(?:-[a-z]+\s+)*/i.test(word) && word.includes('/'));
+  }
+  const hasRecursiveFlag = segment.flags.some((flag) => /^-[a-z]*r/i.test(flag));
+  if (!hasRecursiveFlag) return false;
+  // Scan the words AFTER the rm word for a dangerous target. The post-
+  // commandIndex target slices are unreliable here precisely because the
+  // command slot resolved to null or a wrapper value — that is why this
+  // fallback is running at all.
+  const hasDangerousTarget = words
+    .slice(rmIndex + 1)
+    .some(
+      (word) =>
+        /^\/[.:/]*$/.test(word) ||
+        word === './' ||
+        ['~', '~/', '$HOME', '$HOME/'].includes(word) ||
+        /^\/(?:Users|home)\/[^/]+\/?$/.test(word),
+    );
+  return hasDangerousTarget;
+};
+
+/**
+ * Commands whose non-rm resolution still warrants the ambiguous-shape
+ * fallback: exec-prefix wrappers whose option/positional value swallowed the
+ * real command, and shell interpreters whose -c value IS the payload.
+ */
+const AMBIGUOUS_COMMAND_HINTS = new Set([
+  'bash',
+  'sh',
+  'zsh',
+  'dash',
+  'ksh',
+  'timeout',
+  'flock',
+  'stdbuf',
+  'env',
+  'xargs',
+  'strace',
+  'ltrace',
+  'setsid',
+  'ionice',
+]);
+
+/** True when the segment invokes rm with a recursive flag on a target that
+ * resolves to the filesystem root '/'. */
 const isRmRecursiveRootTarget = (segment: ShellSegment): boolean => {
   if (segment.resolvedCommand !== 'rm') return false;
   const recursive = segment.hasFlag('r') || segment.hasFlag('R');
@@ -78,11 +153,15 @@ export const SEMANTIC_SHELL_PREDICATE_RESOLVERS: Record<
  * Unknown predicate names never match (fail-open for forward compatibility —
  * new predicates shipped to a client whose runtime predates them must not
  * flag unrelated commands).
+ *
+ * Every rm predicate additionally consults the ambiguous-shape fallback so
+ * wrapper-hidden rm payloads (`env -S rm -rf /`, `timeout 30 rm -rf ~`,
+ * `bash -c rm -rf /`, `flock /tmp/l rm -rf /`) stay blocked.
  */
 export const matchSemanticShellPredicate = (predicate: string, value: string): boolean => {
   const resolver = SEMANTIC_SHELL_PREDICATE_RESOLVERS[predicate];
   if (!resolver) return false;
 
   const segments = analyzeShellCommand(value);
-  return segments.some((segment) => resolver(segment, segments));
+  return segments.some((segment) => resolver(segment, segments) || hasAmbiguousRmShape(segment));
 };

--- a/packages/agent-runtime/src/core/semanticShellPredicates.ts
+++ b/packages/agent-runtime/src/core/semanticShellPredicates.ts
@@ -1,0 +1,88 @@
+import type { ShellSegment } from './shellCommand';
+import { analyzeShellCommand } from './shellCommand';
+
+/**
+ * Semantic shell predicates for security rules.
+ *
+ * Unlike string regex matching on the raw command, these evaluate the PARSED
+ * command: segments are split on `;` `&&` `|` respecting quotes, wrappers
+ * (sudo/env/nohup) are unwrapped to the real command, and targets are
+ * classified (trailing-slash paths, home-resolved paths).
+ *
+ * Design principle for the security context: over-detection is acceptable,
+ * under-detection is not. Quoting must NOT hide danger (`rm '-rf' /` is a real
+ * recursive root delete because the shell strips quotes before argv).
+ */
+
+/**
+ * True when the segment invokes rm with a recursive flag on a target that
+ * resolves to the filesystem root '/'.
+ */
+const isRmRecursiveRootTarget = (segment: ShellSegment): boolean => {
+  if (segment.resolvedCommand !== 'rm') return false;
+  const recursive = segment.hasFlag('r') || segment.hasFlag('R');
+  if (!recursive) return false;
+  // Target IS the bare root, or a path that reduces to root ('//' , '/./').
+  return segment.trailingSlashTargets.some((target) => /^\/[.:/]*$/.test(target));
+};
+
+/**
+ * True when the segment invokes rm with a recursive flag on the home
+ * directory ITSELF (~, $HOME, /Users/<name>, /home/<name>, with optional
+ * trailing slash).
+ *
+ * Deliberately narrow: recursive deletes INSIDE the home tree (`rm -r
+ * ~/notes/old`, `~/.cache`) are routine agent work (dotfile/cleanup) and are
+ * covered by the normal approval flow — flagging them would re-create the
+ * false-positive problem this module exists to fix.
+ */
+const isRmRecursiveHomeTarget = (segment: ShellSegment): boolean => {
+  if (segment.resolvedCommand !== 'rm') return false;
+  const recursive = segment.hasFlag('r') || segment.hasFlag('R');
+  if (!recursive) return false;
+  // `$HOME/` ends with a slash so it lands in trailingSlashTargets; check both
+  // target collections so every home-resolved shape is covered.
+  const candidates = [...segment.homeTargets, ...segment.trailingSlashTargets];
+  return candidates.some((target) => {
+    if (target === '~' || target === '$HOME' || target === '~/') return true;
+    if (target === '$HOME/') return true;
+    return /^\/(?:Users|home)\/[^/]+\/?$/.test(target);
+  });
+};
+
+/**
+ * True when the segment invokes rm with a recursive flag and force flag on
+ * the current directory ('.' / './') — a blanket delete whose blast radius is
+ * "whatever cwd happens to be" (the old `rmForceRecursive` rule's intent).
+ */
+const isRmForceDotTarget = (segment: ShellSegment): boolean => {
+  if (segment.resolvedCommand !== 'rm') return false;
+  const recursive = segment.hasFlag('r') || segment.hasFlag('R');
+  const force = segment.hasFlag('f');
+  if (!recursive || !force) return false;
+  return segment.trailingSlashTargets.includes('./') || segment.words.slice(1).includes('.');
+};
+
+// Extensible registry: future predicates (disk writes, fork bombs, ...) plug in here.
+export const SEMANTIC_SHELL_PREDICATE_RESOLVERS: Record<
+  string,
+  (segment: ShellSegment, segments: ShellSegment[]) => boolean
+> = {
+  rmRecursiveRootTarget: isRmRecursiveRootTarget,
+  rmRecursiveHomeTarget: isRmRecursiveHomeTarget,
+  rmForceDotTarget: isRmForceDotTarget,
+};
+
+/**
+ * Check whether any segment of the command satisfies the named predicate.
+ * Unknown predicate names never match (fail-open for forward compatibility —
+ * new predicates shipped to a client whose runtime predates them must not
+ * flag unrelated commands).
+ */
+export const matchSemanticShellPredicate = (predicate: string, value: string): boolean => {
+  const resolver = SEMANTIC_SHELL_PREDICATE_RESOLVERS[predicate];
+  if (!resolver) return false;
+
+  const segments = analyzeShellCommand(value);
+  return segments.some((segment) => resolver(segment, segments));
+};

--- a/packages/agent-runtime/src/core/shellCommand.test.ts
+++ b/packages/agent-runtime/src/core/shellCommand.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeShellCommand } from './shellCommand';
+
+describe('analyzeShellCommand', () => {
+  describe('splitting', () => {
+    it('splits on ; | && and returns all segments', () => {
+      const segments = analyzeShellCommand('jq .x file.json 2>/dev/null; ls dir/');
+      expect(segments).toHaveLength(2);
+      expect(segments[0].words).toEqual(['jq', '.x', 'file.json']);
+      // Redirections like 2>/dev/null are stripped from words
+      expect(segments[1].words).toEqual(['ls', 'dir/']);
+    });
+
+    it('splits on ;', () => {
+      const segments = analyzeShellCommand('echo a; echo b; echo c');
+      expect(segments).toHaveLength(3);
+      expect(segments.map((s) => s.words[0])).toEqual(['echo', 'echo', 'echo']);
+    });
+
+    it('splits on &&', () => {
+      const segments = analyzeShellCommand('cd /tmp && rm file');
+      expect(segments).toHaveLength(2);
+      expect(segments[0].words).toEqual(['cd', '/tmp']);
+      expect(segments[1].words).toEqual(['rm', 'file']);
+    });
+
+    it('splits on pipes', () => {
+      const segments = analyzeShellCommand('cat log.txt | grep error | wc -l');
+      expect(segments.map((s) => s.words[0])).toEqual(['cat', 'grep', 'wc']);
+    });
+
+    it('keeps quoted separators intact', () => {
+      const segments = analyzeShellCommand("echo 'a; b | c' && echo done");
+      expect(segments).toHaveLength(2);
+      expect(segments[0].words).toEqual(['echo', 'a; b | c']);
+      expect(segments[1].words).toEqual(['echo', 'done']);
+    });
+
+    it('keeps semicolons inside double quotes intact', () => {
+      const segments = analyzeShellCommand('echo "x;y" | grep x');
+      expect(segments).toHaveLength(2);
+      expect(segments[0].words).toEqual(['echo', 'x;y']);
+    });
+
+    it('handles unmatched quote gracefully (does not hang or throw)', () => {
+      // Unbalanced quote: everything after it becomes one segment — must not throw
+      const segments = analyzeShellCommand("echo 'a; b");
+      expect(segments.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('redirection stripping', () => {
+    it('strips trailing redirection with fd number (2>/dev/null)', () => {
+      const segments = analyzeShellCommand('ls 2>/dev/null');
+      expect(segments[0].words).toEqual(['ls']);
+    });
+
+    it('strips plain output redirection (> out.txt, >> append.log)', () => {
+      const segments = analyzeShellCommand('echo hi > out.txt >> append.log');
+      expect(segments[0].words).toEqual(['echo', 'hi']);
+    });
+
+    it('strips input redirection (< input.txt)', () => {
+      const segments = analyzeShellCommand('wc -l < input.txt');
+      expect(segments[0].words).toEqual(['wc', '-l']);
+    });
+
+    it('strips heredoc operator from words', () => {
+      const segments = analyzeShellCommand('cat <<EOF');
+      expect(segments[0].words).toEqual(['cat']);
+    });
+
+    it('strips redirections inside quotes-adjacent positions but not quoted redirections', () => {
+      // A redirection-looking string inside a quoted word must survive
+      const segments = analyzeShellCommand("echo 'a > b' | cat");
+      expect(segments[0].words).toEqual(['echo', 'a > b']);
+    });
+  });
+
+  describe('wrapper unwrapping', () => {
+    it('unwraps sudo', () => {
+      const segments = analyzeShellCommand('sudo rm -rf /');
+      expect(segments[0].words[0]).toBe('sudo');
+      expect(segments[0].resolvedCommand).toBe('rm');
+      expect(segments[0].flags).toContain('-rf');
+    });
+
+    it('unwraps chained sudo env', () => {
+      const segments = analyzeShellCommand('sudo env FOO=bar rm -rf /');
+      expect(segments[0].resolvedCommand).toBe('rm');
+      expect(segments[0].flags).toContain('-rf');
+    });
+
+    it('unwraps env with assignments', () => {
+      const segments = analyzeShellCommand('env FOO=bar bash rm file');
+      // `env` consumes FOO=bar; the real command is `bash`, and `rm file` is
+      // bash's argument string — NOT an rm invocation by itself.
+      expect(segments[0].resolvedCommand).toBe('bash');
+    });
+
+    it('unwraps env followed directly by the dangerous command', () => {
+      const segments = analyzeShellCommand('env rm -rf /');
+      expect(segments[0].resolvedCommand).toBe('rm');
+      expect(segments[0].hasFlag('r')).toBe(true);
+    });
+
+    it('unwraps env with variables set inline and command', () => {
+      const segments = analyzeShellCommand('FOO=bar env rm file');
+      // Leading assignments are skipped as part of lightweight word initializers
+      expect(segments[0].resolvedCommand).toBe('rm');
+    });
+
+    it('unwraps nohup wrappers only (still unwraps nohup)', () => {
+      const segments = analyzeShellCommand('nohup rm -rf / &');
+      expect(segments[0].resolvedCommand).toBe('rm');
+    });
+
+    it('does not treat first word as a wrapper when it is the real command', () => {
+      const segments = analyzeShellCommand('rm file');
+      expect(segments[0].resolvedCommand).toBe('rm');
+    });
+
+    it('does not unwrap when wrapper target is another wrapper keyword', () => {
+      // 'sudo sudo' — unwrap loop should terminate
+      const segments = analyzeShellCommand('sudo sudo rm file');
+      expect(segments[0].resolvedCommand).toBe('rm');
+    });
+
+    it('terminates unwrap loop on pathological input', () => {
+      const many = Array.from({ length: 50 }, () => 'sudo').join(' ');
+      const segments = analyzeShellCommand(`${many} rm file`);
+      expect(segments[0].resolvedCommand).toBe('rm');
+    });
+  });
+
+  describe('flags parsing', () => {
+    it('joins combined short flags (-rf)', () => {
+      const segments = analyzeShellCommand('rm -rf dir');
+      expect(segments[0].hasFlag('r')).toBe(true);
+      expect(segments[0].hasFlag('f')).toBe(true);
+    });
+
+    it('recognizes separate flags (-r -f)', () => {
+      const segments = analyzeShellCommand('rm -r -f dir');
+      expect(segments[0].hasFlag('r')).toBe(true);
+      expect(segments[0].hasFlag('f')).toBe(true);
+    });
+
+    it('recognizes long flags (--recursive)', () => {
+      const segments = analyzeShellCommand('rm --recursive dir');
+      expect(segments[0].hasFlag('r')).toBe(true);
+      expect(segments[0].hasFlag('recursive')).toBe(true);
+    });
+
+    it('recognizes separated long flag value (--recursive=yes)', () => {
+      const segments = analyzeShellCommand('rm --recursive=yes dir');
+      expect(segments[0].hasLongFlag('recursive')).toBe(true);
+      expect(segments[0].hasFlag('recursive')).toBe(true);
+    });
+
+    it("flags survive quoting because argv is what matters (rm '-rf' dir IS recursive)", () => {
+      // Shell strips quotes before argv: `rm '-rf' dir` is a REAL recursive
+      // delete. A security checker must NOT let quoting hide dangerous flags.
+      const segments = analyzeShellCommand("grep '-rf' file");
+      expect(segments[0].hasFlag('r')).toBe(true);
+      const rmSegments = analyzeShellCommand("rm '-rf' /");
+      expect(rmSegments[0].hasFlag('r')).toBe(true);
+      expect(rmSegments[0].trailingSlashTargets).toContain('/');
+    });
+
+    it('flags stop at file targets (flags-prefixed word after non-flag is treated as target)', () => {
+      // GNU getopt permutes arguments, so flags after paths are still valid flags for rm.
+      // We conservatively parse ALL leading dash words as flags; this is the safe direction
+      // for a security check (over-detection is acceptable, under-detection is not).
+      const segments = analyzeShellCommand('rm dir/file -rf');
+      expect(segments[0].hasFlag('r')).toBe(true);
+    });
+  });
+
+  describe('targets extraction', () => {
+    it('collects args ending with slash as targets with trailing slash', () => {
+      const segments = analyzeShellCommand('ls /tmp/foo/');
+      const seg = segments[0];
+      expect(seg.trailingSlashTargets).toContain('/tmp/foo/');
+    });
+
+    it('collects bare root as trailing-slash target', () => {
+      const segments = analyzeShellCommand('ls /');
+      expect(segments[0].trailingSlashTargets).toContain('/');
+    });
+
+    it('collects home paths as home-resolved targets', () => {
+      const segments = analyzeShellCommand('grep -r pattern ~/notes/');
+      const seg = segments[0];
+      expect(seg.homeTargets).toContain('~/notes/');
+    });
+
+    it('collects /Users/xxx as home-resolved targets', () => {
+      const segments = analyzeShellCommand('ls /Users/alice/Documents');
+      const seg = segments[0];
+      expect(seg.homeTargets).toContain('/Users/alice/Documents');
+    });
+  });
+
+  describe('command substitution quarantine', () => {
+    it('stops analysis at $( — returns the prefix as one segment', () => {
+      // Anything inside $() could contain rm -rf / that only executes under outer command's
+      // conditions; for security blacklist we ANALYZE the substitution content too, but flag
+      // that substitutions exist so rules can stay conservative.
+      const segments = analyzeShellCommand('echo $(rm -rf /)');
+      expect(segments.some((s) => s.raw.includes('echo'))).toBe(true);
+    });
+
+    it('analyzes backtick substitution content as its own segment', () => {
+      const segments = analyzeShellCommand('echo `rm -rf /`');
+      // The command with substitution is analyzed as a whole (defense in depth):
+      // the segment still contains 'rm' and root target, so any semantic rm-rule
+      // that scans words/targets would see it.
+      const allWords = segments.flatMap((s) => s.words);
+      // The substitution content is inside a word 'echo `rm -rf /`' → words: ['echo', '`rm -rf /`']
+      // The safe design: preserve it as a single word; blacklist should treat embedded
+      // substitutions conservatively.
+      expect(allWords).toContain('`rm -rf /`');
+    });
+
+    it('does not treat | inside $(... ) as pipe separator', () => {
+      const segments = analyzeShellCommand('echo $(cat f | wc -l)');
+      expect(segments).toHaveLength(1);
+      expect(segments[0].words[0]).toBe('echo');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty string', () => {
+      const segments = analyzeShellCommand('');
+      expect(segments).toHaveLength(0);
+    });
+
+    it('handles whitespace-only string', () => {
+      const segments = analyzeShellCommand('   ');
+      expect(segments).toHaveLength(0);
+    });
+
+    it('handles lone separator', () => {
+      const segments = analyzeShellCommand(';;; ||| &&');
+      // Separator-only segments have no words
+      expect(segments.filter((s) => s.words.length > 0)).toHaveLength(0);
+    });
+
+    it('handles command with only redirection', () => {
+      const segments = analyzeShellCommand('> out.txt');
+      expect(segments.filter((s) => s.words.length > 0)).toHaveLength(0);
+    });
+  });
+
+  describe('security-relevant integration shapes (from real false-positive reports)', () => {
+    it('the jq+ls command that triggered rmRootDir false positive class', () => {
+      const command =
+        "jq '.trial // . | {status, error, runner_command}' /Users/arvinxx/CodeProjects/frontierharness/eval/runs/2026-09-10-lobe-smoke/trials/terminal-bench-regex-log/trial.json 2>/dev/null; ls /Users/arvinxx/CodeProjects/frontierharness/eval/runs/2026-09-10-lobe-smoke/trials/terminal-bench-regex-log/";
+      const segments = analyzeShellCommand(command);
+      const lsSeg = segments[1];
+      expect(lsSeg.resolvedCommand).toBe('ls');
+      expect(lsSeg.hasFlag('r')).toBe(false);
+      expect(lsSeg.hasFlag('f')).toBe(false);
+      // rm should not appear as any resolved command
+      expect(segments.some((s) => s.resolvedCommand === 'rm')).toBe(false);
+    });
+
+    it('grep -r over user dirs must not be flagged as rm-homedir', () => {
+      const segments = analyzeShellCommand('grep -r pattern /Users/arvinxx/notes');
+      expect(segments[0].resolvedCommand).toBe('grep');
+      expect(segments[0].hasFlag('r')).toBe(true);
+      // It has recursive flag but the command is not rm — resolver decides, not the analyzer
+    });
+
+    it('real rm -rf / is still fully visible as root-target rm', () => {
+      const segments = analyzeShellCommand('rm -rf /');
+      const seg = segments[0];
+      expect(seg.resolvedCommand).toBe('rm');
+      expect(seg.hasFlag('r')).toBe(true);
+      expect(seg.trailingSlashTargets).toContain('/');
+    });
+
+    it('real rm -rf ~ is fully visible as home-target rm', () => {
+      const segments = analyzeShellCommand('rm -rf ~');
+      const seg = segments[0];
+      expect(seg.resolvedCommand).toBe('rm');
+      expect(seg.hasFlag('r')).toBe(true);
+      expect(seg.homeTargets).toContain('~');
+    });
+  });
+});

--- a/packages/agent-runtime/src/core/shellCommand.ts
+++ b/packages/agent-runtime/src/core/shellCommand.ts
@@ -1,0 +1,446 @@
+/**
+ * Lightweight shell command analysis for security rules.
+ *
+ * The goal is NOT to be a full shell parser. It is a conservative,
+ * security-oriented splitter that turns a raw command string into semantic
+ * segments so rules can match on "command + flags + targets" instead of
+ * brittle full-string regex.
+ *
+ * Design principles (security checker context):
+ * - Over-detection is acceptable; under-detection is not. When unsure, segments
+ *   keep MORE raw context rather than less.
+ * - Quotes are honored: separators/flags/redirections inside quotes are inert.
+ * - Command substitution (backticks, $(...)) does not split the outer command;
+ *   its content is preserved inside words and rules must stay conservative
+ *   about segments that contain substitutions.
+ * - Wrappers (sudo / env / nohup) are unwrapped to expose the real command.
+ */
+
+export interface ShellSegment {
+  /** True when the command could not be split/parsed with confidence. */
+  ambiguous: boolean;
+
+  /**
+   * Flag words as they appeared (e.g. '-rf', '--recursive'), collected from
+   * dash-prefixed words. Quoted words never count as flags.
+   */
+  flags: string[];
+
+  /** Whether this segment contains command substitution (backticks or $()) / variables. */
+  hasCommandSubstitution: boolean;
+
+  /** Check whether a single-letter flag is active (expands combined flags like -rf). */
+  hasFlag: (letter: string) => boolean;
+
+  /** Check whether a long flag name is active (--recursive). */
+  hasLongFlag: (name: string) => boolean;
+
+  /** Argument targets that resolve into a home directory (~, $HOME, /Users/x, /home/x). */
+  homeTargets: string[];
+
+  /** Raw text of this segment (trimmed of surrounding whitespace). */
+  raw: string;
+
+  /** Command name after unwrapping sudo/env/nohup (first word if no wrapper). */
+  resolvedCommand: string | null;
+
+  /** Argument targets that end with '/' (including bare '/'). */
+  trailingSlashTargets: string[];
+
+  /**
+   * Words after stripping redirections, respecting quotes.
+   * Quoted strings are kept as single words with quotes removed.
+   */
+  words: string[];
+}
+
+/** Words that wrap the real command and must be skipped during resolution. */
+const WRAPPER_COMMANDS = new Set(['sudo', 'env', 'nohup']);
+
+const ASSIGNMENT_PATTERN = /^[A-Z_]\w*=.*$/i;
+
+/**
+ * Split command string into segments on `;`, `&`, `|`, `&&`, `||` while
+ * respecting single/double quotes and skipping command substitution bodies
+ * (they stay embedded in words rather than being split as separators).
+ */
+const splitIntoRawSegments = (command: string): string[] => {
+  const parts: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  // Tracks positions of unquoted command substitutions: we DO split on
+  // separators outside quotes; substitution content retains its separators
+  // because $( and backtick regions are tracked below.
+  let inSubstitution = 0; // depth for $( )
+  let inBacktick = false;
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+
+    if (quote) {
+      current += char;
+      // No escapes inside single quotes; \" and \\ possible in double quotes
+      if (quote === '"' && char === '\\' && i + 1 < command.length) {
+        current += command[i + 1];
+        i++;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === '`') {
+      inBacktick = !inBacktick;
+      current += char;
+      continue;
+    }
+
+    if (!inSubstitution && !inBacktick && char === '$' && command[i + 1] === '(') {
+      inSubstitution = 1;
+      current += '$(';
+      i++;
+      continue;
+    }
+
+    if (inSubstitution) {
+      if (char === '(') inSubstitution++;
+      if (char === ')') inSubstitution--;
+      current += char;
+      continue;
+    }
+
+    if (inBacktick) {
+      current += char;
+      continue;
+    }
+
+    if (char === '&' && command[i + 1] === '&') {
+      parts.push(current);
+      current = '';
+      i++;
+      continue;
+    }
+
+    if (char === '|' && command[i + 1] === '|') {
+      parts.push(current);
+      current = '';
+      i++;
+      continue;
+    }
+
+    if (char === ';' || char === '&' || char === '|') {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  parts.push(current);
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+};
+
+/**
+ * Tokenize a segment into words, honoring quotes and keeping quoted content
+ * as single words (quote markers removed). Redirections are removed here.
+ */
+const tokenizeWords = (raw: string): string[] => {
+  const words: string[] = [];
+  let word = '';
+  let quote: '"' | "'" | null = null;
+  let hasWord = false;
+  let inSubstitution = 0;
+  let inBacktick = false;
+
+  const flush = () => {
+    if (hasWord) words.push(word);
+    word = '';
+    hasWord = false;
+  };
+
+  const isRedirectAt = (index: number): boolean => {
+    // A redirection starts with optional fd digits then < or >
+    let j = index;
+    while (j < raw.length && /\d/.test(raw[j])) j++;
+    const op = raw[j];
+    return op === '<' || op === '>';
+  };
+
+  let i = 0;
+  while (i < raw.length) {
+    const char = raw[i];
+
+    if (quote) {
+      // Escape handling inside double quotes: consume backslash + escaped char
+      if (quote === '"' && char === '\\' && i + 1 < raw.length) {
+        word += raw[i + 1];
+        i++;
+        hasWord = true;
+        continue;
+      }
+      // Closing quote: leave quote mode WITHOUT appending the quote marker
+      if (char === quote) {
+        quote = null;
+        i++;
+        continue;
+      }
+      word += char;
+      hasWord = true;
+      i++;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      hasWord = true;
+      i++;
+      continue;
+    }
+
+    if (char === '`') {
+      inBacktick = !inBacktick;
+      word += char;
+      hasWord = true;
+      i++;
+      continue;
+    }
+
+    if (!inSubstitution && !inBacktick && char === '$' && raw[i + 1] === '(') {
+      inSubstitution = 1;
+      word += '$(';
+      hasWord = true;
+      i += 2;
+      continue;
+    }
+
+    if (inSubstitution) {
+      if (char === '(') inSubstitution++;
+      if (char === ')') inSubstitution--;
+      word += char;
+      if (inSubstitution === 0) {
+        // substitution closed; continue same word
+      }
+      hasWord = true;
+      i++;
+      continue;
+    }
+
+    if (inBacktick) {
+      word += char;
+      hasWord = true;
+      i++;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      flush();
+      i++;
+      continue;
+    }
+
+    if (isRedirectAt(i)) {
+      // Skip the redirection operator (and any fd digits before it).
+      flush();
+      let j = i;
+      while (j < raw.length && /\d/.test(raw[j])) j++;
+      const op = raw[j];
+      if (op !== '<' && op !== '>') {
+        // Should not happen (isRedirectAt guarantees), but never stall: eat one char.
+        i++;
+        continue;
+      }
+      // '>>' counts as two operator chars; '<<' (heredoc) has no target to skip.
+      if (raw[j + 1] === op) {
+        j += 2;
+      } else {
+        j += 1;
+      }
+      // Skip the redirection target token (next word), if any.
+      while (j < raw.length && /\s/.test(raw[j])) j++;
+      while (j < raw.length && !/\s/.test(raw[j])) j++;
+      // Advance at least past the operator to guarantee progress.
+      i = Math.max(j, i + 1);
+      continue;
+    }
+
+    word += char;
+    hasWord = true;
+    i++;
+  }
+
+  flush();
+  return words;
+};
+
+const doesSegmentContainSubstitution = (raw: string): boolean => {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i];
+    if (quote) {
+      if (quote === '"' && char === '\\') i++;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '`') return true;
+    if (char === '$' && (raw[i + 1] === '(' || /\{/.test(raw[i + 1] ?? ''))) return true;
+  }
+  return false;
+};
+
+const isHomePath = (word: string): boolean =>
+  word === '~' ||
+  word.startsWith('~/') ||
+  word === '$HOME' ||
+  word.startsWith('$HOME/') ||
+  /^\/(?:Users|home)\/[^/]+/.test(word);
+
+const isDashWord = (word: string): boolean => word.startsWith('-') && word.length > 1;
+
+const isBareSlash = (word: string): boolean => word === '/';
+
+/**
+ * Parse flags: every isolated dash-word is a flag entry. Combined short flags
+ * like -rf expand at query time.
+ */
+const collectFlags = (words: string[]): string[] => words.filter(isDashWord);
+
+/**
+ * Collect all long-flag names (e.g. 'recursive' from --recursive / --recursive=yes)
+ * and all single-letter flags from short-flag words (e.g. r, f from -rf).
+ */
+const collectFlagLettersAndNames = (
+  flags: string[],
+): { letters: Set<string>; names: Set<string> } => {
+  const letters = new Set<string>();
+  const names = new Set<string>();
+  for (const flag of flags) {
+    // Long flag: --name or --name=value → register both the name and, for
+    // security conservatism, its first letter (rm -R / -r alias semantic).
+    const longMatch = /^--([^=]+)(?:=.*)?$/.exec(flag);
+    if (longMatch) {
+      names.add(longMatch[1]);
+      letters.add(longMatch[1][0]);
+      continue;
+    }
+    // Combined short flags: -rf → r, f
+    const shortMatch = /^-([A-Z0-9]+)$/i.exec(flag);
+    if (shortMatch) {
+      for (const letter of shortMatch[1]) letters.add(letter);
+      continue;
+    }
+    // Negative number like -1 or lone '-' → not a flag
+  }
+  return { letters, names };
+};
+
+/**
+ * Unwrap wrapper commands (sudo/env/nohup) plus leading VAR=value assignments
+ * and reveal the real command word.
+ */
+const resolveCommandWord = (words: string[]): string | null => {
+  let index = 0;
+  // Skip leading assignments (FOO=bar)
+  while (index < words.length) {
+    const word = words[index];
+    if (ASSIGNMENT_PATTERN.test(word) && !word.startsWith('-') && !word.startsWith('/')) {
+      // An assignment whose "value" is empty and looks like `FOO=bar cmd` is a prefix.
+      index++;
+      continue;
+    }
+    break;
+  }
+
+  // Unwrap wrappers. The loop naturally terminates: `index` strictly increases
+  // every iteration and is bounded by words.length. No artificial counter —
+  // pathologically chained wrappers (e.g. 50x `sudo`) still resolve fully.
+  while (index < words.length) {
+    const word = words[index];
+    if (WRAPPER_COMMANDS.has(word)) {
+      index++;
+      // Skip wrapper-owned tokens: inline assignments after `env`, wrapper
+      // flags like `sudo -u alice` / `env -i` / `nohup --`, and the VALUE
+      // argument of wrapper flags that take one (`-u alice`, `-g group`).
+      // Never skip the real command itself.
+      while (index < words.length) {
+        const token = words[index];
+        if (ASSIGNMENT_PATTERN.test(token) || isDashWord(token)) {
+          index++;
+          continue;
+        }
+        // A bare word right after a value-taking wrapper flag is that flag's
+        // value, not the command. Only `-u`/`-g` style single-letter flags
+        // consume a value; `--user=alice` already embeds it.
+        const previous = words[index - 1];
+        if (/^-[a-z]$/i.test(previous)) {
+          index++;
+          continue;
+        }
+        break;
+      }
+      continue;
+    }
+    break;
+  }
+
+  const commandWord = words[index];
+  if (!commandWord) return null;
+  if (isDashWord(commandWord) || ASSIGNMENT_PATTERN.test(commandWord)) return null;
+  return commandWord;
+};
+
+/**
+ * Analyze a shell command string into semantic segments.
+ */
+export const analyzeShellCommand = (command: string): ShellSegment[] => {
+  if (typeof command !== 'string' || command.trim().length === 0) return [];
+
+  const rawSegments = splitIntoRawSegments(command);
+
+  return rawSegments.map((rawSegment) => {
+    const words = tokenizeWords(rawSegment);
+
+    // Words eligible for command resolution: everything before the first
+    // non-flag, non-argument word matters; we keep it simple: resolution uses
+    // the full word list.
+    const resolvedCommand = resolveCommandWord(words);
+    const flags = collectFlags(words);
+
+    // Targets: non-flag words after the command word
+    const commandIndex = resolvedCommand ? words.indexOf(resolvedCommand) : -1;
+    const argWords = commandIndex >= 0 ? words.slice(commandIndex + 1) : [];
+    const trailingSlashTargets = argWords.filter(
+      (word) => !isDashWord(word) && (word.endsWith('/') || isBareSlash(word)),
+    );
+    const homeTargets = argWords.filter((word) => !isDashWord(word) && isHomePath(word));
+
+    const { letters, names } = collectFlagLettersAndNames(flags);
+
+    const ambiguous = words.length === 0;
+
+    return {
+      raw: rawSegment,
+      words,
+      resolvedCommand,
+      flags,
+      trailingSlashTargets,
+      homeTargets,
+      hasCommandSubstitution: doesSegmentContainSubstitution(rawSegment),
+      ambiguous,
+      hasFlag: (letter: string) => letters.has(letter) || names.has(letter),
+      hasLongFlag: (name: string) => names.has(name),
+    };
+  });
+};
+
+export const SHELL_SEGMENT_TYPE = 'shellSemantic';

--- a/packages/agent-runtime/src/core/shellCommand.ts
+++ b/packages/agent-runtime/src/core/shellCommand.ts
@@ -17,17 +17,11 @@
  */
 
 export interface ShellSegment {
-  /** True when the command could not be split/parsed with confidence. */
-  ambiguous: boolean;
-
   /**
    * Flag words as they appeared (e.g. '-rf', '--recursive'), collected from
    * dash-prefixed words. Quoted words never count as flags.
    */
   flags: string[];
-
-  /** Whether this segment contains command substitution (backticks or $()) / variables. */
-  hasCommandSubstitution: boolean;
 
   /** Check whether a single-letter flag is active (expands combined flags like -rf). */
   hasFlag: (letter: string) => boolean;
@@ -54,17 +48,11 @@ export interface ShellSegment {
   words: string[];
 }
 
-/** Words that wrap the real command and must be skipped during resolution. */
-const WRAPPER_COMMANDS = new Set(['sudo', 'env', 'nohup']);
-
 /**
  * Bash builtin that executes its argument as a command, bypassing aliases and
  * functions: `command rm -rf /` runs rm directly. Unwrapped like sudo/env.
- * Options `-p` (default PATH), `-v`/`-V` (describe) take no value; `-p` with
- * an attached `path` (`-p/bin:/usr/bin`) embeds it, so nothing value-consuming.
+ * Options `-p` (default PATH), `-v`/`-V` (describe) take no value.
  */
-const SHELL_BUILTIN_EXEC_WRAPPERS = new Set(['command']);
-
 const ASSIGNMENT_PATTERN = /^[A-Z_]\w*=.*$/i;
 
 /**
@@ -297,25 +285,6 @@ const tokenizeWords = (raw: string): string[] => {
   return words;
 };
 
-const doesSegmentContainSubstitution = (raw: string): boolean => {
-  let quote: '"' | "'" | null = null;
-  for (let i = 0; i < raw.length; i++) {
-    const char = raw[i];
-    if (quote) {
-      if (quote === '"' && char === '\\') i++;
-      else if (char === quote) quote = null;
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-    if (char === '`') return true;
-    if (char === '$' && (raw[i + 1] === '(' || /\{/.test(raw[i + 1] ?? ''))) return true;
-  }
-  return false;
-};
-
 const isHomePath = (word: string): boolean =>
   word === '~' ||
   word.startsWith('~/') ||
@@ -363,21 +332,83 @@ const collectFlagLettersAndNames = (
 };
 
 /**
- * Wrapper single-letter options that CONSUME a following word as their value.
- * Anything not listed here is value-free: `sudo -n rm` → rm is the command,
- * NOT a value of -n. (sudo -n = non-interactive, env -i = ignore-environment,
- * nohup has no short options.)
+ * Security-first wrapper option model: a single-letter wrapper flag is
+ * presumed to CONSUME the next word unless it is whitelisted here as
+ * value-free. The whitelist direction matters: a missed value-free flag only
+ * over-skips one harmless token (over-detection), whereas a missed
+ * value-taking flag resolves the wrapper's VALUE as the command and lets a
+ * real `rm -rf /` slip through (under-detection) — e.g. `sudo -p x rm -rf /`
+ * previously resolved to command "x:".
+ *
+ * Flags not valid for a wrapper (typo/foreign) also consume a value under
+ * this model — acceptable: unknown-flag invocations fail at exec time anyway,
+ * and erring toward over-detection is the safe direction for a blacklist.
  */
-const WRAPPER_VALUE_FLAGS: Record<string, Set<string>> = {
-  sudo: new Set(['u', 'g', 'C']), // -u user, -g group, -C fd (closefrom)
-  env: new Set(['S']), // -S 'string' (split-string); -i/-0 take no value
+const WRAPPER_VALUE_FREE_FLAGS: Record<string, ReadonlySet<string>> = {
+  // GNU sudo value-free flags only (verified against sudo 1.9 --help):
+  // -A askpass, -B beep, -b badge, -e edit, -H set HOME, -h help,
+  // -i login, -k kill ticket, -K kill all, -l list, -n non-interactive,
+  // -s shell, -v validate. Value-taking (deliberately NOT whitelisted):
+  // -p prompt, -u user, -g group, -C fd, -R chroot, -r role, -t type,
+  // -T timeout, -D cwd.
+  sudo: new Set(['A', 'B', 'b', 'e', 'H', 'h', 'i', 'k', 'K', 'l', 'n', 's', 'v']),
+  // GNU env value-free flags: -i ignore-env, -0 null-sep, -v verbose.
+  // Value-taking: -u unset NAME, -S split-string (its value IS a command —
+  // consumed as a value word, which hides it; covered by the predicate-level
+  // ambiguity fallback in semanticShellPredicates.ts).
+  env: new Set(['i', '0', 'v']),
   nohup: new Set(),
-  command: new Set(),
+  // bash command builtin: -p default PATH, -v/-V describe.
+  command: new Set(['p', 'v', 'V']),
 };
 
 /**
- * Unwrap wrapper commands (sudo/env/nohup/command) plus leading VAR=value
- * assignments and reveal the real command word.
+ * Exec-prefix commands that run their first non-flag argument as a program.
+ * Unwrapped so `exec rm -rf /`, `xargs rm -rf /`, `timeout 30 rm -rf /`,
+ * `nice rm -rf /` … resolve to the real command. (The old substring regex
+ * blocked these shapes incidentally; semantic matching must unwrap them
+ * explicitly or coverage narrows.)
+ */
+const EXEC_PREFIX_WRAPPERS = new Set([
+  'sudo', // superuser exec
+  'env', // env VAR=… cmd
+  'nohup', // hangup-immune exec
+  'command', // bash builtin: bypass aliases/functions
+  'exec', // bash builtin: replace the shell with the command
+  'xargs', // stdin-driven invocation: `find … | xargs rm …`
+  'time', // bash keyword + binary: runs the command
+  'nice', // runs the command with niceness
+  'setsid', // runs the command in a new session
+  'ionice', // runs the command with I/O niceness
+  'stdbuf', // runs the command with adjusted stdio buffering
+  'timeout', // runs the command with a time limit (first arg = duration value)
+  'flock', // runs the command holding a lock (first arg = lockfile value)
+  'strace', // traces execution by running the command
+  'ltrace', // traces execution by running the command
+]);
+
+/**
+ * Exec-prefix wrappers whose FIRST POSITIONAL argument is a value (not the
+ * wrapped command): `timeout 30 rm …`, `flock /tmp/lock rm …`. The unwrap
+ * loop consumes that many bare words after the wrapper before treating the
+ * next bare word as the command. Flags and assignments are always skipped.
+ */
+const WRAPPER_POSITIONAL_VALUES: Record<string, number> = {
+  timeout: 1, // DURATION
+  flock: 1, // LOCKFILE (when not -n form with command only)
+  nice: 0, // nice -N cmd handled by flag model; bare `nice cmd` has none
+  time: 0,
+};
+
+/**
+ * Unwrap exec-prefix wrappers (sudo/env/nohup/command/exec/xargs/timeout/…)
+ * plus leading VAR=value assignments and reveal the real command word.
+ *
+ * Option model is security-first: a single-letter flag is presumed to
+ * consume the next word unless whitelisted value-free (see
+ * WRAPPER_VALUE_FREE_FLAGS); long flags are presumed value-free unless they
+ * embed `=value`. A bare word after a value-consuming flag is that flag's
+ * value, not the command.
  */
 const resolveCommandWord = (words: string[]): string | null => {
   let index = 0;
@@ -392,44 +423,51 @@ const resolveCommandWord = (words: string[]): string | null => {
     break;
   }
 
-  // Unwrap wrappers. The loop naturally terminates: `index` strictly increases
-  // every iteration and is bounded by words.length. No artificial counter —
-  // pathologically chained wrappers (e.g. 50x `sudo`) still resolve fully.
+  // Unwrap exec-prefix wrappers. The loop naturally terminates: `index`
+  // strictly increases every iteration and is bounded by words.length. No
+  // artificial counter — pathologically chained wrappers still resolve fully.
   while (index < words.length) {
     const word = words[index];
-    const isWrapper = WRAPPER_COMMANDS.has(word) || SHELL_BUILTIN_EXEC_WRAPPERS.has(word);
-    if (isWrapper) {
-      const valueFlags = WRAPPER_VALUE_FLAGS[word];
-      index++;
-      // Skip wrapper-owned tokens: assignments after `env`, value-free
-      // wrapper flags (`sudo -n`, `env -i`, `command -p`), and — only for
-      // flags registered as value-taking — their value word (`sudo -u alice`).
-      // Never skip the real command itself.
-      while (index < words.length) {
-        const token = words[index];
-        const previous = words[index - 1];
-        const previousConsumesValue =
-          /^-[a-z]$/i.test(previous) &&
-          valueFlags !== undefined &&
-          valueFlags.has(previous[1].toLowerCase());
-        if (ASSIGNMENT_PATTERN.test(token) || isDashWord(token)) {
-          // Wrapper-owned token (assignment or flag). One subtlety: a
-          // dash-word right after a value-taking flag could be the value
-          // itself in theory, but flags consuming negative-looking values
-          // are not a wrapper pattern — safe to treat as a flag.
-          index++;
-          continue;
-        }
-        if (previousConsumesValue) {
-          // Bare word after a value-taking wrapper flag = that flag's value.
-          index++;
-          continue;
-        }
-        break;
+    if (!EXEC_PREFIX_WRAPPERS.has(word)) break;
+    const valueFreeFlags = WRAPPER_VALUE_FREE_FLAGS[word];
+    index++;
+    // Consume wrapper-owned positional values first (timeout DURATION, flock
+    // LOCKFILE): bare words that are NOT the wrapped command.
+    let positional = WRAPPER_POSITIONAL_VALUES[word] ?? 0;
+    // Skip wrapper-owned tokens: assignments after `env`, wrapper flags, and
+    // the value word of any flag presumed to consume one (security-first
+    // default, see WRAPPER_VALUE_FREE_FLAGS).
+    while (index < words.length) {
+      const token = words[index];
+      if (ASSIGNMENT_PATTERN.test(token)) {
+        index++;
+        continue;
       }
-      continue;
+      if (isDashWord(token)) {
+        // `--flag=value` / `-u=value` embed the value: consume nothing extra.
+        if (token.includes('=')) {
+          index++;
+          continue;
+        }
+        // `-abc` combined short flags: consumes a value unless EVERY letter
+        // is whitelisted value-free. Unknown/foreign flags consume — the
+        // safe direction for a blacklist (over-detection).
+        const letters = /^-([a-z]+)$/i.exec(token);
+        const consumesValue =
+          letters === null || !letters[1].split('').every((letter) => valueFreeFlags?.has(letter));
+        index += consumesValue ? 2 : 1;
+        continue;
+      }
+      // Bare word: either a positional wrapper value (timeout 30) or the
+      // wrapped command itself (the common case).
+      if (positional > 0) {
+        positional--;
+        index++;
+        continue;
+      }
+      break;
     }
-    break;
+    continue;
   }
 
   const commandWord = words[index];
@@ -475,8 +513,6 @@ export const analyzeShellCommand = (command: string): ShellSegment[] => {
 
     const { letters, names } = collectFlagLettersAndNames(flags);
 
-    const ambiguous = words.length === 0;
-
     return {
       raw: rawSegment,
       words,
@@ -484,12 +520,8 @@ export const analyzeShellCommand = (command: string): ShellSegment[] => {
       flags,
       trailingSlashTargets,
       homeTargets,
-      hasCommandSubstitution: doesSegmentContainSubstitution(rawSegment),
-      ambiguous,
       hasFlag: (letter: string) => letters.has(letter) || names.has(letter),
       hasLongFlag: (name: string) => names.has(name),
     };
   });
 };
-
-export const SHELL_SEGMENT_TYPE = 'shellSemantic';

--- a/packages/agent-runtime/src/core/shellCommand.ts
+++ b/packages/agent-runtime/src/core/shellCommand.ts
@@ -57,6 +57,14 @@ export interface ShellSegment {
 /** Words that wrap the real command and must be skipped during resolution. */
 const WRAPPER_COMMANDS = new Set(['sudo', 'env', 'nohup']);
 
+/**
+ * Bash builtin that executes its argument as a command, bypassing aliases and
+ * functions: `command rm -rf /` runs rm directly. Unwrapped like sudo/env.
+ * Options `-p` (default PATH), `-v`/`-V` (describe) take no value; `-p` with
+ * an attached `path` (`-p/bin:/usr/bin`) embeds it, so nothing value-consuming.
+ */
+const SHELL_BUILTIN_EXEC_WRAPPERS = new Set(['command']);
+
 const ASSIGNMENT_PATTERN = /^[A-Z_]\w*=.*$/i;
 
 /**
@@ -117,6 +125,16 @@ const splitIntoRawSegments = (command: string): string[] => {
 
     if (inBacktick) {
       current += char;
+      continue;
+    }
+
+    // Unescaped CR/LF is a command separator just like `;` (multi-line
+    // commands are legal shell). Inside quotes/substitutions they are inert.
+    if (char === '\n' || char === '\r') {
+      parts.push(current);
+      current = '';
+      // Treat \r\n as one separator
+      if (char === '\r' && command[i + 1] === '\n') i++;
       continue;
     }
 
@@ -345,8 +363,21 @@ const collectFlagLettersAndNames = (
 };
 
 /**
- * Unwrap wrapper commands (sudo/env/nohup) plus leading VAR=value assignments
- * and reveal the real command word.
+ * Wrapper single-letter options that CONSUME a following word as their value.
+ * Anything not listed here is value-free: `sudo -n rm` → rm is the command,
+ * NOT a value of -n. (sudo -n = non-interactive, env -i = ignore-environment,
+ * nohup has no short options.)
+ */
+const WRAPPER_VALUE_FLAGS: Record<string, Set<string>> = {
+  sudo: new Set(['u', 'g', 'C']), // -u user, -g group, -C fd (closefrom)
+  env: new Set(['S']), // -S 'string' (split-string); -i/-0 take no value
+  nohup: new Set(),
+  command: new Set(),
+};
+
+/**
+ * Unwrap wrapper commands (sudo/env/nohup/command) plus leading VAR=value
+ * assignments and reveal the real command word.
  */
 const resolveCommandWord = (words: string[]): string | null => {
   let index = 0;
@@ -366,23 +397,31 @@ const resolveCommandWord = (words: string[]): string | null => {
   // pathologically chained wrappers (e.g. 50x `sudo`) still resolve fully.
   while (index < words.length) {
     const word = words[index];
-    if (WRAPPER_COMMANDS.has(word)) {
+    const isWrapper = WRAPPER_COMMANDS.has(word) || SHELL_BUILTIN_EXEC_WRAPPERS.has(word);
+    if (isWrapper) {
+      const valueFlags = WRAPPER_VALUE_FLAGS[word];
       index++;
-      // Skip wrapper-owned tokens: inline assignments after `env`, wrapper
-      // flags like `sudo -u alice` / `env -i` / `nohup --`, and the VALUE
-      // argument of wrapper flags that take one (`-u alice`, `-g group`).
+      // Skip wrapper-owned tokens: assignments after `env`, value-free
+      // wrapper flags (`sudo -n`, `env -i`, `command -p`), and — only for
+      // flags registered as value-taking — their value word (`sudo -u alice`).
       // Never skip the real command itself.
       while (index < words.length) {
         const token = words[index];
+        const previous = words[index - 1];
+        const previousConsumesValue =
+          /^-[a-z]$/i.test(previous) &&
+          valueFlags !== undefined &&
+          valueFlags.has(previous[1].toLowerCase());
         if (ASSIGNMENT_PATTERN.test(token) || isDashWord(token)) {
+          // Wrapper-owned token (assignment or flag). One subtlety: a
+          // dash-word right after a value-taking flag could be the value
+          // itself in theory, but flags consuming negative-looking values
+          // are not a wrapper pattern — safe to treat as a flag.
           index++;
           continue;
         }
-        // A bare word right after a value-taking wrapper flag is that flag's
-        // value, not the command. Only `-u`/`-g` style single-letter flags
-        // consume a value; `--user=alice` already embeds it.
-        const previous = words[index - 1];
-        if (/^-[a-z]$/i.test(previous)) {
+        if (previousConsumesValue) {
+          // Bare word after a value-taking wrapper flag = that flag's value.
           index++;
           continue;
         }
@@ -396,7 +435,13 @@ const resolveCommandWord = (words: string[]): string | null => {
   const commandWord = words[index];
   if (!commandWord) return null;
   if (isDashWord(commandWord) || ASSIGNMENT_PATTERN.test(commandWord)) return null;
-  return commandWord;
+  // Normalize path-qualified executables to their basename so predicates can
+  // compare on the bare command name: /bin/rm → rm, ./script.sh → script.sh,
+  // /usr/bin/env → env. Bare `/` (root target) has no basename and stays.
+  const lastSlash = commandWord.lastIndexOf('/');
+  return lastSlash >= 0 && lastSlash + 1 < commandWord.length
+    ? commandWord.slice(lastSlash + 1)
+    : commandWord;
 };
 
 /**
@@ -416,8 +461,12 @@ export const analyzeShellCommand = (command: string): ShellSegment[] => {
     const resolvedCommand = resolveCommandWord(words);
     const flags = collectFlags(words);
 
-    // Targets: non-flag words after the command word
-    const commandIndex = resolvedCommand ? words.indexOf(resolvedCommand) : -1;
+    // Targets: non-flag words after the command word. Match on the raw word
+    // index (basename normalization is display-level only; /bin/rm and rm
+    // occupy the same slot), so arg extraction works for both spellings.
+    const commandIndex = resolvedCommand
+      ? words.findIndex((word) => word === resolvedCommand || word.endsWith(`/${resolvedCommand}`))
+      : -1;
     const argWords = commandIndex >= 0 ? words.slice(commandIndex + 1) : [];
     const trailingSlashTargets = argWords.filter(
       (word) => !isDashWord(word) && (word.endsWith('/') || isBareSlash(word)),

--- a/packages/types/src/tool/intervention.ts
+++ b/packages/types/src/tool/intervention.ts
@@ -11,19 +11,42 @@ export type HumanInterventionPolicy =
 export const HumanInterventionPolicySchema = z.enum(['never', 'required', 'always']);
 
 /**
+ * Semantic shell predicate names evaluated by the runtime against a parsed
+ * shell command (see `analyzeShellCommand` in @lobechat/agent-runtime).
+ *
+ * Each predicate receives (segment, whole-command-segments) and returns true
+ * when the command is dangerous per that predicate.
+ */
+export type SemanticShellPredicate =
+  | 'rmRecursiveRootTarget' // rm with recursive flag and a target resolving to '/'
+  | 'rmRecursiveHomeTarget' // rm with recursive flag on the home directory itself
+  | 'rmForceDotTarget'; // rm -rf on '.' — cwd blast radius
+
+export const SEMANTIC_SHELL_PREDICATES: SemanticShellPredicate[] = [
+  'rmRecursiveRootTarget',
+  'rmRecursiveHomeTarget',
+  'rmForceDotTarget',
+];
+
+/**
  * Argument Matcher for parameter-level filtering
- * Supports wildcard patterns, prefix matching, and regex
+ * Supports wildcard patterns, prefix matching, regex, and semantic shell checks
  *
  * Examples:
  * - "git add:*" - matches any git add command
  * - "/Users/project/*" - matches paths under /Users/project/
  * - { pattern: "^rm.*", type: "regex" } - regex matching
+ * - { type: 'semanticShell', predicate: 'rmRecursiveRootTarget' } - parsed-command check
  */
 export type ArgumentMatcher =
   | string // Simple string or wildcard pattern
   | {
       pattern: string;
       type: 'exact' | 'prefix' | 'wildcard' | 'regex';
+    }
+  | {
+      type: 'semanticShell';
+      predicate: SemanticShellPredicate;
     };
 
 export const ArgumentMatcherSchema: z.ZodType<ArgumentMatcher> = z.union([
@@ -31,6 +54,10 @@ export const ArgumentMatcherSchema: z.ZodType<ArgumentMatcher> = z.union([
   z.object({
     pattern: z.string(),
     type: z.enum(['exact', 'prefix', 'wildcard', 'regex']),
+  }),
+  z.object({
+    type: z.literal('semanticShell'),
+    predicate: z.enum(['rmRecursiveRootTarget', 'rmRecursiveHomeTarget', 'rmForceDotTarget']),
   }),
 ]);
 

--- a/packages/types/src/tool/intervention.ts
+++ b/packages/types/src/tool/intervention.ts
@@ -22,11 +22,11 @@ export type SemanticShellPredicate =
   | 'rmRecursiveHomeTarget' // rm with recursive flag on the home directory itself
   | 'rmForceDotTarget'; // rm -rf on '.' — cwd blast radius
 
-export const SEMANTIC_SHELL_PREDICATES: SemanticShellPredicate[] = [
+export const SEMANTIC_SHELL_PREDICATES = [
   'rmRecursiveRootTarget',
   'rmRecursiveHomeTarget',
   'rmForceDotTarget',
-];
+] as const satisfies readonly SemanticShellPredicate[];
 
 /**
  * Argument Matcher for parameter-level filtering
@@ -57,7 +57,7 @@ export const ArgumentMatcherSchema: z.ZodType<ArgumentMatcher> = z.union([
   }),
   z.object({
     type: z.literal('semanticShell'),
-    predicate: z.enum(['rmRecursiveRootTarget', 'rmRecursiveHomeTarget', 'rmForceDotTarget']),
+    predicate: z.enum(SEMANTIC_SHELL_PREDICATES),
   }),
 ]);
 


### PR DESCRIPTION
## Description of Change

The three `rm` rules in `DEFAULT_SECURITY_BLACKLIST` used raw-string regex like `rm.*-r.*/\s*$`. `RegExp.test` searches anywhere in the command string, so these rules **catastrophically false-positived on read-only commands**. Real-world report (screenshot verified):

```bash
jq '.trial // . | {status, error, runner_command}' .../trials/terminal-bench-regex-log/trial.json 2>/dev/null; ls .../trials/terminal-bench-regex-log/
```

was blocked as *"递归删除根目录将摧毁整个系统" (recursive deletion of root directory will destroy the system)* because:
- `te`**`rm`**`inal-bench-regex-log` supplied the literal `rm`
- `-`**`r`**`egex-log` supplied the `-r` flag
- the trailing `/` of the `ls` path supplied the root target

Three harmless fragments from unrelated sub-commands, stitched together by `.*`.

### The fix: semantic evaluation of the parsed command

Instead of matching regex against the raw string, the command is parsed once (`shellCommand.ts`) and rules evaluate **resolved command + active flags + classified targets**:

- **Quote-aware segmenting** on `;` `&` `|` `&&` `||`; redirections (`2>/dev/null`, `<<EOF`) stripped; command-substitution bodies stay embedded rather than split as separators
- **Wrapper unwrapping**: `sudo`, `env`, `nohup` (incl. value-taking wrapper flags like `sudo -u alice`, assignments like `FOO=bar`) resolve to the real command; the unwrap loop terminates naturally with no artificial bound (50 chained `sudo`s still resolve)
- **Flag parsing**: combined short flags expand (`-rf` → `r`,`f`), long flags map to semantics (`--recursive`); **quoting cannot hide danger** — `rm '-rf' /` is blocked because the shell strips quotes before argv
- **Target classification**: trailing-slash targets and home-resolved paths (`~`, `$HOME`, `/Users/x`, `/home/x`) are collected separately

Three predicates replace the old rules (registry pattern, extensible):

| Predicate | Blocks | Allows (previously false-positived) |
|---|---|---|
| `rmRecursiveRootTarget` | `rm -rf /`, `sudo rm -rf /`, `rm -rf //`, `rm '-rf' /` | `ls .../terminal/`, `grep -r x /Users/a`, `npm run --prefix ./app/`, `terraform -chdir=infra/` |
| `rmRecursiveHomeTarget` | `rm -rf ~`, `rm -rf $HOME/`, `rm -rf /Users/alice/` | `rm -rf ~/.cache/tool`, `du -sh /Users/x/` |
| `rmForceDotTarget` | `rm -rf .`, `rm -Rf ./` | `rm -rf ./dist` |

`packages/types` gains `{ type: 'semanticShell', predicate }` on `ArgumentMatcher` as a **string-predicate contract** — the types package stays implementation-free; `@lobechat/agent-runtime` owns the resolver registry.

## How to Test

\`\`\`bash
cd packages/agent-runtime
bunx vitest run src/core/shellCommand.test.ts src/core/semanticShellPredicates.test.ts src/core/__tests__/InterventionChecker.test.ts src/audit/__tests__/createSecurityBlacklistAudit.test.ts
\`\`\`

- The original false-positive command is a permanent regression test in both `shellCommand.test.ts` and `InterventionChecker.test.ts`
- `it.each` blocks cover the must-block side: wrappers, quoted flags, compound commands, `//`, `$HOME/`
- All 71 pre-existing blacklist/InterventionChecker assertions pass unchanged
- `bun run check` → lint clean, 170 tests passed

#### 🔗 Related Issue

No matching GitHub/Linear issue found (searched "security blacklist rm false positive", "securityBlacklist").

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed