### PR TITLE
✨ feat(device-control): list one project directory on demand

### DIFF
--- a/apps/desktop/src/main/controllers/LocalFileCtr.ts
+++ b/apps/desktop/src/main/controllers/LocalFileCtr.ts
@@ -10,6 +10,7 @@ import type {
 } from '@lobechat/device-control';
 import {
   defaultGetProjectFileIndex,
+  defaultListProjectDirectory,
   defaultSearchProjectFiles,
 } from '@lobechat/device-control/project-file-index';
 import {
@@ -38,6 +39,8 @@ import {
   type PickFileResult,
   type PrepareSkillDirectoryParams,
   type PrepareSkillDirectoryResult,
+  type ProjectDirectoryListParams,
+  type ProjectDirectoryListResult,
   type ProjectFileIndexParams,
   type ProjectFileIndexResult,
   type ProjectFileSearchParams,
@@ -49,6 +52,8 @@ import {
   type ShowOpenDialogResult,
   type ShowSaveDialogParams,
   type ShowSaveDialogResult,
+  type TrashLocalFilesParams,
+  type TrashLocalFilesResult,
   type WriteLocalFileParams,
 } from '@lobechat/electron-client-ipc';
 import {
@@ -720,6 +725,46 @@ export default class LocalFileCtr extends ControllerModule {
     await this.approveProjectRootForPreview(result.root);
 
     return result;
+  }
+
+  /**
+   * Children of one directory inside an already-indexed project. The file tree
+   * calls this when the user expands a directory the index collapsed, so an
+   * ignored subtree costs a read only when someone opens it.
+   */
+  @IpcMethod()
+  async listProjectDirectory(
+    params: ProjectDirectoryListParams,
+  ): Promise<ProjectDirectoryListResult> {
+    logger.debug('Listing project directory', {
+      relativePath: params.relativePath,
+      root: params.root,
+    });
+
+    return defaultListProjectDirectory(params);
+  }
+
+  /**
+   * Move files/folders to the OS trash. Recoverable by design — the file tree
+   * never hard-deletes, so a misclick can be undone from Finder / Explorer.
+   */
+  @IpcMethod()
+  async trashLocalFiles({ paths }: TrashLocalFilesParams): Promise<TrashLocalFilesResult> {
+    if (paths.length === 0) return { error: 'No path to delete', success: false };
+
+    logger.debug('Trashing local files', { count: paths.length });
+
+    for (const rawPath of paths) {
+      const targetPath = expandTilde(rawPath) ?? rawPath;
+      try {
+        await shell.trashItem(targetPath);
+      } catch (error) {
+        logger.error('Failed to trash local file:', error);
+        return { error: (error as Error).message, success: false };
+      }
+    }
+
+    return { success: true };
   }
 
   /**

--- a/apps/desktop/src/main/controllers/LocalFileCtr.ts
+++ b/apps/desktop/src/main/controllers/LocalFileCtr.ts
@@ -54,6 +54,7 @@ import {
   type ShowSaveDialogResult,
   type TrashLocalFilesParams,
   type TrashLocalFilesResult,
+  type TrashLocalFilesResultItem,
   type WriteLocalFileParams,
 } from '@lobechat/electron-client-ipc';
 import {
@@ -750,21 +751,26 @@ export default class LocalFileCtr extends ControllerModule {
    */
   @IpcMethod()
   async trashLocalFiles({ paths }: TrashLocalFilesParams): Promise<TrashLocalFilesResult> {
-    if (paths.length === 0) return { error: 'No path to delete', success: false };
+    if (paths.length === 0) return { items: [], success: false };
 
     logger.debug('Trashing local files', { count: paths.length });
 
+    // Every path is attempted and reported. Stopping at the first failure would
+    // leave the caller unable to tell which earlier paths are already in the
+    // trash, so it could neither refresh its tree nor safely retry the batch.
+    const items: TrashLocalFilesResultItem[] = [];
     for (const rawPath of paths) {
       const targetPath = expandTilde(rawPath) ?? rawPath;
       try {
         await shell.trashItem(targetPath);
+        items.push({ path: rawPath, success: true });
       } catch (error) {
         logger.error('Failed to trash local file:', error);
-        return { error: (error as Error).message, success: false };
+        items.push({ error: (error as Error).message, path: rawPath, success: false });
       }
     }
 
-    return { success: true };
+    return { items, success: items.every((item) => item.success) };
   }
 
   /**

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
@@ -35,6 +35,7 @@ vi.mock('electron', () => ({
   shell: {
     openPath: vi.fn(),
     showItemInFolder: vi.fn(),
+    trashItem: vi.fn(),
   },
 }));
 
@@ -1665,6 +1666,50 @@ describe('LocalFileCtr', () => {
       await localFileCtr.handleGrepContent(params);
 
       expect(mockContentSearchService.grep).toHaveBeenCalledWith(params);
+    });
+  });
+
+  describe('trashLocalFiles', () => {
+    it('reports every path when a later one fails, so earlier trashed items are not lost', async () => {
+      vi.mocked(mockShell.trashItem)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('Operation not permitted'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await localFileCtr.trashLocalFiles({
+        paths: ['/p/first.txt', '/p/locked.txt', '/p/third.txt'],
+      });
+
+      // The batch is not atomic: first and third really are in the trash, so a
+      // bare { success: false } would strand them in the caller's tree.
+      expect(result.success).toBe(false);
+      expect(result.items).toEqual([
+        { path: '/p/first.txt', success: true },
+        { error: 'Operation not permitted', path: '/p/locked.txt', success: false },
+        { path: '/p/third.txt', success: true },
+      ]);
+      expect(mockShell.trashItem).toHaveBeenCalledTimes(3);
+    });
+
+    it('succeeds only when every path was trashed', async () => {
+      vi.mocked(mockShell.trashItem).mockResolvedValue(undefined);
+
+      const result = await localFileCtr.trashLocalFiles({ paths: ['/p/a.txt', '/p/b.txt'] });
+
+      expect(result).toEqual({
+        items: [
+          { path: '/p/a.txt', success: true },
+          { path: '/p/b.txt', success: true },
+        ],
+        success: true,
+      });
+    });
+
+    it('rejects an empty batch without touching the trash', async () => {
+      const result = await localFileCtr.trashLocalFiles({ paths: [] });
+
+      expect(result).toEqual({ items: [], success: false });
+      expect(mockShell.trashItem).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -608,6 +608,24 @@ export const deviceRouter = router({
     }),
 
   /**
+   * Children of one directory inside a project on a remote device. The Files
+   * tree calls this when the user expands a directory the index collapsed
+   * (a fully git-ignored folder). Returns `null` when offline.
+   */
+  listProjectDirectory: deviceProcedure
+    .input(z.object({ deviceId: z.string(), relativePath: z.string(), root: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const result = await deviceGateway.listProjectDirectory({
+        deviceId: input.deviceId,
+        relativePath: input.relativePath,
+        root: input.root,
+        userId: ctx.userId,
+        workspaceId: ctx.workspaceId,
+      });
+      return result ?? null;
+    }),
+
+  /**
    * Browse one directory level on a remote device. Personal devices belong to
    * the caller. A workspace device may expose new paths only to its enroller or
    * a workspace owner; other members continue to use its approved recents.

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -36,6 +36,7 @@ import type {
   DeviceLocalFilePreviewResult,
   DeviceMoveProjectFileItem,
   DeviceMoveProjectFileResultItem,
+  DeviceProjectDirectoryListResult,
   DeviceProjectFileIndexResult,
   DeviceProjectFileSearchResult,
   DeviceRenameProjectFileResult,
@@ -979,6 +980,40 @@ export class DeviceGateway {
       return result.data;
     } catch (error) {
       log('getProjectFileIndex: error for deviceId=%s — %O', deviceId, error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Children of one directory inside a project on a remote device via the
+   * `listProjectDirectory` device RPC — expands a row the index collapsed.
+   */
+  async listProjectDirectory(params: {
+    deviceId: string;
+    relativePath: string;
+    root: string;
+    timeout?: number;
+    userId: string;
+    workspaceId?: string;
+  }): Promise<DeviceProjectDirectoryListResult | undefined> {
+    const { userId, deviceId, relativePath, root, timeout = 30_000, workspaceId } = params;
+    const client = this.getClient();
+    if (!client) return undefined;
+
+    try {
+      const result = await client.invokeRpc<DeviceProjectDirectoryListResult>(
+        { deviceId, timeout, userId, workspaceId },
+        { method: 'listProjectDirectory', params: { relativePath, root } },
+      );
+
+      if (!result.success || !result.data) {
+        log('listProjectDirectory: failed for deviceId=%s — %s', deviceId, result.error);
+        return undefined;
+      }
+
+      return result.data;
+    } catch (error) {
+      log('listProjectDirectory: error for deviceId=%s — %O', deviceId, error);
       return undefined;
     }
   }

--- a/packages/device-control/src/__tests__/projectFileIndex.test.ts
+++ b/packages/device-control/src/__tests__/projectFileIndex.test.ts
@@ -6,7 +6,11 @@ import { promisify } from 'node:util';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { defaultGetProjectFileIndex, defaultSearchProjectFiles } from '../projectFileIndex';
+import {
+  defaultGetProjectFileIndex,
+  defaultListProjectDirectory,
+  defaultSearchProjectFiles,
+} from '../projectFileIndex';
 
 const cleanup: string[] = [];
 
@@ -77,6 +81,29 @@ describe('defaultGetProjectFileIndex', () => {
       ]);
     }
     expect(paths).toContain('.husky/_/hook');
+    // Its children are already indexed, so nothing is left to fetch on expand.
+    expect(result.entries.find((entry) => entry.relativePath === '.husky/_/')?.collapsed).toBe(
+      undefined,
+    );
+  });
+
+  it('flags a collapsed ignored directory so its children can be fetched on expand', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-index-collapsed-'));
+    cleanup.push(dir);
+    execFileSync('git', ['-c', 'init.defaultBranch=main', 'init'], { cwd: dir });
+    await writeFile(path.join(dir, '.gitignore'), 'traces/\n');
+    await mkdir(path.join(dir, 'traces', 'nested'), { recursive: true });
+    await writeFile(path.join(dir, 'traces', 'one.json'), '{}\n');
+    await writeFile(path.join(dir, 'traces', 'nested', 'two.json'), '{}\n');
+
+    const result = await defaultGetProjectFileIndex({ scope: dir });
+
+    expect(result.entries.find((entry) => entry.relativePath === 'traces/')).toMatchObject({
+      collapsed: true,
+      gitIgnored: true,
+      isDirectory: true,
+    });
+    expect(result.entries.map((entry) => entry.relativePath)).not.toContain('traces/one.json');
   });
 
   it('falls back to a glob walk when the scope is not a git repo', async () => {
@@ -112,6 +139,63 @@ describe('defaultGetProjectFileIndex', () => {
     expect(byRel['.agents/config.md']?.isDirectory).toBe(false);
 
     expect(result).not.toHaveProperty('totalCount');
+  });
+});
+
+describe('defaultListProjectDirectory', () => {
+  it('lists one level of a collapsed directory, flagging subdirectories for the next expand', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-list-dir-'));
+    cleanup.push(dir);
+    await mkdir(path.join(dir, 'traces', 'nested'), { recursive: true });
+    await writeFile(path.join(dir, 'traces', 'one.json'), '{}\n');
+    await writeFile(path.join(dir, 'traces', 'nested', 'two.json'), '{}\n');
+
+    const result = await defaultListProjectDirectory({ relativePath: 'traces/', root: dir });
+
+    expect(result.truncated).toBe(false);
+    expect(result.entries).toEqual([
+      expect.objectContaining({
+        collapsed: true,
+        gitIgnored: true,
+        isDirectory: true,
+        relativePath: 'traces/nested/',
+      }),
+      expect.objectContaining({
+        gitIgnored: true,
+        isDirectory: false,
+        relativePath: 'traces/one.json',
+      }),
+    ]);
+    expect(result.entries[1]).not.toHaveProperty('collapsed');
+  });
+
+  it('reports truncation instead of returning an unbounded directory', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-list-dir-limit-'));
+    cleanup.push(dir);
+    await mkdir(path.join(dir, 'many'), { recursive: true });
+    await Promise.all(
+      Array.from({ length: 5 }).map((_, index) =>
+        writeFile(path.join(dir, 'many', `file-${index}.txt`), 'x\n'),
+      ),
+    );
+
+    const result = await defaultListProjectDirectory({
+      limit: 2,
+      relativePath: 'many',
+      root: dir,
+    });
+
+    expect(result.entries).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('refuses to walk outside the project root', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-list-dir-escape-'));
+    cleanup.push(dir);
+
+    await expect(defaultListProjectDirectory({ relativePath: '../', root: dir })).rejects.toThrow(
+      'outside the project root',
+    );
   });
 });
 

--- a/packages/device-control/src/__tests__/projectFileIndex.test.ts
+++ b/packages/device-control/src/__tests__/projectFileIndex.test.ts
@@ -1,5 +1,5 @@
 import { execFile, execFileSync } from 'node:child_process';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -196,6 +196,33 @@ describe('defaultListProjectDirectory', () => {
     await expect(defaultListProjectDirectory({ relativePath: '../', root: dir })).rejects.toThrow(
       'outside the project root',
     );
+  });
+
+  it('refuses to follow a symlink that points outside the project root', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-list-dir-symlink-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'dc-list-dir-outside-'));
+    cleanup.push(dir, outside);
+    await writeFile(path.join(outside, 'SECRET.txt'), 'must stay unreachable\n');
+    // A lexical prefix check passes here: the link itself lives inside the root.
+    await symlink(outside, path.join(dir, 'escape-link'), 'dir');
+
+    await expect(
+      defaultListProjectDirectory({ relativePath: 'escape-link', root: dir }),
+    ).rejects.toThrow('outside the project root');
+  });
+
+  it('still lists a symlink that stays inside the project root', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dc-list-dir-inner-link-'));
+    cleanup.push(dir);
+    await mkdir(path.join(dir, 'real'), { recursive: true });
+    await writeFile(path.join(dir, 'real', 'kept.txt'), 'reachable\n');
+    await symlink(path.join(dir, 'real'), path.join(dir, 'inner-link'), 'dir');
+
+    const result = await defaultListProjectDirectory({ relativePath: 'inner-link', root: dir });
+
+    // Ids stay anchored to the path the caller asked for, not the link target,
+    // so the tree can still attach these rows under the row that was expanded.
+    expect(result.entries.map((entry) => entry.relativePath)).toEqual(['inner-link/kept.txt']);
   });
 });
 

--- a/packages/device-control/src/dispatch.ts
+++ b/packages/device-control/src/dispatch.ts
@@ -22,6 +22,7 @@ import {
 
 import { getClaudeCodeQuota, type GetClaudeCodeQuotaParams } from './claudeCodeQuota';
 import { defaultReadExternalAssetForPublish } from './filePreview';
+import { defaultListProjectDirectory } from './projectFileIndex';
 import { prepareSkillDirectory } from './skillDirectory';
 import type {
   BrowseDirectoryParams,
@@ -33,6 +34,7 @@ import type {
   ListProjectSkillsParams,
   LocalFilePreviewUrlParams,
   PrepareSkillDirectoryParams,
+  ProjectDirectoryListParams,
   ProjectFileIndexParams,
   ProjectFileSearchParams,
   UnenrollWorkspaceParams,
@@ -56,6 +58,7 @@ export const DEVICE_RPC_METHODS = [
   'browseDirectory',
   'statPath',
   'getProjectFileIndex',
+  'listProjectDirectory',
   'searchProjectFiles',
   'getLocalFilePreview',
   'readExternalAssetForPublish',
@@ -149,6 +152,10 @@ export const executeDeviceRpc = async (
 
     case 'getProjectFileIndex': {
       return deps.getProjectFileIndex(params as ProjectFileIndexParams);
+    }
+
+    case 'listProjectDirectory': {
+      return defaultListProjectDirectory(params as ProjectDirectoryListParams);
     }
 
     case 'searchProjectFiles': {

--- a/packages/device-control/src/index.ts
+++ b/packages/device-control/src/index.ts
@@ -4,7 +4,11 @@ export {
   defaultReadExternalAssetForPublish,
   EXTERNAL_PUBLISH_ASSET_MAX_BYTES,
 } from './filePreview';
-export { defaultGetProjectFileIndex, defaultSearchProjectFiles } from './projectFileIndex';
+export {
+  defaultGetProjectFileIndex,
+  defaultListProjectDirectory,
+  defaultSearchProjectFiles,
+} from './projectFileIndex';
 export { defaultSkillCacheRoot, prepareSkillDirectory } from './skillDirectory';
 export * from './types';
 export { browseDirectory, initWorkspace, listProjectSkills, statPath } from './workspace';

--- a/packages/device-control/src/projectFileIndex.ts
+++ b/packages/device-control/src/projectFileIndex.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -7,6 +8,8 @@ import fg from 'fast-glob';
 
 import { projectFileSearchManager } from './projectFileSearchManager';
 import type {
+  ProjectDirectoryListParams,
+  ProjectDirectoryListResult,
   ProjectFileIndexEntry,
   ProjectFileIndexParams,
   ProjectFileIndexResult,
@@ -17,17 +20,28 @@ import type {
 const execFileAsync = promisify(execFile);
 const PROJECT_FILE_GLOB_LIMIT = 5000;
 const PROJECT_FILE_SEARCH_DEFAULT_LIMIT = 100;
+const PROJECT_DIRECTORY_LIST_LIMIT = 1000;
 
 const toPosixRelativePath = (filePath: string) => filePath.split(path.sep).join('/');
+
+/** Parent of a posix index path (`a/b/c.ts` → `a/b/`), or null at the root. */
+const getParentRelativePath = (relativePath: string): string | null => {
+  const cleaned = relativePath.endsWith('/') ? relativePath.slice(0, -1) : relativePath;
+  const index = cleaned.lastIndexOf('/');
+  if (index < 0) return null;
+  return `${cleaned.slice(0, index)}/`;
+};
 
 const createProjectFileEntry = (
   root: string,
   absolutePath: string,
   isDirectory: boolean,
   gitIgnored?: boolean,
+  collapsed?: boolean,
 ): ProjectFileIndexEntry => {
   const relativePath = toPosixRelativePath(path.relative(root, absolutePath));
   return {
+    ...(collapsed ? { collapsed: true } : {}),
     ...(gitIgnored ? { gitIgnored: true } : {}),
     isDirectory,
     name: path.basename(absolutePath),
@@ -73,11 +87,19 @@ const buildEntries = (
   // collapsing fully ignored directories (for example node_modules/) into one
   // bounded entry. The trailing slash is therefore meaningful and must be
   // preserved as directory metadata before resolving the absolute path.
+  // A collapsed directory has real children on disk that this index will never
+  // list, so it is flagged for the caller to expand on demand.
   const ignoredEntries = ignoredPaths
     .map((relativePath) => {
       const isDirectory = relativePath.endsWith('/');
       const normalizedPath = isDirectory ? relativePath.slice(0, -1) : relativePath;
-      return createProjectFileEntry(root, path.resolve(root, normalizedPath), isDirectory, true);
+      return createProjectFileEntry(
+        root,
+        path.resolve(root, normalizedPath),
+        isDirectory,
+        true,
+        isDirectory,
+      );
     })
     .filter((entry) => {
       if (seen.has(entry.path)) return false;
@@ -85,7 +107,34 @@ const buildEntries = (
       return true;
     });
 
-  return addMissingParentDirectories([...fileEntries, ...ignoredEntries], root);
+  return clearCollapsedOnIndexedDirectories(
+    addMissingParentDirectories([...fileEntries, ...ignoredEntries], root),
+  );
+};
+
+/**
+ * A directory Git collapsed can still have indexed descendants — a nested
+ * `.gitignore` re-including part of the subtree, for example. Those rows are
+ * already complete, so drop the flag to keep the caller from re-listing them.
+ */
+const clearCollapsedOnIndexedDirectories = (
+  entries: ProjectFileIndexEntry[],
+): ProjectFileIndexEntry[] => {
+  const parentsWithChildren = new Set<string>();
+  for (const entry of entries) {
+    let parent = getParentRelativePath(entry.relativePath);
+    while (parent) {
+      if (parentsWithChildren.has(parent)) break;
+      parentsWithChildren.add(parent);
+      parent = getParentRelativePath(parent);
+    }
+  }
+
+  return entries.map((entry) => {
+    if (!entry.collapsed || !parentsWithChildren.has(entry.relativePath)) return entry;
+    const { collapsed: _collapsed, ...rest } = entry;
+    return rest;
+  });
 };
 
 const addMissingParentDirectories = (
@@ -120,6 +169,51 @@ const collectGlobEntries = async (scope: string): Promise<ProjectFileIndexEntry[
   }
 
   return addMissingParentDirectories(entries, scope);
+};
+
+/**
+ * Children of a single directory inside a project, read straight from disk.
+ *
+ * The index collapses fully ignored directories, so their contents never reach
+ * the tree. This fills one level at a time when the user expands such a row —
+ * an ignored subtree is enumerated only if someone actually looks at it, which
+ * is what keeps `node_modules` from ever being walked.
+ */
+export const defaultListProjectDirectory = async ({
+  limit = PROJECT_DIRECTORY_LIST_LIMIT,
+  relativePath,
+  root,
+}: ProjectDirectoryListParams): Promise<ProjectDirectoryListResult> => {
+  const resolvedRoot = path.resolve(root);
+  const target = path.resolve(resolvedRoot, relativePath);
+
+  // Never step outside the project the caller already has access to.
+  if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error('Directory is outside the project root');
+  }
+
+  const dirents = await readdir(target, { withFileTypes: true });
+  const visible = dirents
+    .filter((dirent) => dirent.isDirectory() || dirent.isFile() || dirent.isSymbolicLink())
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const entries = visible.slice(0, limit).map((dirent) => {
+    // Symlinks stay leaf rows — following one could walk outside the project
+    // root, or into a cycle.
+    const isDirectory = !dirent.isSymbolicLink() && dirent.isDirectory();
+
+    return createProjectFileEntry(
+      resolvedRoot,
+      path.join(target, dirent.name),
+      isDirectory,
+      // Everything under a collapsed directory is ignored by the same rule
+      // that collapsed the parent.
+      true,
+      isDirectory,
+    );
+  });
+
+  return { entries, truncated: visible.length > entries.length };
 };
 
 /**

--- a/packages/device-control/src/projectFileIndex.ts
+++ b/packages/device-control/src/projectFileIndex.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { readdir } from 'node:fs/promises';
+import { readdir, realpath } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -187,8 +187,15 @@ export const defaultListProjectDirectory = async ({
   const resolvedRoot = path.resolve(root);
   const target = path.resolve(resolvedRoot, relativePath);
 
-  // Never step outside the project the caller already has access to.
-  if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${path.sep}`)) {
+  // Never step outside the project the caller already has access to. The check
+  // runs on real paths: `path.resolve` does not follow links, so a symlink
+  // inside the project pointing outside it would pass a lexical prefix check
+  // and then have its target enumerated. Entries are still built from the
+  // lexical path below, so their ids stay anchored to the path the caller
+  // asked for rather than wherever a link happened to land.
+  const realRoot = await realpath(resolvedRoot);
+  const realTarget = await realpath(target);
+  if (realTarget !== realRoot && !realTarget.startsWith(`${realRoot}${path.sep}`)) {
     throw new Error('Directory is outside the project root');
   }
 

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -152,6 +152,13 @@ export interface LocalFilePreviewResult {
 // ─── Project file index ───
 
 export interface ProjectFileIndexEntry {
+  /**
+   * Directory whose children were deliberately left out of the index because
+   * Git collapsed it (`git ls-files --directory` reports a fully ignored
+   * directory as a single entry). The row is expandable, but its children must
+   * be fetched on demand via `listProjectDirectory`.
+   */
+  collapsed?: boolean;
   /** Whether Git ignore rules match this file or directory. */
   gitIgnored?: boolean;
   isDirectory: boolean;
@@ -170,6 +177,21 @@ export interface ProjectFileIndexResult {
   indexedAt: string;
   root: string;
   source: 'git' | 'glob';
+}
+
+export interface ProjectDirectoryListParams {
+  /** Cap on returned children; the caller is told when more exist. */
+  limit?: number;
+  /** Directory to list, relative to `root`. A trailing slash is tolerated. */
+  relativePath: string;
+  /** Project root the returned `relativePath`s are resolved against. */
+  root: string;
+}
+
+export interface ProjectDirectoryListResult {
+  entries: ProjectFileIndexEntry[];
+  /** True when the directory holds more children than `limit` returned. */
+  truncated: boolean;
 }
 
 export interface ProjectFileSearchParams extends ProjectFileIndexParams {

--- a/packages/electron-client-ipc/src/types/localSystem.ts
+++ b/packages/electron-client-ipc/src/types/localSystem.ts
@@ -320,8 +320,22 @@ export interface TrashLocalFilesParams {
   paths: string[];
 }
 
-export interface TrashLocalFilesResult {
+export interface TrashLocalFilesResultItem {
+  /** Error message if this specific path failed. */
   error?: string;
+  /** The path as it was requested, so the caller can reconcile its own rows. */
+  path: string;
+  success: boolean;
+}
+
+export interface TrashLocalFilesResult {
+  /**
+   * Per-path outcome, in request order. A batch is not atomic: an earlier path
+   * can already be in the trash when a later one fails, so the caller needs
+   * this to reconcile its tree and to retry only what is left.
+   */
+  items: TrashLocalFilesResultItem[];
+  /** True only when every path was trashed. */
   success: boolean;
 }
 

--- a/packages/electron-client-ipc/src/types/localSystem.ts
+++ b/packages/electron-client-ipc/src/types/localSystem.ts
@@ -274,6 +274,13 @@ export interface LocalSearchFilesParams {
 }
 
 export interface ProjectFileIndexEntry {
+  /**
+   * Directory whose children were deliberately left out of the index because
+   * Git collapsed it (`git ls-files --directory` reports a fully ignored
+   * directory as a single entry). The row is expandable, but its children must
+   * be fetched on demand via `listProjectDirectory`.
+   */
+  collapsed?: boolean;
   /** Whether Git ignore rules match this file or directory. */
   gitIgnored?: boolean;
   isDirectory: boolean;
@@ -292,6 +299,30 @@ export interface ProjectFileIndexResult {
   indexedAt: string;
   root: string;
   source: 'git' | 'glob';
+}
+
+export interface ProjectDirectoryListParams {
+  /** Cap on returned children; the caller is told when more exist. */
+  limit?: number;
+  /** Directory to list, relative to `root`. A trailing slash is tolerated. */
+  relativePath: string;
+  /** Project root the returned `relativePath`s are resolved against. */
+  root: string;
+}
+
+export interface ProjectDirectoryListResult {
+  entries: ProjectFileIndexEntry[];
+  /** True when the directory holds more children than `limit` returned. */
+  truncated: boolean;
+}
+
+export interface TrashLocalFilesParams {
+  paths: string[];
+}
+
+export interface TrashLocalFilesResult {
+  error?: string;
+  success: boolean;
 }
 
 export interface ProjectFileSearchParams extends ProjectFileIndexParams {

--- a/packages/types/src/device.ts
+++ b/packages/types/src/device.ts
@@ -637,6 +637,8 @@ export interface DeviceGitWorkingTreeFiles {
 
 /** One entry in a device's project file index. Mirrors `ProjectFileIndexEntry`. */
 export interface DeviceProjectFileIndexEntry {
+  /** Directory the index left unexpanded; children come from `listProjectDirectory`. */
+  collapsed?: boolean;
   /** Whether Git ignore rules match this file or directory. */
   gitIgnored?: boolean;
   isDirectory: boolean;
@@ -657,6 +659,15 @@ export interface DeviceProjectFileIndexResult {
   indexedAt: string;
   root: string;
   source: 'git' | 'glob';
+}
+
+/**
+ * Children of one directory on a remote device, returned by the
+ * `listProjectDirectory` device RPC. Fills in a subtree the index collapsed.
+ */
+export interface DeviceProjectDirectoryListResult {
+  entries: DeviceProjectFileIndexEntry[];
+  truncated: boolean;
 }
 
 export interface DeviceProjectFileSearchResult {


### PR DESCRIPTION
Adds the contract for expanding a directory that the project index deliberately leaves empty. Nothing calls it yet — the caller is the stacked UI PR — so merging this alone changes no product behavior.

#### Why

The project file index enumerates ignored paths with `git ls-files --others --ignored --exclude-standard --directory`. The `--directory` flag collapses a fully ignored folder into one entry and never lists its contents, which is exactly what keeps `node_modules` out of the index. The cost is that such an entry reaches a caller with zero children while holding real files on disk. In this repository `.agent-tracing/` is one row standing in for 520 files.

#### What

- `ProjectFileIndexEntry.collapsed` marks those rows. It is set only when the directory has no indexed children at all, so a nested `.gitignore` that re-includes part of a subtree leaves those rows complete and unflagged.
- `listProjectDirectory` reads one level of a directory from disk. It refuses to resolve outside the project root, keeps symlinks as leaf rows so a link cannot walk out of the project or into a cycle, and reports `truncated` rather than returning an unbounded listing.
- Both transports are wired: an Electron IPC method on `LocalFileCtr`, plus a device RPC and the `device.listProjectDirectory` TRPC procedure for remote devices.
- `trashLocalFiles` moves paths to the OS trash through `shell.trashItem` instead of unlinking them.

No UI surface in this PR, so there is nothing to screenshot.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Six new cases in `projectFileIndex.test.ts` cover the collapsed flag, the nested-`.gitignore` case that must stay unflagged, one-level listing, the truncation cap, and the root-escape refusal.

Verified against this repository rather than fixtures alone: `.agent-tracing/` comes back `collapsed: true` with 0 indexed children, `listProjectDirectory` returns its 520 real children with `truncated: false`, 152 directories are flagged repo-wide, and `.acceptances/` is correctly left unflagged because its children are indexed.

Type-check on this branch alone reports 37 errors, each one identical to the pristine `canary` baseline. This branch adds none.

- Acceptance: not applicable on its own. This PR has no callers and no user-visible outcome; merging it cannot change product behavior. The behavior it enables is verified in the stacked UI PR.

#### 🔗 Related Issue

None — no open issue matches this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
