### PR TITLE
🐛 fix(acceptance): show plain-text evidence verbatim instead of as markdown

### DIFF
--- a/src/features/Acceptance/Report/MarkdownEvidence.tsx
+++ b/src/features/Acceptance/Report/MarkdownEvidence.tsx
@@ -20,6 +20,19 @@ import { AcceptanceDrawer } from '../AcceptanceDrawer';
  */
 export const markdownTextEvidenceTypes = new Set(['markdown', 'text']);
 
+/**
+ * Which of those two render as prose, and which stay verbatim.
+ *
+ * Only a document that says it is markdown gets markdown rendering. A `text`
+ * artifact is usually captured command output, where `###`, `-` and `*` are
+ * literal characters the reviewer is meant to read: rendering it as markdown
+ * turned transcript sections into headings, argument lists into bullets, and
+ * reflowed the lines so column alignment — often the point of the capture —
+ * was lost. Everything that is not explicitly markdown is shown verbatim.
+ */
+export const rendersAsMarkdown = (evidence: { fileName?: string | null; type: string }): boolean =>
+  evidence.type === 'markdown' || /\.(?:md|markdown)$/i.test(evidence.fileName ?? '');
+
 export const filenameFromUrl = (url: string): string => {
   try {
     return new URL(url).pathname.split('/').pop() || 'document';
@@ -239,55 +252,69 @@ export const resolveMarkdownEvidenceFold = (content: string, authoredTitle?: str
  * card of space showing the least informative part of the document — and read
  * as noise. Need it → expand; don't → one quiet line.
  */
-export const CollapsibleMarkdownEvidence = memo<{ children: string; title?: string }>(
-  ({ children, title }) => {
-    const { t } = useTranslation('verify');
-    const [expanded, setExpanded] = useState(false);
-    const { fold, foldTitle } = useMemo(
-      () => resolveMarkdownEvidenceFold(children, title),
-      [children, title],
-    );
+export const CollapsibleMarkdownEvidence = memo<{
+  children: string;
+  fileName?: string | null;
+  /** False renders the document verbatim — see `rendersAsMarkdown`. */
+  markdown?: boolean;
+  title?: string;
+}>(({ children, fileName, markdown = true, title }) => {
+  const { t } = useTranslation('verify');
+  const [expanded, setExpanded] = useState(false);
+  const { fold, foldTitle } = useMemo(
+    () => resolveMarkdownEvidenceFold(children, title),
+    [children, title],
+  );
+  const body = markdown ? (
+    <Markdown fontSize={13} headerMultiple={0.1} variant={'chat'}>
+      {children}
+    </Markdown>
+  ) : (
+    <Highlighter
+      wrap
+      language={getLanguageFromFilename(fileName)}
+      showLanguage={false}
+      variant={'borderless'}
+    >
+      {children}
+    </Highlighter>
+  );
 
-    if (!fold) {
-      return (
-        <Markdown fontSize={13} variant={'chat'}>
-          {children}
-        </Markdown>
-      );
-    }
-
-    return (
-      <Flexbox className={styles.foldCard}>
-        <button
-          aria-expanded={expanded}
-          className={styles.foldHeader}
-          title={t(expanded ? 'report.evidence.collapse' : 'report.evidence.expand')}
-          type={'button'}
-          onClick={() => setExpanded(!expanded)}
-        >
-          <Icon
-            className={cx(styles.foldChevron, expanded && styles.foldChevronOpen)}
-            icon={ChevronRight}
-            size={14}
-          />
-          <span className={styles.fileCardIcon}>
-            <Icon icon={FileText} size={13} />
-          </span>
-          <span data-fold-title className={styles.foldTitle}>
-            {foldTitle}
-          </span>
-        </button>
-        {expanded && (
-          <div className={styles.foldBody}>
-            <Markdown fontSize={13} headerMultiple={0.1} variant={'chat'}>
-              {children}
-            </Markdown>
-          </div>
-        )}
-      </Flexbox>
+  if (!fold) {
+    return markdown ? (
+      <Markdown fontSize={13} variant={'chat'}>
+        {children}
+      </Markdown>
+    ) : (
+      body
     );
-  },
-);
+  }
+
+  return (
+    <Flexbox className={styles.foldCard}>
+      <button
+        aria-expanded={expanded}
+        className={styles.foldHeader}
+        title={t(expanded ? 'report.evidence.collapse' : 'report.evidence.expand')}
+        type={'button'}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <Icon
+          className={cx(styles.foldChevron, expanded && styles.foldChevronOpen)}
+          icon={ChevronRight}
+          size={14}
+        />
+        <span className={styles.fileCardIcon}>
+          <Icon icon={FileText} size={13} />
+        </span>
+        <span data-fold-title className={styles.foldTitle}>
+          {foldTitle}
+        </span>
+      </button>
+      {expanded && <div className={styles.foldBody}>{body}</div>}
+    </Flexbox>
+  );
+});
 
 CollapsibleMarkdownEvidence.displayName = 'CollapsibleMarkdownEvidence';
 

--- a/src/features/Acceptance/Report/ReportViewer.tsx
+++ b/src/features/Acceptance/Report/ReportViewer.tsx
@@ -68,6 +68,7 @@ import {
   DocumentViewer,
   filenameFromUrl,
   markdownTextEvidenceTypes,
+  rendersAsMarkdown,
 } from './MarkdownEvidence';
 import { readVisualizationManifest } from './visualization';
 import { VisualizationRenderer } from './VisualizationRenderer';
@@ -830,11 +831,7 @@ const EvidenceItem = memo<{
         />
       ) : e.fileUrl ? (
         <div className={styles.evidenceDoc}>
-          <DocumentViewer
-            fileName={e.fileName}
-            markdown={markdownTextEvidenceTypes.has(e.type)}
-            url={e.fileUrl}
-          />
+          <DocumentViewer fileName={e.fileName} markdown={rendersAsMarkdown(e)} url={e.fileUrl} />
         </div>
       ) : e.content && markdownTextEvidenceTypes.has(e.type) ? (
         // Same dialect as the acceptance viewer: an authored alt/description
@@ -842,6 +839,8 @@ const EvidenceItem = memo<{
         // raw description, not the caption filter — with no fileName the label
         // IS the description, and the filter would null it out.
         <CollapsibleMarkdownEvidence
+          fileName={e.fileName}
+          markdown={rendersAsMarkdown(e)}
           title={e.description?.trim() || e.fileName?.trim() || undefined}
         >
           {e.content}

--- a/src/features/Acceptance/Report/markdownEvidenceTitle.test.ts
+++ b/src/features/Acceptance/Report/markdownEvidenceTitle.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { evidenceTitleFromMarkdown, resolveMarkdownEvidenceFold } from './MarkdownEvidence';
+import {
+  evidenceTitleFromMarkdown,
+  rendersAsMarkdown,
+  resolveMarkdownEvidenceFold,
+} from './MarkdownEvidence';
 
 describe('evidenceTitleFromMarkdown — the collapsed row label', () => {
   it('strips heading syntax so the first line reads as a sentence', () => {
@@ -97,5 +101,22 @@ it('folds short JSON payloads behind a readable type label', () => {
   expect(resolveMarkdownEvidenceFold('[{"id":"wk_123"}]')).toEqual({
     fold: true,
     foldTitle: 'JSON',
+  });
+});
+
+describe('rendersAsMarkdown — only a markdown document is rendered as prose', () => {
+  it('renders a captured transcript verbatim so its ### and - stay literal', () => {
+    expect(rendersAsMarkdown({ fileName: '04-confirmation.txt', type: 'text' })).toBe(false);
+    expect(rendersAsMarkdown({ fileName: 'server.log', type: 'text' })).toBe(false);
+    // No extension at all is the same case: nothing says it is markdown.
+    expect(rendersAsMarkdown({ fileName: 'transcript', type: 'text' })).toBe(false);
+    expect(rendersAsMarkdown({ type: 'text' })).toBe(false);
+  });
+
+  it('renders a markdown document as prose, by type or by extension', () => {
+    expect(rendersAsMarkdown({ fileName: 'findings.md', type: 'markdown' })).toBe(true);
+    expect(rendersAsMarkdown({ type: 'markdown' })).toBe(true);
+    // Uploaded as text but named .md — the name is the explicit signal.
+    expect(rendersAsMarkdown({ fileName: 'report.MARKDOWN', type: 'text' })).toBe(true);
   });
 });

--- a/src/features/Acceptance/Viewer/Evidence/EvidenceList.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/EvidenceList.tsx
@@ -16,6 +16,7 @@ import {
   CollapsibleMarkdownEvidence,
   EvidenceFileCard,
   markdownTextEvidenceTypes,
+  rendersAsMarkdown,
 } from '../../Report/MarkdownEvidence';
 import type { AcceptanceEvidence } from '../Checks/types';
 import { AnnotatedImage } from '../Evidence/Annotation';
@@ -268,7 +269,9 @@ export const EvidenceList = memo<{
             // An authored alt/description becomes the fold row's title itself —
             // the supplement below the row duplicated it one line later.
             <CollapsibleMarkdownEvidence
+              fileName={item.fileName}
               key={item.id}
+              markdown={rendersAsMarkdown(item)}
               title={item.description?.trim() || item.fileName?.trim() || undefined}
             >
               {item.content}
@@ -284,10 +287,10 @@ export const EvidenceList = memo<{
         if (item.fileUrl && markdownTextEvidenceTypes.has(item.type))
           return (
             <EvidenceFileCard
-              markdown
               description={item.description}
               fileName={item.fileName}
               key={item.id}
+              markdown={rendersAsMarkdown(item)}
               url={item.fileUrl}
             />
           );


### PR DESCRIPTION
### 💡 Motivation

The acceptance checklist and the round report both rendered `text` evidence through the markdown renderer, the path prose write-ups take. Captured command output is not prose. A transcript's `###` section markers became bold headings, an argument list's `-` became bullets, and the lines were reflowed in a proportional font, so the column alignment that is often the point of the capture was lost. A reviewer reading a terminal capture was reading a re-typeset version of it.

### 🔨 Changes

Markdown rendering now requires the document to say it is markdown: evidence typed `markdown`, or a `.md` / `.markdown` filename. That is exactly what the ingest CLI derives from a file extension, so a `.txt`, a `.log` or a file with no extension at all renders verbatim.

Everything not explicitly markdown goes through the same highlighter the file drawer already used for non-markdown documents, wrapped, with the fold row and its authored title unchanged. The three surfaces that render evidence share one predicate so they cannot drift apart.

### 🧪 Verification

Same evidence, same page, one variable: the renderer files reverted to canary for the before shot, restored for the after. A markdown evidence on the same page confirms prose rendering is untouched.

Acceptance: https://app.lobehub.com/acceptance/6c336113-85ab-4788-9c1d-8e41a223a23e?r=2

Not covered: a text file large enough to bypass inlining opens in the drawer through the same switch, but this round did not capture one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
