### PR TITLE
🐛 fix(editor): stop the focused code line turning into a white band

### DIFF
--- a/src/components/CodeEditorPane/style.ts
+++ b/src/components/CodeEditorPane/style.ts
@@ -79,18 +79,22 @@ export const styles = createStaticStyles(({ css }) => ({
       color: ${cssVar.colorTextQuaternary};
     }
 
-    .cm-activeLineGutter {
+    /* The bundle carries a base style that paints the caret's line and gutter a
+       hard-coded near-white, in dark mode too, and qualifies both of them with
+       the editor class. Naming that class twice is what outranks it: otherwise
+       the focused line reads as a white band with its punctuation washed out. */
+    .cm-editor.cm-editor .cm-activeLineGutter {
       color: ${cssVar.colorText} !important;
       background: transparent;
     }
 
-    .cm-activeLine {
+    .cm-editor.cm-editor .cm-activeLine {
       background: ${cssVar.colorFillQuaternary};
     }
 
     /* A focused editor gets the stronger cue; an unfocused one keeps a faint
        marker so the caret position is still findable after a click elsewhere. */
-    .cm-editor:not(.cm-focused) .cm-activeLine {
+    .cm-editor.cm-editor:not(.cm-focused) .cm-activeLine {
       background: transparent;
     }
 


### PR DESCRIPTION
## What

In dark mode, clicking a line in the code editor painted the whole line a solid near-white bar. The line's text is drawn in the theme's near-white text colour, so the content of the focused line disappeared — punctuation first, then, on a wrapped line, everything.

## Why it happened

The CodeMirror bundle we load carries a base style that paints `.cm-activeLine` and `.cm-activeLineGutter` a hard-coded `#f3f9ff`, in dark mode too, and it qualifies both selectors with `.cm-editor`. Our own overrides in `CodeEditorPane` named that class at most once, so they tied or lost on specificity and the bundle won regardless of stylesheet insertion order.

## The change

Name the editor class twice in the three active-line rules so ours rank above the bundle's. CSS only, one file, no behaviour change beyond the highlight colour.

Per the repo convention in `AGENTS.md`, no regression test is added: this is a pure style fix whose only practical assertion would match stylesheet source strings.

## Verification

Verified on the running app (Web surface, agent profile "Markdown 源码" editor) with before/after captured by swapping the single changed file between the parent revision and this commit on the same live instance, plus computed styles read from the DOM.

| state | `.cm-activeLine` background | line text colour |
| --- | --- | --- |
| dark, before | `rgb(243, 249, 255)` | `rgb(255, 255, 255)` |
| dark, after | `rgba(255, 255, 255, 0.02)` | `rgb(255, 255, 255)` |
| light, after | `rgba(0, 0, 0, 0.016)` | `rgb(8, 8, 8)` |

Four checks passed: dark-mode legibility, active-line gutter number, no residual highlight after blur, and no light-mode regression.

Known coverage limit: only the agent-profile source editor was exercised. `CodeEditorPane` also renders in the document highlight editor and the local-file preview; those were not verified this round because the document upload input accepts only `.md/.markdown/.pdf/.docx` and the local-file preview needs a connected desktop device. Both render the same component and the same stylesheet class.

Acceptance: https://app.lobehub.com/acceptance/aaa5216b-5913-4454-adee-f18d991bcacf

🤖 Generated with [Claude Code](https://claude.com/claude-code)
