### PR TITLE
🐛 fix: retain action labels for CJK tool arguments

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.test.tsx
@@ -13,6 +13,17 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('ToolTitle', () => {
+  it.each([
+    { title: '沙盒交付链路问题' },
+    { description: '修复沙盒权限问题', title: '沙盒交付链路问题' },
+    { query: '沙盒权限' },
+    { path: '/docs/沙盒说明.md' },
+  ])('keeps the action label for CJK resource arguments: %j', (args) => {
+    render(<ToolTitle apiName={'create_issue'} args={args} identifier={'linear'} />);
+
+    expect(screen.getByText('create_issue')).toBeInTheDocument();
+  });
+
   describe('model-written description rendering', () => {
     it('renders a CJK description standalone — no action label, no code font', () => {
       render(

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
@@ -55,7 +55,7 @@ interface ToolTitleProps {
 const isCJK = (value: string) => /[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF]/.test(value);
 
 /**
- * Collapsed tool row title. When the model wrote a step description it stands
+ * Collapsed tool row title. When a command has a step description it stands
  * alone — the action label ("执行代码") adds nothing next to "恢复登录态", and
  * showing both at different sizes reads as a glitch, so the description takes
  * the label's typography. Command-like keywords (program name, file basename)
@@ -74,13 +74,20 @@ const ToolTitle = memo<ToolTitleProps>(
     // apiName), prefixed with the plugin title when we actually know it.
     const actionLabel = t(`builtins.${identifier}.apiName.${apiName}`, { defaultValue: '' });
 
-    const keyword = useMemo(() => extractToolKeyword(args ?? partialArgs), [args, partialArgs]);
+    const effectiveArgs = args ?? partialArgs;
+    const keyword = useMemo(() => extractToolKeyword(effectiveArgs), [effectiveArgs]);
 
-    // A model-written description states the whole step on its own; pairing it
-    // with the action label duplicates meaning ("执行代码 查看当前运行中的
-    // Docker 容器") at mismatched font sizes. Let it replace the label and
-    // inherit the label's typography instead of the small code font.
-    const isStandaloneDescription = !!keyword && isCJK(keyword);
+    // Only command step descriptions can replace the action. Resource titles,
+    // queries, and paths can also contain CJK text but do not say what the tool
+    // is doing (for example, creating versus updating a Linear issue).
+    const hasCommand = ['command', 'cmd', 'script'].some(
+      (key) => typeof effectiveArgs?.[key] === 'string' && effectiveArgs[key].trim(),
+    );
+    const isStandaloneDescription =
+      hasCommand &&
+      !!keyword &&
+      isCJK(keyword) &&
+      keyword === extractToolKeyword({ description: effectiveArgs?.description });
 
     return (
       <div className={cx(styles.root, isAborted && styles.aborted)}>


### PR DESCRIPTION
Collapsed tool rows treated every CJK keyword as a complete step description. A Chinese Linear issue title therefore hid both the tool name and action, while expanding the row restored them.

Restrict standalone descriptions to command arguments whose extracted keyword is the command description. Resource titles, queries, and file paths retain their action labels.

#### Test

- [x] Tested locally: real Web conversation with controlled client-side messages, expanded/collapsed rows, and 1280px/900px viewports.
- [x] Added/updated tests: four failing regression cases before the fix; all seven component tests and lint pass after it.
- Acceptance: https://app.lobehub.com/acceptance/6029026d-9a76-4dc0-981e-78898acd629d

Both acceptance checks passed with inspected screenshots and fixture evidence. No external tools were executed. Electron and mobile were not exercised.

#### Scope

This changes collapsed title selection only. Existing action-name formatting and tool error-status handling are unchanged.
