### PR TITLE
🐛 fix(ui): restore the NavPanel background after the base-ui DraggablePanel move

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     "@lobehub/icons": "^5.18.0",
     "@lobehub/market-sdk": "0.41.0",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.42.2",
+    "@lobehub/ui": "^5.42.3",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/src/features/Acceptance/Viewer/History/AcceptanceLedgerRail.tsx
+++ b/src/features/Acceptance/Viewer/History/AcceptanceLedgerRail.tsx
@@ -158,6 +158,7 @@ const AcceptanceLedgerRail = () => {
         </AcceptanceDrawer>
       ) : (
         <DraggablePanel
+          backgroundColor={cssVar.colorBgLayout}
           defaultSize={{ width: 340 }}
           expand={expand}
           minWidth={300}

--- a/src/features/HeteroSessionImport/SidebarTree.tsx
+++ b/src/features/HeteroSessionImport/SidebarTree.tsx
@@ -2,7 +2,7 @@ import type { HeteroSessionDirGroup, HeteroSessionDirPref } from '@lobechat/type
 import { ClaudeCode, Codex } from '@lobehub/icons';
 import { Flexbox, Icon, ScrollShadow, Tooltip } from '@lobehub/ui';
 import { ActionIcon, DraggablePanel, Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cx } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronRight, Eye, EyeOff, Folder, FolderGit2, Timer, X } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -134,6 +134,7 @@ const SidebarTree = memo<SidebarTreeProps>(({ groups, scope, onScopeChange, onSe
 
   return (
     <DraggablePanel
+      backgroundColor={cssVar.colorBgLayout}
       defaultSize={{ width: 232 }}
       expandable={false}
       maxWidth={420}


### PR DESCRIPTION
After #19365 the left NavPanel came out flat black on macOS desktop, where it should show its own transparent background for vibrancy.

Two things combined:

- Both DraggablePanel builds paint `colorBgLayout` on the content layer as an unconditional fallback (`background: var(--draggable-panel-bg, …)`).
- The antd build applied the `style` prop to that same content element; the base-ui build applied it to the root `<aside>`.

So NavPanel's `style={{ background: 'transparent' }}` used to land on the element carrying the fallback and cancel it. After the migration it landed on the root, and nothing overrode the content layer any more.

Both halves are fixed in `@lobehub/ui`, not here:

- [`66f111f2`](https://github.com/lobehub/lobe-ui/commit/66f111f21) — drop the fallback (`background: var(--draggable-panel-bg, transparent)`). The panel is headless; a caller that wants a background passes `backgroundColor`. Shipped as 5.42.3.
- [`733aa368`](https://github.com/lobehub/lobe-ui/commit/733aa3680) — put `style` back on the content layer, so every migrated call site's `style` aims at the box it was written for again. Carries a regression test.

The only thing left on this side: two render sites never passed `style`, so they had been living on the fallback since before the migration. They now pass `backgroundColor` explicitly to keep the same appearance — `AcceptanceLedgerRail` and `HeteroSessionImport/SidebarTree`. Every other site (NavPanel, RightPanel, Portal, SharePortal, ChatTerminal, AcceptanceListPanel, group AgentBuilder) already sets its own background.

| Before | After |
| ------ | ----- |
| NavPanel content layer forced to `rgb(0,0,0)` | NavPanel shows its own background, `rgb(35,35,36)` |

Screenshots are in the acceptance round below.

#### Test

Reproduced and fixed in dev Electron on macOS: captured the fixed state, injected the pre-migration fallback into the same running instance to reproduce the regression, then removed it to confirm the return. Pixel sampling shows the change is confined to the left NavPanel column — the main content area, the right workspace panel and the input bar are identical between the two captures.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

The `style`-target regression test lives with the fix in lobe-ui (red before, green after). On this side the change is a version bump plus two props, so nothing new to assert here; `src/features/ChatTerminal/index.test.tsx` and `src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx` (49 tests) still pass and both changed files are lint clean.

- Acceptance: https://app.lobehub.com/acceptance/924043d7-0dec-4855-90a1-df1b25a5a284

The round is `partial`: the NavPanel fix and the sibling panels are verified with screenshots, but `AcceptanceLedgerRail` and `SidebarTree` could not be reached on the desktop surface this round (the desktop acceptance page lives under a project route with no local data, and the hetero-import modal is behind a lab flag), so those two are recorded as unverified rather than passed.

#### 🔗 Related Issue

Follow-up to #19365

https://claude.ai/code/session_01D8V21HYaxmubatCj2Q3hu7