### PR TITLE
⚡️ perf(desktop): show the main window on first paint, compile cache, dev progress

### DIFF
--- a/apps/desktop/src/common/loadingScreen.ts
+++ b/apps/desktop/src/common/loadingScreen.ts
@@ -1,0 +1,1 @@
+export const LOADING_SCREEN_PAINTED_CHANNEL = 'desktop:loading-screen-painted';

--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -13,6 +13,7 @@ import { backendProxyProtocolManager } from '@/core/infrastructure/BackendProxyP
 import { appendVercelCookie, setResponseHeader } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
 import { getSystemLanguage, resolveUILocale } from '@/utils/system-language';
+import { LOADING_SCREEN_PAINTED_CHANNEL } from '~common/loadingScreen';
 import { SYSTEM_LANGUAGE_ARG_PREFIX } from '~common/systemLanguage';
 
 import type { App } from '../App';
@@ -336,17 +337,24 @@ export default class Browser {
 
   private setupReadyToShowListener(browserWindow: BrowserWindow): void {
     logger.debug(`[${this.identifier}] Setting up 'ready-to-show' event listener.`);
+    // `ready-to-show` only fires with the `load` event here, ~150-250ms after the
+    // loading screen was actually painted (measured with --trace-startup). The
+    // preload reports that first paint directly; `ready-to-show` stays as fallback.
+    browserWindow.webContents.ipc.once(LOADING_SCREEN_PAINTED_CHANNEL, () => {
+      logger.debug(`[${this.identifier}] Loading screen painted.`);
+      this.presentFirstFrame();
+    });
     browserWindow.once('ready-to-show', () => {
       logger.debug(`[${this.identifier}] Window 'ready-to-show' event fired.`);
-      this.hasPresentedFirstFrame = true;
-      this.resolveFirstFrame();
-      if (this.options.showOnInit) {
-        logger.debug(`Showing window ${this.identifier} because showOnInit is true.`);
-        this.show();
-      } else {
-        logger.debug(`Window ${this.identifier} not shown because showOnInit is false.`);
-      }
+      this.presentFirstFrame();
     });
+  }
+
+  private presentFirstFrame(): void {
+    if (this.hasPresentedFirstFrame) return;
+    this.hasPresentedFirstFrame = true;
+    this.resolveFirstFrame();
+    if (this.options.showOnInit) this.show();
   }
 
   private setupCloseListener(browserWindow: BrowserWindow): void {

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -41,6 +41,7 @@ const {
     show: vi.fn(),
     unmaximize: vi.fn(),
     webContents: {
+      ipc: { once: vi.fn() },
       openDevTools: vi.fn(),
       send: vi.fn(),
       session: {
@@ -326,6 +327,46 @@ describe('Browser', () => {
   });
 
   describe('retrieveOrInitialize', () => {
+    const firstFrameSignals = () => ({
+      loadingScreenPainted: mockBrowserWindow.webContents.ipc.once.mock.calls.findLast(
+        ([channel]: [string]) => channel === 'desktop:loading-screen-painted',
+      )?.[1],
+      readyToShow: mockBrowserWindow.once.mock.calls.findLast(
+        ([event]: [string]) => event === 'ready-to-show',
+      )?.[1],
+    });
+
+    it('should show the window once the preload reports the loading screen painted', () => {
+      new Browser({ ...defaultOptions, showOnInit: true }, mockApp);
+      expect(mockBrowserWindow.show).not.toHaveBeenCalled();
+
+      const { loadingScreenPainted, readyToShow } = firstFrameSignals();
+      loadingScreenPainted();
+      expect(mockBrowserWindow.show).toHaveBeenCalledTimes(1);
+
+      readyToShow();
+      expect(mockBrowserWindow.show).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to ready-to-show when the paint report never arrives', () => {
+      new Browser({ ...defaultOptions, showOnInit: true }, mockApp);
+
+      const { loadingScreenPainted, readyToShow } = firstFrameSignals();
+      readyToShow();
+      expect(mockBrowserWindow.show).toHaveBeenCalledTimes(1);
+
+      loadingScreenPainted();
+      expect(mockBrowserWindow.show).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not show the window when showOnInit is unset', () => {
+      const { loadingScreenPainted, readyToShow } = firstFrameSignals();
+      loadingScreenPainted();
+      readyToShow();
+
+      expect(mockBrowserWindow.show).not.toHaveBeenCalled();
+    });
+
     it('should restore window size from store', () => {
       mockStoreManagerGet.mockImplementation((key: string) => {
         if (key === 'windowSize_test-window') {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,9 +1,11 @@
 import { setupBootProfiler } from './bootProfiler';
 import { setupElectronApi } from './electronApi';
+import { reportLoadingScreenPainted } from './loadingScreenPainted';
 import { setupRouteInterceptors } from './routeInterceptor';
 
 const setupPreload = () => {
   setupBootProfiler();
+  reportLoadingScreenPainted();
   setupElectronApi();
 
   // Setup route interception logic

--- a/apps/desktop/src/preload/loadingScreenPainted.ts
+++ b/apps/desktop/src/preload/loadingScreenPainted.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron';
+
+import { LOADING_SCREEN_PAINTED_CHANNEL } from '~common/loadingScreen';
+
+export const reportLoadingScreenPainted = () => {
+  const observer = new MutationObserver(() => {
+    if (!document.getElementById('loading-screen')) return;
+    observer.disconnect();
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => ipcRenderer.send(LOADING_SCREEN_PAINTED_CHANNEL)),
+    );
+  });
+  observer.observe(document, { childList: true, subtree: true });
+};

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -57,6 +57,10 @@ export default defineConfig(async (env) => {
         ],
         output: {
           assetFileNames: 'chunks/[name]-[hash].[ext]',
+          // Rolldown hoists chunk requires above any entry statement, so the V8
+          // compile cache has to be switched on from a banner to cover `main-app`.
+          banner: (chunk) =>
+            chunk.isEntry ? 'require("node:module").enableCompileCache?.();' : '',
           // Keep Electron's side-effectful entry as a tiny bootstrap and put the
           // application graph in a normal CommonJS chunk. Electron evaluates its entry
           // outside the usual CJS cache path; when a deferred chunk back-references

--- a/apps/desktop/vite.renderer.config.ts
+++ b/apps/desktop/vite.renderer.config.ts
@@ -7,6 +7,7 @@ import type { PluginOption, UserConfig, ViteDevServer } from 'vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+import { devLoadingProgress } from '../../plugins/vite/devLoadingProgress';
 import {
   createSharedRolldownOutput,
   sharedModulePreload,
@@ -250,6 +251,7 @@ export default defineConfig(async (env) => {
       isCloudDesktop && cloudTsconfigPathsPlugin(),
       isCloudDesktop && cloudDesktopBusinessConstPlugin(),
       electronDesktopHtmlPlugin(),
+      devLoadingProgress(),
       reactDevtoolsPlugin(),
       excludeWebSpaBuildArtifactsPlugin(),
       vanillaExtractPlugin(),

--- a/plugins/vite/devLoadingProgress.test.ts
+++ b/plugins/vite/devLoadingProgress.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { devLoadingProgress } from './devLoadingProgress';
+
+const createServer = (server: Record<string, unknown> = {}) => ({
+  config: {
+    root: '/repo',
+    server: {
+      hmr: { clientPort: 5173, host: '127.0.0.1' },
+      host: '127.0.0.1',
+      port: 5173,
+      ...server,
+    },
+  },
+  hot: { send: vi.fn() },
+});
+
+const setup = (server = createServer()) => {
+  const plugin = devLoadingProgress() as any;
+  plugin.configureServer(server);
+  return { plugin, server };
+};
+
+describe('devLoadingProgress', () => {
+  it('injects a client script pointing at the HMR websocket', () => {
+    const { plugin } = setup();
+
+    const [tag] = plugin.transformIndexHtml();
+
+    expect(tag.tag).toBe('script');
+    expect(tag.children).toContain('"ws://127.0.0.1:5173"');
+    expect(tag.children).toContain('loading-dev-progress');
+  });
+
+  it('injects nothing when HMR is disabled', () => {
+    const { plugin } = setup(createServer({ hmr: false }));
+
+    expect(plugin.transformIndexHtml()).toEqual([]);
+  });
+
+  it('batches transforms into one throttled broadcast with root-relative ids', () => {
+    vi.useFakeTimers();
+    const { plugin, server } = setup();
+
+    plugin.transform('', '/repo/src/a.tsx?v=1');
+    plugin.transform('', '/repo/src/b.tsx');
+    expect(server.hot.send).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(server.hot.send).toHaveBeenCalledTimes(1);
+    expect(server.hot.send).toHaveBeenCalledWith({
+      data: { count: 2, file: 'src/b.tsx' },
+      event: 'lobe:dev-loading-progress',
+      type: 'custom',
+    });
+    vi.useRealTimers();
+  });
+});

--- a/plugins/vite/devLoadingProgress.ts
+++ b/plugins/vite/devLoadingProgress.ts
@@ -1,0 +1,82 @@
+import type { Plugin, ViteDevServer } from 'vite';
+
+const EVENT = 'lobe:dev-loading-progress';
+const BROADCAST_INTERVAL_MS = 80;
+
+const resolveHmrUrl = (server: ViteDevServer) => {
+  const { hmr, host, port } = server.config.server;
+  if (hmr === false) return;
+  const options = typeof hmr === 'object' ? hmr : {};
+  const wsHost = options.host ?? (typeof host === 'string' ? host : 'localhost');
+  const wsPort = options.clientPort ?? options.port ?? port;
+  return `${options.protocol ?? 'ws'}://${wsHost}:${wsPort}`;
+};
+
+// Lives as long as any boot placeholder is on screen: the static `#loading-screen`,
+// then the React boot shell / route fallback skeletons that follow it in dev.
+const PLACEHOLDER_IDS = ['loading-screen', 'boot-shell', 'app-shell-fallback'];
+
+const clientScript = (hmrUrl: string) => `(function () {
+  var ids = ${JSON.stringify(PLACEHOLDER_IDS)};
+  var el = document.createElement('div');
+  el.id = 'loading-dev-progress';
+  el.style.cssText = 'position: fixed; inset-block-end: 12px; inset-inline: 0; z-index: 100000; pointer-events: none; text-align: center; font: 12px ui-monospace, monospace; opacity: 0.55; white-space: nowrap;';
+  var count = 0, file = '', start = performance.now();
+  function placeholderVisible() {
+    for (var i = 0; i < ids.length; i++) if (document.getElementById(ids[i])) return true;
+    return false;
+  }
+  function render() {
+    var visible = placeholderVisible();
+    if (visible && !el.isConnected) document.body.appendChild(el);
+    if (!visible && el.isConnected) el.remove();
+    if (visible) el.textContent = 'vite dev · ' + count + ' modules · ' + ((performance.now() - start) / 1000).toFixed(1) + 's · ' + file;
+    requestAnimationFrame(render);
+  }
+  render();
+  try {
+    var ws = new WebSocket(${JSON.stringify(hmrUrl)}, 'vite-hmr');
+    ws.onmessage = function (e) {
+      var m = JSON.parse(e.data);
+      if (m.type === 'custom' && m.event === ${JSON.stringify(EVENT)}) { count = m.data.count; file = m.data.file; }
+    };
+  } catch (_) {}
+})();`;
+
+/**
+ * Dev-only: streams Vite's transform progress onto the static loading screen so a
+ * cold `dev` start shows "N modules · Xs · current file" instead of a frozen logo.
+ */
+export const devLoadingProgress = (): Plugin => {
+  let server: ViteDevServer | undefined;
+  let count = 0;
+  let latest = '';
+  let timer: NodeJS.Timeout | undefined;
+
+  const scheduleBroadcast = () => {
+    if (timer || !server) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      server?.hot.send({ data: { count, file: latest }, event: EVENT, type: 'custom' });
+    }, BROADCAST_INTERVAL_MS);
+  };
+
+  return {
+    apply: 'serve',
+    configureServer(devServer) {
+      server = devServer;
+    },
+    name: 'dev-loading-progress',
+    transform(_code, id) {
+      if (!server) return;
+      count += 1;
+      latest = id.split('?')[0].replace(server.config.root, '').replace(/^\//, '');
+      scheduleBroadcast();
+    },
+    transformIndexHtml() {
+      const hmrUrl = server && resolveHmrUrl(server);
+      if (!hmrUrl) return [];
+      return [{ children: clientScript(hmrUrl), injectTo: 'body', tag: 'script' }];
+    },
+  };
+};


### PR DESCRIPTION
Three small desktop startup changes, one commit each.

**1. Show the main window on the loading screen's first paint**
`ready-to-show` only fires with the `load` event for the desktop entry, ~250ms after the static loading screen has actually painted (traced with `--trace-startup`; adding an `<img>` to the loading screen did not change it). The preload now reports the first paint (double rAF after `#loading-screen` enters the DOM) and `Browser` shows the window on whichever of that report / `ready-to-show` arrives first, through one idempotent `presentFirstFrame()`.

**2. V8 compile cache for the main bundle**
`module.enableCompileCache()` injected as an entry banner in `vite.main.config.ts` — rolldown hoists chunk requires above any entry statement, so it cannot live in `index.ts`.

**3. Dev-only Vite transform progress on the loading screens**
A cold `bun run dev` sits on the logo / "Still loading…" for 10s+. `plugins/vite/devLoadingProgress.ts` (`apply: 'serve'`) streams the transform count + current file over the HMR socket; the injected client renders `vite dev · 3887 modules · 11.3s · src/…` at the bottom of the window while `#loading-screen`, `#boot-shell` or `#app-shell-fallback` is on screen, then removes itself.

| Before | After |
| ------ | ----- |
| Window visible +370ms after `BrowserWindow` creation | +140ms, loading screen already painted |
| Main bundle load 55ms | 37ms (compile cache warm) |
| Dev: frozen logo for 10s+ | live module count / elapsed / current file |

#### Test

Measured on the packaged app (`package:local`, warm start, macOS arm64) with `DEBUG=core:Browser` timestamps and a Chromium startup trace; dev progress verified via CDP sampling during a cold `bun run dev` (loading-screen → app-shell-fallback → removed).

- [x] Tested locally
- [x] Added/updated tests (`Browser.test.ts`: paint report shows / `ready-to-show` fallback / no `showOnInit`; `devLoadingProgress.test.ts`)
- [ ] No tests needed

- Acceptance: not published — startup-timing change verified with main-process timestamps and a Chromium startup trace on the packaged build (numbers above); no UI flow changes.

#### 🔗 Related Issue

None.

https://claude.ai/code/session_012z4cpfrWDXZDtNgT4uJKoS