### PR TITLE
🐛 fix(portal): repair workspace HTML imports

### DIFF
--- a/src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts
+++ b/src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts
@@ -1,4 +1,9 @@
-import type { GatheredWorkspaceHtmlResource } from '@lobechat/html-artifact';
+import type {
+  GatheredWorkspaceHtmlResource,
+  WorkspaceHtmlArtifactPublisher,
+  WorkspaceHtmlArtifactPublishResult,
+} from '@lobechat/html-artifact';
+import { isPathInsideWorkspace } from '@lobechat/html-artifact';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import debug from 'debug';
 import { useEffect, useRef, useState } from 'react';
@@ -13,11 +18,6 @@ import {
   type WorkspaceHtmlPublishPlan,
 } from './prepareWorkspaceHtmlPublish';
 import { openWorkspaceHtmlPublishConfirm } from './PublishHtmlArtifactConfirm';
-import type {
-  WorkspaceHtmlArtifactPublisher,
-  WorkspaceHtmlArtifactPublishResult,
-} from './workspaceHtmlArtifact';
-import { isPathInsideWorkspace } from './workspaceHtmlPath';
 
 type OutsideWorkspacePlan = Extract<WorkspaceHtmlPublishPlan, { blocked: 'outside-workspace' }>;
 type ResourceSource = 'nested' | 'workspace';


### PR DESCRIPTION
The blocked workspace HTML publishing hook still imports two local re-export shims removed in #19414, causing TS2307 during type checking. Import the existing publisher types and path helper directly from `@lobechat/html-artifact`, consistent with the other Portal modules.

#### Test

- [x] Tested locally: lint, related tests and full Cloud type check.
- [x] No new tests needed: existing type checking reproduces both missing-module errors before this import-only repair.
- Acceptance: no new product run; this restores imports to the same underlying implementations without changing behavior.

#### 🔗 Related Issue

Related to #19414 and #19338.
