### PR TITLE
🐛 fix(about): support build-time app version override

### DIFF
--- a/src/const/appVersion.ts
+++ b/src/const/appVersion.ts
@@ -1,0 +1,4 @@
+import { CURRENT_VERSION } from '@/const/version';
+
+// Cloud injects the release version at build time; other Web builds use package metadata.
+export const WEB_APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || CURRENT_VERSION;

--- a/src/features/Settings/about/features/appVersion.test.ts
+++ b/src/features/Settings/about/features/appVersion.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/const/version', () => ({ CURRENT_VERSION: '2.2.14' }));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('APP_VERSION', () => {
+  it('prefers the injected build version over package metadata', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '2.2.16');
+    expect((await import('./appVersion')).APP_VERSION).toBe('2.2.16');
+  });
+
+  it.each([undefined, ''])(
+    'uses the package version without an injected value (%s)',
+    async (value) => {
+      vi.stubEnv('NEXT_PUBLIC_APP_VERSION', value);
+      expect((await import('./appVersion')).APP_VERSION).toBe('2.2.14');
+    },
+  );
+
+  it('keeps the desktop package version independent of the web build version', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '2.2.16');
+    vi.stubGlobal('__MAIN_VERSION__', '2.2.15');
+    expect((await import('./appVersion.desktop')).APP_VERSION).toBe('2.2.15');
+  });
+});

--- a/src/features/Settings/about/features/appVersion.ts
+++ b/src/features/Settings/about/features/appVersion.ts
@@ -1,3 +1,3 @@
 import { CURRENT_VERSION } from '@/const/version';
 
-export const APP_VERSION = CURRENT_VERSION;
+export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || CURRENT_VERSION;

--- a/src/features/Settings/about/features/appVersion.ts
+++ b/src/features/Settings/about/features/appVersion.ts
@@ -1,3 +1,1 @@
-import { CURRENT_VERSION } from '@/const/version';
-
-export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || CURRENT_VERSION;
+export { WEB_APP_VERSION as APP_VERSION } from '@/const/appVersion';

--- a/src/routes/(main)/agent/_layout/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/index.test.tsx
@@ -16,7 +16,10 @@ vi.mock('react-router', async () => {
   };
 });
 
-vi.mock('@/const/version', () => ({ isDesktop: false }));
+vi.mock(import('@/const/version'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  isDesktop: false,
+}));
 vi.mock('@/hooks/useInitAgentConfig', () => ({ useInitAgentConfig: vi.fn() }));
 vi.mock('@/features/ProtocolUrlHandler', () => ({ default: () => null }));
 vi.mock('./RegisterHotkeys', () => ({ default: () => null }));

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -100,7 +100,8 @@ vi.mock('i18next', () => ({
 }));
 
 // 默认设置 isServerMode 为 false
-vi.mock('@/const/version', () => ({
+vi.mock(import('@/const/version'), async (importOriginal) => ({
+  ...(await importOriginal()),
   isServerMode: false,
   isDeprecatedEdition: true,
   isDesktop: false,

--- a/src/store/chat/slices/thread/action.test.ts
+++ b/src/store/chat/slices/thread/action.test.ts
@@ -23,7 +23,8 @@ vi.mock('@/libs/swr', async () => {
 });
 
 // Mock version constants
-vi.mock('@/const/version', () => ({
+vi.mock(import('@/const/version'), async (importOriginal) => ({
+  ...(await importOriginal()),
   isDeprecatedEdition: false,
   isDesktop: false,
 }));

--- a/src/store/global/actions/__tests__/general.test.ts
+++ b/src/store/global/actions/__tests__/general.test.ts
@@ -1,13 +1,30 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as activeWorkspaceSlugModule from '@/business/client/hooks/useActiveWorkspaceSlug';
+import type * as VersionConstants from '@/const/version';
 import { CURRENT_VERSION } from '@/const/version';
 import { globalService } from '@/services/global';
 import { useGlobalStore } from '@/store/global';
 import { initialState } from '@/store/global/initialState';
 import { switchLang } from '@/utils/client/switchLang';
 import { withSWR } from '~test-utils';
+
+const versionContext = vi.hoisted(() => ({ desktop: false, webVersion: '2.2.14' }));
+
+vi.mock('@/const/version', async (importOriginal) => ({
+  ...(await importOriginal<typeof VersionConstants>()),
+  CURRENT_VERSION: '2.2.14',
+  get isDesktop() {
+    return versionContext.desktop;
+  },
+}));
+
+vi.mock('@/const/appVersion', () => ({
+  get WEB_APP_VERSION() {
+    return versionContext.webVersion;
+  },
+}));
 
 vi.mock('@/utils/client/switchLang', () => ({
   switchLang: vi.fn(),
@@ -22,6 +39,8 @@ vi.mock('@/services/global', () => ({
 describe('generalActionSlice', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    versionContext.desktop = false;
+    versionContext.webVersion = '2.2.14';
     useGlobalStore.setState(initialState);
   });
 
@@ -193,6 +212,28 @@ describe('generalActionSlice', () => {
   });
 
   describe('useCheckLatestVersion', () => {
+    it.each([
+      { desktop: false, expected: undefined, latest: '2.3.0' },
+      { desktop: false, expected: true, latest: '2.4.0' },
+      { desktop: true, expected: true, latest: '2.3.0' },
+    ])(
+      'compares $latest against the platform version (desktop: $desktop)',
+      async ({ desktop, expected, latest }) => {
+        versionContext.desktop = desktop;
+        versionContext.webVersion = '2.3.0';
+        vi.mocked(globalService.getLatestVersion).mockResolvedValueOnce(latest);
+
+        const { result } = renderHook(() => useGlobalStore().useCheckLatestVersion(), {
+          wrapper: withSWR,
+        });
+
+        await waitFor(() => expect(result.current.data).toBe(latest));
+
+        expect(useGlobalStore.getState().hasNewVersion).toBe(expected);
+        expect(useGlobalStore.getState().latestVersion).toBe(expected ? latest : undefined);
+      },
+    );
+
     it('should not fetch version when check is disabled', () => {
       const getLatestVersionSpy = vi.spyOn(globalService, 'getLatestVersion');
 

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -5,6 +5,7 @@ import type { SWRResponse } from 'swr';
 
 import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { getActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
+import { WEB_APP_VERSION } from '@/const/appVersion';
 import { CURRENT_VERSION, isDesktop } from '@/const/version';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useOnlyFetchOnceSWR } from '@/libs/swr';
@@ -250,9 +251,10 @@ export class GlobalGeneralActionImpl {
       {
         focusThrottleInterval: 1000 * 60 * 30,
         onSuccess: (data: string) => {
-          if (!valid(CURRENT_VERSION) || !valid(data)) return;
+          const version = isDesktop ? CURRENT_VERSION : WEB_APP_VERSION;
+          if (!valid(version) || !valid(data)) return;
 
-          const currentVersion = parse(CURRENT_VERSION);
+          const currentVersion = parse(version);
           const latestVersion = parse(data);
 
           if (!currentVersion || !latestVersion) return;


### PR DESCRIPTION
## Description

Use a build-time Web version consistently for About display and update checks.

- Define a frontend-only `WEB_APP_VERSION`: prefer `NEXT_PUBLIC_APP_VERSION`, falling back to `CURRENT_VERSION` when missing or empty.
- Share that value between Web About and Web latest-version checks, preserving the existing major/minor-only update policy.
- Preserve desktop display (`__MAIN_VERSION__`) and desktop update comparisons (`CURRENT_VERSION`). Shared package/server version constants, server compatibility checks, and `/api/version` remain unchanged.
- Prevent a package version of `2.2.14` with an injected Web version of `2.3.0` from advertising `2.3.0` as a new version.

The companion Cloud build script will resolve the latest published stable GitHub release before building and export its version without the leading `v` as `NEXT_PUBLIC_APP_VERSION`. That script belongs in the Cloud repository and is not included here. The Web value is fixed at build time, not fetched at runtime. Builds without the override retain their existing behavior.

#### Test

- [x] Added/updated tests
- [ ] Tested locally (full product acceptance)
- [ ] No tests needed

`bun run check src/const/appVersion.ts src/features/Settings/about/features/appVersion.ts src/features/Settings/about/features/appVersion.test.ts src/store/global/actions/general.ts src/store/global/actions/__tests__/general.test.ts src/store/global/action.test.ts` — lint clean, 59 tests passed.

Regression coverage includes override precedence, missing/empty fallback, desktop display isolation, equal injected/latest versions, a genuinely newer minor release, and desktop update-check isolation. Both the original display regression and the cross-minor false-update regression were observed failing before their respective fixes.

Acceptance: Explicitly waived by the requester for this non-draft PR. No published acceptance round or browser verification is claimed.

#### 🔗 Related Issue

Source discussion: https://ampcode.com/threads/T-01a08e4b-4109-75de-941f-ba2b6d6139ba


### CI follow-up

Fixed three consumer test mocks to preserve real version exports via `importOriginal`, while retaining their platform overrides. This resolves the suite-loading failures caused by the new frontend version constant reading `CURRENT_VERSION` at import time; production logic is unchanged.

Validation: `bun run check src/services/chat/chat.test.ts 'src/routes/(main)/agent/_layout/index.test.tsx' src/store/chat/slices/thread/action.test.ts src/features/Settings/about/features/appVersion.test.ts src/store/global/actions/__tests__/general.test.ts src/store/global/action.test.ts` — lint clean, 134 tests passed, including all three previously failing suites.
