### PR TITLE
💄 style(notification): restore inbox modal dividers in dark mode

### DIFF
--- a/src/features/HomeSidebar/Header/components/InboxModal/Content.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxModal/Content.tsx
@@ -25,8 +25,11 @@ import type { NotificationListHandle } from './useNotificationList';
 import { PAGE_SIZE, useNotificationList } from './useNotificationList';
 
 const styles = createStaticStyles(({ css }) => ({
+  // colorFillSecondary rather than colorBorderSecondary: see the note in
+  // ../InboxModal/index.tsx — the border token collapses into the modal's own
+  // surface in dark mode, which erased the separator between rows.
   item: css`
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+    border-block-end: 1px solid ${cssVar.colorFillSecondary};
 
     &:hover {
       background: ${cssVar.colorFillSecondary};

--- a/src/features/HomeSidebar/Header/components/InboxModal/index.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxModal/index.tsx
@@ -67,11 +67,18 @@ const styles = createStaticStyles(({ css }) => ({
     overscroll-behavior: contain;
     flex: 1;
   `,
+  // Dividers inside this modal use colorFillSecondary, not colorBorderSecondary.
+  // In the dark palette colorBorderSecondary and colorBgElevated are the same
+  // step of the neutral scale, so every border drawn on the modal's own surface
+  // resolves to the surface colour and disappears — the panel reads as one
+  // undifferentiated block. colorFillSecondary is alpha-based, so it lands on
+  // #f0f0f0 over the light surface (identical to what the border token gave)
+  // and stays visible over the dark one.
   header: css`
     flex: none;
     gap: 0;
     padding: 0;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+    border-block-end: 1px solid ${cssVar.colorFillSecondary};
   `,
   headerMain: css`
     min-width: 0;
@@ -101,7 +108,7 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: clamp(160px, 22vw, 220px);
     padding: 8px;
-    border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+    border-inline-end: 1px solid ${cssVar.colorFillSecondary};
   `,
 }));
 


### PR DESCRIPTION
In the dark palette `colorBorderSecondary` and `colorBgElevated` resolve to the same step of the neutral scale:

```ts
colorBgElevated:      appearance === 'dark' ? scale[appearance][2] : scale[appearance][0],
colorBorderSecondary: scale[appearance][2],
```

So every 1px divider drawn on a modal's own surface is painted in the surface colour and vanishes. In the inbox modal that erased all three: the category column boundary, the header rule, and the separator between notification rows — the panel reads as one undifferentiated block in dark mode.

Light mode was unaffected because there the two tokens are `#ffffff` and `#f0f0f0`.

The three dividers now use the alpha-based `colorFillSecondary`, which composites to `#f0f0f0` over the light surface — the exact tone the border token already produced — and stays visible over the dark one. Surfaces are untouched, so light mode is pixel-identical to before.

| | Surface | Divider before | Divider after |
| --- | --- | --- | --- |
| Dark | `rgb(26, 26, 26)` | `rgb(26, 26, 26)` (invisible) | `rgb(49, 49, 49)` |
| Light | `#ffffff` | `#f0f0f0` | `#f0f0f0` (unchanged) |

Scanning a dark-mode screenshot of the unmodified build across the divider positions returns an unbroken run of `rgb(26, 26, 26)` — the borders render no pixels at all. After the change the same scans return `49` at the column boundary, the header rule and both row separators.

#### Key Decisions / Non-goals

- An earlier attempt gave the category column its own `colorBgLayout` fill. That was dropped: it changed the modal's surface design in both themes, and in dark mode the column then matched the page behind the modal, dissolving its left edge. Keeping flat surfaces and fixing the divider token leaves the light appearance untouched.
- The token collision is palette-level, so other modals that draw dividers with `colorBorderSecondary` are likely affected too. Out of scope here; this PR only fixes the inbox modal.

#### Test

- [x] Tested locally

Verified in a local dev build at 1440x900 in both themes: opened the notifications modal with several notifications and sampled the rendered pixels at each divider position, plus the computed border colours, in dark and light.
