### PR TITLE
💄 style: drop ScrollArea content typography workarounds after @lobehub/ui 5.42.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     "@lobehub/icons": "^5.18.0",
     "@lobehub/market-sdk": "0.41.0",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.42.2",
+    "@lobehub/ui": "^5.42.7",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",

--- a/src/components/StreamingMarkdown/index.tsx
+++ b/src/components/StreamingMarkdown/index.tsx
@@ -44,15 +44,6 @@ const StreamingMarkdown = memo<StreamingMarkdownProps>(({ children, maxHeight = 
       disableContentFit
       scrollFade
       className={styles.scrollRoot}
-      contentProps={{
-        style: {
-          color: 'inherit',
-          display: 'block',
-          fontSize: 'inherit',
-          gap: 0,
-          lineHeight: 'inherit',
-        },
-      }}
       viewportProps={{
         className: styles.container,
         ref: ref as RefObject<HTMLDivElement>,

--- a/src/features/AgentTasks/features/TaskStatusCascadeModal.tsx
+++ b/src/features/AgentTasks/features/TaskStatusCascadeModal.tsx
@@ -23,10 +23,6 @@ const styles = createStaticStyles(({ css }) => ({
     margin-block-start: 8px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadius};
-
-    > [role='presentation'] > [role='presentation'] {
-      gap: 0;
-    }
   `,
   row: css`
     padding-block: 6px;

--- a/src/features/ConnectAgent/index.tsx
+++ b/src/features/ConnectAgent/index.tsx
@@ -295,7 +295,6 @@ const ScrollableAgentList = memo<{ children: ReactNode }>(({ children }) => (
     disableContentFit
     scrollFade
     className={styles.groupList}
-    contentProps={{ style: { display: 'block' } }}
     scrollbarProps={{ className: styles.agentListScrollbar }}
     thumbProps={{ className: styles.agentListThumb }}
     viewportProps={{ className: styles.agentListViewport }}

--- a/src/features/Conversation/Messages/AgentCouncil/components/AutoScrollShadow.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/AutoScrollShadow.tsx
@@ -32,15 +32,6 @@ const AutoScrollShadow = memo<AutoScrollShadowProps>(({ children, content, strea
     <ScrollArea
       scrollFade
       style={{ background: 'transparent', borderRadius: 0 }}
-      contentProps={{
-        style: {
-          color: 'inherit',
-          display: 'block',
-          fontSize: 'inherit',
-          gap: 0,
-          lineHeight: 'inherit',
-        },
-      }}
       viewportProps={{
         ref: ref as RefObject<HTMLDivElement>,
         style: { height: 'max(33vh, 480px)' },

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -44,8 +44,7 @@ interface ContentBlocksScrollFromMessages extends ContentBlocksScrollBaseProps {
 }
 
 export type ContentBlocksScrollProps =
-  | ContentBlocksScrollFromBlocks
-  | ContentBlocksScrollFromMessages;
+  ContentBlocksScrollFromBlocks | ContentBlocksScrollFromMessages;
 
 const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
   const { disableEditing, onScroll, scroll = true, scrollRef, variant } = props;
@@ -93,16 +92,7 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
       disableContentFit
       scrollFade
       className={styles.scrollRoot}
-      contentProps={{
-        style: {
-          color: 'inherit',
-          display: 'block',
-          fontSize: 'inherit',
-          gap: 0,
-          lineHeight: 'inherit',
-          paddingInlineEnd: 12,
-        },
-      }}
+      contentProps={{ style: { paddingInlineEnd: 12 } }}
       scrollbarProps={{
         style: {
           marginInlineEnd: 2,

--- a/src/features/Conversation/components/Thinking/index.tsx
+++ b/src/features/Conversation/components/Thinking/index.tsx
@@ -65,15 +65,6 @@ const Thinking = memo<ThinkingProps>((props) => {
           disableContentFit
           scrollFade
           className={styles.scrollRoot}
-          contentProps={{
-            style: {
-              color: 'inherit',
-              display: 'block',
-              fontSize: 'inherit',
-              gap: 0,
-              lineHeight: 'inherit',
-            },
-          }}
           viewportProps={{
             className: styles.contentScroll,
             ref: ref as RefObject<HTMLDivElement>,


### PR DESCRIPTION
## Why

`@lobehub/ui` ScrollArea used to force `font-size: 12px`, `line-height: 22px`, `color` and `display: flex; flex-direction: column; gap: 16px` on its content element (leftover from Base UI's docs demo CSS). Every consumer that didn't override it inherited that, which is what regressed the NavPanel sidebar typography after it moved onto `ScrollArea`.

Fixed upstream in lobehub/lobe-ui `0b822434` / `df093ebd`, released as **5.42.7**: content now inherits from its parent.

## What

- bump `@lobehub/ui` `^5.42.2` → `^5.42.7` (fixes NavPanel with no code change)
- remove the six per-callsite workarounds that only existed to undo the old defaults:
  - `StreamingMarkdown`, `Thinking`, `AutoScrollShadow`, `ContentBlocksScroll`: drop `color/fontSize/lineHeight: inherit`, `display: block`, `gap: 0`
  - `ConnectAgent`: drop `display: block`
  - `TaskStatusCascadeModal`: drop the `[role='presentation'] > [role='presentation'] { gap: 0 }` selector

`LocalFile/TabStrip` keeps its `contentProps` — that one is a real horizontal layout, not a workaround.

## Check

- Acceptance: https://app.lobehub.com/acceptance/123242c6-9bf2-46a9-a6e2-5d2941b3cc66 — round 1 has the measured computed-style before/after (12px flex → inherited 14px block) for the Home sidebar and the Changelog modal; screenshot uploads were blocked by the account storage quota and will land in round 2.
- Not covered: the two Portal confirm modals (`PublishHtmlArtifactConfirm` / `PublishHtmlArtifactBlockedConfirm`) and Electron.

https://claude.ai/code/session_01FYDWLFnDqY7ngaqrECg49A
