### PR TITLE
🐛 fix(ci): restore release metadata sync and dispatch on main

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Sync main to canary
         if: env.SHOULD_TAG == 'true' && steps.check-tag.outputs.exists == 'false'
         run: |
-          gh workflow run sync-main-to-canary.yaml
+          gh workflow run sync-main-to-canary.yaml --ref main
           echo "✅ Dispatched sync-main-to-canary workflow"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 # Changelog
 
+## [Version 2.2.16](https://github.com/lobehub/lobe-chat/compare/v2.2.16-canary.28...v2.2.16)
+
+<sup>Released on **2026-09-04**</sup>
+
+#### 🐛 Bug Fixes
+
+- **heterogeneous-agent**: preserve TRAE auth for model bindings.
+
+#### ✨ Features
+
+- **misc**: relax workspace resource management.
+
+<br/>
+
+<details>
+<summary><kbd>Improvements and Fixes</kbd></summary>
+
+#### What's fixed
+
+- **heterogeneous-agent**: preserve TRAE auth for model bindings, closes [#18932](https://github.com/lobehub/lobe-chat/issues/18932) ([08a22e1](https://github.com/lobehub/lobe-chat/commit/08a22e1))
+
+#### What's improved
+
+- **misc**: relax workspace resource management, closes [#19107](https://github.com/lobehub/lobe-chat/issues/19107) ([29da6a6](https://github.com/lobehub/lobe-chat/commit/29da6a6))
+
+</details>
+
+<div align="right">
+
+[![](https://img.shields.io/badge/-BACK_TO_TOP-151515?style=flat-square)](#readme-top)
+
+</div>
+
 ## [Version 2.2.11](https://github.com/lobehub/lobe-chat/compare/v2.2.11-canary.67...v2.2.11)
 
 <sup>Released on **2026-07-23**</sup>

--- a/changelog/v2.json
+++ b/changelog/v2.json
@@ -1,6 +1,13 @@
 [
   {
     "children": {
+      "features": ["relax workspace resource management."]
+    },
+    "date": "2026-09-04",
+    "version": "2.2.16"
+  },
+  {
+    "children": {
       "fixes": [
         "narrow acceptance empty filter translation key.",
         "enforce agent step execution deadlines."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.2.14",
+  "version": "2.2.16",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/tests/github-scripts/releaseSyncWorkflow.test.ts
+++ b/tests/github-scripts/releaseSyncWorkflow.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { parse } from 'yaml';
+
+interface Workflow {
+  jobs: Record<string, { steps: { name: string; run?: string }[] }>;
+}
+
+describe('Release branch synchronization', () => {
+  it('dispatches the post-release sync on main even when the default branch is canary', async () => {
+    const workflow: Workflow = parse(
+      await readFile(path.resolve(process.cwd(), '.github/workflows/auto-tag-release.yml'), 'utf8'),
+    );
+    const step = workflow.jobs['auto-tag'].steps.find(({ name }) => name === 'Sync main to canary');
+
+    expect(step?.run).toBeDefined();
+    if (!step?.run) throw new Error('Missing post-release sync command');
+
+    // Mock the GitHub CLI boundary: omitting --ref selects the repository default.
+    const { stdout } = await promisify(execFile)('bash', [
+      '-eu',
+      '-c',
+      `
+gh() {
+  test "$1" = workflow && test "$2" = run
+  test "$3" = sync-main-to-canary.yaml
+  shift 3
+  local ref=canary
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --ref) ref="$2"; shift 2 ;;
+      *) return 1 ;;
+    esac
+  done
+  printf 'SYNC_REF=%s\\n' "$ref"
+}
+${step.run}
+`,
+    ]);
+
+    expect(stdout).toContain('SYNC_REF=main\n');
+    expect(stdout).not.toContain('SYNC_REF=canary\n');
+  });
+});


### PR DESCRIPTION
## Summary

Repair the missed v2.2.16 back-sync separately from this week's release preparation.

- Merge the existing release metadata commit from `main` into this canary-based branch. This restores `package.json` to the already-published version `2.2.16` and carries over `CHANGELOG.md` and `changelog/v2.json`. No new version or tag is created.
- Dispatch `sync-main-to-canary.yaml` with `--ref main`, rather than implicitly selecting the repository default branch (`canary`).
- Add a regression test that executes the workflow's shell command with a mocked GitHub CLI and verifies the dispatched ref.

## Confirmed cause

The first sync after the release PR merged ran before the version-bump commit existed:
https://github.com/lobehub/lobehub/actions/runs/33869554536

The post-release dispatch then ran on `canary`. Its `Sync main to canary` step was skipped because it requires `github.ref == 'refs/heads/main'`, although the overall run was marked successful:
https://github.com/lobehub/lobehub/actions/runs/33870279887

## Merge and rollout notes

**Use a merge commit, not squash or rebase.** This PR intentionally preserves the existing `main` release commit as an ancestor. Squashing would copy the files without repairing release ancestry.

After merging, verify that `v2.2.16` is an ancestor of `origin/canary`, then refresh the weekly release candidate from canary.

The dispatch fix must also reach `main` with the next release merge before the release workflow there uses it. This PR does not modify remote main, run a live synchronization, or publish a release.

## Test

- [x] Regression test fails before the workflow fix: dispatch selects `canary`.
- [x] `bun run check --lint --test .github/workflows/auto-tag-release.yml tests/github-scripts/releaseSyncWorkflow.test.ts`: lint clean, 1 test passed.
- [x] `git merge-base --is-ancestor v2.2.16 HEAD` passes on this branch.
- [x] Synced changelog files match `origin/main`; the only package.json change versus canary is the existing release version.
- [x] `git diff --check` passes.
- [ ] GitHub PR checks complete.
- [ ] After merge, confirm release ancestry on remote canary.

Acceptance: skipped because this is release-automation and existing metadata synchronization only, with no new user-facing product behavior. Live workflow dispatch was deliberately not exercised because it can push directly to canary.

Local checks used the existing installed dependencies (Vitest 3.2.6); the candidate declares Vitest 5, so CI remains the gate for that dependency version.