### PR TITLE
🐛 fix(cli): declare url-join and vitest so the standalone install builds

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -60,7 +60,9 @@
     "tinyexec": "^1.3.0",
     "tree-kill": "^1.2.2",
     "tsdown": "^0.21.10",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "url-join": "^5.0.0",
+    "vitest": "5.0.0"
   },
   "engines": {
     "node": ">=22.15"

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -823,6 +823,12 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      url-join:
+        specifier: ^5.0.0
+        version: 5.0.0
+      vitest:
+        specifier: 5.0.0
+        version: 5.0.0(@types/node@24.13.3)(happy-dom@20.10.6)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   stubs/business-const: {}
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

`apps/cli` installs against its own `pnpm-workspace.yaml`, but two direct imports are not declared in `apps/cli/package.json`:

- `src/utils/agentStream.ts` imports `url-join`
- the test files import `vitest`

Both resolve only through the root install's hoisting. CI runs the root install before `Install CLI deps`, so this stays invisible there — it only bites when the CLI is built on its own, which `PROJECT.md` documents as the supported path (`cd apps/cli && pnpm install`):

```
Error: Unresolved import in the CLI bundle:
  Could not resolve 'url-join' in src/utils/agentStream.ts
```

#### 📝 补充信息 | Additional Information

**Deliberately not fixed here.** `src/runtime/*` also imports `@lobechat/agent-runtime` and `@lobechat/conversation-flow` undeclared. Registering those is not a one-line change: their workspace closure is **16 further packages** — `@lobechat/database`, `@lobechat/context-engine`, `@lobechat/business-model-bank`, `@lobechat/shared-tool-ui` and nine `builtin-tool-*` — none of which the CLI workspace lists today. That list looks intentionally slim, so pulling the closure in is a decision for whoever owns that boundary rather than a drive-by fix. I tried it first and backed it out; the error you get is:

```
"@lobechat/context-engine@workspace:*" is in the dependencies but no package
named "@lobechat/context-engine" is present in the workspace
```

**Verified** by deleting `apps/cli/node_modules` and running `pnpm install` + `bun run build` inside `apps/cli` with **no root install** — previously it failed on `url-join`, now the bundle builds (`✔ Build complete in 5813ms`) and `lh artifact publish --help` works from the result. `vitest run src/commands/artifact.test.ts` → 10 passed.

**Acceptance** — skipped: a dependency declaration with no user-visible outcome; the behaviour proof is the standalone build above.

https://claude.ai/code/session_01558yVdNvoxocvnWAs11DGT