### PR TITLE
💄 style(acceptance): tone the dark marks, link the timestamp, show the face

### DIFF
--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -96,6 +96,7 @@
   "acceptance.comments.commentEvidence": "Comment on a region",
   "acceptance.comments.commented": "commented {{time}}",
   "acceptance.comments.copyLink": "Copy link",
+  "acceptance.comments.copyLinkHint": "{{time}} · click to copy this comment’s link",
   "acceptance.comments.createFailed": "Failed to post the comment. Please try again.",
   "acceptance.comments.delete": "Delete",
   "acceptance.comments.deleteConfirm": "Delete this comment?",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -96,6 +96,7 @@
   "acceptance.comments.commentEvidence": "圈选评论",
   "acceptance.comments.commented": "评论于 {{time}}",
   "acceptance.comments.copyLink": "复制链接",
+  "acceptance.comments.copyLinkHint": "{{time}} · 点一下复制这条评论的链接",
   "acceptance.comments.createFailed": "评论发送失败，请重试。",
   "acceptance.comments.delete": "删除",
   "acceptance.comments.deleteConfirm": "删除这条评论？",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -242,6 +242,7 @@ export default {
   'acceptance.comments.author.former': 'Former member',
   'acceptance.comments.author.deactivated': 'Deactivated',
   'acceptance.comments.loadFailed': 'Failed to load the discussion. Please refresh.',
+  'acceptance.comments.copyLinkHint': '{{time}} · click to copy this comment’s link',
   'acceptance.comments.createFailed': 'Failed to post the comment. Please try again.',
   'acceptance.comments.deleteFailed': 'Failed to delete the comment. Please try again.',
   'acceptance.comments.updateFailed': 'Failed to update the comment. Please try again.',

--- a/src/features/Acceptance/Viewer/Checks/CheckRow.tsx
+++ b/src/features/Acceptance/Viewer/Checks/CheckRow.tsx
@@ -31,7 +31,7 @@ import { hasRenderableEvidence, readVisualizationManifest } from '../../Report/v
 import { VisualizationDeltaBadge, VisualizationRenderer } from '../../Report/VisualizationRenderer';
 import { checkDisplayTitle } from '../../utils';
 import { useOptionalAcceptanceScope } from '../AcceptanceScope';
-import { acceptanceAuthorColor } from '../Comments/authorColor';
+import { useAcceptanceAuthorColor } from '../Comments/authorColor';
 import { commentAuthorName } from '../Comments/CommentCard';
 import CommentThread from '../Comments/CommentThread';
 import { openEvidenceCommentModal } from '../Comments/EvidenceCommentModal';
@@ -153,6 +153,7 @@ export const AcceptanceCheckRow = memo<{
     const scope = useOptionalAcceptanceScope();
     const { data: bundle } = useAcceptanceBundle(scope?.acceptanceId ?? '');
     const comments = useAcceptanceComments(scope?.acceptanceId);
+    const authorColor = useAcceptanceAuthorColor();
     const viewerId = useUserStore(userProfileSelectors.userId);
     /**
      * Closing a note is a verdict on it: whoever raised it may close their own,
@@ -203,8 +204,9 @@ export const AcceptanceCheckRow = memo<{
         if (!evidenceId || !rect || deletedAt) return;
         const bucket = map.get(evidenceId) ?? [];
         bucket.push({
+          authorAvatar: author.avatar,
           authorName: commentAuthorName(author),
-          color: acceptanceAuthorColor(authorUserId),
+          color: authorColor(authorUserId),
           comment: content,
           label: index + 1,
           panel: (
@@ -222,7 +224,7 @@ export const AcceptanceCheckRow = memo<{
       });
       return map.size > 0 ? map : undefined;
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [proposalOverlays, checkThreads, comments.canComment, canResolveThread]);
+    }, [proposalOverlays, checkThreads, comments.canComment, canResolveThread, authorColor]);
     const canCommentEvidence =
       comments.canComment && Boolean(check.result) && hasAnnotatableEvidence(check);
     const openEvidenceComment = () =>

--- a/src/features/Acceptance/Viewer/Comments/CommentCard.tsx
+++ b/src/features/Acceptance/Viewer/Comments/CommentCard.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   toast,
 } from '@lobehub/ui/base-ui';
+import { cx } from 'antd-style';
 import { Link2, MoreHorizontal, Trash2 } from 'lucide-react';
 import { memo, type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -88,6 +89,16 @@ const CommentCard = memo<CommentCardProps>(
     const viewerId = useUserStore(userProfileSelectors.userId);
     const own = Boolean(viewerId) && comment.authorUserId === viewerId;
 
+    const copyAnchor = async () => {
+      try {
+        await navigator.clipboard.writeText(commentAnchorUrl(comment.id));
+        toast.success(t('acceptance.comments.linkCopied'));
+      } catch (cause) {
+        console.error('[acceptance:comments]', cause);
+        toast.error(t('acceptance.comments.updateFailed'));
+      }
+    };
+
     const menuItems: DropdownItem[] = [
       ...(anchored
         ? [
@@ -95,15 +106,7 @@ const CommentCard = memo<CommentCardProps>(
               icon: <Icon icon={Link2} />,
               key: 'copy-link',
               label: t('acceptance.comments.copyLink'),
-              onClick: async () => {
-                try {
-                  await navigator.clipboard.writeText(commentAnchorUrl(comment.id));
-                  toast.success(t('acceptance.comments.linkCopied'));
-                } catch (cause) {
-                  console.error('[acceptance:comments]', cause);
-                  toast.error(t('acceptance.comments.updateFailed'));
-                }
-              },
+              onClick: copyAnchor,
             } satisfies DropdownItem,
           ]
         : []),
@@ -165,9 +168,30 @@ const CommentCard = memo<CommentCardProps>(
           {comment.author.status !== 'active' && (
             <Tag size={'small'}>{t(`acceptance.comments.author.${comment.author.status}`)}</Tag>
           )}
-          <span className={styles.meta} title={time.title}>
-            {nameOverride ? time.text : t('acceptance.comments.commented', { time: time.text })}
-          </span>
+          {anchored ? (
+            /*
+             * The timestamp IS the permalink, the way every threaded discussion
+             * has trained people to expect: it is the one part of a remark that
+             * belongs to that remark alone. Clicking copies its address instead
+             * of navigating — the reader is already looking at it, and what they
+             * want is the link to paste somewhere else.
+             */
+            <button
+              className={cx(styles.meta, styles.timeLink)}
+              title={t('acceptance.comments.copyLinkHint', { time: time.title })}
+              type={'button'}
+              onClick={(event) => {
+                event.stopPropagation();
+                void copyAnchor();
+              }}
+            >
+              {nameOverride ? time.text : t('acceptance.comments.commented', { time: time.text })}
+            </button>
+          ) : (
+            <span className={styles.meta} title={time.title}>
+              {nameOverride ? time.text : t('acceptance.comments.commented', { time: time.text })}
+            </span>
+          )}
           {badges}
           {menuItems.length > 0 && (
             <div data-comment-actions className={styles.rowActions}>

--- a/src/features/Acceptance/Viewer/Comments/ThreadEvidence.tsx
+++ b/src/features/Acceptance/Viewer/Comments/ThreadEvidence.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { AcceptanceEvidence } from '../Checks/types';
 import { AnnotatedImage } from '../Evidence/Annotation';
-import { acceptanceAuthorColor } from './authorColor';
+import { useAcceptanceAuthorColor } from './authorColor';
 
 const THUMBNAIL_WIDTH = 220;
 
@@ -42,12 +42,13 @@ interface ThreadEvidenceProps {
  */
 const ThreadEvidence = memo<ThreadEvidenceProps>(({ comment, evidence, roundIndex, stale }) => {
   const { t } = useTranslation('verify');
+  const authorColor = useAcceptanceAuthorColor();
   if (!evidence.fileUrl || !comment.rect) return null;
 
   return (
     <Flexbox className={styles.wrapper} gap={4}>
       <AnnotatedImage
-        annotations={[{ color: acceptanceAuthorColor(comment.authorUserId), rect: comment.rect }]}
+        annotations={[{ color: authorColor(comment.authorUserId), rect: comment.rect }]}
         imageStyle={{ width: THUMBNAIL_WIDTH }}
         showComments={false}
         src={evidence.fileUrl}

--- a/src/features/Acceptance/Viewer/Comments/authorColor.test.ts
+++ b/src/features/Acceptance/Viewer/Comments/authorColor.test.ts
@@ -35,23 +35,20 @@ describe('acceptanceAuthorColor', () => {
     for (const color of ACCEPTANCE_AUTHOR_COLORS) expect(color).toMatch(/-10\)$/);
   });
 
-  // Step 10 is near-white at the dark end (#bdf7e4 for cyan) and glows over a
-  // dark screenshot; step 7 is the readable tone there.
-  it('steps down for the dark page and keeps the hues aligned', () => {
+  // Step 10 resolves to a near-white tint through the dark theme (#bdf7e4 for
+  // cyan) and glows over a dark capture; step 7 is the mid-tone at that end.
+  it('picks the step that is mid-tone at each end of the scale', () => {
     expect(ACCEPTANCE_AUTHOR_COLORS_DARK).toHaveLength(ACCEPTANCE_AUTHOR_COLORS.length);
     for (const color of ACCEPTANCE_AUTHOR_COLORS_DARK) expect(color).toMatch(/-7\)$/);
     for (const [index, light] of ACCEPTANCE_AUTHOR_COLORS.entries())
       expect(ACCEPTANCE_AUTHOR_COLORS_DARK[index]).toBe(light.replace('-10)', '-7)'));
   });
 
-  it('gives one author the same slot in both themes', () => {
-    for (const id of ['user_1', 'user_2', '文一']) {
-      const light = acceptanceAuthorColor(id);
-      const dark = acceptanceAuthorColor(id, 'dark');
-      expect(ACCEPTANCE_AUTHOR_COLORS.indexOf(light as never)).toBe(
-        ACCEPTANCE_AUTHOR_COLORS_DARK.indexOf(dark as never),
+  it('keeps one author in one slot whichever theme reads it', () => {
+    for (const id of ['user_1', 'user_2', '文一'])
+      expect(ACCEPTANCE_AUTHOR_COLORS.indexOf(acceptanceAuthorColor(id) as never)).toBe(
+        ACCEPTANCE_AUTHOR_COLORS_DARK.indexOf(acceptanceAuthorColor(id, 'dark') as never),
       );
-    }
   });
 
   it('leaves the verdict colours to verdicts', () => {

--- a/src/features/Acceptance/Viewer/Comments/authorColor.test.ts
+++ b/src/features/Acceptance/Viewer/Comments/authorColor.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { ACCEPTANCE_AUTHOR_COLORS, acceptanceAuthorColor } from './authorColor';
+import {
+  ACCEPTANCE_AUTHOR_COLORS,
+  ACCEPTANCE_AUTHOR_COLORS_DARK,
+  acceptanceAuthorColor,
+} from './authorColor';
 
 describe('acceptanceAuthorColor', () => {
   it('is stable for one author and independent of call order', () => {
@@ -29,6 +33,25 @@ describe('acceptanceAuthorColor', () => {
   // #95f3d9, and a 2px box in that colour on a white screenshot cannot be seen.
   it('uses the scale step that stays legible on the page', () => {
     for (const color of ACCEPTANCE_AUTHOR_COLORS) expect(color).toMatch(/-10\)$/);
+  });
+
+  // Step 10 is near-white at the dark end (#bdf7e4 for cyan) and glows over a
+  // dark screenshot; step 7 is the readable tone there.
+  it('steps down for the dark page and keeps the hues aligned', () => {
+    expect(ACCEPTANCE_AUTHOR_COLORS_DARK).toHaveLength(ACCEPTANCE_AUTHOR_COLORS.length);
+    for (const color of ACCEPTANCE_AUTHOR_COLORS_DARK) expect(color).toMatch(/-7\)$/);
+    for (const [index, light] of ACCEPTANCE_AUTHOR_COLORS.entries())
+      expect(ACCEPTANCE_AUTHOR_COLORS_DARK[index]).toBe(light.replace('-10)', '-7)'));
+  });
+
+  it('gives one author the same slot in both themes', () => {
+    for (const id of ['user_1', 'user_2', '文一']) {
+      const light = acceptanceAuthorColor(id);
+      const dark = acceptanceAuthorColor(id, 'dark');
+      expect(ACCEPTANCE_AUTHOR_COLORS.indexOf(light as never)).toBe(
+        ACCEPTANCE_AUTHOR_COLORS_DARK.indexOf(dark as never),
+      );
+    }
   });
 
   it('leaves the verdict colours to verdicts', () => {

--- a/src/features/Acceptance/Viewer/Comments/authorColor.ts
+++ b/src/features/Acceptance/Viewer/Comments/authorColor.ts
@@ -7,16 +7,19 @@ import { useCallback } from 'react';
  * author gets a stable hue from the design system's preset scale, so the box on
  * the image, the ring on their avatar and the marker badge always agree.
  *
- * Theme tokens rather than raw hexes, and a different STEP per theme. The
- * scale's steps are not symmetrical: step 10 is the solid, readable tone on a
- * light page (cyan lands near #2fa28a) but a near-white tint on a dark one
- * (#bdf7e4), which glows over a dark screenshot. Step 7 is the solid tone at
- * the dark end (#55bca4). Picking per theme is what keeps one mark equally
- * legible and equally quiet in both.
+ * Two separate problems meet on this box, and each has its own answer.
  *
- * The semantic hues are deliberately absent: `volcano` is `colorError` and
- * `green` is `colorSuccess`, and a person's box wearing either would read as a
- * verdict on the evidence rather than as an author.
+ * The token resolves per theme, and the same step is not the same tone on both
+ * ends: step 10 is the mid-tone solid in light (#2fa28a for cyan) but a
+ * near-white tint in dark (#bdf7e4). Reading one step in both themes therefore
+ * hands the dark page a glowing mark, so the step is picked per theme — 10 in
+ * light, 7 in dark — to land on the mid-tone either way.
+ *
+ * That still says nothing about whether the mark is legible, because it does
+ * not sit on the page: it sits on the evidence IMAGE, which can be a white
+ * report or a dark IDE capture no matter which theme the reader is in. No hue
+ * survives both, so the box carries its own two-sided halo (see `rect`) and the
+ * hue is left to say who, not to carry contrast.
  */
 export const ACCEPTANCE_AUTHOR_COLORS = [
   cssVar.geekblue10,
@@ -29,7 +32,7 @@ export const ACCEPTANCE_AUTHOR_COLORS = [
   cssVar.blue10,
 ] as const;
 
-/** Same hues, one step in from the light end — the dark page's readable tone. */
+/** The same hues at the step that is mid-tone on the dark end of the scale. */
 export const ACCEPTANCE_AUTHOR_COLORS_DARK = [
   cssVar.geekblue7,
   cssVar.magenta7,
@@ -41,7 +44,7 @@ export const ACCEPTANCE_AUTHOR_COLORS_DARK = [
   cssVar.blue7,
 ] as const;
 
-/** Deterministic, order-independent: the same author keeps their colour across rounds and reloads. */
+/** Deterministic, order-independent: the same author keeps their slot across rounds and reloads. */
 const authorSlot = (authorUserId?: string | null): number => {
   if (!authorUserId) return 0;
   let hash = 0;

--- a/src/features/Acceptance/Viewer/Comments/authorColor.ts
+++ b/src/features/Acceptance/Viewer/Comments/authorColor.ts
@@ -1,4 +1,5 @@
-import { cssVar } from 'antd-style';
+import { cssVar, useThemeMode } from 'antd-style';
+import { useCallback } from 'react';
 
 /**
  * Marks drawn on evidence need to say WHO drew them at a glance: two reviewers
@@ -6,16 +7,16 @@ import { cssVar } from 'antd-style';
  * author gets a stable hue from the design system's preset scale, so the box on
  * the image, the ring on their avatar and the marker badge always agree.
  *
- * Theme tokens rather than raw hexes, so the marks follow light/dark like every
- * other surface. The semantic hues are deliberately absent: `volcano` is
- * `colorError` and `green` is `colorSuccess`, and a person's box wearing either
- * would read as a verdict on the evidence rather than as an author.
+ * Theme tokens rather than raw hexes, and a different STEP per theme. The
+ * scale's steps are not symmetrical: step 10 is the solid, readable tone on a
+ * light page (cyan lands near #2fa28a) but a near-white tint on a dark one
+ * (#bdf7e4), which glows over a dark screenshot. Step 7 is the solid tone at
+ * the dark end (#55bca4). Picking per theme is what keeps one mark equally
+ * legible and equally quiet in both.
  *
- * Step 10, not the bare hue. The bare token is the scale's tint step, which in
- * light mode lands somewhere around #95f3d9 for cyan — a 2px box in that colour
- * on a white screenshot is invisible, and a mark nobody can see is a mark
- * nobody answers. Step 10 is the scale's solid step: legible on the page in
- * light mode, and a light tint of the same hue in dark mode.
+ * The semantic hues are deliberately absent: `volcano` is `colorError` and
+ * `green` is `colorSuccess`, and a person's box wearing either would read as a
+ * verdict on the evidence rather than as an author.
  */
 export const ACCEPTANCE_AUTHOR_COLORS = [
   cssVar.geekblue10,
@@ -28,12 +29,42 @@ export const ACCEPTANCE_AUTHOR_COLORS = [
   cssVar.blue10,
 ] as const;
 
+/** Same hues, one step in from the light end — the dark page's readable tone. */
+export const ACCEPTANCE_AUTHOR_COLORS_DARK = [
+  cssVar.geekblue7,
+  cssVar.magenta7,
+  cssVar.gold7,
+  cssVar.cyan7,
+  cssVar.purple7,
+  cssVar.lime7,
+  cssVar.orange7,
+  cssVar.blue7,
+] as const;
+
 /** Deterministic, order-independent: the same author keeps their colour across rounds and reloads. */
-export const acceptanceAuthorColor = (authorUserId?: string | null): string => {
-  if (!authorUserId) return ACCEPTANCE_AUTHOR_COLORS[0];
+const authorSlot = (authorUserId?: string | null): number => {
+  if (!authorUserId) return 0;
   let hash = 0;
   for (let index = 0; index < authorUserId.length; index++) {
     hash = (hash * 31 + authorUserId.codePointAt(index)!) >>> 0;
   }
-  return ACCEPTANCE_AUTHOR_COLORS[hash % ACCEPTANCE_AUTHOR_COLORS.length];
+  return hash % ACCEPTANCE_AUTHOR_COLORS.length;
+};
+
+export const acceptanceAuthorColor = (
+  authorUserId?: string | null,
+  appearance: 'dark' | 'light' = 'light',
+): string =>
+  (appearance === 'dark' ? ACCEPTANCE_AUTHOR_COLORS_DARK : ACCEPTANCE_AUTHOR_COLORS)[
+    authorSlot(authorUserId)
+  ];
+
+/** The same mapping, bound to the theme the reader is actually looking at. */
+export const useAcceptanceAuthorColor = () => {
+  const { isDarkMode } = useThemeMode();
+  return useCallback(
+    (authorUserId?: string | null) =>
+      acceptanceAuthorColor(authorUserId, isDarkMode ? 'dark' : 'light'),
+    [isDarkMode],
+  );
 };

--- a/src/features/Acceptance/Viewer/Comments/styles.ts
+++ b/src/features/Acceptance/Viewer/Comments/styles.ts
@@ -141,6 +141,22 @@ export const styles = createStaticStyles(({ css }) => ({
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
   `,
+  /** The timestamp doubles as the permalink: quiet until you reach for it. */
+  timeLink: css`
+    cursor: pointer;
+
+    padding: 0;
+    border: none;
+
+    background: none;
+
+    transition: color ${cssVar.motionDurationFast};
+
+    &:hover {
+      color: ${cssVar.colorText};
+      text-decoration: underline;
+    }
+  `,
   panelBody: css`
     padding-block-start: 6px;
 

--- a/src/features/Acceptance/Viewer/Evidence/Annotation.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/Annotation.tsx
@@ -107,7 +107,16 @@ const styles = createStaticStyles(({ css }) => ({
     position: absolute;
     border: 2px solid ${cssVar.colorError};
     border-radius: 4px;
-    box-shadow: 0 0 0 1px ${cssVar.colorFillSecondary};
+
+    /*
+     * Two rings instead of one: the dark outside separates the box from a white
+     * screenshot, the light inside separates it from a dark one. The evidence
+     * image can be either, and neither the hue nor the reader's theme can tell
+     * us which — so the box carries its own contrast.
+     */
+    box-shadow:
+      0 0 0 1px rgb(0 0 0 / 45%),
+      inset 0 0 0 1px rgb(255 255 255 / 45%);
   `,
   resizeHandle: css`
     cursor: nwse-resize;

--- a/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
@@ -218,7 +218,15 @@ const styles = createStaticStyles(({ css }) => ({
     border: 2px solid ${cssVar.colorError};
     border-radius: ${cssVar.borderRadiusXS};
 
-    box-shadow: 0 0 0 1px ${cssVar.colorFillSecondary};
+    /*
+     * Two rings instead of one: the dark outside separates the box from a white
+     * screenshot, the light inside separates it from a dark one. The evidence
+     * image can be either, and neither the hue nor the reader's theme can tell
+     * us which — so the box carries its own contrast.
+     */
+    box-shadow:
+      0 0 0 1px rgb(0 0 0 / 45%),
+      inset 0 0 0 1px rgb(255 255 255 / 45%);
   `,
   swatch: css`
     flex: none;

--- a/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
@@ -155,6 +155,18 @@ const styles = createStaticStyles(({ css }) => ({
       inset-inline: calc(100% + 12px) auto;
     }
   `,
+  /** The avatar fills the pin; the pin's own colour stays visible as its rim. */
+  pinFace: css`
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    object-fit: cover;
+  `,
+  pinInitial: css`
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+  `,
   /** Positioning context for the floating note; the frame itself clips. */
   stage: css`
     position: relative;
@@ -226,7 +238,15 @@ const OverlayRect = memo<OverlayRectProps>(
             type={'button'}
             onClick={() => onToggle(index)}
           >
-            <Icon icon={annotation.resolved ? Check : MessageSquare} size={10} />
+            {annotation.resolved ? (
+              <Icon icon={Check} size={10} />
+            ) : (
+              <AnnotationFace
+                name={annotation.authorName}
+                size={14}
+                src={annotation.authorAvatar}
+              />
+            )}
           </button>
         )}
       </div>
@@ -235,6 +255,35 @@ const OverlayRect = memo<OverlayRectProps>(
 );
 
 OverlayRect.displayName = 'AcceptanceOverlayRect';
+
+/**
+ * The author inside a pin. An avatar when we have one, their initial when we
+ * do not, and the speech bubble only when the author is unknown — a pin with
+ * no face is indistinguishable from the next pin along.
+ */
+const AnnotationFace = memo<{ name?: string; size?: number; src?: string | null }>(
+  ({ name, size = 18, src }) => {
+    if (src)
+      return (
+        <img
+          alt={name ?? ''}
+          className={styles.pinFace}
+          src={src}
+          style={{ height: size, width: size }}
+        />
+      );
+    const initial = name?.trim().slice(0, 1);
+    if (initial)
+      return (
+        <span className={styles.pinInitial} style={{ fontSize: size < 16 ? 9 : 11 }}>
+          {initial.toUpperCase()}
+        </span>
+      );
+    return <Icon icon={MessageSquare} size={size < 16 ? 10 : 12} />;
+  },
+);
+
+AnnotationFace.displayName = 'AcceptanceAnnotationFace';
 
 interface ScreenshotTilesProps {
   alt: string;
@@ -311,7 +360,11 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
             }}
             onClick={() => toggleNote(index)}
           >
-            <Icon icon={annotation.resolved ? Check : MessageSquare} size={12} />
+            {annotation.resolved ? (
+              <Icon icon={Check} size={12} />
+            ) : (
+              <AnnotationFace name={annotation.authorName} src={annotation.authorAvatar} />
+            )}
           </button>
         ) : null,
       );

--- a/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
@@ -3,8 +3,9 @@
 import { Flexbox, Icon, Image } from '@lobehub/ui';
 import { Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { Check, MessageSquare } from 'lucide-react';
+import { Check, MessageSquare, X } from 'lucide-react';
 import { memo, type ReactNode, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { EvidenceOverlay } from './overlay';
 import {
@@ -104,6 +105,9 @@ const styles = createStaticStyles(({ css }) => ({
     width: min(280px, 76%);
     padding: 12px;
 
+    /* Room for the close control, so it never lands on the author's name. */
+    padding-inline-end: 32px;
+
     /* No frame: an elevated surface is the whole affordance, the way Figma's
        comments read. A 1px box around content that already sits in a box is
        what made the earlier rounds look like wireframes. */
@@ -117,6 +121,35 @@ const styles = createStaticStyles(({ css }) => ({
     @media (width >= 1440px) {
       inset-inline: calc(100% + 12px) auto;
       width: 240px;
+    }
+  `,
+  /** Sits in the gutter the note reserves for it, clear of the panel's text. */
+  noteClose: css`
+    cursor: pointer;
+
+    position: absolute;
+    inset-block-start: 8px;
+    inset-inline-end: 8px;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    border-radius: ${cssVar.borderRadius};
+
+    color: ${cssVar.colorTextTertiary};
+
+    background: none;
+
+    transition: all ${cssVar.motionDurationFast};
+
+    &:hover {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillTertiary};
     }
   `,
   noteFallbackHead: css`
@@ -298,6 +331,7 @@ interface ScreenshotTilesProps {
 
 export const ScreenshotTiles = memo<ScreenshotTilesProps>(
   ({ alt, annotations, caption, fileHeight, fileWidth, flat = false, src }) => {
+    const { t } = useTranslation('verify');
     const [natural, setNatural] = useState(
       fileWidth && fileHeight ? { height: fileHeight, width: fileWidth } : undefined,
     );
@@ -325,6 +359,20 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
         className={styles.note}
         style={{ insetBlockStart: `${Math.min(Math.max(opened.rect.y, 0), 0.62) * 100}%` }}
       >
+        {/*
+         * Opening a note hides every pin, including the one that opened it, so
+         * without this the only way back is the small marker on the box itself
+         * — findable if you know it is there, and nowhere near where the reader
+         * is looking.
+         */}
+        <button
+          className={styles.noteClose}
+          title={t('acceptance.comments.collapseThread')}
+          type={'button'}
+          onClick={() => setOpenedNote(undefined)}
+        >
+          <Icon icon={X} size={12} />
+        </button>
         {opened.panel ?? (
           <Flexbox gap={4}>
             <Flexbox horizontal align={'center'} className={styles.noteFallbackHead} gap={6}>

--- a/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
+++ b/src/features/Acceptance/Viewer/Evidence/ScreenshotTiles.tsx
@@ -63,14 +63,16 @@ const styles = createStaticStyles(({ css }) => ({
     inset-inline-end: -10px;
 
     display: inline-flex;
-    gap: 2px;
     align-items: center;
     justify-content: center;
 
-    padding-block: 2px;
-    padding-inline: 5px;
+    /* A circle, not a pill: the face inside is round, and a rounded rectangle
+       hugging it reads as a squashed oval. Same 18px as the numbered badge on
+       the opposite corner, so the two corners of one box match. */
+    width: 18px;
+    height: 18px;
     border: none;
-    border-radius: 999px;
+    border-radius: 50%;
 
     font-size: 10px;
     font-weight: 600;

--- a/src/features/Acceptance/Viewer/Evidence/overlay.ts
+++ b/src/features/Acceptance/Viewer/Evidence/overlay.ts
@@ -9,6 +9,13 @@ import type { ReactNode } from 'react';
  * screenshot tellable apart; `comment` is what the marker reveals when clicked.
  */
 export interface EvidenceOverlay {
+  /**
+   * The author's face for the pin. A mark on a screenshot is somebody's
+   * remark, and a row of identical speech bubbles says only "there are
+   * remarks" — the face says who is waiting for an answer, the way Figma's
+   * comment pins do.
+   */
+  authorAvatar?: string | null;
   /** Rendered next to the note when the marker is opened. */
   authorName?: string;
   /** Author colour — border, badge and marker share it. Falls back to the error red. */


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] style

## 🔀 变更说明 | Description of Change

Three notes from reading the acceptance page in the dark.

**A mark has to survive the screenshot it is drawn on.** Two separate things went wrong here. The palette step resolves differently per theme — step 10 is the mid-tone solid in light (#2fa28a for cyan) but a near-white tint in dark (#bdf7e4), which glows over a dark capture — so the step is now picked per theme. That alone was not enough: the mark sits on the evidence image, whose brightness has nothing to do with the reader's theme, and a mid-tone purple on a dark capture in light mode all but disappears. The box now also carries a two-sided halo, a dark ring outside and a light ring inside, so its edge reads on a white report and a dark capture alike.

**A comment's timestamp is now its permalink.** It is the one part of a remark that belongs to that remark alone, and every threaded discussion has trained people to reach for it. Underlined on hover; a click copies the address rather than navigating, since the reader is already looking at it. The menu item stays for pointerless surfaces.

**A pin carries the author's face.** It carried the same speech bubble for everyone, which says only "there are remarks here". Now it shows the author's avatar, their initial when there is no avatar, and the bubble only when the author is unknown — what Figma's comment pins do, and what lets three people circling one screenshot be told apart without opening anything. A settled thread keeps its tick.

**An opened note can be closed.** Opening one hides every pin in the margin, including the one that opened it, so the only way back was the small marker on the box. It now carries a close control in the corner, with the room reserved for it.

## 📝 补充信息 | Additional Information

Stacked on #19448 (`fix/acceptance-comment-hardening`); merge that one first. The palette test now pins both ramps and asserts one author keeps the same slot in either theme.

## ✅ 验收 | Acceptance

暗色那条是同环境 A/B：临时改回旧色档取一张，还原后再取一张，两次都读描边的计算色值，不靠肉眼判断。三轮：r1 3 项、r2 4 项、r3 按评审意见把配色那项换成「任何截图上都读得清」重做，各轮全过：

https://app.lobehub.com/acceptance/bf50db96-4575-4b0d-9fbf-56afeb932c09

🤖 Generated with [Claude Code](https://claude.com/claude-code)
