### PR TITLE
✅ test(mcp): cover deployment package serialization

### DIFF
--- a/src/features/MCP/utils.test.ts
+++ b/src/features/MCP/utils.test.ts
@@ -39,6 +39,24 @@ describe('genServerConfig', () => {
     });
   });
 
+  it('should preserve the package from deployment args when it differs from the marketplace identifier', () => {
+    const result = genServerConfig('ising-tech-isingq-toolkit', {
+      args: ['-y', '@ising-tech/isingq-mcp', 'serve'],
+      command: 'npx',
+      type: 'stdio',
+    } as any);
+
+    const config = JSON.parse(result);
+
+    expect(config.mcpServers['ising-tech-isingq-toolkit']).toEqual({
+      args: ['-y', '@ising-tech/isingq-mcp', 'serve'],
+      command: 'npx',
+    });
+    expect(config.mcpServers['ising-tech-isingq-toolkit'].args).not.toContain(
+      'ising-tech-isingq-toolkit',
+    );
+  });
+
   it('should handle empty connection config', () => {
     const result = genServerConfig('test-plugin', {} as any);
 


### PR DESCRIPTION
The MCP serializer must preserve executable arguments from the deployment connection when the marketplace identifier differs from the npm package. This adds regression coverage for the scoped-package example reported in #18706; the serializer fix itself is already on `canary`, so this PR is test-only.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Acceptance: not required — test-only change, no behavior change.

#### 🔗 Related Issue

Related to #18706

Reviewers: Innei, Arvin Xu, Tsuki
