### PR TITLE
🐛 fix(tool-execution): sign Market calls with the run identity

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DiscoverService } from '@/server/services/discover';
+
 import { agentBuilderRuntime } from '../agentBuilder';
 
 const {
@@ -67,6 +69,15 @@ const createRuntime = () =>
     serverDB: {} as never,
     toolManifestMap: {},
     userId: 'user-1',
+  });
+
+const createWorkspaceRuntime = () =>
+  agentBuilderRuntime.factory({
+    editingAgentId: 'agent-1',
+    serverDB: {} as never,
+    toolManifestMap: {},
+    userId: 'user-1',
+    workspaceId: 'workspace-1',
   });
 
 describe('agentBuilderRuntime', () => {
@@ -292,6 +303,29 @@ describe('agentBuilderRuntime', () => {
       expect(result.state).toMatchObject({ agentId: 'agent-1' });
       expect(mockUpdateConfig).toHaveBeenCalledWith('agent-1', {
         plugins: [{ identifier: 'market-plugin', mode: 'pinned' }],
+      });
+    });
+  });
+
+  // Regression guard for `searchMarketTools` returning `unauthorized`: built
+  // without an identity, DiscoverService signs no trusted-client token, so every
+  // server-executed market search failed — which the model reports as a plain
+  // tool failure and silently works around, leaving the built agent with no
+  // market tool.
+  describe('market identity', () => {
+    it('passes the run identity to DiscoverService', () => {
+      createRuntime();
+
+      expect(DiscoverService).toHaveBeenCalledWith({
+        userInfo: { userId: 'user-1', workspaceId: undefined },
+      });
+    });
+
+    it('scopes the market identity to the run workspace', () => {
+      createWorkspaceRuntime();
+
+      expect(DiscoverService).toHaveBeenCalledWith({
+        userInfo: { userId: 'user-1', workspaceId: 'workspace-1' },
       });
     });
   });

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentManagement.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentManagement.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentModel } from '@/database/models/agent';
 import { PluginModel } from '@/database/models/plugin';
+import { DiscoverService } from '@/server/services/discover';
 
 import { agentManagementRuntime } from '../agentManagement';
 
@@ -421,6 +422,28 @@ describe('agentManagementRuntime', () => {
 
       expect(result.success).toBe(true);
       expect(mockUpdateConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  // Regression guard: built without an identity, DiscoverService sends no
+  // credentials at all, so every market read from this runtime failed as
+  // `unauthorized` while the client-side path — which signs a trusted-client
+  // token — kept working.
+  describe('market identity', () => {
+    it('passes the run identity to DiscoverService', () => {
+      createRuntime();
+
+      expect(DiscoverService).toHaveBeenCalledWith({
+        userInfo: { userId: 'user-1', workspaceId: undefined },
+      });
+    });
+
+    it('scopes the market identity to the run workspace', () => {
+      createWorkspaceRuntime();
+
+      expect(DiscoverService).toHaveBeenCalledWith({
+        userInfo: { userId: 'user-1', workspaceId: 'workspace-1' },
+      });
     });
   });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -1009,4 +1009,42 @@ describe('skillsRuntime', () => {
       canExecuteOnDevice: true,
     });
   });
+
+  // Regression guard for the split-sandbox bug: the sandbox session is keyed by
+  // the acting account, which is derived from the trusted-client token. Without
+  // `workspaceId` this runtime acted as the personal account while `lobe-creds`
+  // and `lobe-cloud-sandbox` (which pass it) acted as the workspace, so
+  // credentials injected for a workspace topic were invisible to every command
+  // run here.
+  it('scopes the market identity to the run workspace so sandbox calls share one session', async () => {
+    const { MarketService } = await import('@/server/services/market');
+    const { skillsRuntime } = await import('../skills');
+
+    await skillsRuntime.factory({
+      serverDB: {} as never,
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    });
+
+    expect(MarketService).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        userInfo: { userId: 'user-1', workspaceId: 'workspace-1' },
+      }),
+    );
+
+    await skillsRuntime.factory({
+      serverDB: {} as never,
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    expect(MarketService).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        userInfo: { userId: 'user-1', workspaceId: undefined },
+      }),
+    );
+  });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts
@@ -39,7 +39,17 @@ export const agentBuilderRuntime: ServerRuntimeRegistration = {
     const agentModel = new AgentModel(context.serverDB, userId, context.workspaceId);
     const pluginModel = new PluginModel(context.serverDB, userId, context.workspaceId);
     const aiInfraRepos = new AiInfraRepos(context.serverDB, userId, {}, context.workspaceId);
-    const discoverService = new DiscoverService();
+    /**
+     * Market list endpoints require an authenticated caller, and `DiscoverService`
+     * only signs a trusted-client token when it is given an identity — built
+     * without one it sends no credentials at all and every market read fails as
+     * `unauthorized`, which `searchMarketTools` surfaces as a plain tool failure
+     * the model silently works around. `workspaceId` additionally attributes the
+     * read to the workspace rather than the personal account.
+     */
+    const discoverService = new DiscoverService({
+      userInfo: { userId, workspaceId: context.workspaceId },
+    });
 
     return {
       getAvailableModels: async (

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentManagement.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentManagement.ts
@@ -41,7 +41,12 @@ export const agentManagementRuntime: ServerRuntimeRegistration = {
 
     const agentModel = new AgentModel(context.serverDB, context.userId, context.workspaceId);
     const pluginModel = new PluginModel(context.serverDB, context.userId, context.workspaceId);
-    const discoverService = new DiscoverService();
+    // Same identity requirement as the Agent Builder runtime: built without an
+    // identity, DiscoverService sends no credentials and every market read fails
+    // as `unauthorized`.
+    const discoverService = new DiscoverService({
+      userInfo: { userId: context.userId, workspaceId: context.workspaceId },
+    });
 
     return {
       callAgent: async (

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -685,9 +685,16 @@ export const skillsRuntime: ServerRuntimeRegistration = {
       context.userId,
       context.workspaceId,
     );
+    /**
+     * `workspaceId` decides which sandbox session this runtime reaches: the
+     * session is keyed by the acting account, so a token without it acts as the
+     * personal account while `lobe-creds` and `lobe-cloud-sandbox` — which do
+     * pass it — act as the workspace. Omitting it split one workspace topic
+     * across two sandboxes, leaving injected credentials invisible here.
+     */
     const marketService = new MarketService({
       accessToken: marketAccessToken,
-      userInfo: { userId: context.userId },
+      userInfo: { userId: context.userId, workspaceId: context.workspaceId },
     });
     const fileService = new FileService(context.serverDB, context.userId, context.workspaceId);
     const fileModel = new FileModel(context.serverDB, context.userId, context.workspaceId);


### PR DESCRIPTION
Three server tool runtimes built their Market client without the identity they already had in `context`. Two distinct user-visible bugs, one root cause.

#### Bug 1 — every server-executed market read fails as `unauthorized`

`agentBuilder.ts` and `agentManagement.ts` built `new DiscoverService()` with no options. `MarketService` only signs a trusted-client token when it is given an identity, so these two runtimes sent no credentials at all and Market rejected every read.

The damage is quiet rather than loud: `searchMarketTools` surfaces the rejection as an ordinary tool failure, the model works around it ("market search isn't available, I'll use the official tools instead"), and the operation still ends `done`. In the report that prompted this fix, the user asked for a Feishu sales assistant and got one with no market tool attached, with nothing on the error dashboard.

The client path was never affected — `routers/lambda/market` signs the token in its procedure — so this only ever hit server-executed operations. These were the only two of 30+ `DiscoverService` / `MarketService` construction sites without an identity.

#### Bug 2 — a workspace topic was split across two sandboxes

The sandbox session is keyed by the acting account, which is derived from the trusted-client token. `skills.ts` passed `userInfo: { userId }` without `workspaceId`, so `lobe-skills` acted as the personal account while `lobe-creds` and `lobe-cloud-sandbox` — which both pass it — acted as the workspace.

In a workspace topic that meant two separate sandboxes: `injectCredsToSandbox` reported success, but every `lobe-skills` command ran somewhere else, where `~/.creds` did not exist. Personal topics were unaffected (both sides act as the same account).

One detail that makes this hard to spot: `preprocessSandboxCommand` resolves `workspaceId` separately for the `lh` auth prelude, so `lh` commands carried the right workspace scope while the session routing did not. The line dates from #12424, which predates workspace support.

#### Key Decisions / Non-goals

- **`agentBuilder` / `agentManagement` get `userInfo` only, not a market `accessToken`.** The other runtimes read one from user settings, but that requires an `async` factory, and `groupAgentBuilder.ts` consumes `agentBuilderRuntime.factory(context)` synchronously. The trusted-client token is the credential this path authenticates with anyway, so the extra query and the `await` ripple buy nothing here.
- **Workspace topics move `lobe-skills` onto the workspace sandbox session.** Sessions already keyed to the personal account for a workspace topic are abandoned: the next call cold-starts the workspace session and does not carry over scratch files. This is the intended end state — under a workspace the sandbox belongs to the organization, not the individual — and is the reason this is a `fix` rather than a silent alignment.
- **Not de-duplicated:** four runtimes each carry their own copy of the "read the market access token from user settings" block. Left alone to keep this diff to the defect.

#### Test

- [x] Added/updated tests

Regression tests in all three runtime specs, each failing before the corresponding line changed:

- `agentBuilder.test.ts` / `agentManagement.test.ts` — `DiscoverService` receives the run identity, and the workspace run scopes it to `workspaceId`
- `skills.test.ts` — `MarketService` is signed with the run's `workspaceId`, so `lobe-skills` reaches the same sandbox session as `lobe-creds` and `lobe-cloud-sandbox`; a personal run still carries no workspace

- Acceptance: not yet run. The change is server-side and only observable against real Market with a workspace-scoped operation, so it cannot be proven from unit tests. The round to run is (1) in a workspace topic, have agent-builder call `searchMarketTools` and confirm results instead of `unauthorized`, and (2) in the same topic, `injectCredsToSandbox` then read the variable back from `lobe-skills.runCommand`.

#### 🔗 Related Issue

Fixes LOBE-14033 — https://linear.app/lobehub/issue/LOBE-14033
