### PR TITLE
✨ feat(desktop): pilot Sparkle delta updates on the macOS canary channel

### DIFF
--- a/.github/actions/desktop-publish-sparkle/action.yml
+++ b/.github/actions/desktop-publish-sparkle/action.yml
@@ -1,0 +1,154 @@
+name: Desktop Publish Sparkle Appcast
+description: Generate, sign and upload the macOS Sparkle appcast and delta patches for a published release
+
+inputs:
+  channel:
+    description: 'Update channel (canary)'
+    required: true
+  version:
+    description: 'Release version (e.g., 2.1.29-canary.1)'
+    required: true
+  server-url:
+    description: 'Public update server base URL (UPDATE_SERVER_URL)'
+    required: true
+  ed-private-key:
+    description: 'Sparkle EdDSA private key value; empty skips publishing'
+    required: false
+    default: ''
+  release-notes:
+    description: 'Markdown release notes embedded into the appcast item'
+    required: false
+    default: ''
+  delta-bases:
+    description: 'Previous releases to generate direct delta patches from'
+    required: false
+    default: '1'
+  delta-history:
+    description: 'Previous releases kept in the appcast for delta chains (0-32)'
+    required: false
+    default: '6'
+  sparkle-version:
+    description: 'Sparkle release providing generate_appcast and sign_update'
+    required: false
+    default: '2.9.4'
+  sparkle-sha256:
+    description: 'Expected sha256 of the Sparkle release tarball'
+    required: false
+    default: 'ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9'
+  aws-access-key-id:
+    description: 'AWS access key ID'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS secret access key'
+    required: true
+  s3-bucket:
+    description: 'S3 bucket name'
+    required: true
+  s3-region:
+    description: 'S3 region'
+    required: false
+    default: 'us-east-1'
+  s3-endpoint:
+    description: 'Custom S3 endpoint (for R2/MinIO etc.)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Check Sparkle publishing is configured
+      id: gate
+      shell: bash
+      env:
+        ED_PRIVATE_KEY: ${{ inputs.ed-private-key }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        SERVER_URL: ${{ inputs.server-url }}
+      run: |
+        if [ -z "$ED_PRIVATE_KEY" ] || [ -z "$S3_BUCKET" ] || [ -z "$SERVER_URL" ]; then
+          echo "⏭️ Sparkle publishing skipped: SPARKLE_ED_PRIVATE_KEY, S3 bucket or UPDATE_SERVER_URL not configured"
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Download merged artifacts
+      if: steps.gate.outputs.enabled == 'true'
+      uses: actions/download-artifact@v7
+      with:
+        name: merged-release
+        path: release
+
+    - name: Fetch Sparkle tools
+      if: steps.gate.outputs.enabled == 'true'
+      shell: bash
+      env:
+        SPARKLE_VERSION: ${{ inputs.sparkle-version }}
+        SPARKLE_TARBALL_SHA256: ${{ inputs.sparkle-sha256 }}
+      run: |
+        set -euo pipefail
+        TOOLS_DIR="$RUNNER_TEMP/sparkle-tools"
+        TARBALL="$RUNNER_TEMP/sparkle.tar.xz"
+        curl -sSL --retry 3 -o "$TARBALL" \
+          "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+        echo "${SPARKLE_TARBALL_SHA256}  $TARBALL" | shasum -a 256 -c -
+        mkdir -p "$TOOLS_DIR"
+        tar -xf "$TARBALL" -C "$TOOLS_DIR" bin/
+        chmod +x "$TOOLS_DIR"/bin/*
+        echo "SPARKLE_BIN=$TOOLS_DIR/bin" >> "$GITHUB_ENV"
+
+    - name: Fetch appcast history tooling from electron-sparkle-updater
+      if: steps.gate.outputs.enabled == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        SPEC=$(node -p "require('./apps/desktop/package.json').dependencies['electron-sparkle-updater']")
+        PKG_DIR="$RUNNER_TEMP/electron-sparkle-updater"
+        mkdir -p "$PKG_DIR"
+        cd "$PKG_DIR"
+        TARBALL=$(npm pack "electron-sparkle-updater@${SPEC}" --silent)
+        tar -xzf "$TARBALL" package/native/scripts/appcast-history.py
+        echo "SPARKLE_HISTORY_SCRIPT=$PKG_DIR/package/native/scripts/appcast-history.py" >> "$GITHUB_ENV"
+
+    - name: Generate, sign and upload appcasts (EdDSA key lives only on a RAM disk)
+      if: steps.gate.outputs.enabled == 'true'
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_REGION: ${{ inputs.s3-region }}
+        SPARKLE_ED_PRIVATE_KEY: ${{ inputs.ed-private-key }}
+        RELEASE_NOTES: ${{ inputs.release-notes }}
+        CHANNEL: ${{ inputs.channel }}
+        VERSION: ${{ inputs.version }}
+        SERVER_URL: ${{ inputs.server-url }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_ENDPOINT: ${{ inputs.s3-endpoint }}
+        DELTA_BASES: ${{ inputs.delta-bases }}
+        DELTA_HISTORY: ${{ inputs.delta-history }}
+      run: |
+        set -euo pipefail
+        DEV="$(hdiutil attach -nomount ram://16384 | awk '{print $1}')"
+        diskutil erasevolume HFS+ SparkleKeyRAM "$DEV" >/dev/null
+        KEY_FILE="/Volumes/SparkleKeyRAM/ed_private_key"
+        printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"
+
+        cleanup() {
+          dd if=/dev/urandom of="$KEY_FILE" bs=1024 count=4 conv=notrunc 2>/dev/null || true
+          rm -f "$KEY_FILE" || true
+          hdiutil detach "$DEV" || true
+        }
+        trap cleanup EXIT
+
+        node apps/desktop/scripts/sparkleAppcast.mjs \
+          --release-dir release \
+          --out "$RUNNER_TEMP/sparkle-appcast" \
+          --channel "$CHANNEL" \
+          --version "$VERSION" \
+          --server-url "$SERVER_URL" \
+          --bucket "$S3_BUCKET" \
+          --endpoint "$S3_ENDPOINT" \
+          --key-file "$KEY_FILE" \
+          --sparkle-bin "$SPARKLE_BIN" \
+          --history-script "$SPARKLE_HISTORY_SCRIPT" \
+          --delta-bases "$DELTA_BASES" \
+          --delta-history "$DELTA_HISTORY"

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -15,6 +15,11 @@ name: Release Desktop Canary
 #   基于最新 stable tag 的 patch+1, postfix 为递增序号
 #   格式: X.Y.(Z+1)-canary.N
 #   例: 当前 tag v2.1.28 → v2.1.29-canary.1, 下次 → v2.1.29-canary.2
+#
+# macOS Sparkle 试点 (缺少任一 secret 时自动跳过，客户端回退 electron-updater):
+#   - SPARKLE_ED_PUBLIC_KEY: 打进 Info.plist 的 SUPublicEDKey
+#   - SPARKLE_ED_PRIVATE_KEY: `generate_keys -x` 导出的 base64 seed，用于签 appcast/delta
+#   发布 {channel}/appcast-{arch}.xml 与 {channel}/{version}/*.delta 到 S3
 # ============================================
 
 on:
@@ -298,6 +303,7 @@ jobs:
           UPDATE_CHANNEL: canary
           UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}
           RENDERER_OTA_PUBLIC_KEY: ${{ secrets.RENDERER_OTA_PUBLIC_KEY }}
+          SPARKLE_ED_PUBLIC_KEY: ${{ secrets.SPARKLE_ED_PUBLIC_KEY }}
           RELEASE_NOTES: ${{ needs.calculate-version.outputs.release_notes }}
           APP_URL: http://localhost:3015
           DATABASE_URL: 'postgresql://postgres@localhost:5432/postgres'
@@ -483,6 +489,37 @@ jobs:
           channel: canary
           cloud-ref: ${{ needs.calculate-version.outputs.cloud_ref }}
           version: ${{ needs.calculate-version.outputs.version }}
+          aws-access-key-id: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.UPDATE_AWS_SECRET_ACCESS_KEY }}
+          s3-bucket: ${{ secrets.UPDATE_S3_BUCKET }}
+          s3-region: ${{ secrets.UPDATE_S3_REGION }}
+          s3-endpoint: ${{ secrets.UPDATE_S3_ENDPOINT }}
+
+  # ============================================
+  # 发布 Sparkle appcast + delta（macOS canary 试点）
+  # 依赖 publish-s3：appcast 的 enclosure 指向 S3 上已经存在的 zip
+  # ============================================
+  publish-sparkle:
+    needs: [publish-s3, calculate-version]
+    name: Publish Sparkle Appcast
+    runs-on: macos-15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+
+      - uses: ./.github/actions/desktop-publish-sparkle
+        with:
+          channel: canary
+          version: ${{ needs.calculate-version.outputs.version }}
+          server-url: ${{ secrets.UPDATE_SERVER_URL }}
+          ed-private-key: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          release-notes: ${{ needs.calculate-version.outputs.release_notes }}
           aws-access-key-id: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.UPDATE_AWS_SECRET_ACCESS_KEY }}
           s3-bucket: ${{ secrets.UPDATE_S3_BUCKET }}

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -16,6 +16,7 @@ import {
   getAsarUnpackPatterns,
   getNativeModulesFilesConfig,
 } from './native-deps.config.mjs';
+import { toSparkleBuildVersion } from './scripts/sparkleBuildVersion.mjs';
 import { verifyFontListSignature } from './scripts/verifyFontListSigning.mjs';
 
 dotenv.config();
@@ -129,6 +130,23 @@ const getProtocolScheme = () => {
 
 const protocolScheme = getProtocolScheme();
 
+// Sparkle pilots on macOS canary builds only; stable keeps electron-updater.
+const sparklePublicKey = process.env.SPARKLE_ED_PUBLIC_KEY;
+const useSparkle =
+  process.platform === 'darwin' &&
+  isCanary &&
+  Boolean(updateServerUrl) &&
+  Boolean(sparklePublicKey);
+if (process.platform === 'darwin' && isCanary && !useSparkle) {
+  console.info('⏭️  Sparkle disabled: SPARKLE_ED_PUBLIC_KEY or UPDATE_SERVER_URL is not set');
+}
+const sparklePackageDir = useSparkle
+  ? await fs.realpath(path.join(__dirname, 'node_modules/electron-sparkle-updater'))
+  : null;
+const sparkleFeedUrl = useSparkle
+  ? `${stripChannelSuffix(updateServerUrl)}/canary/appcast-${arch}.xml`
+  : null;
+
 // Determine icon file based on version type
 const getIconFileName = () => {
   if (isStable || isCanary) return 'Icon';
@@ -147,6 +165,14 @@ const config = {
    */
   beforePack: async () => {
     buildFirstPartyNativeAddons();
+
+    if (sparklePackageDir) {
+      console.info('🔧 Building Sparkle bridge addon...');
+      execSync(
+        `node "${path.join(sparklePackageDir, 'bin/electron-sparkle-updater.js')}" rebuild --arch ${arch}`,
+        { cwd: __dirname, stdio: 'inherit' },
+      );
+    }
 
     await copyNativeModulesToSource();
     await copyExternalRuntimeModulesToSource();
@@ -234,6 +260,10 @@ const config = {
   // Native modules must be unpacked from asar to work correctly
   asarUnpack: getAsarUnpackPatterns(),
 
+  ...(process.platform === 'darwin' && isCanary
+    ? { buildVersion: toSparkleBuildVersion(packageJSON.version) }
+    : {}),
+
   detectUpdateChannel: true,
 
   directories: {
@@ -303,6 +333,15 @@ const config = {
         }
       : {}),
     extendInfo: {
+      ...(useSparkle
+        ? {
+            SUDeltaChainHistory: 6,
+            SUEnableAutomaticChecks: false,
+            SUEnableInstallerLauncherService: false,
+            SUFeedURL: sparkleFeedUrl,
+            SUPublicEDKey: sparklePublicKey,
+          }
+        : {}),
       CFBundleIconName: 'AppIcon',
       CFBundleURLTypes: [
         {
@@ -358,8 +397,28 @@ const config = {
     releaseNotes: process.env.RELEASE_NOTES || undefined,
   },
 
+  ...(sparklePackageDir
+    ? {
+        extraFiles: [
+          {
+            from: path.join(sparklePackageDir, 'native/vendor/Sparkle.framework'),
+            to: 'Frameworks/Sparkle.framework',
+          },
+        ],
+      }
+    : {}),
   extraResources: [
     { from: 'resources/bin', to: 'bin' },
+    // The Sparkle bridge addon is loaded by an explicit path outside app.asar; pnpm's
+    // symlinked package dir cannot be matched by asarUnpack, so it ships as a resource.
+    ...(sparklePackageDir
+      ? [
+          {
+            from: path.join(sparklePackageDir, 'native/build/Release/sparkle_bridge.node'),
+            to: 'sparkle/sparkle_bridge.node',
+          },
+        ]
+      : []),
     { from: 'resources/cli-package.json', to: 'package.json' },
     // Local Sandbox helper binaries. The sandbox spawns these by path, so they
     // must be real files — not entries inside app.asar, and not something the

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,6 +53,7 @@
     "@lobehub/fluent-emoji": "^4.1.0",
     "@lydell/node-pty": "1.2.0-beta.12",
     "electron-log": "^5.4.4",
+    "electron-sparkle-updater": "^0.5.0",
     "font-list": "^2.1.0",
     "get-windows": "^9.3.0",
     "node-screenshots": "^0.2.8"

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -23,19 +23,22 @@ importers:
         version: 0.0.16
       '@lobehub/fluent-emoji':
         specifier: ^4.1.0
-        version: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       '@lydell/node-pty':
         specifier: 1.2.0-beta.12
         version: 1.2.0-beta.12
       electron-log:
         specifier: ^5.4.4
         version: 5.4.4
+      electron-sparkle-updater:
+        specifier: ^0.5.0
+        version: 0.5.0(electron@43.2.0(supports-color@9.4.0))
       font-list:
         specifier: ^2.1.0
         version: 2.1.0
       get-windows:
         specifier: ^9.3.0
-        version: 9.3.0(encoding@0.1.13)
+        version: 9.3.0(encoding@0.1.13)(supports-color@9.4.0)
       node-screenshots:
         specifier: ^0.2.8
         version: 0.2.8
@@ -48,19 +51,19 @@ importers:
         version: 1.8.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@electron-toolkit/eslint-config-prettier':
         specifier: ^3.0.0
-        version: 3.0.0(eslint@10.0.0(jiti@2.7.0))(prettier@3.9.5)
+        version: 3.0.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(prettier@3.9.5)
       '@electron-toolkit/eslint-config-ts':
         specifier: ^3.1.0
-        version: 3.1.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 3.1.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@43.2.0)
+        version: 3.0.2(electron@43.2.0(supports-color@9.4.0))
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.13.3)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@43.2.0)
+        version: 4.0.0(electron@43.2.0(supports-color@9.4.0))
       '@lobechat/chat-adapter-imessage':
         specifier: workspace:*
         version: link:../../packages/chat-adapter-imessage
@@ -108,16 +111,16 @@ importers:
         version: link:../../packages/utils
       '@lobehub/i18n-cli':
         specifier: ^1.27.0
-        version: 1.27.0(@types/react@19.2.17)(encoding@0.1.13)(immer@11.1.18)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(ws@8.21.0)(zod@4.5.4)
+        version: 1.27.0(@types/react@19.2.17)(encoding@0.1.13)(immer@11.1.18)(supports-color@9.4.0)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(ws@8.21.0)(zod@4.5.4)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.5.4)
+        version: 1.29.0(supports-color@9.4.0)(zod@4.5.4)
       '@sentry/electron':
         specifier: 7.15.0
-        version: 7.15.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
+        version: 7.15.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(supports-color@9.4.0)
       '@sentry/vite-plugin':
         specifier: 5.3.0
-        version: 5.3.0(encoding@0.1.13)(rollup@4.62.2)
+        version: 5.3.0(encoding@0.1.13)(rollup@4.62.2)(supports-color@9.4.0)
       '@t3-oss/env-core':
         specifier: ^0.13.11
         version: 0.13.11(typescript@6.0.3)(zod@4.5.4)
@@ -138,7 +141,7 @@ importers:
         version: 1.21.1(babel-plugin-macros@3.1.0)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.2.3
-        version: 5.2.4(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 5.2.4(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(supports-color@9.4.0)(tsx@4.23.0)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -159,16 +162,16 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.1)
       electron:
         specifier: 43.2.0
-        version: 43.2.0
+        version: 43.2.0(supports-color@9.4.0)
       electron-builder:
         specifier: 26.16.1
-        version: 26.16.1(electron-builder-squirrel-windows@26.16.1)
+        version: 26.16.1(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0)
       electron-store:
         specifier: ^8.2.0
         version: 8.2.0
       electron-updater:
         specifier: ^6.8.9
-        version: 6.8.9
+        version: 6.8.9(supports-color@9.4.0)
       electron-window-state:
         specifier: ^5.0.3
         version: 5.0.3
@@ -177,7 +180,7 @@ importers:
         version: 1.52.0
       eslint:
         specifier: 10.0.0
-        version: 10.0.0(jiti@2.7.0)
+        version: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       execa:
         specifier: ^9.6.1
         version: 9.6.1
@@ -198,10 +201,10 @@ importers:
         version: 20.10.6
       http-proxy-agent:
         specifier: ^7.0.2
-        version: 7.0.2
+        version: 7.0.2(supports-color@9.4.0)
       https-proxy-agent:
         specifier: ^7.0.6
-        version: 7.0.6
+        version: 7.0.6(supports-color@9.4.0)
       i18next:
         specifier: ^25.10.10
         version: 25.10.10(typescript@6.0.3)
@@ -216,7 +219,7 @@ importers:
         version: 3.9.5
       remark-cli:
         specifier: ^12.0.1
-        version: 12.0.1
+        version: 12.0.1(bluebird@3.7.2)(supports-color@9.4.0)
       resolve:
         specifier: ^1.22.12
         version: 1.22.12
@@ -231,7 +234,7 @@ importers:
         version: 6.0.1
       stylelint:
         specifier: ^15.11.0
-        version: 15.11.0(typescript@6.0.3)
+        version: 15.11.0(supports-color@9.4.0)(typescript@6.0.3)
       superjson:
         specifier: ^2.2.6
         version: 2.2.6
@@ -293,14 +296,14 @@ importers:
     dependencies:
       chat:
         specifier: ~4.38.0
-        version: 4.38.1(zod@4.5.4)
+        version: 4.38.1(supports-color@9.4.0)(zod@4.5.4)
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(supports-color@9.4.0)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -315,7 +318,7 @@ importers:
         version: link:../../apps/desktop/stubs/business-const
       '@lobehub/ui':
         specifier: ^5
-        version: 5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       query-string:
         specifier: ^9.4.1
         version: 9.5.1
@@ -407,7 +410,7 @@ importers:
     devDependencies:
       electron:
         specifier: ^43.2.0
-        version: 43.2.0
+        version: 43.2.0(supports-color@9.4.0)
 
   ../../packages/electron-mac-notifications:
     dependencies:
@@ -426,7 +429,7 @@ importers:
     dependencies:
       debug:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.4.3(supports-color@9.4.0)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.13
@@ -455,7 +458,7 @@ importers:
         version: 2.0.0
       debug:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.4.3(supports-color@9.4.0)
       mammoth:
         specifier: ^1.12.0
         version: 1.12.0
@@ -489,7 +492,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.204
-        version: 0.3.204(@anthropic-ai/sdk@0.93.0(zod@4.5.4))(@modelcontextprotocol/sdk@1.29.0(zod@4.5.4))(zod@4.5.4)
+        version: 0.3.204(@anthropic-ai/sdk@0.93.0(zod@4.5.4))(@modelcontextprotocol/sdk@1.29.0(supports-color@9.4.0)(zod@4.5.4))(zod@4.5.4)
       '@anthropic-ai/sdk':
         specifier: ^0.93.0
         version: 0.93.0(zod@4.5.4)
@@ -504,10 +507,10 @@ importers:
         version: link:../utils
       '@lobehub/icons':
         specifier: ^5.15.0
-        version: 5.18.0(@lobehub/ui@5.20.0)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 5.18.0(@lobehub/ui@5.20.0)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.5.4)
+        version: 1.29.0(supports-color@9.4.0)(zod@4.5.4)
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -546,7 +549,7 @@ importers:
         version: link:../file-loaders
       debug:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.4.3(supports-color@9.4.0)
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -628,13 +631,13 @@ importers:
     dependencies:
       '@lobehub/market-sdk':
         specifier: 0.41.0
-        version: 0.41.0(zod@4.5.4)
+        version: 0.41.0(supports-color@9.4.0)(zod@4.5.4)
       '@lobehub/market-types':
         specifier: ^1.17.1
         version: 1.17.1
       '@lobehub/ui':
         specifier: ^5
-        version: 5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -682,7 +685,7 @@ importers:
         version: 1.11.23
       debug:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.4.3(supports-color@9.4.0)
       dompurify:
         specifier: ^3.4.11
         version: 3.4.15
@@ -694,7 +697,7 @@ importers:
         version: 3.1.3
       file-type:
         specifier: ^21.3.4
-        version: 21.3.4
+        version: 21.3.4(supports-color@9.4.0)
       mime:
         specifier: ^4.1.0
         version: 4.1.0
@@ -707,15 +710,18 @@ importers:
       numeral:
         specifier: ^2.0.6
         version: 2.0.6
+      partial-json:
+        specifier: ^0.1.7
+        version: 0.1.7
       pure-rand:
         specifier: ^7.0.1
         version: 7.0.1
       remark:
         specifier: ^15.0.1
-        version: 15.0.1
+        version: 15.0.1(supports-color@9.4.0)
       remark-gfm:
         specifier: ^4.0.1
-        version: 4.0.1
+        version: 4.0.1(supports-color@9.4.0)
       remark-html:
         specifier: ^16.0.1
         version: 16.0.1
@@ -804,7 +810,7 @@ importers:
         version: 1.11.23
       debug:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.4.3(supports-color@9.4.0)
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -840,7 +846,7 @@ importers:
         version: 5.0.0
       vitest:
         specifier: 5.0.0
-        version: 5.0.0(@types/node@24.13.3)(happy-dom@20.10.6)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.10.6)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   stubs/business-const: {}
 
@@ -5179,6 +5185,16 @@ packages:
   electron-publish@26.16.0:
     resolution: {integrity: sha512-Vt3KzQIiw9BImvNOYtndg9Mjki+tl4+1sQiC/+G5j8khWaENOJFWodiB+sUl6yyHwtd37avehskdtPw7f8y/+Q==}
 
+  electron-sparkle-updater@0.5.0:
+    resolution: {integrity: sha512-70hjbltmVFoAByfSMe6HnSc+VbAeYczx52jUy0GUW4lgsbuPV6Rwcveipvs0bT4YFBuekTEFnShKVFdZaeFlJg==}
+    engines: {node: '>=20.19'}
+    hasBin: true
+    peerDependencies:
+      electron: '>=28'
+    peerDependenciesMeta:
+      electron:
+        optional: true
+
   electron-store@8.2.0:
     resolution: {integrity: sha512-ukLL5Bevdil6oieAOXz3CMy+OgaItMiVBg701MNlG6W5RaC0AHN7rvlqTCmeb6O7jP0Qa1KKYTE0xV0xbhF4Hw==}
 
@@ -7335,6 +7351,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -9330,10 +9349,10 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.204':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.204(@anthropic-ai/sdk@0.93.0(zod@4.5.4))(@modelcontextprotocol/sdk@1.29.0(zod@4.5.4))(zod@4.5.4)':
+  '@anthropic-ai/claude-agent-sdk@0.3.204(@anthropic-ai/sdk@0.93.0(zod@4.5.4))(@modelcontextprotocol/sdk@1.29.0(supports-color@9.4.0)(zod@4.5.4))(zod@4.5.4)':
     dependencies:
       '@anthropic-ai/sdk': 0.93.0(zod@4.5.4)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.5.4)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@9.4.0)(zod@4.5.4)
       zod: 4.5.4
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.204
@@ -9374,10 +9393,10 @@ snapshots:
       semifies: 1.0.0
       source-map: 0.6.1
 
-  '@apm-js-collab/tracing-hooks@0.10.1':
+  '@apm-js-collab/tracing-hooks@0.10.1(supports-color@9.4.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -9426,20 +9445,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@9.4.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@9.4.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9473,19 +9492,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@9.4.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@9.4.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@9.4.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@9.4.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9520,9 +9539,9 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.4
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -9535,7 +9554,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@9.4.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -9543,7 +9562,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9669,37 +9688,37 @@ snapshots:
 
   '@electron-internal/extract-zip@1.0.5': {}
 
-  '@electron-toolkit/eslint-config-prettier@3.0.0(eslint@10.0.0(jiti@2.7.0))(prettier@3.9.5)':
+  '@electron-toolkit/eslint-config-prettier@3.0.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(prettier@3.9.5)':
     dependencies:
-      eslint: 10.0.0(jiti@2.7.0)
-      eslint-config-prettier: 10.1.8(eslint@10.0.0(jiti@2.7.0))
-      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.0.0(jiti@2.7.0)))(eslint@10.0.0(jiti@2.7.0))(prettier@3.9.5)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
+      eslint-config-prettier: 10.1.8(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))
+      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0)))(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(prettier@3.9.5)
       prettier: 3.9.5
     transitivePeerDependencies:
       - '@types/eslint'
 
-  '@electron-toolkit/eslint-config-ts@3.1.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@electron-toolkit/eslint-config-ts@3.1.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint/js': 9.39.4
-      eslint: 10.0.0(jiti@2.7.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       globals: 16.5.0
-      typescript-eslint: 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
+      typescript-eslint: 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@electron-toolkit/preload@3.0.2(electron@43.2.0)':
+  '@electron-toolkit/preload@3.0.2(electron@43.2.0(supports-color@9.4.0))':
     dependencies:
-      electron: 43.2.0
+      electron: 43.2.0(supports-color@9.4.0)
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@24.13.3)':
     dependencies:
       '@types/node': 24.13.3
 
-  '@electron-toolkit/utils@4.0.0(electron@43.2.0)':
+  '@electron-toolkit/utils@4.0.0(electron@43.2.0(supports-color@9.4.0))':
     dependencies:
-      electron: 43.2.0
+      electron: 43.2.0(supports-color@9.4.0)
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -9713,45 +9732,45 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@3.1.0':
+  '@electron/get@3.1.0(supports-color@9.4.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@9.4.0)
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@5.1.0':
+  '@electron/get@5.1.0(supports-color@9.4.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
       semver: 7.8.5
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@9.4.0)
     optionalDependencies:
       undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/notarize@2.5.0':
+  '@electron/notarize@2.5.0(supports-color@9.4.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/osx-sign@1.3.3':
+  '@electron/osx-sign@1.3.3(supports-color@9.4.0)':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -9759,22 +9778,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@4.2.0':
+  '@electron/rebuild@4.2.0(supports-color@9.4.0)':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       node-abi: 4.33.0
       node-api-version: 0.2.1
       node-gyp: 12.4.0
-      read-binary-file-arch: 1.0.6
+      read-binary-file-arch: 1.0.6(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/universal@2.0.3':
+  '@electron/universal@2.0.3(supports-color@9.4.0)':
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       dir-compare: 4.2.0
       fs-extra: 11.4.0
       minimatch: 9.0.9
@@ -9782,10 +9801,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/windows-sign@1.2.2':
+  '@electron/windows-sign@1.2.2(supports-color@9.4.0)':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 11.4.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -9816,9 +9835,9 @@ snapshots:
       emoji-mart: 5.6.0
       react: 19.2.7
 
-  '@emotion/babel-plugin@11.13.5':
+  '@emotion/babel-plugin@11.13.5(supports-color@9.4.0)':
     dependencies:
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-module-imports': 7.29.7(supports-color@9.4.0)
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -9840,9 +9859,9 @@ snapshots:
       '@emotion/weak-memoize': 0.4.0
       stylis: 4.2.0
 
-  '@emotion/css@11.13.5':
+  '@emotion/css@11.13.5(supports-color@9.4.0)':
     dependencies:
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@9.4.0)
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -9860,10 +9879,10 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7)':
+  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@9.4.0)
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.7)
@@ -10210,17 +10229,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))':
     dependencies:
-      eslint: 10.0.0(jiti@2.7.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@9.4.0)':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -10376,10 +10395,10 @@ snapshots:
 
   '@lobehub/emojilib@1.0.0': {}
 
-  '@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
       '@lobehub/emojilib': 1.0.0
-      antd-style: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      antd-style: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       emoji-regex: 10.6.0
       es-toolkit: 1.52.0
       lucide-react: 0.562.0(react@19.2.7)
@@ -10391,7 +10410,7 @@ snapshots:
       - antd
       - supports-color
 
-  '@lobehub/i18n-cli@1.27.0(@types/react@19.2.17)(encoding@0.1.13)(immer@11.1.18)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(ws@8.21.0)(zod@4.5.4)':
+  '@lobehub/i18n-cli@1.27.0(@types/react@19.2.17)(encoding@0.1.13)(immer@11.1.18)(supports-color@9.4.0)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(ws@8.21.0)(zod@4.5.4)':
     dependencies:
       '@lobehub/cli-ui': 1.13.0(@types/react@19.2.17)
       chalk: 5.6.2
@@ -10414,9 +10433,9 @@ snapshots:
       p-map: 7.0.5
       pangu: 4.0.7
       react: 19.2.7
-      remark-frontmatter: 5.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-frontmatter: 5.0.0(supports-color@9.4.0)
+      remark-gfm: 4.0.1(supports-color@9.4.0)
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
       swr: 2.4.2(react@19.2.7)
       unified: 11.0.5
@@ -10436,11 +10455,11 @@ snapshots:
       - ws
       - zod
 
-  '@lobehub/icons@5.18.0(@lobehub/ui@5.20.0)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@lobehub/icons@5.18.0(@lobehub/ui@5.20.0)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
-      '@lobehub/ui': 5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@lobehub/ui': 5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       antd: 6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      antd-style: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      antd-style: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       es-toolkit: 1.51.0
       lucide-react: 0.469.0(react@19.2.7)
       polished: 4.3.1
@@ -10450,10 +10469,10 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@lobehub/market-sdk@0.41.0(zod@4.5.4)':
+  '@lobehub/market-sdk@0.41.0(supports-color@9.4.0)(zod@4.5.4)':
     dependencies:
       '@lobehub/market-types': 1.17.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       jose: 6.2.4
       url-join: 5.0.0
       zod: 4.5.4
@@ -10464,7 +10483,7 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@lobehub/ui@5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@lobehub/ui@5.20.0(@lobehub/fluent-emoji@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0))(@lobehub/icons@5.18.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(date-fns@4.4.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))(motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
       '@ant-design/cssinjs': 2.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@base-ui/react': 1.7.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -10477,9 +10496,9 @@ snapshots:
       '@emotion/is-prop-valid': 1.4.0
       '@floating-ui/react': 0.27.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@giscus/react': 3.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@lobehub/fluent-emoji': 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@lobehub/icons': 5.18.0(@lobehub/ui@5.20.0)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mdx-js/mdx': 3.1.1
+      '@lobehub/fluent-emoji': 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
+      '@lobehub/icons': 5.18.0(@lobehub/ui@5.20.0)(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
+      '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@pierre/diffs': 1.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.7)
@@ -10488,7 +10507,7 @@ snapshots:
       '@splinetool/runtime': 0.9.526
       ahooks: 3.9.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       antd: 6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      antd-style: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      antd-style: 4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0)
       chroma-js: 3.2.0
       class-variance-authority: 0.7.1
       clsx: 2.1.1
@@ -10496,7 +10515,7 @@ snapshots:
       emoji-mart: 5.6.0
       es-toolkit: 1.51.0
       fast-deep-equal: 3.1.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@9.4.0)
       html-url-attributes: 3.0.1
       immer: 11.1.18
       katex: 0.16.47
@@ -10519,7 +10538,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-error-boundary: 6.1.3(@types/react@19.2.17)(react@19.2.7)
       react-hotkeys-hook: 5.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-markdown: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      react-markdown: 10.1.0(@types/react@19.2.17)(react@19.2.7)(supports-color@9.4.0)
       react-merge-refs: 3.0.2(react@19.2.7)
       react-rnd: 10.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-zoom-pan-pinch: 3.7.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -10527,11 +10546,11 @@ snapshots:
       rehype-katex: 7.0.1
       rehype-raw: 7.0.0
       remark-breaks: 4.0.0
-      remark-cjk-friendly: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
-      remark-gfm: 4.0.1
+      remark-cjk-friendly: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))(unified@11.0.5)
+      remark-gfm: 4.0.1(supports-color@9.4.0)
       remark-github: 12.0.0
-      remark-math: 6.0.0
-      remark-parse: 11.0.0
+      remark-math: 6.0.0(supports-color@9.4.0)
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-rehype: 11.1.2
       remend: 1.3.0
       shiki: 4.4.3
@@ -10588,19 +10607,19 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@malept/flatpak-bundler@0.4.0':
+  '@malept/flatpak-bundler@0.4.0(supports-color@9.4.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)':
+  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)(supports-color@9.4.0)':
     dependencies:
       detect-libc: 2.1.2
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@9.4.0)
       make-dir: 3.1.0
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 5.0.0
@@ -10613,7 +10632,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@mdx-js/mdx@3.1.1':
+  '@mdx-js/mdx@3.1.1(supports-color@9.4.0)':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -10625,14 +10644,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.1
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@9.4.0)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.18.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@9.4.0)
+      remark-mdx: 3.1.1(supports-color@9.4.0)
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -10653,7 +10672,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.5.4)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@9.4.0)(zod@4.5.4)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.28)
       ajv: 8.20.0
@@ -10663,8 +10682,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      express: 5.2.1(supports-color@9.4.0)
+      express-rate-limit: 8.5.2(express@5.2.1(supports-color@9.4.0))
       hono: 4.12.28
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -10748,10 +10767,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/config@8.3.4':
+  '@npmcli/config@8.3.4(bluebird@3.7.2)':
     dependencies:
       '@npmcli/map-workspaces': 3.0.6
-      '@npmcli/package-json': 5.2.1
+      '@npmcli/package-json': 5.2.1(bluebird@3.7.2)
       ci-info: 4.4.0
       ini: 4.1.3
       nopt: 7.2.1
@@ -10761,14 +10780,14 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  '@npmcli/git@5.0.8':
+  '@npmcli/git@5.0.8(bluebird@3.7.2)':
     dependencies:
       '@npmcli/promise-spawn': 7.0.2
       ini: 4.1.3
       lru-cache: 10.4.3
       npm-pick-manifest: 9.1.0
       proc-log: 4.2.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1(bluebird@3.7.2)
       promise-retry: 2.0.1
       semver: 7.8.5
       which: 4.0.0
@@ -10784,9 +10803,9 @@ snapshots:
 
   '@npmcli/name-from-folder@2.0.0': {}
 
-  '@npmcli/package-json@5.2.1':
+  '@npmcli/package-json@5.2.1(bluebird@3.7.2)':
     dependencies:
-      '@npmcli/git': 5.0.8
+      '@npmcli/git': 5.0.8(bluebird@3.7.2)
       glob: 10.5.0
       hosted-git-info: 7.0.2
       json-parse-even-better-errors: 3.0.2
@@ -10811,12 +10830,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.214.0
       import-in-the-middle: 3.5.0
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11648,11 +11667,11 @@ snapshots:
       '@sentry/replay': 10.62.0
       '@sentry/replay-canvas': 10.62.0
 
-  '@sentry/bundler-plugin-core@5.3.0(encoding@0.1.13)':
+  '@sentry/bundler-plugin-core@5.3.0(encoding@0.1.13)(supports-color@9.4.0)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@9.4.0)
       '@sentry/babel-plugin-component-annotate': 5.3.0
-      '@sentry/cli': 2.58.6(encoding@0.1.13)
+      '@sentry/cli': 2.58.6(encoding@0.1.13)(supports-color@9.4.0)
       dotenv: 16.6.1
       find-up: 5.0.0
       glob: 13.0.6
@@ -11685,9 +11704,9 @@ snapshots:
   '@sentry/cli-win32-x64@2.58.6':
     optional: true
 
-  '@sentry/cli@2.58.6(encoding@0.1.13)':
+  '@sentry/cli@2.58.6(encoding@0.1.13)(supports-color@9.4.0)':
     dependencies:
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@9.4.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       progress: 2.0.3
       proxy-from-env: 1.1.0
@@ -11709,11 +11728,11 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/electron@7.15.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/electron@7.15.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(supports-color@9.4.0)':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
-      '@sentry/node': 10.62.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/node': 10.62.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(supports-color@9.4.0)
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
@@ -11723,7 +11742,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.62.0
 
-  '@sentry/node-core@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.62.0
@@ -11732,19 +11751,19 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.62.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.62.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(supports-color@9.4.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
       '@sentry/core': 10.62.0
-      '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.62.0
+      '@sentry/server-utils': 10.62.0(supports-color@9.4.0)
       import-in-the-middle: 3.5.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
@@ -11769,9 +11788,9 @@ snapshots:
       '@sentry/browser-utils': 10.62.0
       '@sentry/core': 10.62.0
 
-  '@sentry/rollup-plugin@5.3.0(encoding@0.1.13)(rollup@4.62.2)':
+  '@sentry/rollup-plugin@5.3.0(encoding@0.1.13)(rollup@4.62.2)(supports-color@9.4.0)':
     dependencies:
-      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)
+      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)(supports-color@9.4.0)
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
@@ -11779,21 +11798,21 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/server-utils@10.62.0':
+  '@sentry/server-utils@10.62.0(supports-color@9.4.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
-      '@apm-js-collab/tracing-hooks': 0.10.1
+      '@apm-js-collab/tracing-hooks': 0.10.1(supports-color@9.4.0)
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.62.0
       magic-string: 0.30.21
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/vite-plugin@5.3.0(encoding@0.1.13)(rollup@4.62.2)':
+  '@sentry/vite-plugin@5.3.0(encoding@0.1.13)(rollup@4.62.2)(supports-color@9.4.0)':
     dependencies:
-      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)
-      '@sentry/rollup-plugin': 5.3.0(encoding@0.1.13)(rollup@4.62.2)
+      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)(supports-color@9.4.0)
+      '@sentry/rollup-plugin': 5.3.0(encoding@0.1.13)(rollup@4.62.2)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -11908,9 +11927,9 @@ snapshots:
       typescript: 6.0.3
       zod: 4.5.4
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@9.4.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12171,15 +12190,15 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 10.0.0(jiti@2.7.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -12187,23 +12206,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
-      eslint: 10.0.0(jiti@2.7.0)
+      debug: 4.4.3(supports-color@9.4.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.63.0(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -12217,13 +12236,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.0.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@9.4.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12231,13 +12250,13 @@ snapshots:
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.63.0(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -12246,13 +12265,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      eslint: 10.0.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@9.4.0)(typescript@6.0.3)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -12309,16 +12328,16 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.7
 
-  '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
+  '@vanilla-extract/babel-plugin-debug-ids@1.2.2(supports-color@9.4.0)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vanilla-extract/compiler@0.7.1(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)':
+  '@vanilla-extract/compiler@0.7.1(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(supports-color@9.4.0)(tsx@4.23.0)(yaml@2.9.0)':
     dependencies:
       '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
-      '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)(supports-color@9.4.0)
       vite: 8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -12353,11 +12372,11 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@8.0.10(babel-plugin-macros@3.1.0)':
+  '@vanilla-extract/integration@8.0.10(babel-plugin-macros@3.1.0)(supports-color@9.4.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
-      '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
+      '@babel/core': 7.29.7(supports-color@9.4.0)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@9.4.0))
+      '@vanilla-extract/babel-plugin-debug-ids': 1.2.2(supports-color@9.4.0)
       '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
       esbuild: 0.28.1
@@ -12371,10 +12390,10 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/vite-plugin@5.2.4(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)':
+  '@vanilla-extract/vite-plugin@5.2.4(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(supports-color@9.4.0)(tsx@4.23.0)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
-      '@vanilla-extract/compiler': 0.7.1(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
-      '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/compiler': 0.7.1(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(supports-color@9.4.0)(tsx@4.23.0)(yaml@2.9.0)
+      '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)(supports-color@9.4.0)
       vite: 8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -12458,9 +12477,9 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12527,13 +12546,13 @@ snapshots:
 
   ansis@4.3.1: {}
 
-  antd-style@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  antd-style@4.1.0(@types/react@19.2.17)(antd@6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@9.4.0):
     dependencies:
       '@ant-design/cssinjs': 2.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/css': 11.13.5(supports-color@9.4.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)(supports-color@9.4.0)
       '@emotion/serialize': 1.3.3
       '@emotion/utils': 1.4.2
       antd: 6.5.0(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -12607,33 +12626,33 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  app-builder-lib@26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1):
+  app-builder-lib@26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
-      '@electron/get': 3.1.0
-      '@electron/notarize': 2.5.0
-      '@electron/osx-sign': 1.3.3
-      '@electron/rebuild': 4.2.0
-      '@electron/universal': 2.0.3
-      '@malept/flatpak-bundler': 0.4.0
+      '@electron/get': 3.1.0(supports-color@9.4.0)
+      '@electron/notarize': 2.5.0(supports-color@9.4.0)
+      '@electron/osx-sign': 1.3.3(supports-color@9.4.0)
+      '@electron/rebuild': 4.2.0(supports-color@9.4.0)
+      '@electron/universal': 2.0.3(supports-color@9.4.0)
+      '@malept/flatpak-bundler': 0.4.0(supports-color@9.4.0)
       '@noble/hashes': 1.8.0
       '@peculiar/webcrypto': 1.7.1
       '@types/fs-extra': 9.0.13
       ajv: 8.20.0
       asn1js: 3.0.10
       async-exit-hook: 2.0.1
-      builder-util: 26.16.0
-      builder-util-runtime: 9.7.0
+      builder-util: 26.16.0(supports-color@9.4.0)
+      builder-util-runtime: 9.7.0(supports-color@9.4.0)
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
-      debug: 4.4.3
-      dmg-builder: 26.16.1(electron-builder-squirrel-windows@26.16.1)
+      debug: 4.4.3(supports-color@9.4.0)
+      dmg-builder: 26.16.1(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.16.1(dmg-builder@26.16.1)
-      electron-publish: 26.16.0
+      electron-builder-squirrel-windows: 26.16.1(dmg-builder@26.16.1)(supports-color@9.4.0)
+      electron-publish: 26.16.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
@@ -12748,11 +12767,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@9.4.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -12816,23 +12835,23 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builder-util-runtime@9.7.0:
+  builder-util-runtime@9.7.0(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       sax: 1.6.0
     transitivePeerDependencies:
       - supports-color
 
-  builder-util@26.16.0:
+  builder-util@26.16.0(supports-color@9.4.0):
     dependencies:
       '@types/debug': 4.1.13
-      builder-util-runtime: 9.7.0
+      builder-util-runtime: 9.7.0(supports-color@9.4.0)
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 10.1.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@9.4.0)
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       js-yaml: 4.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
@@ -12918,12 +12937,12 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chat@4.38.1(zod@4.5.4):
+  chat@4.38.1(supports-color@9.4.0)(zod@4.5.4):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-gfm: 4.0.1(supports-color@9.4.0)
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
       remend: 1.3.0
       unified: 11.0.5
@@ -13383,9 +13402,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@9.4.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 9.4.0
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -13478,10 +13499,10 @@ snapshots:
       unescape-js: 1.1.4
       utf8: 3.0.0
 
-  dmg-builder@26.16.1(electron-builder-squirrel-windows@26.16.1):
+  dmg-builder@26.16.1(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0):
     dependencies:
-      app-builder-lib: 26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)
-      builder-util: 26.16.0
+      app-builder-lib: 26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0)
+      builder-util: 26.16.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       js-yaml: 4.3.0
     transitivePeerDependencies:
@@ -13547,23 +13568,23 @@ snapshots:
 
   eld@2.0.3: {}
 
-  electron-builder-squirrel-windows@26.16.1(dmg-builder@26.16.1):
+  electron-builder-squirrel-windows@26.16.1(dmg-builder@26.16.1)(supports-color@9.4.0):
     dependencies:
-      app-builder-lib: 26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)
-      builder-util: 26.16.0
-      electron-winstaller: 5.4.0
+      app-builder-lib: 26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0)
+      builder-util: 26.16.0(supports-color@9.4.0)
+      electron-winstaller: 5.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.16.1(electron-builder-squirrel-windows@26.16.1):
+  electron-builder@26.16.1(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0):
     dependencies:
-      app-builder-lib: 26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)
-      builder-util: 26.16.0
-      builder-util-runtime: 9.7.0
+      app-builder-lib: 26.16.1(dmg-builder@26.16.1)(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0)
+      builder-util: 26.16.0(supports-color@9.4.0)
+      builder-util-runtime: 9.7.0(supports-color@9.4.0)
       chalk: 4.1.2
       ci-info: 4.4.0
-      dmg-builder: 26.16.1(electron-builder-squirrel-windows@26.16.1)
+      dmg-builder: 26.16.1(electron-builder-squirrel-windows@26.16.1)(supports-color@9.4.0)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -13574,12 +13595,12 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-publish@26.16.0:
+  electron-publish@26.16.0(supports-color@9.4.0):
     dependencies:
       '@types/fs-extra': 9.0.13
       aws4: 1.13.2
-      builder-util: 26.16.0
-      builder-util-runtime: 9.7.0
+      builder-util: 26.16.0(supports-color@9.4.0)
+      builder-util-runtime: 9.7.0(supports-color@9.4.0)
       chalk: 4.1.2
       form-data: 4.0.6
       fs-extra: 10.1.0
@@ -13588,6 +13609,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  electron-sparkle-updater@0.5.0(electron@43.2.0(supports-color@9.4.0)):
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp: 12.4.0
+    optionalDependencies:
+      electron: 43.2.0(supports-color@9.4.0)
+
   electron-store@8.2.0:
     dependencies:
       conf: 10.2.0
@@ -13595,9 +13623,9 @@ snapshots:
 
   electron-to-chromium@1.5.389: {}
 
-  electron-updater@6.8.9:
+  electron-updater@6.8.9(supports-color@9.4.0):
     dependencies:
-      builder-util-runtime: 9.7.0
+      builder-util-runtime: 9.7.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       js-yaml: 4.3.0
       lazy-val: 1.0.5
@@ -13613,22 +13641,22 @@ snapshots:
       jsonfile: 4.0.0
       mkdirp: 0.5.6
 
-  electron-winstaller@5.4.0:
+  electron-winstaller@5.4.0(supports-color@9.4.0):
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 7.0.1
       lodash: 4.18.1
       temp: 0.9.4
     optionalDependencies:
-      '@electron/windows-sign': 1.2.2
+      '@electron/windows-sign': 1.2.2(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.2.0:
+  electron@43.2.0(supports-color@9.4.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
-      '@electron/get': 5.1.0
+      '@electron/get': 5.1.0(supports-color@9.4.0)
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
@@ -13836,18 +13864,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.0.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0)):
     dependencies:
-      eslint: 10.0.0(jiti@2.7.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.0.0(jiti@2.7.0)))(eslint@10.0.0(jiti@2.7.0))(prettier@3.9.5):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0)))(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(prettier@3.9.5):
     dependencies:
-      eslint: 10.0.0(jiti@2.7.0)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       prettier: 3.9.5
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.0.0(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))
 
   eslint-scope@9.1.2:
     dependencies:
@@ -13860,11 +13888,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.0.0(jiti@2.7.0):
+  eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@9.4.0)
       '@eslint/config-helpers': 0.5.5
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.6.1
@@ -13874,7 +13902,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -13998,25 +14026,25 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1(supports-color@9.4.0)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@9.4.0)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@9.4.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@9.4.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@9.4.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -14027,9 +14055,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@9.4.0)
+      send: 1.2.1(supports-color@9.4.0)
+      serve-static: 2.2.1(supports-color@9.4.0)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -14121,9 +14149,9 @@ snapshots:
       strtok3: 6.3.0
       token-types: 4.2.1
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@9.4.0):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@9.4.0)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -14143,9 +14171,9 @@ snapshots:
 
   filter-obj@5.1.0: {}
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -14333,9 +14361,9 @@ snapshots:
 
   get-value@2.0.6: {}
 
-  get-windows@9.3.0(encoding@0.1.13):
+  get-windows@9.3.0(encoding@0.1.13)(supports-color@9.4.0):
     optionalDependencies:
-      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
+      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)(supports-color@9.4.0)
       node-addon-api: 8.9.0
       node-gyp: 12.4.0
     transitivePeerDependencies:
@@ -14551,7 +14579,7 @@ snapshots:
       '@ungap/structured-clone': 1.3.3
       unist-util-position: 5.0.0
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@9.4.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -14561,9 +14589,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@9.4.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@9.4.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@9.4.0)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -14586,7 +14614,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@9.4.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
@@ -14595,9 +14623,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@9.4.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@9.4.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@9.4.0)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -14667,10 +14695,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@9.4.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14679,17 +14707,17 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@9.4.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@9.4.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@9.4.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15132,9 +15160,9 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.3
 
-  load-plugin@6.0.3:
+  load-plugin@6.0.3(bluebird@3.7.2):
     dependencies:
-      '@npmcli/config': 8.3.4
+      '@npmcli/config': 8.3.4(bluebird@3.7.2)
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - bluebird
@@ -15258,14 +15286,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@9.4.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -15275,12 +15303,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1:
+  mdast-util-frontmatter@2.0.1(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -15294,79 +15322,79 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@9.4.0):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@9.4.0)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@9.4.0)
+      mdast-util-gfm-table: 2.0.0(supports-color@9.4.0)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-math@3.0.0:
+  mdast-util-math@3.0.0(supports-color@9.4.0):
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@9.4.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@9.4.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -15374,7 +15402,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -15383,23 +15411,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@9.4.0):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
+      mdast-util-mdx-expression: 2.0.1(supports-color@9.4.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@9.4.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@9.4.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15542,10 +15570,10 @@ snapshots:
     optionalDependencies:
       micromark-util-types: 2.0.2
 
-  micromark-extension-cjk-friendly@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+  micromark-extension-cjk-friendly@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0)):
     dependencies:
       devlop: 1.1.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@9.4.0)
       micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
       micromark-util-chunked: 2.0.1
       micromark-util-resolve-all: 2.0.1
@@ -15793,10 +15821,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@9.4.0):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -16254,6 +16282,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  partial-json@0.1.7: {}
+
   patch-console@2.0.0: {}
 
   path-browserify-esm@1.0.6: {}
@@ -16401,7 +16431,9 @@ snapshots:
 
   progress@2.0.3: {}
 
-  promise-inflight@1.0.1: {}
+  promise-inflight@1.0.1(bluebird@3.7.2):
+    optionalDependencies:
+      bluebird: 3.7.2
 
   promise-retry@2.0.1:
     dependencies:
@@ -16649,17 +16681,17 @@ snapshots:
 
   react-is@19.2.8: {}
 
-  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7)(supports-color@9.4.0):
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@9.4.0)
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 19.2.7
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -16691,9 +16723,9 @@ snapshots:
 
   react@19.2.7: {}
 
-  read-binary-file-arch@1.0.6:
+  read-binary-file-arch@1.0.6(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16824,11 +16856,11 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@9.4.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16838,10 +16870,10 @@ snapshots:
       mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
 
-  remark-cjk-friendly@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+  remark-cjk-friendly@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))(unified@11.0.5):
     dependencies:
       mdast-util-to-markdown-cjk-friendly: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)
-      micromark-extension-cjk-friendly: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      micromark-extension-cjk-friendly: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@9.4.0))
       unified: 11.0.5
     optionalDependencies:
       '@types/mdast': 4.0.4
@@ -16849,31 +16881,31 @@ snapshots:
       - micromark
       - micromark-util-types
 
-  remark-cli@12.0.1:
+  remark-cli@12.0.1(bluebird@3.7.2)(supports-color@9.4.0):
     dependencies:
       import-meta-resolve: 4.2.0
       markdown-extensions: 2.0.0
-      remark: 15.0.1
-      unified-args: 11.0.1
+      remark: 15.0.1(supports-color@9.4.0)
+      unified-args: 11.0.1(bluebird@3.7.2)(supports-color@9.4.0)
     transitivePeerDependencies:
       - bluebird
       - supports-color
 
-  remark-frontmatter@5.0.0:
+  remark-frontmatter@5.0.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-frontmatter: 2.0.1
+      mdast-util-frontmatter: 2.0.1(supports-color@9.4.0)
       micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@9.4.0)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -16896,26 +16928,26 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
 
-  remark-math@6.0.0:
+  remark-math@6.0.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-math: 3.0.0
+      mdast-util-math: 3.0.0(supports-color@9.4.0)
       micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@9.4.0):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@9.4.0)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -16935,10 +16967,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1:
+  remark@15.0.1(supports-color@9.4.0):
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -16954,9 +16986,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -17118,9 +17150,9 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -17175,9 +17207,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -17196,12 +17228,12 @@ snapshots:
       type-fest: 0.13.1
     optional: true
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@9.4.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17469,7 +17501,7 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylelint@15.11.0(typescript@6.0.3):
+  stylelint@15.11.0(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
@@ -17480,7 +17512,7 @@ snapshots:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       css-functions-list: 3.3.3
       css-tree: 2.3.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 7.0.2
@@ -17529,9 +17561,9 @@ snapshots:
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
-  sumchecker@3.0.1:
+  sumchecker@3.0.1(supports-color@9.4.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17731,13 +17763,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.16)(supports-color@9.4.0)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -17792,13 +17824,13 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.0.0(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.0.0(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.0.0(jiti@2.7.0)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      eslint: 10.0.0(jiti@2.7.0)(supports-color@9.4.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -17834,7 +17866,7 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
-  unified-args@11.0.1:
+  unified-args@11.0.1(bluebird@3.7.2)(supports-color@9.4.0):
     dependencies:
       '@types/text-table': 0.2.5
       chalk: 5.6.2
@@ -17844,12 +17876,12 @@ snapshots:
       minimist: 1.2.8
       strip-ansi: 7.2.0
       text-table: 0.2.0
-      unified-engine: 11.2.2
+      unified-engine: 11.2.2(bluebird@3.7.2)(supports-color@9.4.0)
     transitivePeerDependencies:
       - bluebird
       - supports-color
 
-  unified-engine@11.2.2:
+  unified-engine@11.2.2(bluebird@3.7.2)(supports-color@9.4.0):
     dependencies:
       '@types/concat-stream': 2.0.3
       '@types/debug': 4.1.13
@@ -17857,13 +17889,13 @@ snapshots:
       '@types/node': 22.20.1
       '@types/unist': 3.0.3
       concat-stream: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@9.4.0)
       extend: 3.0.2
       glob: 10.5.0
       ignore: 6.0.2
       is-empty: 1.2.0
       is-plain-obj: 4.1.0
-      load-plugin: 6.0.3
+      load-plugin: 6.0.3(bluebird@3.7.2)
       parse-json: 7.1.1
       trough: 2.2.0
       unist-util-inspect: 8.1.0

--- a/apps/desktop/pnpm-workspace.yaml
+++ b/apps/desktop/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ allowBuilds:
   '@sentry/cli': true
   electron: true
   electron-builder: true
+  electron-sparkle-updater: false
   electron-winstaller: false
   esbuild: false
   get-windows: false
@@ -71,3 +72,4 @@ minimumReleaseAgeExclude:
   - '@auv-js/cli-win32-x64-msvc@0.0.16'
   - '@auv-js/cli@0.0.16'
   - '@auv-js/sdk@0.0.16'
+  - electron-sparkle-updater@0.5.0

--- a/apps/desktop/scripts/__tests__/sparkleAppcast.test.mjs
+++ b/apps/desktop/scripts/__tests__/sparkleAppcast.test.mjs
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { ownZipName, previousArchives, s3KeyFromUrl } from '../sparkleAppcast.mjs';
+
+const files = [
+  'LobeHub-2.2.19-canary.1-arm64-mac.zip',
+  'LobeHub-2.2.19-canary.1-arm64-mac.zip.blockmap',
+  'LobeHub-2.2.19-canary.1-mac.zip',
+  'LobeHub-2.2.19-canary.1-arm64.dmg',
+  'LobeHub-2.2.19-canary.1-x64.dmg',
+];
+
+describe('ownZipName', () => {
+  it('picks the arm64 zip by its arch suffix', () => {
+    expect(ownZipName(files, '2.2.19-canary.1', 'arm64')).toBe(
+      'LobeHub-2.2.19-canary.1-arm64-mac.zip',
+    );
+  });
+
+  it('picks the x64 zip, which electron-builder names without an arch', () => {
+    expect(ownZipName(files, '2.2.19-canary.1', 'x64')).toBe('LobeHub-2.2.19-canary.1-mac.zip');
+  });
+
+  it('fails when the version has no matching zip', () => {
+    expect(() => ownZipName(files, '2.2.18-canary.9', 'x64')).toThrow(/found 0/);
+  });
+});
+
+describe('previousArchives', () => {
+  const feed = `<?xml version="1.0"?><rss><channel>
+<item><title>2.2.18-canary.2</title><sparkle:version>2.2.18-canary.2</sparkle:version>
+<enclosure url="https://cdn.example.com/canary/2.2.18-canary.2/LobeHub-2.2.18-canary.2-mac.zip" length="1" type="application/octet-stream" sparkle:edSignature="sig"/>
+<sparkle:deltas><enclosure url="https://cdn.example.com/canary/2.2.18-canary.2/LobeHub-1.delta" sparkle:deltaFrom="2.2.18-canary.1"/></sparkle:deltas></item>
+<item><title>2.2.18-canary.1</title>
+<enclosure url="https://cdn.example.com/canary/2.2.18-canary.1/LobeHub-2.2.18-canary.1-mac.zip" sparkle:version="2.2.18-canary.1"/></item>
+</channel></rss>`;
+
+  it('lists the newest full archives first, ignoring delta enclosures', () => {
+    expect(previousArchives(feed, 2)).toEqual([
+      {
+        url: 'https://cdn.example.com/canary/2.2.18-canary.2/LobeHub-2.2.18-canary.2-mac.zip',
+        version: '2.2.18-canary.2',
+      },
+      {
+        url: 'https://cdn.example.com/canary/2.2.18-canary.1/LobeHub-2.2.18-canary.1-mac.zip',
+        version: '2.2.18-canary.1',
+      },
+    ]);
+  });
+
+  it('bounds the result to the requested delta bases', () => {
+    expect(previousArchives(feed, 1)).toHaveLength(1);
+  });
+});
+
+describe('s3KeyFromUrl', () => {
+  it('maps an enclosure back to its bucket key', () => {
+    expect(
+      s3KeyFromUrl(
+        'https://cdn.example.com/canary/2.2.18-canary.2/a.zip',
+        'https://cdn.example.com/',
+      ),
+    ).toBe('canary/2.2.18-canary.2/a.zip');
+  });
+
+  it('rejects enclosures hosted elsewhere', () => {
+    expect(() =>
+      s3KeyFromUrl('https://evil.example.com/a.zip', 'https://cdn.example.com'),
+    ).toThrow();
+  });
+});

--- a/apps/desktop/scripts/__tests__/sparkleBuildVersion.test.mjs
+++ b/apps/desktop/scripts/__tests__/sparkleBuildVersion.test.mjs
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { toSparkleBuildVersion } from '../sparkleBuildVersion.mjs';
+
+describe('toSparkleBuildVersion', () => {
+  it('turns a canary semver into a dash-free, monotonically increasing build number', () => {
+    expect(toSparkleBuildVersion('2.2.19-canary.1')).toBe('2.2.19.1');
+    expect(toSparkleBuildVersion('2.2.19-canary.12')).toBe('2.2.19.12');
+  });
+
+  it('leaves stable and unknown versions untouched', () => {
+    expect(toSparkleBuildVersion('2.2.19')).toBe('2.2.19');
+    expect(toSparkleBuildVersion('2.2.19-beta.1')).toBe('2.2.19-beta.1');
+  });
+});

--- a/apps/desktop/scripts/sparkleAppcast.mjs
+++ b/apps/desktop/scripts/sparkleAppcast.mjs
@@ -1,0 +1,208 @@
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+export const ARCHES = ['arm64', 'x64'];
+
+export const ownZipName = (fileNames, version, arch) => {
+  const suffix = arch === 'arm64' ? `-${version}-arm64-mac.zip` : `-${version}-mac.zip`;
+  const matches = fileNames.filter((name) => name.endsWith(suffix));
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one ${arch} zip for ${version}, found ${matches.length}`);
+  }
+  return matches[0];
+};
+
+export const previousArchives = (appcastXml, count) => {
+  const items = [];
+  for (const [, item] of appcastXml.matchAll(/<item>([\S\s]*?)<\/item>/g)) {
+    const url = item.match(/<enclosure[^>]*\surl="([^"]+)"/)?.[1];
+    const version =
+      item.match(/<sparkle:version>([^<]+)<\/sparkle:version>/)?.[1] ??
+      item.match(/<enclosure[^>]*\ssparkle:version="([^"]+)"/)?.[1];
+    if (url && version) items.push({ url, version });
+  }
+  return items.slice(0, count);
+};
+
+export const s3KeyFromUrl = (url, serverUrl) => {
+  const base = serverUrl.replace(/\/$/, '');
+  if (!url.startsWith(`${base}/`)) throw new Error(`enclosure ${url} is outside ${serverUrl}`);
+  return url.slice(base.length + 1);
+};
+
+const run = (command, args, options = {}) => {
+  console.info(`$ ${command} ${args.join(' ')}`);
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    ...options,
+  });
+};
+
+const createS3 = ({ bucket, endpoint }) => {
+  const endpointArgs = endpoint ? ['--endpoint-url', endpoint] : [];
+  const aws = (args) => run('aws', ['s3', ...args, ...endpointArgs]);
+  return {
+    download: (key, dest) => {
+      try {
+        aws(['cp', `s3://${bucket}/${key}`, dest]);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    upload: (src, key, cacheControl) =>
+      aws(['cp', src, `s3://${bucket}/${key}`, '--cache-control', cacheControl]),
+  };
+};
+
+export const publishArch = (arch, options) => {
+  const {
+    channel,
+    deltaBases,
+    deltaHistory,
+    historyScript,
+    keyFile,
+    out,
+    releaseDir,
+    releaseNotes,
+    s3,
+    serverUrl,
+    sparkleBin,
+    version,
+  } = options;
+  const dir = path.join(out, arch);
+  const historyDir = path.join(dir, 'history');
+  mkdirSync(path.join(historyDir, '00'), { recursive: true });
+
+  const zipName = ownZipName(readdirSync(releaseDir), version, arch);
+  copyFileSync(path.join(releaseDir, zipName), path.join(dir, zipName));
+  if (releaseNotes) writeFileSync(path.join(dir, zipName.replace(/\.zip$/, '.md')), releaseNotes);
+
+  const feedKey = `${channel}/appcast-${arch}.xml`;
+  const previousFeed = path.join(historyDir, '00', 'appcast.xml');
+  if (s3.download(feedKey, previousFeed)) {
+    for (const archive of previousArchives(readFileSync(previousFeed, 'utf8'), deltaBases)) {
+      const key = s3KeyFromUrl(archive.url, serverUrl);
+      if (!s3.download(key, path.join(dir, path.basename(key)))) {
+        console.warn(`delta base ${archive.version} missing at ${key}; skipping`);
+      }
+    }
+  } else {
+    console.info(`no previous ${feedKey}; publishing a first appcast without deltas`);
+  }
+
+  const buildVersion = run('python3', [historyScript, 'version', path.join(dir, zipName)]).trim();
+  const appcast = path.join(dir, 'appcast.xml');
+  run(
+    path.join(sparkleBin, 'generate_appcast'),
+    [
+      '--versions',
+      buildVersion,
+      '--maximum-versions',
+      '1',
+      '--maximum-deltas',
+      String(deltaBases),
+      '--ed-key-file',
+      keyFile,
+      '--download-url-prefix',
+      `${serverUrl}/${channel}/${version}/`,
+      '--embed-release-notes',
+      '-o',
+      appcast,
+      dir,
+    ],
+    { stdio: 'inherit' },
+  );
+  run(
+    'python3',
+    [
+      historyScript,
+      'merge',
+      appcast,
+      '--history-dir',
+      historyDir,
+      '--history',
+      String(deltaHistory),
+    ],
+    { stdio: 'inherit' },
+  );
+  run(path.join(sparkleBin, 'sign_update'), ['--ed-key-file', keyFile, appcast], {
+    stdio: 'inherit',
+  });
+
+  for (const name of readdirSync(dir).filter((f) => f.endsWith('.delta'))) {
+    s3.upload(
+      path.join(dir, name),
+      `${channel}/${version}/${name}`,
+      'public,max-age=31536000,immutable',
+    );
+  }
+  s3.upload(appcast, `${channel}/${version}/appcast-${arch}.xml`, 'no-store');
+  s3.upload(appcast, feedKey, 'no-store');
+  console.info(`published ${feedKey} for ${version}`);
+};
+
+const main = () => {
+  const { values } = parseArgs({
+    options: {
+      'arches': { default: ARCHES.join(','), type: 'string' },
+      'bucket': { type: 'string' },
+      'channel': { type: 'string' },
+      'delta-bases': { default: '1', type: 'string' },
+      'delta-history': { default: '6', type: 'string' },
+      'endpoint': { default: '', type: 'string' },
+      'history-script': { type: 'string' },
+      'key-file': { type: 'string' },
+      'out': { type: 'string' },
+      'release-dir': { type: 'string' },
+      'server-url': { type: 'string' },
+      'sparkle-bin': { type: 'string' },
+      'version': { type: 'string' },
+    },
+  });
+  for (const key of [
+    'bucket',
+    'channel',
+    'history-script',
+    'key-file',
+    'out',
+    'release-dir',
+    'server-url',
+    'sparkle-bin',
+    'version',
+  ]) {
+    if (!values[key]) throw new Error(`--${key} is required`);
+  }
+  if (!existsSync(values['key-file'])) throw new Error('EdDSA key file not found');
+
+  const serverUrl = values['server-url'].replace(/\/(stable|nightly|canary|beta)?\/?$/, '');
+  const options = {
+    channel: values.channel,
+    deltaBases: Number(values['delta-bases']),
+    deltaHistory: Number(values['delta-history']),
+    historyScript: values['history-script'],
+    keyFile: values['key-file'],
+    out: values.out,
+    releaseDir: values['release-dir'],
+    releaseNotes: process.env.RELEASE_NOTES,
+    s3: createS3({ bucket: values.bucket, endpoint: values.endpoint }),
+    serverUrl,
+    sparkleBin: values['sparkle-bin'],
+    version: values.version,
+  };
+  for (const arch of values.arches.split(',')) publishArch(arch, options);
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === new URL(import.meta.url).pathname) {
+  main();
+}

--- a/apps/desktop/scripts/sparkleBuildVersion.mjs
+++ b/apps/desktop/scripts/sparkleBuildVersion.mjs
@@ -1,0 +1,8 @@
+// Sparkle's SUStandardVersionComparator truncates CFBundleVersion at the first dash, so
+// `2.2.19-canary.1` and `2.2.19-canary.2` compare equal and no update is ever offered.
+// Canary builds therefore carry a dash-free build number and keep the semver as
+// CFBundleShortVersionString (what app.getVersion() and electron-updater still read).
+export const toSparkleBuildVersion = (version) => {
+  const match = version.match(/^(\d+\.\d+\.\d+)-canary\.(\d+)$/);
+  return match ? `${match[1]}.${match[2]}` : version;
+};

--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -12,7 +12,16 @@ import semver from 'semver';
 
 import { isDev, isWindows } from '@/const/env';
 import { getDesktopEnv } from '@/env';
-import { UPDATE_CHANNEL, UPDATE_SERVER_URL, updaterConfig } from '@/modules/updater/configs';
+import {
+  getSparkleFeedUrl,
+  isSparkleChannel,
+  UPDATE_CHANNEL,
+  UPDATE_SERVER_URL,
+  updaterConfig,
+} from '@/modules/updater/configs';
+import { electronUpdaterEngine } from '@/modules/updater/electronUpdaterEngine';
+import type { UpdateEngine } from '@/modules/updater/engine';
+import { SparkleEngine } from '@/modules/updater/sparkleEngine';
 import { extractRestoreRoute } from '@/modules/updater/utils';
 import { createLogger } from '@/utils/logger';
 
@@ -28,6 +37,8 @@ export class UpdaterManager {
   private downloading: boolean = false;
   private updateAvailable: boolean = false;
   private currentChannel: UpdateChannel = UPDATE_CHANNEL;
+  private sparkleEngine: SparkleEngine | null = null;
+  private engine: UpdateEngine = electronUpdaterEngine;
   /** Incremented on each channel switch to invalidate in-flight checks */
   private checkGeneration: number = 0;
   /** Generation at the start of the current active check */
@@ -126,12 +137,14 @@ export class UpdaterManager {
         `Production mode: channel=${this.currentChannel}, allowPrerelease=${this.currentChannel !== 'stable'}`,
       );
       this.configureUpdateProvider();
+      this.sparkleEngine = await this.createSparkleEngine();
     }
 
     // Keep every release channel rollback-capable. Assign this after configuring the provider because
     // electron-updater's channel setter mutates allowDowngrade as a side effect.
     autoUpdater.allowDowngrade = true;
 
+    this.engine = this.resolveEngine(this.currentChannel);
     this.registerEvents();
 
     if (updaterConfig.app.autoCheckUpdate) {
@@ -140,7 +153,7 @@ export class UpdaterManager {
     }
 
     logger.debug(
-      `Initialized with channel: ${autoUpdater.channel}, allowPrerelease: ${autoUpdater.allowPrerelease}`,
+      `Initialized with channel: ${autoUpdater.channel}, allowPrerelease: ${autoUpdater.allowPrerelease}, engine: ${this.engine.kind}`,
     );
 
     logger.info('UpdaterManager initialization completed');
@@ -159,6 +172,9 @@ export class UpdaterManager {
     // Reapply after configureUpdateProvider for the same channel-setter side effect as initialize.
     autoUpdater.allowDowngrade = true;
     logger.info('allowDowngrade=true');
+
+    this.engine = this.resolveEngine(channel);
+    logger.info(`Update engine: ${this.engine.kind}`);
 
     this.installLaterVersion = null;
 
@@ -188,6 +204,7 @@ export class UpdaterManager {
       `${manual ? 'Manually checking' : 'Auto checking'} for updates... (gen=${this.activeGeneration})`,
     );
 
+    logger.info('[Updater Config] Engine:', this.engine.kind);
     logger.info('[Updater Config] Channel:', autoUpdater.channel);
     logger.info('[Updater Config] currentChannel:', this.currentChannel);
     logger.info('[Updater Config] allowPrerelease:', autoUpdater.allowPrerelease);
@@ -201,7 +218,7 @@ export class UpdaterManager {
     this.setStage('checking');
 
     try {
-      await autoUpdater.checkForUpdates();
+      await this.engine.checkForUpdates();
     } catch (error) {
       if (this.isStaleCheck()) return;
 
@@ -242,7 +259,7 @@ export class UpdaterManager {
     this.setStage('downloading');
 
     try {
-      await autoUpdater.downloadUpdate();
+      await this.engine.downloadUpdate();
     } catch (error) {
       this.downloading = false;
       logger.error('Error downloading update:', error);
@@ -293,8 +310,8 @@ export class UpdaterManager {
     app.releaseSingleInstanceLock();
 
     setTimeout(() => {
-      logger.info('Calling autoUpdater.quitAndInstall...');
-      autoUpdater.quitAndInstall(true, true);
+      logger.info(`Calling ${this.engine.kind} quitAndInstall...`);
+      this.engine.quitAndInstall();
     }, 100);
   };
 
@@ -304,7 +321,7 @@ export class UpdaterManager {
   public installLater = () => {
     logger.info('Update will be installed on next restart');
 
-    autoUpdater.autoInstallOnAppQuit = true;
+    this.engine.installOnQuit();
     if (this.latestUpdateInfo?.version) {
       this.installLaterVersion = this.latestUpdateInfo.version;
       logger.info(`Suppressing further prompts for version ${this.installLaterVersion}`);
@@ -445,16 +462,43 @@ export class UpdaterManager {
     }
   }
 
+  private async createSparkleEngine(): Promise<SparkleEngine | null> {
+    if (process.platform !== 'darwin') return null;
+
+    const baseUrl = this.getBaseUpdateUrl();
+    if (!baseUrl) return null;
+
+    const engine = await SparkleEngine.create({
+      appcastUrl: getSparkleFeedUrl(baseUrl, 'canary'),
+      currentVersion: electronApp.getVersion(),
+    });
+    logger.info(engine ? 'Sparkle engine ready' : 'Sparkle engine unavailable');
+    return engine;
+  }
+
+  private resolveEngine(channel: UpdateChannel): UpdateEngine {
+    return isSparkleChannel(channel) && this.sparkleEngine
+      ? this.sparkleEngine
+      : electronUpdaterEngine;
+  }
+
   private registerEvents() {
     logger.debug('Registering updater events');
 
-    autoUpdater.on('checking-for-update', () => {
+    this.bindEngine(electronUpdaterEngine);
+    if (this.sparkleEngine) this.bindEngine(this.sparkleEngine);
+
+    logger.debug('Updater events registered');
+  }
+
+  private bindEngine(engine: UpdateEngine) {
+    engine.on('checking-for-update', () => {
       logger.info('[Updater] Checking for update...');
       logger.info('[Updater] Current channel:', autoUpdater.channel);
       logger.info('[Updater] Current allowPrerelease:', autoUpdater.allowPrerelease);
     });
 
-    autoUpdater.on('update-available', (info) => {
+    engine.on('update-available', (info) => {
       logger.info(
         `Update available: ${info.version} (activeGen=${this.activeGeneration}, currentGen=${this.checkGeneration})`,
       );
@@ -478,7 +522,7 @@ export class UpdaterManager {
       this.downloadUpdate();
     });
 
-    autoUpdater.on('update-not-available', (info) => {
+    engine.on('update-not-available', (info) => {
       logger.info(`Update not available. Current: ${info.version}`);
 
       this.setStage('latest');
@@ -487,7 +531,8 @@ export class UpdaterManager {
       }, 5000);
     });
 
-    autoUpdater.on('error', async (err) => {
+    engine.on('error', async (err) => {
+      this.downloading = false;
       const message = err instanceof Error ? err.message : String(err);
 
       if (this.isMissingUpdateManifestError(err)) {
@@ -512,7 +557,7 @@ export class UpdaterManager {
       }, 3000);
     });
 
-    autoUpdater.on('download-progress', (progressObj) => {
+    engine.on('download-progress', (progressObj) => {
       logger.debug(
         `Download speed: ${progressObj.bytesPerSecond} - Downloaded ${progressObj.percent}% (${progressObj.transferred}/${progressObj.total})`,
       );
@@ -522,7 +567,7 @@ export class UpdaterManager {
       this.mainWindow.broadcast('updateDownloadProgress', progressObj);
     });
 
-    autoUpdater.on('update-downloaded', (info) => {
+    engine.on('update-downloaded', (info) => {
       logger.info(`Update downloaded: ${info.version}`);
       this.downloading = false;
 
@@ -540,8 +585,6 @@ export class UpdaterManager {
 
       this.mainWindow.broadcast('updateReady', updateInfo);
     });
-
-    logger.debug('Updater events registered');
   }
 
   /**

--- a/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
@@ -5,10 +5,15 @@ import type { App as AppCore } from '../../App';
 import { UpdaterManager } from '../UpdaterManager';
 
 // Use vi.hoisted to ensure mocks work with require()
-const { mockGetAllWindows, mockReleaseSingleInstanceLock } = vi.hoisted(() => ({
-  mockGetAllWindows: vi.fn().mockReturnValue([]),
-  mockReleaseSingleInstanceLock: vi.fn(),
-}));
+const { mockGetAllWindows, mockLoadSparkleBridge, mockReleaseSingleInstanceLock } = vi.hoisted(
+  () => ({
+    mockGetAllWindows: vi.fn().mockReturnValue([]),
+    mockLoadSparkleBridge: vi.fn(),
+    mockReleaseSingleInstanceLock: vi.fn(),
+  }),
+);
+
+vi.mock('electron-sparkle-updater', () => ({ loadSparkleBridge: mockLoadSparkleBridge }));
 
 // Mock electron-log
 vi.mock('electron-log', () => ({
@@ -58,12 +63,14 @@ vi.mock('electron', () => ({
   },
   app: {
     getVersion: vi.fn().mockReturnValue('0.0.0'),
+    isPackaged: true,
     releaseSingleInstanceLock: mockReleaseSingleInstanceLock,
   },
 }));
 
 // Mock updater configs
-vi.mock('@/modules/updater/configs', () => ({
+vi.mock('@/modules/updater/configs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   UPDATE_CHANNEL: 'stable',
   UPDATE_SERVER_URL: 'https://mock.update.server',
   updaterConfig: {
@@ -86,6 +93,7 @@ vi.mock('@/env', () => ({
 // Mock isDev
 vi.mock('@/const/env', () => ({
   isDev: false,
+  isWindows: false,
 }));
 
 describe('UpdaterManager', () => {
@@ -97,6 +105,7 @@ describe('UpdaterManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mockLoadSparkleBridge.mockReturnValue(null);
 
     // Reset autoUpdater state
     (autoUpdater as any).autoDownload = false;
@@ -177,6 +186,102 @@ describe('UpdaterManager', () => {
       expect(autoUpdater.on).toHaveBeenCalledWith('error', expect.any(Function));
       expect(autoUpdater.on).toHaveBeenCalledWith('download-progress', expect.any(Function));
       expect(autoUpdater.on).toHaveBeenCalledWith('update-downloaded', expect.any(Function));
+    });
+  });
+
+  describe('sparkle engine', () => {
+    const createBridge = () => ({
+      checkForUpdates: vi.fn(),
+      init: vi.fn().mockReturnValue(true),
+      installUpdateNow: vi.fn(),
+      installUpdateOnQuit: vi.fn(),
+      setAutomaticChecks: vi.fn(),
+      setEventHandler: vi.fn(),
+    });
+
+    let bridge: ReturnType<typeof createBridge>;
+    const originalPlatform = process.platform;
+
+    beforeEach(() => {
+      bridge = createBridge();
+      mockLoadSparkleBridge.mockReturnValue(bridge);
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('drives canary through Sparkle with the arch-specific appcast', async () => {
+      vi.mocked(mockApp.storeManager.get).mockReturnValue('canary');
+      await updaterManager.initialize();
+
+      expect(bridge.init).toHaveBeenCalledWith({
+        appcastUrl: `https://mock.update.server/canary/appcast-${process.arch}.xml`,
+      });
+
+      await updaterManager.checkForUpdates();
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    });
+
+    it('keeps stable on electron-updater even when Sparkle is available', async () => {
+      await updaterManager.initialize();
+      vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({} as any);
+
+      await updaterManager.checkForUpdates();
+
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(bridge.checkForUpdates).not.toHaveBeenCalled();
+    });
+
+    it('switches engines together with the channel', async () => {
+      vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({} as any);
+      await updaterManager.initialize();
+
+      updaterManager.switchChannel('canary');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+
+      updaterManager.switchChannel('stable');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('defers install-later to Sparkle on canary', async () => {
+      vi.mocked(mockApp.storeManager.get).mockReturnValue('canary');
+      await updaterManager.initialize();
+
+      updaterManager.installLater();
+
+      expect(bridge.installUpdateOnQuit).toHaveBeenCalledTimes(1);
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+    });
+
+    it('unblocks the next check when a Sparkle download fails', async () => {
+      let sparkleEvents: ((event: any) => void) | undefined;
+      bridge.setEventHandler.mockImplementation((fn) => {
+        sparkleEvents = fn;
+      });
+      vi.mocked(mockApp.storeManager.get).mockReturnValue('canary');
+      await updaterManager.initialize();
+
+      sparkleEvents?.({ type: 'update-available', version: '9.9.9' });
+      sparkleEvents?.({ message: 'download failed', type: 'error' });
+      await updaterManager.checkForUpdates();
+
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(mockBroadcast).toHaveBeenCalledWith('updateError', 'download failed');
+    });
+
+    it('never loads Sparkle outside macOS', async () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      vi.mocked(mockApp.storeManager.get).mockReturnValue('canary');
+
+      await updaterManager.initialize();
+
+      expect(mockLoadSparkleBridge).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/modules/updater/__tests__/sparkleEngine.test.ts
+++ b/apps/desktop/src/main/modules/updater/__tests__/sparkleEngine.test.ts
@@ -1,0 +1,179 @@
+import type { SparkleBridge, SparkleBridgeEvent } from 'electron-sparkle-updater';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SparkleEngine } from '../sparkleEngine';
+
+const { mockLoadBridge } = vi.hoisted(() => ({ mockLoadBridge: vi.fn() }));
+
+vi.mock('electron-sparkle-updater', () => ({ loadSparkleBridge: mockLoadBridge }));
+
+vi.mock('electron', () => ({ app: { isPackaged: true } }));
+
+vi.mock('@/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+const createBridge = () => {
+  let handler: ((event: SparkleBridgeEvent) => void) | undefined;
+  const bridge: SparkleBridge = {
+    checkForUpdates: vi.fn(),
+    init: vi.fn().mockReturnValue(true),
+    installUpdateNow: vi.fn(),
+    installUpdateOnQuit: vi.fn(),
+    setAutomaticChecks: vi.fn(),
+    setEventHandler: vi.fn((fn) => {
+      handler = fn;
+    }),
+  };
+  return { bridge, emit: (event: SparkleBridgeEvent) => handler?.(event) };
+};
+
+describe('SparkleEngine.create', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (process as any).resourcesPath = '/Applications/LobeHub.app/Contents/Resources';
+  });
+
+  it('returns null when no bridge is available', async () => {
+    mockLoadBridge.mockReturnValue(null);
+
+    await expect(
+      SparkleEngine.create({ appcastUrl: 'https://cdn/appcast.xml', currentVersion: '1.0.0' }),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when Sparkle fails to initialize', async () => {
+    const { bridge } = createBridge();
+    vi.mocked(bridge.init).mockReturnValue(false);
+    mockLoadBridge.mockReturnValue(bridge);
+
+    await expect(
+      SparkleEngine.create({ appcastUrl: 'https://cdn/appcast.xml', currentVersion: '1.0.0' }),
+    ).resolves.toBeNull();
+  });
+
+  it('initializes with the feed url and disables Sparkle scheduled checks', async () => {
+    const { bridge } = createBridge();
+    mockLoadBridge.mockReturnValue(bridge);
+
+    const engine = await SparkleEngine.create({
+      appcastUrl: 'https://cdn/canary/appcast-arm64.xml',
+      currentVersion: '1.0.0',
+    });
+
+    expect(engine?.kind).toBe('sparkle');
+    expect(mockLoadBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addonPath: expect.stringMatching(/[/\\]sparkle[/\\]sparkle_bridge\.node$/),
+        isPackaged: true,
+      }),
+    );
+    expect(bridge.init).toHaveBeenCalledWith({
+      appcastUrl: 'https://cdn/canary/appcast-arm64.xml',
+    });
+    expect(bridge.setAutomaticChecks).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('SparkleEngine', () => {
+  const setup = () => {
+    const { bridge, emit } = createBridge();
+    const engine = new SparkleEngine(bridge, '1.0.0');
+    return { bridge, emit, engine };
+  };
+
+  it('delegates commands to the bridge without a separate download step', async () => {
+    const { bridge, engine } = setup();
+
+    await engine.checkForUpdates();
+    await engine.downloadUpdate();
+    engine.installOnQuit();
+    engine.quitAndInstall();
+
+    expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(bridge.installUpdateOnQuit).toHaveBeenCalledTimes(1);
+    expect(bridge.installUpdateNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps the Sparkle lifecycle onto electron-updater events', () => {
+    const { emit, engine } = setup();
+    const events: Array<[string, unknown]> = [];
+    for (const name of [
+      'checking-for-update',
+      'update-available',
+      'update-not-available',
+      'update-downloaded',
+      'error',
+    ] as const) {
+      engine.on(name, (...args: unknown[]) => events.push([name, args[0]]));
+    }
+
+    emit({ type: 'checking' });
+    emit({
+      releaseDate: '2026-09-12T00:00:00Z',
+      releaseNotes: 'notes',
+      type: 'update-available',
+      version: '1.1.0',
+    });
+    emit({ type: 'update-downloaded', version: '1.1.0' });
+    emit({ type: 'update-not-available' });
+    emit({ message: 'boom', type: 'error' });
+
+    expect(events[0]).toEqual(['checking-for-update', undefined]);
+    expect(events[1]).toEqual([
+      'update-available',
+      expect.objectContaining({
+        releaseDate: '2026-09-12T00:00:00Z',
+        releaseNotes: 'notes',
+        version: '1.1.0',
+      }),
+    ]);
+    expect(events[2]).toEqual([
+      'update-downloaded',
+      expect.objectContaining({ releaseNotes: 'notes', version: '1.1.0' }),
+    ]);
+    expect(events[3]).toEqual([
+      'update-not-available',
+      expect.objectContaining({ version: '1.0.0' }),
+    ]);
+    expect(events[4]).toEqual(['error', expect.any(Error)]);
+    expect((events[4][1] as Error).message).toBe('boom');
+  });
+
+  it('reports download progress only for the download phase and restarts on fallback', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-12T00:00:00Z'));
+    const { emit, engine } = setup();
+    const progress: unknown[] = [];
+    engine.on('download-progress', (info) => progress.push(info));
+
+    emit({ type: 'download-progress', phase: 'download', percent: 0, transferred: 0 });
+    vi.setSystemTime(new Date('2026-09-12T00:00:02Z'));
+    emit({
+      type: 'download-progress',
+      phase: 'download',
+      percent: 50,
+      total: 200,
+      transferred: 100,
+    });
+    emit({ type: 'download-progress', phase: 'apply', percent: 30 });
+    emit({
+      type: 'download-progress',
+      phase: 'download',
+      percent: 0,
+      transferred: 0,
+      fallback: true,
+    });
+
+    expect(progress).toHaveLength(3);
+    expect(progress[1]).toEqual({
+      bytesPerSecond: 50,
+      delta: 100,
+      percent: 50,
+      total: 200,
+      transferred: 100,
+    });
+    expect(progress[2]).toMatchObject({ delta: 0, percent: 0, transferred: 0 });
+    vi.useRealTimers();
+  });
+});

--- a/apps/desktop/src/main/modules/updater/configs.ts
+++ b/apps/desktop/src/main/modules/updater/configs.ts
@@ -26,3 +26,9 @@ export const updaterConfig = {
   },
   enableAppUpdate: !isDev,
 };
+
+// Canary pilots Sparkle on macOS; stable keeps electron-updater until the pilot is promoted.
+export const isSparkleChannel = (channel: UpdateChannel) => channel === 'canary';
+
+export const getSparkleFeedUrl = (baseUrl: string, channel: UpdateChannel) =>
+  `${baseUrl}/${channel}/appcast-${process.arch}.xml`;

--- a/apps/desktop/src/main/modules/updater/electronUpdaterEngine.ts
+++ b/apps/desktop/src/main/modules/updater/electronUpdaterEngine.ts
@@ -1,0 +1,16 @@
+import { autoUpdater } from 'electron-updater';
+
+import type { UpdateEngine } from './engine';
+
+export const electronUpdaterEngine: UpdateEngine = {
+  checkForUpdates: () => autoUpdater.checkForUpdates(),
+  downloadUpdate: () => autoUpdater.downloadUpdate(),
+  installOnQuit: () => {
+    autoUpdater.autoInstallOnAppQuit = true;
+  },
+  kind: 'electron-updater',
+  on: (event, listener) => {
+    autoUpdater.on(event, listener as (...args: any[]) => void);
+  },
+  quitAndInstall: () => autoUpdater.quitAndInstall(true, true),
+};

--- a/apps/desktop/src/main/modules/updater/engine.ts
+++ b/apps/desktop/src/main/modules/updater/engine.ts
@@ -1,0 +1,24 @@
+import type { ProgressInfo, UpdateInfo } from 'electron-updater';
+
+export interface UpdateEngineEvents {
+  'checking-for-update': [];
+  'download-progress': [ProgressInfo];
+  'error': [Error];
+  'update-available': [UpdateInfo];
+  'update-downloaded': [UpdateInfo];
+  'update-not-available': [UpdateInfo];
+}
+
+export type UpdateEngineKind = 'electron-updater' | 'sparkle';
+
+export interface UpdateEngine {
+  checkForUpdates: () => Promise<unknown>;
+  downloadUpdate: () => Promise<unknown>;
+  installOnQuit: () => void;
+  kind: UpdateEngineKind;
+  on: <K extends keyof UpdateEngineEvents>(
+    event: K,
+    listener: (...args: UpdateEngineEvents[K]) => void,
+  ) => void;
+  quitAndInstall: () => void;
+}

--- a/apps/desktop/src/main/modules/updater/sparkleEngine.ts
+++ b/apps/desktop/src/main/modules/updater/sparkleEngine.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+
+import { app } from 'electron';
+import type { SparkleBridge, SparkleBridgeEvent } from 'electron-sparkle-updater';
+import { loadSparkleBridge } from 'electron-sparkle-updater';
+import type { ProgressInfo, UpdateInfo } from 'electron-updater';
+
+import { createLogger } from '@/utils/logger';
+
+import type { UpdateEngine, UpdateEngineEvents } from './engine';
+
+const logger = createLogger('modules:updater:sparkle');
+
+const toUpdateInfo = (version: string, event: Partial<SparkleBridgeEvent> = {}): UpdateInfo => ({
+  files: [],
+  path: '',
+  releaseDate: event.releaseDate ?? new Date().toISOString(),
+  releaseName: event.releaseName,
+  releaseNotes: event.releaseNotes,
+  sha512: '',
+  version,
+});
+
+export class SparkleEngine extends EventEmitter<UpdateEngineEvents> implements UpdateEngine {
+  readonly kind = 'sparkle';
+  private available: UpdateInfo | null = null;
+  private progressStartedAt = 0;
+  private lastTransferred = 0;
+
+  constructor(
+    private readonly bridge: SparkleBridge,
+    private readonly currentVersion: string,
+  ) {
+    super();
+    bridge.setEventHandler(this.handleEvent);
+  }
+
+  static async create(options: {
+    appcastUrl: string;
+    currentVersion: string;
+  }): Promise<SparkleEngine | null> {
+    const resourcesPath = process.resourcesPath ?? '';
+    const bridge = loadSparkleBridge({
+      addonPath:
+        app.isPackaged && resourcesPath
+          ? path.join(resourcesPath, 'sparkle', 'sparkle_bridge.node')
+          : undefined,
+      isPackaged: app.isPackaged,
+      log: (message) => logger.info(message),
+      resourcesPath,
+    });
+    if (!bridge) return null;
+
+    if (!bridge.init({ appcastUrl: options.appcastUrl })) {
+      logger.warn('Sparkle bridge failed to initialize, falling back to electron-updater');
+      return null;
+    }
+
+    bridge.setAutomaticChecks(false);
+    return new SparkleEngine(bridge, options.currentVersion);
+  }
+
+  checkForUpdates = async () => {
+    this.bridge.checkForUpdates();
+  };
+
+  // Sparkle starts downloading as soon as the silent driver accepts the found update.
+  downloadUpdate = async () => {};
+
+  installOnQuit = () => this.bridge.installUpdateOnQuit();
+
+  quitAndInstall = () => this.bridge.installUpdateNow();
+
+  private handleEvent = (event: SparkleBridgeEvent) => {
+    switch (event.type) {
+      case 'checking': {
+        this.emit('checking-for-update');
+        return;
+      }
+      case 'update-available': {
+        this.available = toUpdateInfo(event.version ?? '', event);
+        this.progressStartedAt = 0;
+        this.lastTransferred = 0;
+        this.emit('update-available', this.available);
+        return;
+      }
+      case 'download-progress': {
+        this.handleProgress(event);
+        return;
+      }
+      case 'update-downloaded': {
+        const info = this.available ?? toUpdateInfo(event.version ?? '');
+        this.emit('update-downloaded', event.version ? { ...info, version: event.version } : info);
+        return;
+      }
+      case 'update-not-available': {
+        this.emit('update-not-available', toUpdateInfo(this.currentVersion));
+        return;
+      }
+      case 'error': {
+        this.emit('error', new Error(event.message ?? 'Sparkle update failed'));
+        return;
+      }
+      default: {
+        logger.debug(`Ignoring Sparkle event: ${event.type}`);
+      }
+    }
+  };
+
+  private handleProgress(event: SparkleBridgeEvent) {
+    if (event.phase !== 'download') return;
+
+    const transferred = event.transferred ?? 0;
+    if (event.fallback || transferred < this.lastTransferred) {
+      this.progressStartedAt = 0;
+      this.lastTransferred = 0;
+    }
+
+    const now = Date.now();
+    if (!this.progressStartedAt) this.progressStartedAt = now;
+    const elapsedSeconds = (now - this.progressStartedAt) / 1000;
+
+    const progress: ProgressInfo = {
+      bytesPerSecond: elapsedSeconds > 0 ? Math.round(transferred / elapsedSeconds) : 0,
+      delta: transferred - this.lastTransferred,
+      percent: event.percent ?? 0,
+      total: event.total ?? 0,
+      transferred,
+    };
+    this.lastTransferred = transferred;
+    this.emit('download-progress', progress);
+  }
+}


### PR DESCRIPTION
Pilots [electron-sparkle-updater](https://github.com/Innei/electron-sparkle-updater) on the macOS **canary** channel so returning users download a small binary delta instead of the full archive. Stable, Windows and Linux keep electron-updater; the electron-updater manifests are still published, so clients that predate this change upgrade to the latest build in one full download as before.

#### What changed

- **Client** — `UpdaterManager` now picks an update engine per channel: `SparkleEngine` (new) for canary on darwin, the existing electron-updater elsewhere. The engine interface maps Sparkle's events onto the shapes the renderer already consumes, so the update UI and IPC are unchanged. Switching stable ↔ canary at runtime switches the engine; the canary → stable rollback still goes through electron-updater with `allowDowngrade`.
- **Packaging** — canary macOS builds embed `Sparkle.framework`, ship the native bridge as a resource loaded by explicit path (pnpm's symlinked package dir cannot be matched by `asarUnpack`), and bake `SUFeedURL` / `SUPublicEDKey` / `SUDeltaChainHistory=6` into Info.plist. Canary builds get a dash-free `CFBundleVersion` (`X.Y.Z.N`): Sparkle's version comparator truncates at the first dash, so `2.2.19-canary.1` and `-canary.2` would otherwise compare equal and no update would ever be offered. `CFBundleShortVersionString` stays the semver, which is what `app.getVersion()` and electron-updater read.
- **Release** — a new `publish-sparkle` job in the canary workflow (macOS runner) runs `apps/desktop/scripts/sparkleAppcast.mjs`: fetch the previous release's appcast + zip from S3, `generate_appcast` with one delta per release, merge a six-release history window, sign the per-arch appcast, upload `{channel}/{version}/*.delta` and `{channel}/appcast-{arch}.xml`. It skips itself when `SPARKLE_ED_PRIVATE_KEY` is absent; the build step embeds Sparkle only when `SPARKLE_ED_PUBLIC_KEY` is set. Both secrets are configured on this repo and stored in the LobeHub 1Password shared vault.

Delta chains are bounded: a client up to six releases behind applies the intermediate patches in sequence; anything older, or any patch that fails to verify or apply, falls back to the full archive.

| Before | After |
| ------ | ----- |
| canary macOS update = full ~190 MB zip via Squirrel | canary macOS update = ~30 KB delta via Sparkle (measured locally between two builds of this branch); full zip only as fallback |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Two packaged builds of this branch were served from a local static bucket produced by the release script. The running 9.0.0-canary.1 build found 9.0.0-canary.2 on its automatic check, requested only the appcast and the 29 KB `.delta` (never the zip), and "Restart to Update" replaced the bundle in place and relaunched as 9.0.0-canary.2. Unit tests cover engine selection, the Sparkle event mapping, the download-error recovery, the appcast script helpers and the build-number mapping; `bun run check` and `tsc` are clean.

Not verified: install-on-quit ("install later"), the x64 feed (same code path, unit-tested only), and the CI job itself, which first runs on the next canary release.

- Acceptance: https://app.lobehub.com/acceptance/fe4c3835-7ded-49f3-b7ed-56d465e465f1

#### 🔗 Related Issue

None.

https://claude.ai/code/session_01GA4f8KqcEAokWKcMnXFhUu