### PR TITLE
🐛 fix(portal): repair weekly HTML publish imports

### DIFF
--- a/src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts
+++ b/src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts
@@ -1,4 +1,9 @@
-import type { GatheredWorkspaceHtmlResource } from '@lobechat/html-artifact';
+import type {
+  GatheredWorkspaceHtmlResource,
+  WorkspaceHtmlArtifactPublisher,
+  WorkspaceHtmlArtifactPublishResult,
+} from '@lobechat/html-artifact';
+import { isPathInsideWorkspace } from '@lobechat/html-artifact';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import debug from 'debug';
 import { useEffect, useRef, useState } from 'react';
@@ -13,11 +18,6 @@ import {
   type WorkspaceHtmlPublishPlan,
 } from './prepareWorkspaceHtmlPublish';
 import { openWorkspaceHtmlPublishConfirm } from './PublishHtmlArtifactConfirm';
-import type {
-  WorkspaceHtmlArtifactPublisher,
-  WorkspaceHtmlArtifactPublishResult,
-} from './workspaceHtmlArtifact';
-import { isPathInsideWorkspace } from './workspaceHtmlPath';
 
 type OutsideWorkspacePlan = Extract<WorkspaceHtmlPublishPlan, { blocked: 'outside-workspace' }>;
 type ResourceSource = 'nested' | 'workspace';


### PR DESCRIPTION
## Summary

Fix the confirmed Desktop PR Build type-check failure blocking weekly release #19426.

The refreshed candidate deleted the local `workspaceHtmlArtifact` and `workspaceHtmlPath` re-export shims, but `useBlockedWorkspaceHtmlPublish` still imported them. Import the publisher types and `isPathInsideWorkspace` directly from the existing `@lobechat/html-artifact` package. No deleted shims are restored and no runtime logic changes.

Failure evidence: https://github.com/lobehub/lobehub/actions/runs/34579576112/job/103199749660

## Test

- Reproduced before the fix: the existing hook test suite could not load because `./workspaceHtmlPath` no longer exists.
- After the fix: `bun run check --lint --test src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.test.ts` — lint clean, 6 tests passed.
- `git diff --check` passes; confirmed all replacement symbols are exported by the shared package.
- Local tests used the existing installed Vitest 3.2.6 dependencies. The full candidate CI type-check and declared Vitest 5 run remain pending.

Acceptance: skipped for this import-only module wiring repair; no UI, interaction, or product behavior was changed. The existing behavior tests exercise the real imported helper after the fix.

## Release scope

This PR targets `release/weekly-20260911`, not main. Merging it updates the candidate and does not publish a release. It does not alter branch rules or bypass required reviews. Ensure this repair also reaches canary through the release back-sync (or a separate forward-port if needed before release).