### PR TITLE
🐛 fix(portal): import workspace HTML helpers from the html-artifact package

### DIFF
--- a/src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts
+++ b/src/features/Portal/LocalFile/useBlockedWorkspaceHtmlPublish.ts
@@ -1,4 +1,9 @@
-import type { GatheredWorkspaceHtmlResource } from '@lobechat/html-artifact';
+import {
+  type GatheredWorkspaceHtmlResource,
+  isPathInsideWorkspace,
+  type WorkspaceHtmlArtifactPublisher,
+  type WorkspaceHtmlArtifactPublishResult,
+} from '@lobechat/html-artifact';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import debug from 'debug';
 import { useEffect, useRef, useState } from 'react';
@@ -13,11 +18,6 @@ import {
   type WorkspaceHtmlPublishPlan,
 } from './prepareWorkspaceHtmlPublish';
 import { openWorkspaceHtmlPublishConfirm } from './PublishHtmlArtifactConfirm';
-import type {
-  WorkspaceHtmlArtifactPublisher,
-  WorkspaceHtmlArtifactPublishResult,
-} from './workspaceHtmlArtifact';
-import { isPathInsideWorkspace } from './workspaceHtmlPath';
 
 type OutsideWorkspacePlan = Extract<WorkspaceHtmlPublishPlan, { blocked: 'outside-workspace' }>;
 type ResourceSource = 'nested' | 'workspace';


### PR DESCRIPTION
#19338 landed after #19414 removed the `./workspaceHtmlArtifact` and `./workspaceHtmlPath` re-export shims, so `useBlockedWorkspaceHtmlPublish.ts` on canary imports two modules that no longer exist. Canary Test CI and the Cloud Vercel type-check both fail with `TS2307` on that file.

This switches the two imports to `@lobechat/html-artifact`, matching `prepareWorkspaceHtmlPublish.ts` and `readWorkspaceAsset.ts`.

#### Test

- [x] Tested locally (`tsgo --noEmit` clean; `useBlockedWorkspaceHtmlPublish.test.ts` 6 passed)
- [x] No tests needed

- Acceptance: none needed, import path only.

#### 🔗 Related Issue

Follow-up to #19338 and #19414.

https://claude.ai/code/session_01R4DbhAz5Z9Uf2Bxk2Viz3k
