### PR TITLE
🐛 fix(cli): wait for gateway connection before daemon readiness

### DIFF
--- a/apps/cli/src/commands/connect.integration.test.ts
+++ b/apps/cli/src/commands/connect.integration.test.ts
@@ -101,7 +101,7 @@ describe('connect daemon startup', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout).not.toContain('Daemon started');
-    expect(result.stderr).toContain('ConnectionRefused');
+    expect(result.stderr).toContain('Unable to transform response from server');
   }, 15_000);
 
   it('does not report startup readiness before workspace registration succeeds', async () => {

--- a/apps/cli/src/commands/connect.test.ts
+++ b/apps/cli/src/commands/connect.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveToken } from '../auth/resolveToken';
 import {
   removeStatus,
+  reportDaemonStartupError,
   reportDaemonStartupReady,
   spawnDaemon,
   stopDaemon,
@@ -179,6 +180,29 @@ describe('connect command', () => {
     clientEventHandlers.connected?.();
 
     expect(reportDaemonStartupReady).toHaveBeenCalledOnce();
+  });
+
+  it('should exit a spawned daemon once the startup failure reached its parent', async () => {
+    vi.mocked(reportDaemonStartupError).mockResolvedValueOnce(true);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', 'connect', '--daemon-child']);
+
+    clientEventHandlers.error?.(new Error('ECONNRESET'));
+
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1));
+  });
+
+  it('should let a service child auto-reconnect instead of exiting on a startup error', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', 'connect', '--service-child']);
+
+    clientEventHandlers.error?.(new Error('ECONNRESET'));
+
+    await vi.waitFor(() => expect(reportDaemonStartupError).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('should connect to gateway', async () => {

--- a/apps/cli/src/commands/connect.test.ts
+++ b/apps/cli/src/commands/connect.test.ts
@@ -3,7 +3,13 @@ import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveToken } from '../auth/resolveToken';
-import { removeStatus, spawnDaemon, stopDaemon, writeStatus } from '../daemon/manager';
+import {
+  removeStatus,
+  reportDaemonStartupReady,
+  spawnDaemon,
+  stopDaemon,
+  writeStatus,
+} from '../daemon/manager';
 import type * as DeviceRegister from '../device/register';
 import { loadSettings, saveSettings } from '../settings';
 import { executeToolCall } from '../tools';
@@ -56,6 +62,7 @@ vi.mock('../daemon/manager', () => ({
   readStatus: vi.fn().mockImplementation(() => mockStatus),
   removePid: vi.fn(),
   removeStatus: vi.fn(),
+  reportDaemonStartupError: vi.fn().mockResolvedValue(undefined),
   reportDaemonStartupReady: vi.fn().mockResolvedValue(undefined),
   spawnDaemon: vi.fn().mockImplementation(() => {
     mockSpawnedPid = 99999;
@@ -84,7 +91,7 @@ let connectCalled = false;
 let lastSentToolResponse: any = null;
 let lastSentSystemInfoResponse: any = null;
 vi.mock('@lobechat/device-gateway-client', () => ({
-  GatewayClient: vi.fn().mockImplementation((opts: any) => {
+  GatewayClient: vi.fn().mockImplementation(function (this: any, opts: any) {
     clientOptions = opts;
     clientEventHandlers = {};
     connectCalled = false;
@@ -161,6 +168,17 @@ describe('connect command', () => {
     expect(writeStatus).toHaveBeenLastCalledWith(
       expect.objectContaining({ connectionStatus: 'connected', deviceId: 'mock-device-id' }),
     );
+  });
+
+  it('should report daemon readiness only after the gateway connects', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', 'connect', '--daemon-child']);
+
+    expect(reportDaemonStartupReady).not.toHaveBeenCalled();
+
+    clientEventHandlers.connected?.();
+
+    expect(reportDaemonStartupReady).toHaveBeenCalledOnce();
   });
 
   it('should connect to gateway', async () => {

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -38,6 +38,7 @@ import {
   readStatus,
   removePid,
   removeStatus,
+  reportDaemonStartupError,
   reportDaemonStartupReady,
   spawnDaemon,
   stopDaemon,
@@ -465,8 +466,14 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
   // shared with the workspace-share connections opened via `enrollWorkspace`.
   bindGatewayClientHandlers(client, handlerContext, workspaceId);
 
+  let daemonStartupReported = !isDaemonChild;
+
   client.on('connected', () => {
     updateStatus('connected');
+    if (isDaemonChild && !daemonStartupReported) {
+      daemonStartupReported = true;
+      void reportDaemonStartupReady();
+    }
   });
 
   client.on('disconnected', () => {
@@ -747,6 +754,9 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
   // Handle errors
   client.on('error', (err) => {
     error(`Connection error: ${err.message}`);
+    if (isDaemonChild && !daemonStartupReported) {
+      reportDaemonStartupFailure(err.message);
+    }
   });
 
   // Graceful shutdown
@@ -762,6 +772,15 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
     if (isDaemonChild) {
       removePid();
     }
+  };
+
+  const reportDaemonStartupFailure = (message: string) => {
+    if (!isDaemonChild || daemonStartupReported) return;
+    daemonStartupReported = true;
+    void reportDaemonStartupError(message).finally(() => {
+      cleanup();
+      process.exit(1);
+    });
   };
 
   process.on('SIGINT', () => {
@@ -808,9 +827,8 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
     }
   }
 
-  await reportDaemonStartupReady();
-
-  // Connect
+  // Start the connection; daemon readiness is reported from the first `connected`
+  // event so a failed initial gateway handshake reaches the invoking command.
   await client.connect();
 
   // Personal mode: re-open any workspace share connections from a previous run.

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -777,7 +777,13 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
   const reportDaemonStartupFailure = (message: string) => {
     if (!isDaemonChild || daemonStartupReported) return;
     daemonStartupReported = true;
-    void reportDaemonStartupError(message).finally(() => {
+    void reportDaemonStartupError(message).then((delivered) => {
+      // Only a spawned daemon has a parent waiting on the readiness report, so
+      // exiting is the signal it needs. A `--service-child` run has no parent:
+      // the unit lists exit 1 in SuccessExitStatus, so exiting here would make
+      // systemd treat the failure as success and never restart the service.
+      // Leave the client auto-reconnecting instead.
+      if (!delivered) return;
       cleanup();
       process.exit(1);
     });

--- a/apps/cli/src/daemon/manager.ts
+++ b/apps/cli/src/daemon/manager.ts
@@ -282,24 +282,25 @@ function readStartupError(startOffset: number): string | undefined {
   }
 }
 
-function sendStartupMessage(message: DaemonStartupMessage): Promise<void> {
+/** Resolves true only when a spawned parent was holding the IPC channel to receive the report. */
+function sendStartupMessage(message: DaemonStartupMessage): Promise<boolean> {
   if (process.env.LOBEHUB_DAEMON !== '1' || !process.send || !process.connected) {
-    return Promise.resolve();
+    return Promise.resolve(false);
   }
 
   return new Promise((resolve) => {
     process.send!(message, () => {
       if (process.connected) process.disconnect();
-      resolve();
+      resolve(true);
     });
   });
 }
 
-export function reportDaemonStartupError(message: string): Promise<void> {
+export function reportDaemonStartupError(message: string): Promise<boolean> {
   return sendStartupMessage({ message, type: 'startup-error' });
 }
 
-export function reportDaemonStartupReady(): Promise<void> {
+export function reportDaemonStartupReady(): Promise<boolean> {
   return sendStartupMessage({ type: 'startup-ready' });
 }
 


### PR DESCRIPTION
Daemon startup could report success before the first gateway connection completed, so the invoking command saw a ready daemon while the connection was still failing. Readiness now waits for the first gateway connection and reports initial connection failures to the invoking command instead of swallowing them.

| Before | After |
| ------ | ----- |
| Daemon startup could report success before the gateway connection completed. | Readiness waits for the first gateway connection, and initial failures are reported to the invoking command. |

#### Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

<!-- Acceptance round for user-visible changes (AGENTS.md → Acceptance); or state why none is needed -->

- Acceptance: Not run; automated CLI regression coverage is included.

#### Reviewer

@Innei @arvinxx @Rdmclin2

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

Fixes #19251
