### PR TITLE
🐛 fix: weight message TPS by generation duration

### DIFF
--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/assistantGroup/assistant-with-tools.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/assistantGroup/assistant-with-tools.json
@@ -166,7 +166,7 @@
         "ttft": 245,
         "duration": 3877,
         "latency": 4465,
-        "tps": 50.166666666666664
+        "tps": 51.3283466597885
       },
       "usage": {
         "totalInputTokens": 429,

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/compare/with-tools.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/compare/with-tools.json
@@ -192,7 +192,7 @@
               "ttft": 198,
               "duration": 3521,
               "latency": 3953,
-              "tps": 50
+              "tps": 48.84975859130929
             },
             "usage": {
               "totalInputTokens": 180,

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/simple.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/simple.json
@@ -103,7 +103,7 @@
         "ttft": 1490,
         "duration": 11935,
         "latency": 13425,
-        "tps": 29.33
+        "tps": 29.32551319648094
       },
       "usage": {
         "totalInputTokens": 9793,

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/single-task-with-tool-chain.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/single-task-with-tool-chain.json
@@ -115,7 +115,7 @@
         "ttft": 3163,
         "duration": 5611,
         "latency": 8774,
-        "tps": 31.55
+        "tps": 31.545179112457674
       },
       "usage": {
         "totalInputTokens": 12324,
@@ -215,7 +215,7 @@
         "ttft": 3135,
         "duration": 10399,
         "latency": 16321,
-        "tps": 51.254999999999995
+        "tps": 62.3136840080777
       },
       "usage": {
         "totalInputTokens": 26063,

--- a/packages/conversation-flow/src/transformation/MessageTransformer.ts
+++ b/packages/conversation-flow/src/transformation/MessageTransformer.ts
@@ -103,7 +103,7 @@ export class MessageTransformer {
    * Aggregate metadata from multiple children
    * - Sums token counts and costs
    * - Takes first ttft
-   * - Averages tps
+   * - Calculates tps from paired output tokens and generation durations
    * - Sums duration and latency
    */
   aggregateMetadata(children: AssistantContentBlock[]): {
@@ -114,8 +114,8 @@ export class MessageTransformer {
     const performance: ModelPerformance = {};
     let hasUsageData = false;
     let hasPerformanceData = false;
-    let tpsSum = 0;
-    let tpsCount = 0;
+    let measuredOutputTokens = 0;
+    let generationDuration = 0;
 
     children.forEach((child) => {
       if (child.usage) {
@@ -160,11 +160,20 @@ export class MessageTransformer {
           hasPerformanceData = true;
         }
 
-        // Average tps (tokens per second)
-        if (typeof child.performance.tps === 'number') {
-          tpsSum += child.performance.tps;
-          tpsCount += 1;
-          hasPerformanceData = true;
+        // Pair tokens with their measured duration so incomplete calls cannot skew either sum.
+        // Averaging per-call rates would give short bursts the same weight as long generations.
+        const outputTokens = child.usage?.totalOutputTokens;
+        const duration = child.performance.duration;
+        if (
+          typeof outputTokens === 'number' &&
+          Number.isFinite(outputTokens) &&
+          outputTokens >= 0 &&
+          typeof duration === 'number' &&
+          Number.isFinite(duration) &&
+          duration > 0
+        ) {
+          measuredOutputTokens += outputTokens;
+          generationDuration += duration;
         }
 
         // Sum duration
@@ -181,9 +190,8 @@ export class MessageTransformer {
       }
     });
 
-    // Calculate average tps
-    if (tpsCount > 0) {
-      performance.tps = tpsSum / tpsCount;
+    if (generationDuration > 0) {
+      performance.tps = (measuredOutputTokens / generationDuration) * 1000;
     }
 
     return {

--- a/packages/conversation-flow/src/transformation/__tests__/MessageTransformer.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageTransformer.test.ts
@@ -201,7 +201,7 @@ describe('MessageTransformer', () => {
       expect(result.performance).toEqual({
         duration: 3000,
         latency: 3200,
-        tps: 25, // average of 20 and 30
+        tps: 15, // 45 output tokens over 3 seconds
         ttft: 100, // first value
       });
     });
@@ -267,28 +267,82 @@ describe('MessageTransformer', () => {
       });
     });
 
-    it('should average tps correctly', () => {
+    it('should divide total output tokens by total generation time', () => {
       const children: AssistantContentBlock[] = [
         {
           content: 'First',
           id: 'msg-1',
-          performance: { tps: 10 },
+          performance: { duration: 1000, tps: 500 },
+          usage: { totalOutputTokens: 500 },
         },
         {
           content: 'Second',
           id: 'msg-2',
-          performance: { tps: 20 },
-        },
-        {
-          content: 'Third',
-          id: 'msg-3',
-          performance: { tps: 30 },
+          performance: { duration: 20_000, tps: 50 },
+          usage: { totalOutputTokens: 1000 },
         },
       ];
 
       const result = transformer.aggregateMetadata(children);
 
-      expect(result.performance?.tps).toBe(20); // average of 10, 20, 30
+      expect(result.performance?.tps).toBeCloseTo(1500 / 21);
+    });
+
+    it.each([
+      [undefined, 1000],
+      [100, undefined],
+      [100, 0],
+      [100, -1],
+      [100, Number.NaN],
+      [100, Number.POSITIVE_INFINITY],
+      [-1, 1000],
+      [Number.NaN, 1000],
+      [Number.POSITIVE_INFINITY, 1000],
+    ])('should exclude invalid token/time pairs (%s, %s) from TPS', (tokens, duration) => {
+      const children: AssistantContentBlock[] = [
+        {
+          content: 'Valid',
+          id: 'valid',
+          performance: { duration: 2000, tps: 50 },
+          usage: { totalOutputTokens: 100 },
+        },
+        {
+          content: 'Incomplete',
+          id: 'incomplete',
+          performance: { duration, tps: 1000 },
+          usage: { totalOutputTokens: tokens },
+        },
+      ];
+
+      expect(transformer.aggregateMetadata(children).performance?.tps).toBe(50);
+      expect(transformer.aggregateMetadata(children.slice(1)).performance?.tps).toBeUndefined();
+    });
+
+    it('should include reasoning tokens once and preserve single-call generation speed', () => {
+      const result = transformer.aggregateMetadata([
+        {
+          content: 'Answer',
+          id: 'msg-1',
+          performance: { duration: 2000, latency: 5000, tps: 50, ttft: 3000 },
+          usage: { outputReasoningTokens: 80, outputTextTokens: 20, totalOutputTokens: 100 },
+        },
+      ]);
+
+      expect(result.performance?.tps).toBe(50);
+    });
+
+    it('should include measured zero-output calls without requiring a stored TPS', () => {
+      const result = transformer.aggregateMetadata([
+        { content: '', id: 'a', performance: { duration: 1000 }, usage: { totalOutputTokens: 0 } },
+        {
+          content: 'Answer',
+          id: 'b',
+          performance: { duration: 1000 },
+          usage: { totalOutputTokens: 100 },
+        },
+      ]);
+
+      expect(result.performance?.tps).toBe(50);
     });
 
     it('should take first ttft value only', () => {


### PR DESCRIPTION
Multi-call replies currently average each call's TPS equally, so a brief high-speed call can inflate the footer. Calculate aggregate TPS from total output tokens divided by the corresponding total generation duration instead. For 500 tokens in 1 second followed by 1,000 tokens in 20 seconds, the footer now shows 71.4 tok/s instead of 275.

Only calls with finite, nonnegative output counts and finite, positive durations contribute to either sum. Groups without valid pairs omit TPS. Token/cost totals, single-request timing collection, and UI layout remain unchanged. Existing messages with complete timing and usage data use the corrected aggregate automatically; no migration is needed.

#### Test

- [x] Tested locally: all 235 conversation-flow tests pass; lint is clean.
- [x] Added/updated tests: reproduced 275 versus 71.4 before the fix; covered missing/invalid pairs, zero output, reasoning tokens, and single-call speed. Updated four parser fixtures.
- [x] Browser acceptance: weighted group, incomplete pairs, and single-call display; 3/3 criteria with inspected screenshots and raw input/readback evidence.
- Acceptance: https://app.lobehub.com/acceptance/44064b89-95de-41f0-aec1-f17eb0590f3f?r=1
