### PR TITLE
🐛 fix(theme): compose ConfigProvider outside ThemeProvider in every shell

### DIFF
--- a/apps/share/src/shell/ShareTheme.tsx
+++ b/apps/share/src/shell/ShareTheme.tsx
@@ -18,20 +18,20 @@ const ShareTheme = memo<PropsWithChildren>(({ children }) => {
   const appearance = isDark ? 'dark' : 'light';
 
   return (
-    <ThemeProvider
-      appearance={appearance}
-      className={'share-layout'}
-      defaultAppearance={appearance}
-      defaultThemeMode={appearance}
-      style={{ height: '100%', minHeight: '100dvh', width: '100%' }}
-      theme={{ cssVar: { key: 'lobe-vars' } }}
-    >
-      <App style={{ height: '100%' }}>
-        <ConfigProvider config={{ aAs: Link, imgAs: Image, imgUnoptimized: true }} motion={m}>
+    <ConfigProvider config={{ aAs: Link, imgAs: Image, imgUnoptimized: true }} motion={m}>
+      <ThemeProvider
+        appearance={appearance}
+        className={'share-layout'}
+        defaultAppearance={appearance}
+        defaultThemeMode={appearance}
+        style={{ height: '100%', minHeight: '100dvh', width: '100%' }}
+        theme={{ cssVar: { key: 'lobe-vars' } }}
+      >
+        <App style={{ height: '100%' }}>
           <LazyMotion features={domMax}>{children}</LazyMotion>
-        </ConfigProvider>
-      </App>
-    </ThemeProvider>
+        </App>
+      </ThemeProvider>
+    </ConfigProvider>
   );
 });
 

--- a/apps/workbench/src/shell/WorkbenchTheme.tsx
+++ b/apps/workbench/src/shell/WorkbenchTheme.tsx
@@ -18,20 +18,20 @@ const WorkbenchTheme = memo<PropsWithChildren>(({ children }) => {
   const appearance = isDark ? 'dark' : 'light';
 
   return (
-    <ThemeProvider
-      appearance={appearance}
-      className={'workbench-layout'}
-      defaultAppearance={appearance}
-      defaultThemeMode={appearance}
-      style={{ height: '100%', minHeight: '100dvh', width: '100%' }}
-      theme={{ cssVar: { key: 'lobe-vars' } }}
-    >
-      <App style={{ height: '100%' }}>
-        <ConfigProvider config={{ aAs: Link, imgAs: Image, imgUnoptimized: true }} motion={m}>
+    <ConfigProvider config={{ aAs: Link, imgAs: Image, imgUnoptimized: true }} motion={m}>
+      <ThemeProvider
+        appearance={appearance}
+        className={'workbench-layout'}
+        defaultAppearance={appearance}
+        defaultThemeMode={appearance}
+        style={{ height: '100%', minHeight: '100dvh', width: '100%' }}
+        theme={{ cssVar: { key: 'lobe-vars' } }}
+      >
+        <App style={{ height: '100%' }}>
           <LazyMotion features={domMax}>{children}</LazyMotion>
-        </ConfigProvider>
-      </App>
-    </ThemeProvider>
+        </App>
+      </ThemeProvider>
+    </ConfigProvider>
   );
 });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,13 @@ const performanceRestrictedImportPaths = [
   },
   {
     allowTypeImports: true,
+    importNames: ['motion'],
+    message:
+      'The app runs under <LazyMotion features={domMax}>; `motion` bundles every feature again. Use `m` from "motion/react" (or "motion/react-m").',
+    name: 'motion/react',
+  },
+  {
+    allowTypeImports: true,
     message:
       'Do not import the model-bank root barrel; it re-exports the full aiModels catalog (1.4 MB raw). Use a subpath such as "model-bank/aiModel", "model-bank/modelProvider", "model-bank/standardParameters" or "model-bank/utils".',
     name: 'model-bank',

--- a/src/features/AuthShell/AuthThemeLite.tsx
+++ b/src/features/AuthShell/AuthThemeLite.tsx
@@ -23,31 +23,31 @@ const AuthThemeLite = memo<AuthThemeLiteProps>(({ children, globalCDN }) => {
   const currentAppearance = isDark ? 'dark' : 'light';
 
   return (
-    <ThemeProvider
-      appearance={currentAppearance}
-      className={'auth-layout'}
-      defaultAppearance={currentAppearance}
-      defaultThemeMode={currentAppearance}
-      style={{ height: '100%' }}
-      theme={{
-        cssVar: { key: 'lobe-vars' },
+    <ConfigProvider
+      motion={m}
+      config={{
+        aAs: Link,
+        imgAs: Image,
+        imgUnoptimized: true,
+        proxy: globalCDN ? 'unpkg' : undefined,
       }}
     >
-      <App style={{ height: '100%' }}>
-        <ConfigProvider
-          motion={m}
-          config={{
-            aAs: Link,
-            imgAs: Image,
-            imgUnoptimized: true,
-            proxy: globalCDN ? 'unpkg' : undefined,
-          }}
-        >
+      <ThemeProvider
+        appearance={currentAppearance}
+        className={'auth-layout'}
+        defaultAppearance={currentAppearance}
+        defaultThemeMode={currentAppearance}
+        style={{ height: '100%' }}
+        theme={{
+          cssVar: { key: 'lobe-vars' },
+        }}
+      >
+        <App style={{ height: '100%' }}>
           <LazyMotion features={domMax}>{children}</LazyMotion>
           <ToastHost />
-        </ConfigProvider>
-      </App>
-    </ThemeProvider>
+        </App>
+      </ThemeProvider>
+    </ConfigProvider>
   );
 });
 

--- a/src/features/Billboard/Carousel.tsx
+++ b/src/features/Billboard/Carousel.tsx
@@ -5,7 +5,7 @@ import { ActionIcon, Button } from '@lobehub/ui/base-ui';
 import { Carousel as AntCarousel } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { X } from 'lucide-react';
-import { motion } from 'motion/react';
+import { m } from 'motion/react';
 import {
   type ComponentRef,
   memo,
@@ -283,7 +283,7 @@ const BillboardCarousel = memo<BillboardCarouselProps>(
     const cardDataProps = cardAttr ? { [cardAttr]: '' } : {};
 
     return (
-      <motion.div
+      <m.div
         {...cardDataProps}
         className={styles.card}
         initial={{ opacity: 0, scale: 0.92, y: 16 }}
@@ -339,7 +339,7 @@ const BillboardCarousel = memo<BillboardCarouselProps>(
             </Flexbox>
           </>
         )}
-      </motion.div>
+      </m.div>
     );
   },
 );

--- a/src/layout/GlobalProvider/AppTheme.tsx
+++ b/src/layout/GlobalProvider/AppTheme.tsx
@@ -158,41 +158,41 @@ const AppTheme = memo<AppThemeProps>(
     const currentAppearence = isDark ? 'dark' : 'light';
 
     return (
-      <ThemeProvider
-        appearance={currentAppearence}
-        className={cx(styles.app, styles.scrollbar, styles.scrollbarPolyfill)}
-        defaultAppearance={currentAppearence}
-        defaultThemeMode={currentAppearence}
-        customTheme={{
-          neutralColor: neutralColor ?? defaultNeutralColor,
-          primaryColor: primaryColor ?? defaultPrimaryColor,
-        }}
-        theme={{
-          cssVar: { key: 'lobe-vars' },
-          token: {
-            fontFamily,
-            fontFamilyCode,
-            motion: animationMode !== 'disabled',
-            motionUnit: animationMode === 'agile' ? 0.05 : 0.1,
-          },
+      <ConfigProvider
+        locale={uiLocale}
+        motion={m}
+        resources={uiResources}
+        config={{
+          aAs: Link,
+          imgAs: Image,
+          imgUnoptimized: true,
+          proxy: globalCDN ? 'unpkg' : undefined,
         }}
       >
-        {!!customFontURL && <FontLoader url={customFontURL} />}
-        <GlobalStyle />
-        <ConfigProvider
-          locale={uiLocale}
-          motion={m}
-          resources={uiResources}
-          config={{
-            aAs: Link,
-            imgAs: Image,
-            imgUnoptimized: true,
-            proxy: globalCDN ? 'unpkg' : undefined,
+        <ThemeProvider
+          appearance={currentAppearence}
+          className={cx(styles.app, styles.scrollbar, styles.scrollbarPolyfill)}
+          defaultAppearance={currentAppearence}
+          defaultThemeMode={currentAppearence}
+          customTheme={{
+            neutralColor: neutralColor ?? defaultNeutralColor,
+            primaryColor: primaryColor ?? defaultPrimaryColor,
+          }}
+          theme={{
+            cssVar: { key: 'lobe-vars' },
+            token: {
+              fontFamily,
+              fontFamilyCode,
+              motion: animationMode !== 'disabled',
+              motionUnit: animationMode === 'agile' ? 0.05 : 0.1,
+            },
           }}
         >
+          {!!customFontURL && <FontLoader url={customFontURL} />}
+          <GlobalStyle />
           {children}
-        </ConfigProvider>
-      </ThemeProvider>
+        </ThemeProvider>
+      </ConfigProvider>
     );
   },
 );

--- a/src/utils/router.tsx
+++ b/src/utils/router.tsx
@@ -152,16 +152,16 @@ export const ErrorBoundary = ({ resetPath }: ErrorBoundaryProps) => {
   }
 
   return (
-    <ThemeProvider
-      appearance={appearance}
-      defaultAppearance={appearance}
-      defaultThemeMode={appearance}
-      theme={{ cssVar: { key: 'lobe-vars' } }}
-    >
-      <ConfigProvider motion={m}>
+    <ConfigProvider motion={m}>
+      <ThemeProvider
+        appearance={appearance}
+        defaultAppearance={appearance}
+        defaultThemeMode={appearance}
+        theme={{ cssVar: { key: 'lobe-vars' } }}
+      >
         <ErrorCapture error={error} resetPath={resetPath} />
-      </ConfigProvider>
-    </ThemeProvider>
+      </ThemeProvider>
+    </ConfigProvider>
   );
 };
 


### PR DESCRIPTION
Inserting an image into the chat input while the workspace is over its storage quota crashed the whole renderer.

The cloud `handleFileUploadError` shows `notification.error({ actions: <Button /> })` using `@lobehub/ui/base-ui` Button. antd `App` — which hosts the static `notification` / `modal` holders — is rendered by lobe-ui `ThemeProvider`. Every one of our theme shells composed lobe-ui `ConfigProvider` (motion / i18n / CDN contexts) *inside* `ThemeProvider`, so the Button's `useMotionComponent()` threw `Please wrap your app with <ConfigProvider> (or <MotionProvider>)`. The throw unmounted the editor, and the trailing debounced onChange then hit a null kernel (`Cannot read properties of null (reading 'getEditorState')`).

The intended composition is `ConfigProvider > ThemeProvider` — lobe-ui's demos and docs site do this, and `ThemeProvider` itself reads `useCdnFn()` from `ConfigContext` for its webfont URLs. We had it inverted, which also meant `globalCDN → proxy: 'unpkg'` never reached the webfont loader. Upstream docs now state the order explicitly: lobehub/lobe-ui#654.

**Fix**: flip the order in every mount — `AppTheme`, `AuthThemeLite`, `WorkbenchTheme`, `ShareTheme` and the route `ErrorBoundary` in `src/utils/router.tsx`. No new providers.

**LazyMotion convention**: the SPA already mounts `<LazyMotion features={domMax}>`, so importing `motion` from `motion/react` re-bundles every feature. `Billboard/Carousel.tsx` was the only offender (→ `m`), and `no-restricted-imports` now blocks `motion` in `src/**` with a pointer to `m`.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

No regression test: in vitest `@lobehub/ui` is prebundled with its own antd copy, so the app's `App.useApp()` never reaches the `ThemeProvider` holder, and `MotionProvider` is stubbed there — the failing path cannot be exercised in unit tests.

- Acceptance: pending — reproduce the over-quota image upload in the desktop app; expect the error notification with two buttons and no crash.

#### 🔗 Related Issue

Supersedes #19450. Related to #19453 (same upload-error flow).

https://claude.ai/code/session_019rSFnGHUE9kq3LMCUxugzR