### PR TITLE
🔨 chore: upgrade pnpm to 12.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -583,7 +583,7 @@
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "5.0.0"
   },
-  "packageManager": "pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457",
+  "packageManager": "pnpm@12.4.1+sha512.2e81e399d73fe8390dab25e06aa788ab7a5908248d2f5a370f82b481147a6a7a367bf8048f9a6fdb6460f21a66f0542dedb8b94ca2c8723596741920b1656d4c",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/vercel.json
+++ b/vercel.json
@@ -49,7 +49,7 @@
       ]
     }
   ],
-  "installCommand": "npx pnpm@12.3.4 install",
+  "installCommand": "npx pnpm@12.4.1 install",
   "rewrites": [
     {
       "source": "/_dangerous_local_dev_proxy",


### PR DESCRIPTION
Upgrade the package manager pin (including its published SHA-512 integrity) and the Vercel install command from pnpm 12.3.4 to 12.4.1. This fixes installs creating a project lockfile containing only package-manager dependencies despite `lockfile: false`, while preserving automatic version selection.

GitHub Actions already reads the package manager version from `package.json`.

#### Test

- [x] Tested locally
- `bun run check lobehub/package.json lobehub/vercel.json`: passed for both files.
- `git diff --check`: passed.
- In isolated projects with `packageManager` and `lockfile: false`, `pnpm install --ignore-scripts --prefer-offline` reproduced the unwanted lockfile with 12.3.4 and created none with 12.4.1.
- Repeated the isolated install with the exact new OSS `packageManager` value, including integrity: `pnpm --version` reported 12.4.1, installation exited 0, and no project lockfile was created.
- Acceptance: not applicable to this package-manager tooling update; no user-facing product behavior changes.

#### Existing CI blocker

The Vercel preview passed. Database-job type checking and app tests encounter existing imports of deleted `./workspaceHtmlArtifact` and `./workspaceHtmlPath` modules in `src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts:19-20`. Commit `81ad585522` removed the shims and `07fb752547` subsequently added the hook with the stale imports. Neither the hook nor its imports are changed here; another app shard was canceled by matrix fail-fast.

#### 🔗 Related Issue

- Fixes LOBE-14029
- [pnpm issue #14728](https://github.com/pnpm/pnpm/issues/14728)
- [pnpm PR #14753](https://github.com/pnpm/pnpm/pull/14753)
- [pnpm 12.4.1 release](https://github.com/pnpm/pnpm/releases/tag/v12.4.1)
