### PR TITLE
📝 fix(docs): correct stale e2e directory layout in testing guide

### DIFF
--- a/docs/development/basic/test.mdx
+++ b/docs/development/basic/test.mdx
@@ -276,19 +276,19 @@ E2E tests live in the `e2e/` directory:
 
 ```
 e2e/
-├── features/             # Cucumber feature files (.feature)
+├── src/features/         # Cucumber feature files (.feature)
 │   ├── auth.feature
 │   └── chat.feature
-├── step-definitions/     # Step implementations
+├── src/steps/            # Step implementations
 │   ├── auth.steps.ts
 │   └── chat.steps.ts
-├── support/              # Shared helpers and hooks
-└── playwright.config.ts
+├── src/support/          # Shared helpers and hooks
+└── cucumber.config.js
 ```
 
 ### Writing E2E Tests
 
-**Feature file** (`e2e/features/chat.feature`):
+**Feature file** (`e2e/src/features/chat.feature`):
 
 ```gherkin
 Feature: Chat Functionality
@@ -302,7 +302,7 @@ Feature: Chat Functionality
     And I should see a response from the AI
 ```
 
-**Step definitions** (`e2e/step-definitions/chat.steps.ts`):
+**Step definitions** (`e2e/src/steps/chat.steps.ts`):
 
 ```typescript
 import { Given, When, Then } from '@cucumber/cucumber';


### PR DESCRIPTION
The E2E section of the testing guide (`docs/development/basic/test.mdx`) documents a directory layout that no longer matches the repo: `e2e/features/`, `e2e/step-definitions/`, `e2e/support/`, and `e2e/playwright.config.ts`.

The actual layout (see `e2e/cucumber.config.js`, which sets `paths: ['src/features/**/*.feature']` and `require: ['src/steps/**/*.ts', 'src/support/**/*.ts']`) is `e2e/src/features/`, `e2e/src/steps/`, `e2e/src/support/`, driven by `cucumber.config.js` rather than a Playwright config file.

Updated the directory tree and the two file-path references in the doc to match.

---
This pull request was prepared with the assistance of an AI agent (Claude) supervised by the submitter.