### PR TITLE
💄 style(self-learning): anchor the habit lesson preview below the row

### DIFF
--- a/src/features/SelfLearning/Portrait/HabitList.tsx
+++ b/src/features/SelfLearning/Portrait/HabitList.tsx
@@ -163,12 +163,11 @@ const HabitRow = memo<HabitRowProps>(({ agentId, domainTitle, habit, onChanged, 
         <Popover
           // Long enough that dragging the pointer down the list does not fetch every row.
           openDelay={420}
-          // Above the row rather than below it: the row's own hint sits directly beneath the
-          // title, so a card there buries the line the reader just came from.
-          placement={'topRight'}
-          // This stack never flips a popup to the opposite side, so the card has to fit in the
-          // space above the row; the padding keeps it clear of the viewport edge.
-          positionerProps={{ collisionPadding: 12 }}
+          // Keep the row visible while the reader moves into the preview beneath it.
+          placement={'bottomRight'}
+          // The product direction is deliberately stable: fit/scroll in the available space
+          // below instead of letting Base UI flip the card above rows near the viewport edge.
+          positionerProps={{ collisionAvoidance: { side: 'none' }, collisionPadding: 12 }}
           trigger={'hover'}
           content={
             <LessonPreview

--- a/src/features/SelfLearning/Portrait/HabitList.tsx
+++ b/src/features/SelfLearning/Portrait/HabitList.tsx
@@ -163,11 +163,13 @@ const HabitRow = memo<HabitRowProps>(({ agentId, domainTitle, habit, onChanged, 
         <Popover
           // Long enough that dragging the pointer down the list does not fetch every row.
           openDelay={420}
-          // Keep the row visible while the reader moves into the preview beneath it.
+          // Below the row by preference, so the row the reader is pointing at stays visible
+          // while they move into the card.
           placement={'bottomRight'}
-          // The product direction is deliberately stable: fit/scroll in the available space
-          // below instead of letting Base UI flip the card above rows near the viewport edge.
-          positionerProps={{ collisionAvoidance: { side: 'none' }, collisionPadding: 12 }}
+          // Preference, not a rule: reading down a list parks the pointer on the last visible
+          // row, and pinning the card downward there pushes its body off-screen. Base UI's
+          // default side avoidance flips it back above when the space below runs out.
+          positionerProps={{ collisionPadding: 12 }}
           trigger={'hover'}
           content={
             <LessonPreview

--- a/src/features/SelfLearning/Portrait/LessonPreview.tsx
+++ b/src/features/SelfLearning/Portrait/LessonPreview.tsx
@@ -26,9 +26,8 @@ const styles = createStaticStyles(({ css }) => ({
     /* less the popup's own chrome, which sits outside this element */
 
     /*
-     * The card is anchored below the row with side-axis collision flipping disabled. For a row
-     * low on the page it therefore has to fit in the space below it or its tail becomes
-     * unreachable.
+     * The card prefers the space below the row but flips above when that runs out, so this
+     * tracks whichever side Base UI actually chose rather than assuming one of them.
      */
     max-height: calc(var(--available-height, 100dvh) - 16px);
   `,
@@ -64,7 +63,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-/** Kept low so the card fits below the row it describes; the rest is one line away. */
+/** Kept low so the card fits beside the row it describes; the rest is one line away. */
 const MAX_EVIDENCE = 2;
 
 interface LessonPreviewProps {

--- a/src/features/SelfLearning/Portrait/LessonPreview.tsx
+++ b/src/features/SelfLearning/Portrait/LessonPreview.tsx
@@ -26,9 +26,9 @@ const styles = createStaticStyles(({ css }) => ({
     /* less the popup's own chrome, which sits outside this element */
 
     /*
-     * The card is anchored above the row, and this stack never flips a popup to the opposite
-     * side — an explicit collisionAvoidance side:'flip' was measured to do nothing. So for a row
-     * high on the page the card has to fit in the space above it or its tail becomes unreachable.
+     * The card is anchored below the row with side-axis collision flipping disabled. For a row
+     * low on the page it therefore has to fit in the space below it or its tail becomes
+     * unreachable.
      */
     max-height: calc(var(--available-height, 100dvh) - 16px);
   `,
@@ -64,7 +64,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-/** Kept low so the card fits above the row it describes; the rest is one line away. */
+/** Kept low so the card fits below the row it describes; the rest is one line away. */
 const MAX_EVIDENCE = 2;
 
 interface LessonPreviewProps {


### PR DESCRIPTION
The habit lesson preview popover was anchored above the row it describes. This anchors it below instead, so the row the reader is pointing at stays visible while they move into the card.

Below the row is a preference, not a rule. Base UI's default side avoidance flips the card back above when the space below runs out, which is what a row at the bottom of a scrolled list hits constantly.

Recovered from a stale worktree that was cut on 2026-08-26 and never landed; the change was reapplied cleanly on current canary.

#### Test

Driven on the real web app against a local full-stack dev server, with a seeded self-learning domain and six habits. The same habit row was hovered at two scroll positions and the row/card boundaries measured each time.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Round 1 shipped the change with the side axis pinned to `none`, and the review rejected it: a row at the bottom of the viewport opened a card whose body fell outside the screen and could not be scrolled to. Round 2 drops that override. The card now flips above at the bottom edge and stays fully readable, and a regression pass confirms a mid-viewport row still opens the card below.

- Acceptance: https://app.lobehub.com/acceptance/089bb971-398a-4b95-ba5a-c94af95a3527?r=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)