### PR TITLE
💄 style(goal): stop showing a running chip on an open question node

### DIFF
--- a/src/features/AgentGoals/ProcessControl/Graph/index.tsx
+++ b/src/features/AgentGoals/ProcessControl/Graph/index.tsx
@@ -31,7 +31,7 @@ import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
 import { type GoalGraphNodeKind, graphNodeKind, graphNodeLabel } from '../../Experiments/model';
-import type { GoalGraphView, GoalNodeView } from '../goalGraphViewModel';
+import { type GoalGraphView, type GoalNodeView, isRunningNode } from '../goalGraphViewModel';
 import { KindDot } from '../shared';
 import { edgeDirection } from './edgeRouting';
 import ExperimentGroup, { type ExperimentGroupData } from './ExperimentGroup';
@@ -435,7 +435,7 @@ const Canvas = memo<
                 false,
               ).size,
               kind: graphNodeKind(graph, item),
-              running: item.node.status === 'active' && !item.isStale,
+              running: isRunningNode(item),
               selected: selectedId === item.node.id,
               stale: item.isStale,
               subtitle: subtitleOf(item),

--- a/src/features/AgentGoals/ProcessControl/goalGraphViewModel.test.ts
+++ b/src/features/AgentGoals/ProcessControl/goalGraphViewModel.test.ts
@@ -10,7 +10,12 @@ import type {
 import { describe, expect, it } from 'vitest';
 
 import { experimentRelations, graphNodeKind, isExperiment } from '../Experiments/model';
-import { buildGoalGraphView, hasReviewableResult, isTroubledTaskNode } from './goalGraphViewModel';
+import {
+  buildGoalGraphView,
+  hasReviewableResult,
+  isRunningNode,
+  isTroubledTaskNode,
+} from './goalGraphViewModel';
 
 const T0 = new Date('2026-08-01T00:00:00Z');
 const at = (minutes: number) => new Date(T0.getTime() + minutes * 60_000);
@@ -567,6 +572,40 @@ describe('isTroubledTaskNode', () => {
     );
 
     expect(isTroubledTaskNode(view.byId.p1)).toBe(false);
+  });
+});
+
+describe('isRunningNode', () => {
+  it('reads an active task as running', () => {
+    const view = buildGoalGraphView(
+      snapshot({
+        events: [event('w1', 'activated', 110)],
+        nodes: [node('w1', { status: 'active', updatedAt: at(115) })],
+      }),
+      NOW,
+    );
+
+    expect(isRunningNode(view.byId.w1)).toBe(true);
+  });
+
+  // An open question is not work in flight — the card already says it is
+  // unanswered, and a running chip there promises activity nobody is doing.
+  it('never reads a question as running', () => {
+    const view = buildGoalGraphView(
+      snapshot({ nodes: [node('p1', { kind: 'problem', status: 'active', updatedAt: at(115) })] }),
+      NOW,
+    );
+
+    expect(isRunningNode(view.byId.p1)).toBe(false);
+  });
+
+  it('does not read a stale task as running', () => {
+    const view = buildGoalGraphView(
+      snapshot({ nodes: [node('w1', { status: 'active', updatedAt: at(0) })] }),
+      NOW,
+    );
+
+    expect(isRunningNode(view.byId.w1)).toBe(false);
   });
 });
 

--- a/src/features/AgentGoals/ProcessControl/goalGraphViewModel.ts
+++ b/src/features/AgentGoals/ProcessControl/goalGraphViewModel.ts
@@ -132,6 +132,19 @@ export const hasReviewableResult = (view: GoalNodeView): boolean => {
   return view.node.status === 'resolved' || view.isVerifying;
 };
 
+/**
+ * Whether a node reads as "running" on the map — the animated ring, the chip
+ * and the elapsed clock all hang off this.
+ *
+ * A question is excluded: an open question is not work in flight, its state is
+ * whether it has an answer yet, and the card already says that. A "Running"
+ * chip on a question that nobody is working promises activity that isn't there.
+ */
+export const isRunningNode = (view: GoalNodeView): boolean => {
+  if (view.node.kind === 'problem') return false;
+  return view.node.status === 'active' && !view.isStale;
+};
+
 export type FrontierItemKind = 'gate' | 'stale' | 'verifying' | 'running' | 'ready' | 'done';
 
 export interface FrontierItem {


### PR DESCRIPTION
An open question in the goal exploration graph carried a "Running" chip, an animated ring and an elapsed clock, purely because the node's status is `active`. A question is not work in flight. Its real state is whether it has an answer, and the card subtitle already says that ("Unanswered" / "Answered"). The chip promised activity nobody was doing.

The map's running rule now lives in the view model as `isRunningNode()`, which excludes question nodes. The chip, the ring and the clock all read that one flag, so they drop together. Stale and needs-decision states are untouched, so a question that lost its heartbeat still surfaces.

| Before | After |
| ------ | ----- |
| Question card shows an orange "Running" chip above the title | Question card shows only its kind icon, title and "Unanswered" subtitle |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Three cases added to `goalGraphViewModel.test.ts`: an active task is running, a question never is, a stale task is not. The question case fails without the fix and passes with it. Lint and the 33 tests in that file are green.

- Acceptance: not published yet. Reproducing the surface needs a live goal whose coordinator has just posted an unanswered question node, so the round is not captured here. Say the word and I will drive it locally and attach the link before merge.

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)