### PR TITLE
🙈 chore: ignore the AUV computer-use runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,11 @@ docs/superpowers/
 # Kagura agent runtime
 .kagura/
 
+# AUV computer-use runtime: run records plus captured screenshots, written
+# relative to whatever directory the CLI was invoked from, so this can appear
+# at the repo root or inside an app.
+.auv/
+
 # Amp agent runtime
 .amp/*
 !.amp/settings.json


### PR DESCRIPTION
`auv` (the computer-use CLI behind the Computer Use builtin tool) writes its run records and captured screenshots to `.auv/`, relative to whatever directory it was invoked from. Running it anywhere inside the repo therefore leaves untracked artifacts at the root or inside an app.

This is not hypothetical: during a local verification run, 16 screenshots and a `records.jsonl` were swept into a staged commit before being caught and removed by hand.

Grouped with the existing agent-runtime ignores (`.kagura/`, `.amp/`). The pattern has no leading slash, so it matches at any depth. Verified against both `.auv/store/records.jsonl` and `apps/desktop/.auv/store/records.jsonl` with `git check-ignore -v`; both resolve to this rule.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Created the two directories AUV actually writes to, confirmed `git status` reports nothing untracked, and confirmed `git check-ignore -v` attributes both paths to the new line. Removed the probe directories afterwards.

- Acceptance: not applicable. A `.gitignore` entry has no user-visible product behavior — nothing to drive or capture.

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
