### PR TITLE
🐛 fix(ui): keep the two panels that lived on DraggablePanel's default background

### DIFF
--- a/src/features/Acceptance/Viewer/History/AcceptanceLedgerRail.tsx
+++ b/src/features/Acceptance/Viewer/History/AcceptanceLedgerRail.tsx
@@ -158,6 +158,7 @@ const AcceptanceLedgerRail = () => {
         </AcceptanceDrawer>
       ) : (
         <DraggablePanel
+          backgroundColor={cssVar.colorBgLayout}
           defaultSize={{ width: 340 }}
           expand={expand}
           minWidth={300}

--- a/src/features/HeteroSessionImport/SidebarTree.tsx
+++ b/src/features/HeteroSessionImport/SidebarTree.tsx
@@ -2,7 +2,7 @@ import type { HeteroSessionDirGroup, HeteroSessionDirPref } from '@lobechat/type
 import { ClaudeCode, Codex } from '@lobehub/icons';
 import { Flexbox, Icon, ScrollShadow, Tooltip } from '@lobehub/ui';
 import { ActionIcon, DraggablePanel, Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cx } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronRight, Eye, EyeOff, Folder, FolderGit2, Timer, X } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -134,6 +134,7 @@ const SidebarTree = memo<SidebarTreeProps>(({ groups, scope, onScopeChange, onSe
 
   return (
     <DraggablePanel
+      backgroundColor={cssVar.colorBgLayout}
       defaultSize={{ width: 232 }}
       expandable={false}
       maxWidth={420}


### PR DESCRIPTION
Follow-up to the DraggablePanel background work in `@lobehub/ui`.

[`66f111f2`](https://github.com/lobehub/lobe-ui/commit/66f111f21) (5.42.3) drops the unconditional `colorBgLayout` the panel painted on its content layer, so a panel that sets its own background is no longer covered up. `AcceptanceLedgerRail` and `HeteroSessionImport/SidebarTree` never set one — they had been living on that default since before the base-ui migration — so they now pass it explicitly and keep the same appearance.

That is the whole diff: two `backgroundColor` props and one import. No version bump is needed; `^5.42.2` already covers 5.42.x and the repo commits no root lockfile.

The NavPanel regression that started this is fixed entirely in `@lobehub/ui` and needs nothing here:

- [`66f111f2`](https://github.com/lobehub/lobe-ui/commit/66f111f21) — the fallback above.
- [`733aa368`](https://github.com/lobehub/lobe-ui/commit/733aa3680) — put the `style` prop back on the content layer. The antd build applied `style` there; the base-ui build had moved it to the root `<aside>`, which is why NavPanel's `style={{ background: 'transparent' }}` stopped reaching the box it was written for. Carries a regression test.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Lint clean. The regression test for the underlying behavior lives with the fix in lobe-ui (red before, green after).

- Acceptance: https://app.lobehub.com/acceptance/924043d7-0dec-4855-90a1-df1b25a5a284

Round 1 proves the NavPanel fix on macOS desktop. Round 2 proves `SidebarTree` on the real import modal: with the prop the tree column samples 3.7% grey against the session list's 10.9%; drop the prop and it inverts to 13.5%, lighter than the list.

`AcceptanceLedgerRail` is recorded as **unverified**. It renders only under the web-only `/acceptance/:acceptanceId` route (`webOnlyRoutes` in `desktopRouter.config.tsx`; the router sync test asserts Electron excludes it), and the desktop project acceptance page mounts the list workspace instead. Driving the web surface locally needs a signed-in localhost session that the acceptance adapter refuses to seed into a developer's own `.env` database. It takes the same one-line prop as the panel that *was* verified, and restores a background it had for months.

#### 🔗 Related Issue

Follow-up to #19365

https://claude.ai/code/session_01D8V21HYaxmubatCj2Q3hu7