### PR TITLE
🐛 fix(prompts): mark an empty command result as (no output)

### DIFF
--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -105,7 +105,7 @@ describe('SkillsExecutionRuntime', () => {
 
         const result = await runtime.execScript(args);
 
-        expect(result.content).toBe('Command completed successfully.');
+        expect(result.content).toBe('Command completed successfully.\n\n(no output)');
       });
 
       it('should return success: false when execScript throws', async () => {

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
@@ -5,7 +5,34 @@ import { formatCommandResult } from './formatCommandResult';
 describe('formatCommandResult', () => {
   it('should format successful command without output', () => {
     const result = formatCommandResult({ exitCode: 0, success: true });
-    expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
+    expect(result).toMatchInlineSnapshot(`
+      "Command completed successfully.
+
+      (no output)"
+    `);
+  });
+
+  it('should mark empty output when the command crashed with stderr discarded', () => {
+    const result = formatCommandResult({ exitCode: 0, stderr: '', stdout: '', success: true });
+    expect(result).toMatchInlineSnapshot(`
+      "Command completed successfully.
+
+      (no output)"
+    `);
+  });
+
+  it('should mark empty output on a failed command too', () => {
+    const result = formatCommandResult({ exitCode: 1, success: true });
+    expect(result).toMatchInlineSnapshot(`
+      "Command failed with exit code 1
+
+      (no output)"
+    `);
+  });
+
+  it('should not mark empty output while the command is still running', () => {
+    const result = formatCommandResult({ shellId: 'shell-123', success: true });
+    expect(result).not.toContain('(no output)');
   });
 
   it('should format still-running command', () => {
@@ -112,7 +139,11 @@ describe('formatCommandResult', () => {
       exitCode: 0,
       success: true,
     });
-    expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
+    expect(result).toMatchInlineSnapshot(`
+      "Command completed successfully.
+
+      (no output)"
+    `);
   });
 
   it('should treat shell id with exitCode 0 as completed', () => {
@@ -121,7 +152,11 @@ describe('formatCommandResult', () => {
       shellId: 'shell-123',
       success: true,
     });
-    expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
+    expect(result).toMatchInlineSnapshot(`
+      "Command completed successfully.
+
+      (no output)"
+    `);
   });
 
   it('should treat a non-zero exit code as failure even when envelope success is true', () => {

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
@@ -60,5 +60,14 @@ export const formatCommandResult = ({
   if (stdout) parts.push(`Stdout:\n${stdout}`);
   if (stderr) parts.push(`Stderr:\n${stderr}`);
 
+  // A command that ran but wrote nothing to either stream has to say so. Without
+  // the marker, "wrote nothing" and "wrote to stderr, which `2>/dev/null` threw
+  // away" render as the same lone header line, and the caller reads that silence
+  // as a clean run. Only for a command that actually finished — `exitCode`
+  // undefined is the still-running branch, where empty output means nothing yet.
+  const hasOutput =
+    !!stdout || !!stderr || !!outputFiles?.stdout?.path || !!outputFiles?.stderr?.path;
+  if (!hasOutput && exitCode !== undefined) parts.push('(no output)');
+
   return parts.join('\n\n');
 };


### PR DESCRIPTION
## What

A command that ran but wrote nothing to stdout and stderr rendered as the lone line `Command completed successfully.` — identical to a run whose real output was thrown away. The caller reads that silence as a clean run and moves on.

Real case: `lh topic show ... 2>/dev/null | head -100` against a broken embedded CLI. The CLI crashed with `ERR_MODULE_NOT_FOUND` on stderr, `2>/dev/null` discarded it, and `| head` made the pipeline exit 0, so the whole failure rendered as one success line with no output at all.

## Change

`formatCommandResult` now appends an explicit `(no output)` line when the command finished and stdout, stderr and the saved output files are all empty. The still-running branch is untouched: there, empty output only means nothing has arrived yet.

```
Command completed successfully.

(no output)
```

The assertion in `builtin-tool-skills` had drifted from its own test name, `should return "(no output)" when output is empty`, which is what the contract was meant to be all along. It is corrected here.

## Test

Four new cases cover empty output on success, on a non-zero exit, with explicit empty strings, and the still-running branch that must not carry the marker. `bun run check` is clean on the three touched files, 43 tests passing.

Pure prompt-formatting change with no user-visible surface, so no acceptance round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)