### PR TITLE
🐛 fix(wechat): report partial and uncertain message sends

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@lobechat/agent-gateway-client": "workspace:*",
     "@lobechat/agent-tracing": "workspace:*",
+    "@lobechat/builtin-tool-message": "workspace:*",
     "@lobechat/const": "workspace:*",
     "@lobechat/device-control": "workspace:*",
     "@lobechat/device-gateway-client": "workspace:*",

--- a/apps/cli/pnpm-workspace.yaml
+++ b/apps/cli/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - '../../packages/agent-gateway-client'
   - '../../packages/agent-tracing'
+  - '../../packages/builtin-tool-message'
   - '../../packages/device-control'
   - '../../packages/device-sandbox'
   - '../../packages/device-gateway-client'

--- a/apps/cli/src/commands/botMessage.test.ts
+++ b/apps/cli/src/commands/botMessage.test.ts
@@ -2,6 +2,10 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import type {
+  SendMessageDelivery,
+  SendMessageState,
+} from '@lobechat/builtin-tool-message/delivery';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -22,6 +26,148 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
+
+describe('bot message send delivery outcomes', () => {
+  let originalExitCode: typeof process.exitCode;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let exitCodesAtOutput: Array<typeof process.exitCode>;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    process.exitCode = 0;
+    exitCodesAtOutput = [];
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+      exitCodesAtOutput.push(process.exitCode);
+    });
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('Output must finish before setting the exit status');
+    });
+    mockGetTrpcClient.mockResolvedValue(mockTrpcClient);
+    mockTrpcClient.botMessage.sendMessage.mutate.mockReset();
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  const deliveries: SendMessageDelivery[] = [
+    {
+      attachments: [{ index: 0, status: 'accepted', type: 'image' }],
+      receipt: 'unconfirmed',
+      status: 'accepted',
+      text: { status: 'accepted' },
+    },
+    {
+      attachments: [{ index: 0, reason: 'over_budget', status: 'link_fallback', type: 'image' }],
+      receipt: 'unconfirmed',
+      status: 'degraded',
+      text: { status: 'accepted' },
+    },
+    {
+      attachments: [{ index: 0, reason: 'upload_failed', status: 'failed', type: 'image' }],
+      receipt: 'unconfirmed',
+      status: 'partial',
+      text: { status: 'accepted' },
+    },
+    {
+      attachments: [{ index: 0, reason: 'upload_failed', status: 'failed', type: 'image' }],
+      receipt: 'unconfirmed',
+      status: 'failed',
+      text: { status: 'not_requested' },
+    },
+    {
+      attachments: [{ index: 0, reason: 'send_unconfirmed', status: 'unknown', type: 'image' }],
+      receipt: 'unconfirmed',
+      status: 'unknown',
+      text: { status: 'accepted' },
+    },
+  ];
+
+  const runSend = async (json: boolean, message = 'fixture text') => {
+    const program = new Command();
+    program.exitOverride();
+    registerBotMessageCommands(program.command('bot'));
+    await program.parseAsync([
+      'node',
+      'test',
+      'bot',
+      'message',
+      'send',
+      'fixture-bot',
+      '--target',
+      'fixture',
+      '--message',
+      message,
+      '--attachment',
+      'https://example.com/fixture.png',
+      ...(json ? ['--json'] : []),
+    ]);
+    return consoleSpy.mock.calls.map(([text]) => String(text)).join('\n');
+  };
+
+  it.each(
+    deliveries.flatMap((delivery) => [
+      { delivery, json: false },
+      { delivery, json: true },
+    ]),
+  )(
+    'reports $delivery.status with json=$json before setting the exit code',
+    async ({ delivery, json }) => {
+      const state: SendMessageState = { channelId: 'fixture', delivery, platform: 'wechat' };
+      mockTrpcClient.botMessage.sendMessage.mutate.mockResolvedValueOnce(state);
+
+      const output = await runSend(json, delivery.status === 'failed' ? '' : 'fixture text');
+
+      expect(process.exitCode).toBe(delivery.status === 'accepted' ? 0 : 1);
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(exitCodesAtOutput).toEqual([0]);
+      expect(mockTrpcClient.botMessage.sendMessage.mutate).toHaveBeenCalledTimes(1);
+      if (json) {
+        expect(JSON.parse(output)).toEqual(state);
+      } else {
+        expect(output).toContain(JSON.stringify(delivery, null, 2));
+        expect(output).not.toContain('with 1 attachment(s)');
+        if (delivery.status !== 'accepted') {
+          expect(output).toContain('Do not resend the entire request');
+          expect(output).not.toContain('Message sent');
+        }
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'reports an old WeChat response as unconfirmed with json=%s',
+    async (json) => {
+      const state = { channelId: 'fixture', platform: 'wechat' };
+      mockTrpcClient.botMessage.sendMessage.mutate.mockResolvedValueOnce(state);
+
+      const output = await runSend(json);
+
+      expect(process.exitCode).toBe(1);
+      if (json) expect(JSON.parse(output)).toEqual(state);
+      else expect(output).toContain('did not provide per-item send results');
+    },
+  );
+
+  it.each([false, true])('preserves legacy non-WeChat results with json=%s', async (json) => {
+    const state = { channelId: 'fixture', messageId: 'actual-id', platform: 'discord' };
+    mockTrpcClient.botMessage.sendMessage.mutate.mockResolvedValueOnce(state);
+
+    const output = await runSend(json);
+
+    expect(process.exitCode).toBe(0);
+    if (json) expect(JSON.parse(output)).toEqual(state);
+    else {
+      expect(output).toContain('Message sent');
+      expect(output).toContain('actual-id');
+      expect(output).toContain('with 1 attachment(s)');
+    }
+  });
+});
+
 describe('bot message send --attachment', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/cli/src/commands/botMessage.ts
+++ b/apps/cli/src/commands/botMessage.ts
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import type { SendMessageState } from '@lobechat/builtin-tool-message/delivery';
+import { getSendMessagePresentation } from '@lobechat/builtin-tool-message/delivery';
 import { DEFAULT_BOT_HISTORY_LIMIT } from '@lobechat/const';
 import { getMimeType, resolveMimeType } from '@lobechat/utils/mimeType';
 import type { Command } from 'commander';
@@ -111,7 +113,8 @@ export function registerBotMessageCommands(bot: Command) {
     .command('send <botIdOrAtKey>')
     .description(
       'Send a message to a channel. Pass a per-agent bot id, or "@<messenger-install-id>" ' +
-        'to send through a System Bot messenger installation (see `lh bot messengers list`).',
+        'to send through a System Bot messenger installation (see `lh bot messengers list`). ' +
+        'A nonzero exit code can include partial or uncertain sends; inspect --json before a targeted retry.',
     )
     .requiredOption('--target <channelId>', 'Target channel / conversation ID')
     .requiredOption('--message <text>', 'Message content')
@@ -146,13 +149,22 @@ export function registerBotMessageCommands(bot: Command) {
           content: options.message,
           replyTo: options.replyTo,
         });
+        const r = result as SendMessageState;
+        const presentation =
+          r.delivery || r.platform === 'wechat' ? getSendMessagePresentation(r) : undefined;
 
         if (options.json) {
           outputJson(result);
+          if (presentation && !presentation.success) process.exitCode = 1;
           return;
         }
 
-        const r = result as any;
+        if (presentation) {
+          console.log(presentation.content);
+          if (!presentation.success) process.exitCode = 1;
+          return;
+        }
+
         const suffix = attachments?.length ? ` with ${attachments.length} attachment(s)` : '';
         console.log(
           `${pc.green('✓')} Message sent${r.messageId ? ` (${pc.dim(r.messageId)})` : ''}${suffix}`,

--- a/apps/server/src/routers/lambda/botMessage.delivery.test.ts
+++ b/apps/server/src/routers/lambda/botMessage.delivery.test.ts
@@ -7,15 +7,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: async () => ({}) }));
 vi.mock('@/database/models/agentBotProvider', () => ({
-  AgentBotProviderModel: vi.fn().mockImplementation(() => ({
-    findById: async () => ({
-      applicationId: 'fixture-app',
-      credentials: { botId: 'fixture-bot', botToken: 'fixture-token' },
-      enabled: true,
-      platform: 'wechat',
-      settings: {},
-    }),
-  })),
+  AgentBotProviderModel: vi.fn().mockImplementation(function () {
+    return {
+      findById: async () => ({
+        applicationId: 'fixture-app',
+        credentials: { botId: 'fixture-bot', botToken: 'fixture-token' },
+        enabled: true,
+        platform: 'wechat',
+        settings: {},
+      }),
+    };
+  }),
 }));
 vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
   KeyVaultsGateKeeper: { initWithEnvKey: async () => ({}) },

--- a/apps/server/src/routers/lambda/botMessage.delivery.test.ts
+++ b/apps/server/src/routers/lambda/botMessage.delivery.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import type { SendMessageState } from '@lobechat/builtin-tool-message/delivery';
+import { WechatApiClient } from '@lobechat/chat-adapter-wechat';
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import superjson from 'superjson';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: async () => ({}) }));
+vi.mock('@/database/models/agentBotProvider', () => ({
+  AgentBotProviderModel: vi.fn().mockImplementation(() => ({
+    findById: async () => ({
+      applicationId: 'fixture-app',
+      credentials: { botId: 'fixture-bot', botToken: 'fixture-token' },
+      enabled: true,
+      platform: 'wechat',
+      settings: {},
+    }),
+  })),
+}));
+vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
+  KeyVaultsGateKeeper: { initWithEnvKey: async () => ({}) },
+}));
+vi.mock('@/server/modules/AgentRuntime/redis', () => ({
+  getAgentRuntimeRedisClient: () => null,
+}));
+
+const { botMessageRouter } = await import('./botMessage');
+
+describe('botMessage send result transport', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('serializes the real WeChat service partial result through the tRPC HTTP handler', async () => {
+    const sendText = vi
+      .spyOn(WechatApiClient.prototype, 'sendMessage')
+      .mockResolvedValue({ ret: 0 });
+    vi.spyOn(WechatApiClient.prototype, 'uploadCdnMedia').mockRejectedValue(
+      new Error('upload failed'),
+    );
+    const sendItem = vi.spyOn(WechatApiClient.prototype, 'sendItem').mockResolvedValue({ ret: 0 });
+    const input = {
+      attachments: [{ data: 'YQ==', type: 'image' }],
+      botId: 'fixture-bot',
+      channelId: 'fixture',
+      content: 'fixture text',
+    };
+
+    const response = await fetchRequestHandler({
+      createContext: async () => ({ userId: 'fixture-user' }),
+      endpoint: '/trpc',
+      req: new Request('http://localhost/trpc/sendMessage', {
+        body: JSON.stringify(superjson.serialize(input)),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }),
+      router: botMessageRouter,
+    });
+
+    expect(response.status).toBe(200);
+    const envelope = await response.json();
+    const result = superjson.deserialize<SendMessageState>(envelope.result.data);
+    expect(result).toEqual({
+      channelId: 'fixture',
+      delivery: {
+        attachments: [{ index: 0, reason: 'upload_failed', status: 'failed', type: 'image' }],
+        receipt: 'unconfirmed',
+        status: 'partial',
+        text: { status: 'accepted' },
+      },
+      platform: 'wechat',
+    });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendItem).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/bot/platforms/attachmentBudget.delivery.test.ts
+++ b/apps/server/src/services/bot/platforms/attachmentBudget.delivery.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { splitFallbackMessageBatches, splitFallbackMessages } from './attachmentBudget';
+
+describe('fallback message batching', () => {
+  it.each([
+    { lines: [], maxChars: 5, messages: [] },
+    { lines: ['a'], maxChars: 5, messages: ['a'] },
+    { lines: ['a', 'bb'], maxChars: 5, messages: ['a\n\nbb'] },
+    { lines: ['a', 'bbb'], maxChars: 5, messages: ['a', 'bbb'] },
+    { lines: ['aa', 'bb', 'cc'], maxChars: 5, messages: ['aa', 'bb', 'cc'] },
+    { lines: ['too long'], maxChars: 5, messages: ['too long'] },
+    { lines: ['', 'a', ''], maxChars: 5, messages: ['a\n\n'] },
+    { lines: ['', ''], maxChars: 5, messages: [] },
+  ])('preserves message text for $lines at $maxChars characters', ({ lines, maxChars, messages }) => {
+    const items = lines.map((line, index) => ({ index, line }));
+    const batches = splitFallbackMessageBatches(items, (item) => item.line, maxChars);
+
+    expect(batches.map((batch) => batch.message)).toEqual(messages);
+    expect(splitFallbackMessages(lines, maxChars)).toEqual(messages);
+  });
+
+  it('retains input references and order when repeated lines span multiple batches', () => {
+    const first = { index: 0, line: 'aa' };
+    const second = { index: 1, line: 'aa' };
+    const third = { index: 2, line: 'bb' };
+    const batches = splitFallbackMessageBatches([first, second, third], (item) => item.line, 6);
+
+    expect(batches).toEqual([
+      { items: [first, second], message: 'aa\n\naa' },
+      { items: [third], message: 'bb' },
+    ]);
+    expect(batches[0].items[0]).toBe(first);
+    expect(batches[0].items[1]).toBe(second);
+    expect(batches[1].items[0]).toBe(third);
+  });
+});

--- a/apps/server/src/services/bot/platforms/attachmentBudget.delivery.test.ts
+++ b/apps/server/src/services/bot/platforms/attachmentBudget.delivery.test.ts
@@ -13,13 +13,16 @@ describe('fallback message batching', () => {
     { lines: ['too long'], maxChars: 5, messages: ['too long'] },
     { lines: ['', 'a', ''], maxChars: 5, messages: ['a\n\n'] },
     { lines: ['', ''], maxChars: 5, messages: [] },
-  ])('preserves message text for $lines at $maxChars characters', ({ lines, maxChars, messages }) => {
-    const items = lines.map((line, index) => ({ index, line }));
-    const batches = splitFallbackMessageBatches(items, (item) => item.line, maxChars);
+  ])(
+    'preserves message text for $lines at $maxChars characters',
+    ({ lines, maxChars, messages }) => {
+      const items = lines.map((line, index) => ({ index, line }));
+      const batches = splitFallbackMessageBatches(items, (item) => item.line, maxChars);
 
-    expect(batches.map((batch) => batch.message)).toEqual(messages);
-    expect(splitFallbackMessages(lines, maxChars)).toEqual(messages);
-  });
+      expect(batches.map((batch) => batch.message)).toEqual(messages);
+      expect(splitFallbackMessages(lines, maxChars)).toEqual(messages);
+    },
+  );
 
   it('retains input references and order when repeated lines span multiple batches', () => {
     const first = { index: 0, line: 'aa' };

--- a/apps/server/src/services/bot/platforms/attachmentBudget.ts
+++ b/apps/server/src/services/bot/platforms/attachmentBudget.ts
@@ -477,4 +477,6 @@ export function splitFallbackMessageBatches<T>(
 }
 
 export const splitFallbackMessages = (fallbackLines: string[], maxChars: number): string[] =>
-  splitFallbackMessageBatches(fallbackLines, (line) => line, maxChars).map((batch) => batch.message);
+  splitFallbackMessageBatches(fallbackLines, (line) => line, maxChars).map(
+    (batch) => batch.message,
+  );

--- a/apps/server/src/services/bot/platforms/attachmentBudget.ts
+++ b/apps/server/src/services/bot/platforms/attachmentBudget.ts
@@ -438,6 +438,11 @@ export const prepareAttachmentsForBudget = async (
   return { attachments: kept, degradations, degraded, fallbackLines, keptOriginals };
 };
 
+export interface FallbackMessageBatch<T> {
+  items: T[];
+  message: string;
+}
+
 /**
  * Pack fallback link lines into as few follow-up text messages as fit under
  * `maxChars`. Batching is by whole line: Discord rejects a message over its
@@ -445,20 +450,31 @@ export const prepareAttachmentsForBudget = async (
  * cut a URL in half and hand the user a dead link. Lines are already length
  * capped (see MAX_FALLBACK_NAME_CHARS), so a single line always fits.
  */
-export const splitFallbackMessages = (fallbackLines: string[], maxChars: number): string[] => {
-  const messages: string[] = [];
+export function splitFallbackMessageBatches<T>(
+  items: T[],
+  getLine: (item: T) => string,
+  maxChars: number,
+): FallbackMessageBatch<T>[] {
+  const batches: FallbackMessageBatch<T>[] = [];
   let current = '';
+  let currentItems: T[] = [];
 
-  for (const line of fallbackLines) {
+  for (const item of items) {
+    const line = getLine(item);
     const candidate = current ? `${current}\n\n${line}` : line;
     if (current && candidate.length > maxChars) {
-      messages.push(current);
+      batches.push({ items: currentItems, message: current });
       current = line;
+      currentItems = [item];
     } else {
       current = candidate;
+      currentItems.push(item);
     }
   }
-  if (current) messages.push(current);
+  if (current) batches.push({ items: currentItems, message: current });
 
-  return messages;
-};
+  return batches;
+}
+
+export const splitFallbackMessages = (fallbackLines: string[], maxChars: number): string[] =>
+  splitFallbackMessageBatches(fallbackLines, (line) => line, maxChars).map((batch) => batch.message);

--- a/apps/server/src/services/bot/platforms/wechat/sendAttachments.test.ts
+++ b/apps/server/src/services/bot/platforms/wechat/sendAttachments.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
+import type { WechatApiClient } from '@lobechat/chat-adapter-wechat';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as AttachmentBudgetModule from '../attachmentBudget';
 import type * as PublicUrlFetchModule from '../publicUrlFetch';
+import type { WechatOutboundAttachment } from './sendAttachments';
 
 // These tests stub `fetch` directly; the SSRF guard in front of it resolves DNS
 // for real, which has nothing to do with what they assert. Its own behaviour is
@@ -21,13 +24,21 @@ const budgetMocks = vi.hoisted(() => ({
   compressImageToBudget: vi.fn(),
 }));
 
-vi.mock('../attachmentBudget', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  compressImageToBudget: budgetMocks.compressImageToBudget,
-}));
+vi.mock('../attachmentBudget', async (importOriginal) => {
+  const original = await importOriginal<typeof AttachmentBudgetModule>();
+  return {
+    ...original,
+    compressImageToBudget: budgetMocks.compressImageToBudget,
+    PLATFORM_ATTACHMENT_BUDGETS: {
+      ...original.PLATFORM_ATTACHMENT_BUDGETS,
+      wechat: { ...original.PLATFORM_ATTACHMENT_BUDGETS.wechat },
+    },
+  };
+});
 
 const { PLATFORM_ATTACHMENT_BUDGETS } = await import('../attachmentBudget');
-const { sendWechatAttachments } = await import('./sendAttachments');
+const { sendWechatAttachments, WechatAttachmentSendError } = await import('./sendAttachments');
+const defaultWechatBudget = { ...PLATFORM_ATTACHMENT_BUDGETS.wechat };
 
 const MB = 1024 * 1024;
 
@@ -46,13 +57,14 @@ describe('sendWechatAttachments', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    Object.assign(PLATFORM_ATTACHMENT_BUDGETS.wechat, defaultWechatBudget);
   });
 
   it('uploads an in-budget attachment as-is', async () => {
     const api = makeApi();
     const bytes = Buffer.alloc(1024, 1);
 
-    await sendWechatAttachments(
+    const result = await sendWechatAttachments(
       api as any,
       'user-1',
       [{ data: bytes.toString('base64'), name: 'a.png', type: 'image' }],
@@ -63,6 +75,7 @@ describe('sendWechatAttachments', () => {
     expect(api.uploadCdnMedia).toHaveBeenCalledTimes(1);
     expect(api.sendItem).toHaveBeenCalledTimes(1);
     expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(result.outcomes).toEqual([{ index: 0, status: 'accepted', type: 'image' }]);
   });
 
   it('recompresses an over-budget image before uploading', async () => {
@@ -71,7 +84,7 @@ describe('sendWechatAttachments', () => {
     const compressed = Buffer.alloc(1 * MB, 2);
     budgetMocks.compressImageToBudget.mockResolvedValueOnce(compressed);
 
-    await sendWechatAttachments(
+    const result = await sendWechatAttachments(
       api as any,
       'user-1',
       [{ data: oversized.toString('base64'), name: 'big.png', type: 'image' }],
@@ -86,6 +99,7 @@ describe('sendWechatAttachments', () => {
     expect(uploadTarget).toBe('user-1');
     expect(uploadedBytes).toBe(compressed);
     expect(api.sendItem).toHaveBeenCalledTimes(1);
+    expect(result.outcomes).toEqual([{ index: 0, status: 'accepted', type: 'image' }]);
   });
 
   it('sends a download link when an image cannot be compressed under budget', async () => {
@@ -93,7 +107,7 @@ describe('sendWechatAttachments', () => {
     const oversized = Buffer.alloc(3 * MB, 1);
     budgetMocks.compressImageToBudget.mockResolvedValueOnce(undefined);
 
-    await sendWechatAttachments(
+    const result = await sendWechatAttachments(
       api as any,
       'user-1',
       [
@@ -113,6 +127,9 @@ describe('sendWechatAttachments', () => {
       expect.stringContaining('https://example.com/f/big.png'),
       'token-1',
     );
+    expect(result.outcomes).toEqual([
+      { index: 0, reason: 'over_budget', status: 'link_fallback', type: 'image' },
+    ]);
   });
 
   it('sends a download link for an over-budget file without trying compression', async () => {
@@ -186,7 +203,7 @@ describe('sendWechatAttachments', () => {
     const api = makeApi();
     budgetMocks.compressImageToBudget.mockResolvedValueOnce(undefined);
 
-    await sendWechatAttachments(
+    const result = await sendWechatAttachments(
       api as any,
       'user-1',
       [{ data: Buffer.alloc(3 * MB).toString('base64'), name: 'big.png', type: 'image' }],
@@ -195,5 +212,149 @@ describe('sendWechatAttachments', () => {
 
     expect(api.uploadCdnMedia).not.toHaveBeenCalled();
     expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(result.outcomes).toEqual([
+      { index: 0, reason: 'over_budget_no_link', status: 'failed', type: 'image' },
+    ]);
+    expect(result.failures).toEqual([
+      { name: 'big.png', reason: 'over-budget-no-link', type: 'image' },
+    ]);
+  });
+
+  it('retains legacy failure details and original references while later attachments succeed', async () => {
+    const api = makeApi();
+    const unavailable = { name: 'missing.png', type: 'image' } as const;
+    const first = { data: 'YQ==', name: 'same.png', type: 'image' } as const;
+    const second = { data: 'Yg==', name: 'same.png', type: 'image' } as const;
+    api.uploadCdnMedia.mockRejectedValueOnce(new Error('synthetic upload failure'));
+
+    const result = await sendWechatAttachments(
+      api as unknown as WechatApiClient,
+      'user-1',
+      [unavailable, first, second],
+      'token-1',
+    );
+
+    expect(result.outcomes).toEqual([
+      { index: 0, reason: 'source_unavailable', status: 'failed', type: 'image' },
+      { index: 1, reason: 'upload_failed', status: 'failed', type: 'image' },
+      { index: 2, status: 'accepted', type: 'image' },
+    ]);
+    expect(result.undelivered[0]).toBe(unavailable);
+    expect(result.undelivered[1]).toBe(first);
+    expect(result.failures).toEqual([
+      { name: 'missing.png', reason: 'source-unavailable', type: 'image' },
+      {
+        detail: 'synthetic upload failure',
+        name: 'same.png',
+        reason: 'upload-failed',
+        type: 'image',
+      },
+    ]);
+    expect(api.sendItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('distinguishes a failed preparation from an uncertain media submission', async () => {
+    const api = makeApi();
+    PLATFORM_ATTACHMENT_BUDGETS.wechat.imageMaxBytes = 2;
+    budgetMocks.compressImageToBudget.mockRejectedValueOnce(new Error('prepare failed'));
+    api.sendItem.mockRejectedValueOnce(new Error('response lost'));
+
+    const result = await sendWechatAttachments(
+      api as unknown as WechatApiClient,
+      'user-1',
+      [
+        { data: Buffer.from('big').toString('base64'), type: 'image' },
+        { data: 'YQ==', type: 'image' },
+        { data: 'Yg==', type: 'image' },
+      ],
+      'token-1',
+    );
+
+    expect(result.outcomes).toEqual([
+      { index: 0, reason: 'prepare_failed', status: 'failed', type: 'image' },
+      { index: 1, reason: 'send_unconfirmed', status: 'unknown', type: 'image' },
+      { index: 2, status: 'accepted', type: 'image' },
+    ]);
+    expect(api.sendItem).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps separate outcomes for repeated objects and matching source URLs', async () => {
+    const api = makeApi();
+    const attachment = { data: 'YQ==', fetchUrl: 'https://example.com/same', type: 'file' } as const;
+    api.uploadCdnMedia.mockResolvedValueOnce({ aesKey: 'key', cipherSize: 16, encryptQueryParam: 'p', rawSize: 1 });
+    api.uploadCdnMedia.mockRejectedValueOnce(new Error('second upload failed'));
+
+    const result = await sendWechatAttachments(
+      api as unknown as WechatApiClient,
+      'user-1',
+      [attachment, attachment, { ...attachment }],
+      'token-1',
+    );
+
+    expect(result.outcomes).toEqual([
+      { index: 0, status: 'accepted', type: 'file' },
+      { index: 1, reason: 'upload_failed', status: 'failed', type: 'file' },
+      { index: 2, status: 'accepted', type: 'file' },
+    ]);
+    expect(result.undelivered).toHaveLength(1);
+    expect(result.undelivered[0]).toBe(attachment);
+  });
+
+  it('marks every link in a successful batch as fallback without adding sends', async () => {
+    const api = makeApi();
+    PLATFORM_ATTACHMENT_BUDGETS.wechat.fileMaxBytes = 2;
+    const attachments: WechatOutboundAttachment[] = ['a', 'b'].map((name) => ({
+      data: Buffer.from('big').toString('base64'),
+      fetchUrl: `https://example.com/${name}`,
+      name,
+      type: 'file',
+    }));
+
+    const result = await sendWechatAttachments(
+      api as unknown as WechatApiClient,
+      'user-1',
+      attachments,
+      'token-1',
+    );
+
+    expect(result.outcomes).toEqual([
+      { index: 0, reason: 'over_budget', status: 'link_fallback', type: 'file' },
+      { index: 1, reason: 'over_budget', status: 'link_fallback', type: 'file' },
+    ]);
+    expect(result.failures).toEqual([]);
+    expect(result.undelivered).toEqual([]);
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves accepted media and links when a later link batch rejects', async () => {
+    const api = makeApi();
+    Object.assign(PLATFORM_ATTACHMENT_BUDGETS.wechat, { fileMaxBytes: 2, textMaxChars: 1 });
+    api.sendMessage.mockResolvedValueOnce({});
+    api.sendMessage.mockRejectedValueOnce(new Error('iLink down'));
+    const links: WechatOutboundAttachment[] = ['a', 'b', 'c'].map((name) => ({
+      data: Buffer.from('big').toString('base64'),
+      fetchUrl: `https://example.com/${name}`,
+      name,
+      type: 'file',
+    }));
+
+    const error = await sendWechatAttachments(
+      api as unknown as WechatApiClient,
+      'user-1',
+      [{ data: 'YQ==', type: 'image' }, ...links],
+      'token-1',
+    ).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(WechatAttachmentSendError);
+    const failure = error as InstanceType<typeof WechatAttachmentSendError>;
+    expect(failure.message).toBe('iLink down');
+    expect(failure.result.outcomes).toEqual([
+      { index: 0, status: 'accepted', type: 'image' },
+      { index: 1, reason: 'over_budget', status: 'link_fallback', type: 'file' },
+      { index: 2, reason: 'link_send_unconfirmed', status: 'unknown', type: 'file' },
+      { index: 3, reason: 'prior_failure', status: 'not_attempted', type: 'file' },
+    ]);
+    expect(api.sendItem).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/server/src/services/bot/platforms/wechat/sendAttachments.test.ts
+++ b/apps/server/src/services/bot/platforms/wechat/sendAttachments.test.ts
@@ -280,8 +280,17 @@ describe('sendWechatAttachments', () => {
 
   it('keeps separate outcomes for repeated objects and matching source URLs', async () => {
     const api = makeApi();
-    const attachment = { data: 'YQ==', fetchUrl: 'https://example.com/same', type: 'file' } as const;
-    api.uploadCdnMedia.mockResolvedValueOnce({ aesKey: 'key', cipherSize: 16, encryptQueryParam: 'p', rawSize: 1 });
+    const attachment = {
+      data: 'YQ==',
+      fetchUrl: 'https://example.com/same',
+      type: 'file',
+    } as const;
+    api.uploadCdnMedia.mockResolvedValueOnce({
+      aesKey: 'key',
+      cipherSize: 16,
+      encryptQueryParam: 'p',
+      rawSize: 1,
+    });
     api.uploadCdnMedia.mockRejectedValueOnce(new Error('second upload failed'));
 
     const result = await sendWechatAttachments(

--- a/apps/server/src/services/bot/platforms/wechat/sendAttachments.ts
+++ b/apps/server/src/services/bot/platforms/wechat/sendAttachments.ts
@@ -1,3 +1,4 @@
+import type { SendMessageAttachmentOutcome } from '@lobechat/builtin-tool-message/delivery';
 import type { MessageItem, WechatApiClient } from '@lobechat/chat-adapter-wechat';
 import { MessageItemType, WechatUploadMediaType } from '@lobechat/chat-adapter-wechat';
 import debug from 'debug';
@@ -6,7 +7,7 @@ import {
   buildAttachmentFallbackLine,
   compressImageToBudget,
   PLATFORM_ATTACHMENT_BUDGETS,
-  splitFallbackMessages,
+  splitFallbackMessageBatches,
 } from '../attachmentBudget';
 import { loadAttachmentBuffer } from '../loadAttachmentBuffer';
 
@@ -49,7 +50,23 @@ export interface WechatAttachmentFailure {
 export interface WechatAttachmentSendResult {
   /** Describes the same attachments as `undelivered`. */
   failures: WechatAttachmentFailure[];
+  outcomes: SendMessageAttachmentOutcome[];
   undelivered: WechatOutboundAttachment[];
+}
+
+/** Carries known progress to the service while preserving rejection for replay callers. */
+export class WechatAttachmentSendError extends Error {
+  readonly result: WechatAttachmentSendResult;
+
+  constructor(result: WechatAttachmentSendResult, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = 'WechatAttachmentSendError';
+    this.result = {
+      failures: [...result.failures],
+      outcomes: result.outcomes.map((item) => ({ ...item })),
+      undelivered: [...result.undelivered],
+    };
+  }
 }
 
 const mapAttachmentTypeToUploadMediaType = (
@@ -118,11 +135,10 @@ const buildMediaItemFromUpload = (
  * are logged and skipped so the rest still ship — mirroring the chat-adapter
  * adapter's per-item try/catch.
  *
- * Returns the attachments that did NOT reach the user, so a caller with a
- * replay queue can requeue exactly those instead of assuming the whole leg
- * landed, alongside WHY each one failed. Attachments degraded to a download
- * link count as delivered once the link message sends; if that send throws,
- * the whole call throws and the return value is moot.
+ * Retains the legacy failure arrays for replay callers and records submission
+ * outcomes by input index. Link fallback counts as handled for the legacy
+ * arrays once the link message sends. A link failure still rejects, carrying
+ * the known outcomes for callers that report partial progress.
  */
 export const sendWechatAttachments = async (
   api: WechatApiClient,
@@ -131,11 +147,19 @@ export const sendWechatAttachments = async (
   contextToken: string,
 ): Promise<WechatAttachmentSendResult> => {
   const budget = PLATFORM_ATTACHMENT_BUDGETS.wechat;
-  const fallbackLines: string[] = [];
+  const fallbackLines: Array<{ attachment: WechatOutboundAttachment; index: number; line: string }> =
+    [];
   const undelivered: WechatOutboundAttachment[] = [];
   const failures: WechatAttachmentFailure[] = [];
+  const outcomes: SendMessageAttachmentOutcome[] = attachments.map((attachment, index) => ({
+    index,
+    reason: 'prior_failure',
+    status: 'not_attempted',
+    type: attachment.type,
+  }));
 
-  for (const attachment of attachments) {
+  for (const [index, attachment] of attachments.entries()) {
+    let stage: 'prepare' | 'upload' | 'send' = 'prepare';
     try {
       let buffer = await loadAttachmentBuffer(attachment);
       if (!buffer) {
@@ -146,6 +170,12 @@ export const sendWechatAttachments = async (
           type: attachment.type,
         });
         undelivered.push(attachment);
+        outcomes[index] = {
+          index,
+          reason: 'source_unavailable',
+          status: 'failed',
+          type: attachment.type,
+        };
         continue;
       }
 
@@ -171,7 +201,11 @@ export const sendWechatAttachments = async (
           // the rest, but a failing `sendMessage` means the text channel itself
           // is down — swallowing it would let `deliver` resolve and the replay
           // queue drop a payload that was never delivered.
-          fallbackLines.push(buildAttachmentFallbackLine(attachment, attachment.fetchUrl));
+          fallbackLines.push({
+            attachment,
+            index,
+            line: buildAttachmentFallbackLine(attachment, attachment.fetchUrl),
+          });
         } else {
           log('sendWechatAttachments: skipping over-budget attachment without fetchUrl');
           failures.push({
@@ -180,12 +214,20 @@ export const sendWechatAttachments = async (
             type: attachment.type,
           });
           undelivered.push(attachment);
+          outcomes[index] = {
+            index,
+            reason: 'over_budget_no_link',
+            status: 'failed',
+            type: attachment.type,
+          };
         }
         continue;
       }
 
       const mediaType = mapAttachmentTypeToUploadMediaType(attachment.type);
+      stage = 'upload';
       const uploadResult = await api.uploadCdnMedia(toUserId, mediaType, buffer);
+      stage = 'prepare';
       const cdnMedia = {
         aes_key: uploadResult.aesKey,
         encrypt_query_param: uploadResult.encryptQueryParam,
@@ -198,7 +240,9 @@ export const sendWechatAttachments = async (
         attachment,
         buffer.length,
       );
+      stage = 'send';
       await api.sendItem(toUserId, item, contextToken);
+      outcomes[index] = { index, status: 'accepted', type: attachment.type };
     } catch (error) {
       // iLink refusing an upload is the other half of "it sent a link instead
       // of the picture". The message is the diagnostic part — it carries the
@@ -217,14 +261,44 @@ export const sendWechatAttachments = async (
         type: attachment.type,
       });
       undelivered.push(attachment);
+      outcomes[index] =
+        stage === 'send'
+          ? { index, reason: 'send_unconfirmed', status: 'unknown', type: attachment.type }
+          : {
+              index,
+              reason: stage === 'upload' ? 'upload_failed' : 'prepare_failed',
+              status: 'failed',
+              type: attachment.type,
+            };
     }
   }
 
   // Deliberately outside the loop's try/catch — see the note above.
-  const linkMessages = splitFallbackMessages(fallbackLines, budget.textMaxChars);
-  for (const message of linkMessages) {
-    await api.sendMessage(toUserId, message, contextToken);
+  const linkMessages = splitFallbackMessageBatches(fallbackLines, (item) => item.line, budget.textMaxChars);
+  for (const { items, message } of linkMessages) {
+    try {
+      await api.sendMessage(toUserId, message, contextToken);
+      for (const { attachment, index } of items) {
+        outcomes[index] = {
+          index,
+          reason: 'over_budget',
+          status: 'link_fallback',
+          type: attachment.type,
+        };
+      }
+    } catch (error) {
+      // sendMessage can submit multiple text chunks before rejecting.
+      for (const { attachment, index } of items) {
+        outcomes[index] = {
+          index,
+          reason: 'link_send_unconfirmed',
+          status: 'unknown',
+          type: attachment.type,
+        };
+      }
+      throw new WechatAttachmentSendError({ failures, outcomes, undelivered }, error);
+    }
   }
 
-  return { failures, undelivered };
+  return { failures, outcomes, undelivered };
 };

--- a/apps/server/src/services/bot/platforms/wechat/sendAttachments.ts
+++ b/apps/server/src/services/bot/platforms/wechat/sendAttachments.ts
@@ -147,8 +147,11 @@ export const sendWechatAttachments = async (
   contextToken: string,
 ): Promise<WechatAttachmentSendResult> => {
   const budget = PLATFORM_ATTACHMENT_BUDGETS.wechat;
-  const fallbackLines: Array<{ attachment: WechatOutboundAttachment; index: number; line: string }> =
-    [];
+  const fallbackLines: Array<{
+    attachment: WechatOutboundAttachment;
+    index: number;
+    line: string;
+  }> = [];
   const undelivered: WechatOutboundAttachment[] = [];
   const failures: WechatAttachmentFailure[] = [];
   const outcomes: SendMessageAttachmentOutcome[] = attachments.map((attachment, index) => ({
@@ -274,7 +277,11 @@ export const sendWechatAttachments = async (
   }
 
   // Deliberately outside the loop's try/catch — see the note above.
-  const linkMessages = splitFallbackMessageBatches(fallbackLines, (item) => item.line, budget.textMaxChars);
+  const linkMessages = splitFallbackMessageBatches(
+    fallbackLines,
+    (item) => item.line,
+    budget.textMaxChars,
+  );
   for (const { items, message } of linkMessages) {
     try {
       await api.sendMessage(toUserId, message, contextToken);

--- a/apps/server/src/services/bot/platforms/wechat/service.test.ts
+++ b/apps/server/src/services/bot/platforms/wechat/service.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageExecutionRuntime } from '@lobechat/builtin-tool-message/executionRuntime';
+import type * as WechatAdapterModule from '@lobechat/chat-adapter-wechat';
+import type { WechatApiClient } from '@lobechat/chat-adapter-wechat';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as AttachmentBudgetModule from '../attachmentBudget';
 import type * as PublicUrlFetchModule from '../publicUrlFetch';
 
 // These tests stub `fetch` directly; the SSRF guard in front of it resolves DNS
@@ -51,6 +55,19 @@ vi.mock('@/server/modules/AgentRuntime/redis', () => ({
 }));
 
 const { WechatMessageService } = await import('./service');
+const { PLATFORM_ATTACHMENT_BUDGETS } = await import('../attachmentBudget');
+
+vi.mock('../attachmentBudget', async (importOriginal) => {
+  const original = await importOriginal<typeof AttachmentBudgetModule>();
+  return {
+    ...original,
+    PLATFORM_ATTACHMENT_BUDGETS: {
+      ...original.PLATFORM_ATTACHMENT_BUDGETS,
+      wechat: { ...original.PLATFORM_ATTACHMENT_BUDGETS.wechat },
+    },
+  };
+});
+const defaultWechatBudget = { ...PLATFORM_ATTACHMENT_BUDGETS.wechat };
 
 const makeApi = () => ({
   sendItem: vi.fn().mockResolvedValue({ ret: 0 }),
@@ -67,13 +84,54 @@ describe('WechatMessageService.sendMessage', () => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', vi.fn());
     mockRedisGet.mockResolvedValue(null);
+    Object.assign(PLATFORM_ATTACHMENT_BUDGETS.wechat, defaultWechatBudget);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves text success and reports an attachment upload failure to the runtime', async () => {
+    const api = makeApi();
+    api.uploadCdnMedia.mockRejectedValueOnce(new Error('synthetic upload failure'));
+    const service = new WechatMessageService(api as unknown as WechatApiClient, 'app-1');
+    const runtime = new MessageExecutionRuntime({ service });
+
+    const result = await runtime.sendMessage({
+      attachments: [
+        {
+          data: Buffer.from('synthetic-image').toString('base64'),
+          name: 'fixture.png',
+          type: 'image',
+        },
+      ],
+      channelId: 'user-1@im.wechat',
+      content: 'fixture text',
+      platform: 'wechat',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.state).toMatchObject({
+      delivery: {
+        attachments: [{ index: 0, reason: 'upload_failed', status: 'failed', type: 'image' }],
+        receipt: 'unconfirmed',
+        status: 'partial',
+        text: { status: 'accepted' },
+      },
+    });
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.uploadCdnMedia).toHaveBeenCalledTimes(1);
+    expect(api.sendItem).not.toHaveBeenCalled();
+    expect(result.content).not.toContain('messageId: undefined');
+    expect(result.content).toContain('Do not resend the entire request');
   });
 
   it('forwards text via api.sendMessage', async () => {
     const api = makeApi();
     const service = new WechatMessageService(api as any, 'app-1');
 
-    await service.sendMessage({
+    const result = await service.sendMessage({
       channelId: 'user-1@im.wechat',
       content: 'hello',
       platform: 'wechat',
@@ -82,6 +140,12 @@ describe('WechatMessageService.sendMessage', () => {
     expect(api.sendMessage).toHaveBeenCalledWith('user-1@im.wechat', 'hello', '');
     expect(api.uploadCdnMedia).not.toHaveBeenCalled();
     expect(api.sendItem).not.toHaveBeenCalled();
+    expect(result.delivery).toEqual({
+      attachments: [],
+      receipt: 'unconfirmed',
+      status: 'accepted',
+      text: { status: 'accepted' },
+    });
   });
 
   it('consumes one send-window credit per long-text chunk', async () => {
@@ -151,7 +215,7 @@ describe('WechatMessageService.sendMessage', () => {
     const api = makeApi();
     const service = new WechatMessageService(api as any, 'app-1');
 
-    await service.sendMessage({
+    const result = await service.sendMessage({
       attachments: [
         { data: Buffer.from('pdf-bytes').toString('base64'), name: 'a.pdf', type: 'file' },
       ],
@@ -163,6 +227,12 @@ describe('WechatMessageService.sendMessage', () => {
     expect(api.sendMessage).not.toHaveBeenCalled();
     expect(api.uploadCdnMedia).toHaveBeenCalledTimes(1);
     expect(api.sendItem).toHaveBeenCalledTimes(1);
+    expect(result.delivery).toEqual({
+      attachments: [{ index: 0, status: 'accepted', type: 'file' }],
+      receipt: 'unconfirmed',
+      status: 'accepted',
+      text: { status: 'not_requested' },
+    });
   });
 
   it('fetches attachments delivered as fetchUrl', async () => {
@@ -186,5 +256,145 @@ describe('WechatMessageService.sendMessage', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://cdn.example.com/pic.png', expect.any(Object));
     expect(api.uploadCdnMedia).toHaveBeenCalledTimes(1);
     expect(api.sendItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not consume quota or call the platform for an empty request', async () => {
+    const api = makeApi();
+    const service = new WechatMessageService(api as unknown as WechatApiClient, 'app-1');
+
+    const result = await service.sendMessage({
+      channelId: 'fixture',
+      content: '',
+      platform: 'wechat',
+    });
+
+    expect(result.delivery).toEqual({
+      attachments: [],
+      receipt: 'unconfirmed',
+      status: 'failed',
+      text: { status: 'not_requested' },
+    });
+    expect(mockWindowRedis.hincrby).not.toHaveBeenCalled();
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.uploadCdnMedia).not.toHaveBeenCalled();
+  });
+
+  it('reports attachment-only failures without inventing a successful text leg', async () => {
+    const api = makeApi();
+    const service = new WechatMessageService(api as unknown as WechatApiClient, 'app-1');
+
+    const result = await service.sendMessage({
+      attachments: [{ type: 'image' }],
+      channelId: 'fixture',
+      content: '',
+      platform: 'wechat',
+    });
+
+    expect(result.delivery).toEqual({
+      attachments: [{ index: 0, reason: 'source_unavailable', status: 'failed', type: 'image' }],
+      receipt: 'unconfirmed',
+      status: 'failed',
+      text: { status: 'not_requested' },
+    });
+    expect(api.sendItem).not.toHaveBeenCalled();
+  });
+
+  it('preserves uncertain long-text submission and does not begin attachments', async () => {
+    const { WechatApiClient: ActualWechatApiClient } = await vi.importActual<
+      typeof WechatAdapterModule
+    >('@lobechat/chat-adapter-wechat');
+    const api = new ActualWechatApiClient('fixture-token', 'fixture-bot');
+    const sendItem = vi.spyOn(api, 'sendItem').mockResolvedValueOnce({ ret: 0 });
+    sendItem.mockRejectedValueOnce(new Error('second chunk response lost'));
+    const upload = vi.spyOn(api, 'uploadCdnMedia');
+    const runtime = new MessageExecutionRuntime({
+      service: new WechatMessageService(api, 'app-1'),
+    });
+
+    const result = await runtime.sendMessage({
+      attachments: [{ data: 'YQ==', type: 'file' }],
+      channelId: 'fixture',
+      content: 'a'.repeat(6000),
+      platform: 'wechat',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.state.delivery).toEqual({
+      attachments: [
+        { index: 0, reason: 'text_not_accepted', status: 'not_attempted', type: 'file' },
+      ],
+      receipt: 'unconfirmed',
+      status: 'unknown',
+      text: { reason: 'text_send_unconfirmed', status: 'unknown' },
+    });
+    expect(sendItem).toHaveBeenCalledTimes(2);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    'preserves text acceptance when a fallback link rejects: %s',
+    async (rejectLink) => {
+      const api = makeApi();
+      PLATFORM_ATTACHMENT_BUDGETS.wechat.fileMaxBytes = 2;
+      if (rejectLink) {
+        api.sendMessage.mockResolvedValueOnce({ ret: 0 });
+        api.sendMessage.mockRejectedValueOnce(new Error('fallback response lost'));
+      }
+      const runtime = new MessageExecutionRuntime({
+        service: new WechatMessageService(api as unknown as WechatApiClient, 'app-1'),
+      });
+
+      const result = await runtime.sendMessage({
+        attachments: [{ data: 'Ymln', fetchUrl: 'https://example.com/fixture', type: 'file' }],
+        channelId: 'fixture',
+        content: 'fixture text',
+        platform: 'wechat',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.state.delivery).toEqual({
+        attachments: [
+          {
+            index: 0,
+            reason: rejectLink ? 'link_send_unconfirmed' : 'over_budget',
+            status: rejectLink ? 'unknown' : 'link_fallback',
+            type: 'file',
+          },
+        ],
+        receipt: 'unconfirmed',
+        status: rejectLink ? 'unknown' : 'degraded',
+        text: { status: 'accepted' },
+      });
+      expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('publishes only outcome fields when a media submission error includes request details', async () => {
+    const api = makeApi();
+    const markers = [
+      'https://example.com/private-source',
+      'fixture-private-token',
+      'fixture-base64',
+    ];
+    api.sendItem.mockRejectedValueOnce(new Error(markers.join(' ')));
+    const runtime = new MessageExecutionRuntime({
+      service: new WechatMessageService(api as unknown as WechatApiClient, 'app-1'),
+    });
+
+    const result = await runtime.sendMessage({
+      attachments: [{ data: 'YQ==', fetchUrl: markers[0], type: 'image' }],
+      channelId: 'fixture',
+      content: 'fixture text',
+      platform: 'wechat',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.state.delivery).toMatchObject({
+      attachments: [{ index: 0, reason: 'send_unconfirmed', status: 'unknown', type: 'image' }],
+      status: 'unknown',
+      text: { status: 'accepted' },
+    });
+    for (const marker of markers) expect(JSON.stringify(result)).not.toContain(marker);
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
   });
 });

--- a/apps/server/src/services/bot/platforms/wechat/service.ts
+++ b/apps/server/src/services/bot/platforms/wechat/service.ts
@@ -1,4 +1,9 @@
 import type {
+  SendMessageAttachmentOutcome,
+  SendMessageTextOutcome,
+} from '@lobechat/builtin-tool-message/delivery';
+import { resolveDeliveryStatus } from '@lobechat/builtin-tool-message/delivery';
+import type {
   CreatePollParams,
   CreatePollState,
   CreateThreadParams,
@@ -42,7 +47,24 @@ import type { MessageRuntimeService } from '@/server/services/toolExecution/serv
 import { PlatformUnsupportedError } from '@/server/services/toolExecution/serverRuntimes/message/PlatformUnsupportedError';
 
 import { consumeSendCredits, type WechatWindowRedis } from './contextWindow';
-import { sendWechatAttachments } from './sendAttachments';
+import { sendWechatAttachments, WechatAttachmentSendError } from './sendAttachments';
+
+function buildWechatSendState(
+  channelId: string,
+  text: SendMessageTextOutcome,
+  attachments: SendMessageAttachmentOutcome[],
+): SendMessageState {
+  return {
+    channelId,
+    delivery: {
+      attachments,
+      receipt: 'unconfirmed',
+      status: resolveDeliveryStatus({ attachments, text }),
+      text,
+    },
+    platform: 'wechat',
+  };
+}
 
 /**
  * WeChat iLink Bot message adapter.
@@ -92,20 +114,58 @@ export class WechatMessageService implements MessageRuntimeService {
   // ==================== Core Message Operations ====================
 
   sendMessage = async (params: SendMessageParams): Promise<SendMessageState> => {
+    const attachments = params.attachments ?? [];
+    let text: SendMessageTextOutcome = { status: 'not_requested' };
+    if (!params.content && attachments.length === 0) {
+      return buildWechatSendState(params.channelId, text, []);
+    }
+
     const sendCount =
       (params.content ? getWechatTextSendCount(params.content) : 0) +
       (params.attachments?.length ?? 0);
     const contextToken = await this.resolveContextToken(params.channelId, Math.max(1, sendCount));
     if (params.content) {
-      await this.api.sendMessage(params.channelId, params.content, contextToken);
+      try {
+        await this.api.sendMessage(params.channelId, params.content, contextToken);
+        text = { status: 'accepted' };
+      } catch {
+        // Earlier text chunks may already have been accepted.
+        return buildWechatSendState(
+          params.channelId,
+          { reason: 'text_send_unconfirmed', status: 'unknown' },
+          attachments.map((attachment, index) => ({
+            index,
+            reason: 'text_not_accepted',
+            status: 'not_attempted',
+            type: attachment.type,
+          })),
+        );
+      }
     }
-    if (params.attachments?.length) {
-      await sendWechatAttachments(this.api, params.channelId, params.attachments, contextToken);
+
+    let outcomes: SendMessageAttachmentOutcome[] = [];
+    if (attachments.length) {
+      try {
+        const result = await sendWechatAttachments(
+          this.api,
+          params.channelId,
+          attachments,
+          contextToken,
+        );
+        outcomes = result.outcomes;
+      } catch (error) {
+        outcomes =
+          error instanceof WechatAttachmentSendError
+            ? error.result.outcomes
+            : attachments.map((attachment, index) => ({
+                index,
+                reason: 'execution_unconfirmed',
+                status: 'unknown',
+                type: attachment.type,
+              }));
+      }
     }
-    return {
-      channelId: params.channelId,
-      platform: 'wechat',
-    };
+    return buildWechatSendState(params.channelId, text, outcomes);
   };
 
   readMessages = async (_params: ReadMessagesParams): Promise<ReadMessagesState> => {

--- a/apps/server/src/services/toolExecution/__tests__/index.test.ts
+++ b/apps/server/src/services/toolExecution/__tests__/index.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { deviceGateway } from '@/server/services/deviceGateway';
 import { getScopedOnlineDevices } from '@/server/services/deviceGateway/scopedDevices';
 
+import type { MCPService } from '../../mcp';
+import type { BuiltinToolsExecutor } from '../builtin';
 import { ToolExecutionService } from '../index';
 
 vi.mock('@/server/services/deviceGateway', () => ({
@@ -23,6 +25,39 @@ vi.mock('@/server/services/deviceGateway/scopedDevices', () => ({
 }));
 
 describe('ToolExecutionService', () => {
+  it('preserves partial message content and state when normalizing a failed tool result', async () => {
+    const content = 'Send partially completed. Do not resend the entire request automatically.';
+    const state = {
+      channelId: 'fixture',
+      delivery: {
+        attachments: [{ index: 0, reason: 'upload_failed', status: 'failed', type: 'image' }],
+        receipt: 'unconfirmed',
+        status: 'partial',
+        text: { status: 'accepted' },
+      },
+      platform: 'wechat',
+    };
+    const execute = vi.fn().mockResolvedValue({ content, state, success: false });
+    const service = new ToolExecutionService({
+      builtinToolsExecutor: { execute } as unknown as BuiltinToolsExecutor,
+      mcpService: {} as MCPService,
+    });
+
+    const result = await service.executeTool(
+      {
+        apiName: 'sendMessage',
+        arguments: '{}',
+        id: 'fixture-call',
+        identifier: 'lobe-message',
+        type: 'builtin',
+      },
+      { toolManifestMap: {} },
+    );
+
+    expect(result).toMatchObject({ content, error: { message: content }, state, success: false });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it('can skip low-level result truncation for AgentRuntime archival', async () => {
     const builtinToolsExecutor = {
       execute: vi.fn().mockResolvedValue({

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/message.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/message.test.ts
@@ -1,4 +1,5 @@
 import { MessageToolIdentifier } from '@lobechat/builtin-tool-message';
+import { WechatApiClient } from '@lobechat/chat-adapter-wechat';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ToolExecutionContext } from '../../types';
@@ -260,6 +261,42 @@ const mockProviderFor = (platform: string, credentials: Record<string, string>) 
 // ==================== Tests ====================
 
 describe('messageRuntime', () => {
+  it('carries partial WeChat attachment failures through the actual runtime factory', async () => {
+    mockProviderFor('wechat', { botId: 'fixture-bot', botToken: 'fixture-token' });
+    const sendText = vi
+      .spyOn(WechatApiClient.prototype, 'sendMessage')
+      .mockResolvedValue({ ret: 0 });
+    const upload = vi
+      .spyOn(WechatApiClient.prototype, 'uploadCdnMedia')
+      .mockRejectedValue(new Error('upload failed'));
+    const sendItem = vi.spyOn(WechatApiClient.prototype, 'sendItem').mockResolvedValue({ ret: 0 });
+    try {
+      const runtime = await messageRuntime.factory(validContext);
+
+      const result = await runtime.sendMessage({
+        attachments: [{ data: 'YQ==', type: 'image' }],
+        channelId: 'fixture',
+        content: 'fixture text',
+        platform: 'wechat',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.state.delivery).toEqual({
+        attachments: [{ index: 0, reason: 'upload_failed', status: 'failed', type: 'image' }],
+        receipt: 'unconfirmed',
+        status: 'partial',
+        text: { status: 'accepted' },
+      });
+      expect(result.content).toContain('Do not resend the entire request');
+      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendItem).not.toHaveBeenCalled();
+    } finally {
+      sendText.mockRestore();
+      upload.mockRestore();
+      sendItem.mockRestore();
+    }
+  });
+
   it('should have correct identifier', () => {
     expect(messageRuntime.identifier).toBe(MessageToolIdentifier);
   });

--- a/packages/builtin-tool-message/package.json
+++ b/packages/builtin-tool-message/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client/index.ts",
+    "./delivery": "./src/delivery.ts",
     "./executor": "./src/executor/index.ts",
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },

--- a/packages/builtin-tool-message/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-message/src/ExecutionRuntime/index.ts
@@ -1,5 +1,6 @@
 import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
 
+import { getSendMessagePresentation } from '../delivery';
 import type {
   ConfiguredBotInfo,
   ConnectBotParams,
@@ -267,10 +268,11 @@ export class MessageExecutionRuntime {
   async sendMessage(params: SendMessageParams): Promise<BuiltinServerRuntimeOutput> {
     try {
       const result = await this.service.sendMessage(params);
+      const presentation = getSendMessagePresentation(result, params);
       return {
-        content: `Message sent to ${params.platform}:${params.channelId} (messageId: ${result.messageId})`,
+        content: presentation.content,
         state: result,
-        success: true,
+        success: presentation.success,
       };
     } catch (e) {
       return {

--- a/packages/builtin-tool-message/src/delivery.test.ts
+++ b/packages/builtin-tool-message/src/delivery.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSendMessagePresentation, resolveDeliveryStatus } from './delivery';
+import type { SendMessageAttachmentOutcome, SendMessageDelivery } from './types';
+
+const acceptedImage = { index: 0, status: 'accepted', type: 'image' } as const;
+const failedImage = {
+  index: 0,
+  reason: 'upload_failed',
+  status: 'failed',
+  type: 'image',
+} as const;
+const fallbackImage = {
+  index: 0,
+  reason: 'over_budget',
+  status: 'link_fallback',
+  type: 'image',
+} as const;
+const unknownImage = {
+  index: 0,
+  reason: 'send_unconfirmed',
+  status: 'unknown',
+  type: 'image',
+} as const;
+
+describe('resolveDeliveryStatus', () => {
+  it.each<{
+    attachments: SendMessageAttachmentOutcome[];
+    name: string;
+    status: SendMessageDelivery['status'];
+    text: SendMessageDelivery['text'];
+  }>([
+    { attachments: [], name: 'text only', status: 'accepted', text: { status: 'accepted' } },
+    {
+      attachments: [acceptedImage],
+      name: 'media only',
+      status: 'accepted',
+      text: { status: 'not_requested' },
+    },
+    {
+      attachments: [failedImage],
+      name: 'text accepted and media failed',
+      status: 'partial',
+      text: { status: 'accepted' },
+    },
+    {
+      attachments: [failedImage],
+      name: 'all media failed',
+      status: 'failed',
+      text: { status: 'not_requested' },
+    },
+    {
+      attachments: [fallbackImage],
+      name: 'link fallback',
+      status: 'degraded',
+      text: { status: 'accepted' },
+    },
+    {
+      attachments: [fallbackImage, { ...failedImage, index: 1 }],
+      name: 'link accepted and other media failed',
+      status: 'partial',
+      text: { status: 'not_requested' },
+    },
+    {
+      attachments: [unknownImage, { ...failedImage, index: 1 }],
+      name: 'uncertain submission with accepted text and failed media',
+      status: 'unknown',
+      text: { status: 'accepted' },
+    },
+    {
+      attachments: [
+        { index: 0, reason: 'text_not_accepted', status: 'not_attempted', type: 'file' },
+      ],
+      name: 'uncertain text prevents attachments',
+      status: 'unknown',
+      text: { reason: 'text_send_unconfirmed', status: 'unknown' },
+    },
+    {
+      attachments: [
+        fallbackImage,
+        { index: 1, reason: 'prior_failure', status: 'not_attempted', type: 'file' },
+      ],
+      name: 'accepted link and unattempted media',
+      status: 'partial',
+      text: { status: 'not_requested' },
+    },
+    { attachments: [], name: 'empty request', status: 'failed', text: { status: 'not_requested' } },
+  ])('$name is $status', ({ attachments, status, text }) => {
+    expect(resolveDeliveryStatus({ attachments, text })).toBe(status);
+  });
+});
+
+describe('getSendMessagePresentation', () => {
+  it.each<SendMessageDelivery['status']>(['accepted', 'degraded', 'partial', 'failed', 'unknown'])(
+    'keeps %s feedback consistent with the structured report',
+    (status) => {
+      const attachments = {
+        accepted: [acceptedImage],
+        degraded: [fallbackImage],
+        failed: [failedImage],
+        partial: [failedImage],
+        unknown: [unknownImage],
+      }[status];
+      const delivery: SendMessageDelivery = {
+        attachments,
+        receipt: 'unconfirmed',
+        status,
+        text: { status: status === 'failed' ? 'not_requested' : 'accepted' },
+      };
+      const result = getSendMessagePresentation({
+        channelId: 'fixture',
+        delivery,
+        platform: 'wechat',
+      });
+
+      expect(result).toMatchObject({ status, success: status === 'accepted' });
+      expect(result.content).toContain(JSON.stringify(delivery, null, 2));
+      expect(result.content).toContain('Recipient receipt is unconfirmed');
+      expect(result.content).not.toContain('undefined');
+      if (status !== 'accepted') {
+        expect(result.content).toContain('Do not resend the entire request');
+        expect(result.content).not.toContain('Message sent');
+      }
+      if (status === 'degraded') expect(result.content).toContain('download links');
+    },
+  );
+
+  it('reports old WeChat results as unconfirmed', () => {
+    expect(getSendMessagePresentation({ channelId: 'fixture', platform: 'wechat' })).toMatchObject({
+      content: expect.stringContaining('did not provide per-item send results'),
+      status: 'unknown',
+      success: false,
+    });
+  });
+
+  it('uses the requested platform when an old server omits it', () => {
+    expect(
+      getSendMessagePresentation({}, { channelId: 'fixture', platform: 'wechat' }),
+    ).toMatchObject({
+      content: expect.stringContaining('wechat:fixture'),
+      status: 'unknown',
+      success: false,
+    });
+  });
+
+  it.each(['discord', 'telegram', 'slack', 'feishu'])(
+    'preserves legacy %s success and the returned message ID',
+    (platform) => {
+      expect(
+        getSendMessagePresentation({ channelId: 'fixture', messageId: 'actual-id', platform }),
+      ).toEqual({
+        content: `Message sent to ${platform}:fixture (messageId: actual-id)`,
+        status: 'legacy',
+        success: true,
+      });
+    },
+  );
+
+  it('omits missing IDs and uses the returned destination', () => {
+    const result = getSendMessagePresentation(
+      { channelId: 'resolved', platform: 'discord' },
+      { channelId: 'requested', platform: 'slack' },
+    );
+
+    expect(result.content).toBe('Message sent to discord:resolved');
+  });
+});

--- a/packages/builtin-tool-message/src/delivery.ts
+++ b/packages/builtin-tool-message/src/delivery.ts
@@ -1,0 +1,100 @@
+import type {
+  MessageDeliveryStatus,
+  SendMessageAttachmentOutcome,
+  SendMessageDelivery,
+  SendMessageState,
+  SendMessageTextOutcome,
+} from './types';
+
+export type {
+  MessageDeliveryStatus,
+  SendMessageAttachmentOutcome,
+  SendMessageDelivery,
+  SendMessageState,
+  SendMessageTextOutcome,
+} from './types';
+
+export function resolveDeliveryStatus(
+  input: Pick<SendMessageDelivery, 'attachments' | 'text'>,
+): MessageDeliveryStatus {
+  const statuses: Array<SendMessageAttachmentOutcome['status'] | SendMessageTextOutcome['status']> =
+    input.attachments.map((item) => item.status);
+
+  if (input.text.status !== 'not_requested') statuses.push(input.text.status);
+
+  if (statuses.length === 0) return 'failed';
+  if (statuses.includes('unknown')) return 'unknown';
+
+  const hasAccepted = statuses.some(
+    (status) => status === 'accepted' || status === 'link_fallback',
+  );
+  const hasUnfulfilled = statuses.some(
+    (status) => status === 'failed' || status === 'not_attempted',
+  );
+
+  if (hasUnfulfilled) return hasAccepted ? 'partial' : 'failed';
+  if (statuses.includes('link_fallback')) return 'degraded';
+  return 'accepted';
+}
+
+export interface MessageSendPresentation {
+  content: string;
+  status: MessageDeliveryStatus | 'legacy';
+  success: boolean;
+}
+
+export function getSendMessagePresentation(
+  result: SendMessageState,
+  target?: { channelId?: string; platform?: string },
+): MessageSendPresentation {
+  const platform = result.platform ?? target?.platform;
+  const channelId = result.channelId ?? target?.channelId;
+  const destination = [platform, channelId].filter(Boolean).join(':') || 'target';
+  const idSuffix = result.messageId ? ` (messageId: ${result.messageId})` : '';
+  const delivery = result.delivery;
+
+  if (!delivery) {
+    if (platform === 'wechat') {
+      return {
+        content:
+          `WeChat send outcome is unconfirmed for ${destination}${idSuffix}. ` +
+          'The server did not provide per-item send results. ' +
+          'Do not assume that the attachments were sent or resend the entire request automatically. ' +
+          'Recipient receipt is unconfirmed; use a server version that reports delivery details.',
+        status: 'unknown',
+        success: false,
+      };
+    }
+    return {
+      content: `Message sent to ${destination}${idSuffix}`,
+      status: 'legacy',
+      success: true,
+    };
+  }
+
+  const headings: Record<MessageDeliveryStatus, string> = {
+    accepted: 'Send accepted by the platform API.',
+    degraded:
+      'Send degraded: some attachments were submitted as download links, not original media.',
+    failed: 'Send not completed: no requested part was confirmed accepted.',
+    partial: 'Send partially completed: some requested parts failed or were not attempted.',
+    unknown: 'Send outcome uncertain: at least one submission could not be confirmed.',
+  };
+  // Put the outcome and resend guidance before details that a tool runner may truncate.
+  const retryNotice =
+    delivery.status === 'accepted'
+      ? 'No resend is needed.'
+      : 'Do not resend the entire request automatically. Preserve accepted parts and confirm uncertain parts before any targeted resend.';
+
+  return {
+    content: [
+      headings[delivery.status],
+      retryNotice,
+      'Recipient receipt is unconfirmed; API acceptance is not proof of receipt.',
+      `Target: ${destination}${idSuffix}`,
+      JSON.stringify(delivery, null, 2),
+    ].join('\n'),
+    status: delivery.status,
+    success: delivery.status === 'accepted',
+  };
+}

--- a/packages/builtin-tool-message/src/types.ts
+++ b/packages/builtin-tool-message/src/types.ts
@@ -211,8 +211,42 @@ export interface SendMessageParams {
   replyTo?: string;
 }
 
+export type MessageDeliveryStatus = 'accepted' | 'degraded' | 'partial' | 'failed' | 'unknown';
+
+export type SendMessageTextOutcome =
+  | { status: 'not_requested' }
+  | { status: 'accepted' }
+  | { reason: 'text_send_unconfirmed'; status: 'unknown' };
+
+export type SendMessageAttachmentOutcome = {
+  /** Zero-based position in the original attachments input. */
+  index: number;
+  type: SendMessageAttachment['type'];
+} & (
+  | { status: 'accepted' }
+  | { reason: 'over_budget'; status: 'link_fallback' }
+  | {
+      reason: 'source_unavailable' | 'over_budget_no_link' | 'prepare_failed' | 'upload_failed';
+      status: 'failed';
+    }
+  | {
+      reason: 'send_unconfirmed' | 'link_send_unconfirmed' | 'execution_unconfirmed';
+      status: 'unknown';
+    }
+  | { reason: 'text_not_accepted' | 'prior_failure'; status: 'not_attempted' }
+);
+
+export interface SendMessageDelivery {
+  attachments: SendMessageAttachmentOutcome[];
+  /** This path does not provide a recipient receipt. */
+  receipt: 'unconfirmed';
+  status: MessageDeliveryStatus;
+  text: SendMessageTextOutcome;
+}
+
 export interface SendMessageState {
   channelId?: string;
+  delivery?: SendMessageDelivery;
   messageId?: string;
   platform?: string;
 }

--- a/src/store/tool/slices/builtin/executors/lobe-message/trpcAdapters.delivery.test.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-message/trpcAdapters.delivery.test.ts
@@ -1,0 +1,90 @@
+import type {
+  SendMessageDelivery,
+  SendMessageState,
+} from '@lobechat/builtin-tool-message/delivery';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ send: vi.fn() }));
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    agentBotProvider: {
+      list: { query: async () => [{ enabled: true, id: 'fixture-bot', platform: 'wechat' }] },
+    },
+    botMessage: { sendMessage: { mutate: mocks.send } },
+  },
+}));
+
+const { messageExecutor } = await import('./index');
+
+describe('message executor delivery feedback', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each<SendMessageDelivery['status']>(['accepted', 'degraded', 'partial', 'failed', 'unknown'])(
+    'preserves %s across the frontend adapter and shared runtime',
+    async (status) => {
+      const result: SendMessageState = {
+        channelId: 'fixture',
+        delivery: {
+          attachments:
+            status === 'accepted'
+              ? []
+              : [
+                  {
+                    index: 0,
+                    type: 'image',
+                    ...(status === 'degraded'
+                      ? ({ reason: 'over_budget', status: 'link_fallback' } as const)
+                      : status === 'unknown'
+                        ? ({ reason: 'send_unconfirmed', status: 'unknown' } as const)
+                        : ({ reason: 'upload_failed', status: 'failed' } as const)),
+                  },
+                ],
+          receipt: 'unconfirmed',
+          status,
+          text: { status: status === 'failed' ? 'not_requested' : 'accepted' },
+        },
+        platform: 'wechat',
+      };
+      mocks.send.mockResolvedValueOnce(result);
+
+      const output = await messageExecutor.sendMessage({
+        channelId: 'fixture',
+        content: 'fixture text',
+        platform: 'wechat',
+      });
+
+      expect(output.success).toBe(status === 'accepted');
+      expect(output.state).toEqual(result);
+      expect(output.content).toContain(JSON.stringify(result.delivery, null, 2));
+      expect(mocks.send).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does not claim success when an older WeChat server omits outcomes', async () => {
+    mocks.send.mockResolvedValueOnce({ channelId: 'fixture', platform: 'wechat' });
+
+    const result = await messageExecutor.sendMessage({
+      channelId: 'fixture',
+      content: 'fixture text',
+      platform: 'wechat',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.content).toContain('did not provide per-item send results');
+    expect(result.content).not.toContain('undefined');
+  });
+
+  it('retains the existing error path for transport failures', async () => {
+    mocks.send.mockRejectedValueOnce(new Error('fixture transport failed'));
+
+    const result = await messageExecutor.sendMessage({
+      channelId: 'fixture',
+      content: 'fixture text',
+      platform: 'wechat',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.content).toContain('fixture transport failed');
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
WeChat attachment failures can be discarded while the Agent tool and CLI report that the whole message was sent. This change preserves per-item outcomes from the attachment helper through the platform service, shared Agent Runtime, tRPC and CLI.

- Report accepted, degraded, partial, failed or unknown results. API acceptance does not claim recipient receipt; link fallback is degraded original-media delivery.
- Preserve accepted parts, existing helper failure arrays and fallback rejection behavior. Add no automatic retry.
- Share Runtime/CLI wording. Only accepted is successful; the CLI writes JSON before setting a nonzero exit code and warns against automatically resending the whole request.
- Keep existing non-WeChat responses compatible; legacy WeChat responses without delivery details remain unconfirmed.

| Before | After |
| --- | --- |
| Text accepted, attachment upload fails: reported as sent | Reports partial, preserves accepted text and the failed attachment |
| Original attachment becomes a download link: reported as sent | Reports degraded original-media delivery |
| Media submission response is lost | Reports unknown and advises against resending the entire request automatically |

#### Test

226 targeted tests passed across 13 files, including regressions for the false-success path and CLI outcome handling. CLI build and format checks passed; scoped lint completed with no errors and three warnings. No full-suite run.

Type checks are not clean on the current upstream baseline (`13342094`): the root has two missing Portal imports (`workspaceHtmlArtifact` and `workspaceHtmlPath`), and standalone CLI has 124 diagnostics. Both sets match the baseline on the final comparison. An initial root run also reported TS2352 in the unchanged upstream OpenAPI `message.service.ts`; it did not reproduce on either the baseline or the unchanged branch rerun.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Controlled-transport acceptance: https://app.lobehub.com/acceptance/930ede4b-f3d2-4321-a178-5b47c8bd76be?r=1
- Real WeChat and DeepSeek acceptance: https://app.lobehub.com/acceptance/930ede4b-f3d2-4321-a178-5b47c8bd76be?r=2

The first round contains seven local product checks with controlled WeChat/model HTTP responses: CLI JSON/text output and exit codes, per-invocation transport counts, server Agent execution, persisted tool content/state, subsequent model input, and the browser client executor.

Three follow-up checks used real WeChat and DeepSeek V4 Pro. The recipient confirmed receiving/opening text, image and small file without duplicates, and downloading the 21 MiB link fallback. For text plus an unavailable attachment, the model called sendMessage once, received the persisted partial/source_unavailable result, explained the failure and did not resend the whole request. Round 2 contains the recipient screenshot, saved-topic UI screenshots and execution records: three passed cases and twelve evidence entries, verified after publication. Existing generic tool completion icons are unchanged; expanded results show the partial outcome.

Both acceptance rounds ran on `8a2bbbcc`. This branch was subsequently rebased onto `13342094`, producing `2de71f3a`; `git range-diff` confirms all five patches are unchanged. The checks above were rerun after rebase; the live acceptance rounds were not rerun.

#### 🔗 Related Issue

Related to #19318. This fixes a reproducible false-success path. Receipt is verified for the new live test conversation; the original cloud incident's cause and its historical recipient receipt remain unverified.