### PR TITLE
💄 style(acceptance): always show the comment reaction button

### DIFF
--- a/src/features/Acceptance/Viewer/Comments/CommentReactions.tsx
+++ b/src/features/Acceptance/Viewer/Comments/CommentReactions.tsx
@@ -88,7 +88,12 @@ const styles = createStaticStyles(({ css }) => ({
       background: ${cssVar.colorFillSecondary};
     }
   `,
-  /** The add button, quiet until the comment is hovered — GitHub's behaviour. */
+  /**
+   * The add button stands on its own rather than waiting for a hover: reacting
+   * is the cheapest way to answer a delivery, and an affordance you have to
+   * find by sweeping the mouse is one most readers never find at all. Quiet by
+   * default, it darkens under the cursor.
+   */
   trigger: css`
     cursor: pointer;
 
@@ -103,22 +108,13 @@ const styles = createStaticStyles(({ css }) => ({
 
     color: ${cssVar.colorTextTertiary};
 
-    opacity: 0;
-
-    transition: opacity ${cssVar.motionDurationFast};
+    transition: color ${cssVar.motionDurationFast};
 
     &:hover,
     &[data-open] {
       color: ${cssVar.colorText};
-      opacity: 1;
+      background: ${cssVar.colorFillQuaternary};
     }
-
-    @media (hover: none) {
-      opacity: 1;
-    }
-  `,
-  triggerVisible: css`
-    opacity: 1;
   `,
 }));
 
@@ -211,7 +207,7 @@ const CommentReactions = memo<CommentReactionsProps>(({ onReact, reactions }) =>
         >
           <span
             data-comment-reaction-add
-            className={cx(styles.trigger, open && styles.triggerVisible)}
+            className={styles.trigger}
             title={t('acceptance.comments.addReaction')}
             {...(open ? { 'data-open': '' } : {})}
           >

--- a/src/features/Acceptance/Viewer/Comments/styles.ts
+++ b/src/features/Acceptance/Viewer/Comments/styles.ts
@@ -255,8 +255,7 @@ export const styles = createStaticStyles(({ css }) => ({
       background: ${cssVar.colorBorderSecondary};
     }
 
-    &:hover [data-comment-actions],
-    &:hover [data-comment-reaction-add] {
+    &:hover [data-comment-actions] {
       opacity: 1;
     }
 


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] style

## 🔀 变更说明 | Description of Change

验收讨论里每条评论下方的「加表情」按钮原本 `opacity: 0`，要把鼠标移到该条 timeline entry 上才会浮现。表情是回应一次交付最轻量的方式，靠扫鼠标才能发现的入口等于没有入口 —— 现在默认常驻，保持低饱和的三级灰，hover / 打开 picker 时加深并带底色。

- `CommentReactions.tsx`：去掉 `trigger` 的 `opacity: 0` 与 `triggerVisible` 覆写，改为 `color` 过渡 + hover 底色
- `styles.ts`：`timelineEntry` 的 hover 规则不再需要唤起 `[data-comment-reaction-add]`，`[data-comment-actions]`（删除等操作）仍保持 hover 出现

## 📝 补充信息 | Additional Information

纯 CSS 调整，无逻辑变更，因此未加回归测试（唯一可断言的只有样式源码字符串）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)