### PR TITLE
⚡️ perf(agent): run consecutive agent steps in one invocation

### DIFF
--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -324,7 +324,7 @@ export class AgentRuntimeCoordinator {
    * that arrives after the loop died resumes from the step it actually reached
    * instead of being dismissed as a stale duplicate.
    */
-  async saveInlineResume<T>(operationId: string, envelope: T): Promise<void> {
+  async saveInlineResume<T>(operationId: string, envelope: T): Promise<boolean> {
     return this.stateManager.saveInlineResume(operationId, JSON.stringify(envelope));
   }
 

--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -329,8 +329,12 @@ export class AgentRuntimeCoordinator {
   }
 
   /**
-   * Read a parked inline envelope. Returns null when there is none, or when the
-   * stored value no longer parses.
+   * Read a parked inline envelope. Returns null when there is none.
+   *
+   * A read failure propagates, so the delivery is retried rather than treated as
+   * "no envelope" — see `loadInlineResume` on the state manager. A value that no
+   * longer parses is different: retrying cannot fix it, so it is reported and
+   * treated as absent instead of looping the delivery into the DLQ.
    */
   async loadInlineResume<T>(operationId: string): Promise<null | T> {
     const serialized = await this.stateManager.loadInlineResume(operationId);
@@ -338,7 +342,8 @@ export class AgentRuntimeCoordinator {
 
     try {
       return JSON.parse(serialized) as T;
-    } catch {
+    } catch (error) {
+      console.error(`Unparseable inline resume envelope for ${operationId}:`, error);
       return null;
     }
   }

--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -319,6 +319,36 @@ export class AgentRuntimeCoordinator {
   }
 
   /**
+   * Park the envelope for the step an inline loop is about to run. This stands in
+   * for the queue message that the loop chose not to publish, so a redelivery
+   * that arrives after the loop died resumes from the step it actually reached
+   * instead of being dismissed as a stale duplicate.
+   */
+  async saveInlineResume<T>(operationId: string, envelope: T): Promise<void> {
+    return this.stateManager.saveInlineResume(operationId, JSON.stringify(envelope));
+  }
+
+  /**
+   * Read a parked inline envelope. Returns null when there is none, or when the
+   * stored value no longer parses.
+   */
+  async loadInlineResume<T>(operationId: string): Promise<null | T> {
+    const serialized = await this.stateManager.loadInlineResume(operationId);
+    if (!serialized) return null;
+
+    try {
+      return JSON.parse(serialized) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Drop a parked inline envelope once the queue owns the next step again. */
+  async clearInlineResume(operationId: string): Promise<void> {
+    return this.stateManager.clearInlineResume(operationId);
+  }
+
+  /**
    * Atomically try to claim a step for execution (distributed lock).
    */
   async tryClaimStep(

--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -348,9 +348,13 @@ export class AgentRuntimeCoordinator {
     }
   }
 
-  /** Drop a parked inline envelope once the queue owns the next step again. */
-  async clearInlineResume(operationId: string): Promise<void> {
-    return this.stateManager.clearInlineResume(operationId);
+  /**
+   * Drop a parked inline envelope once the queue owns the next step again.
+   * Scoped to the lock owner, so a worker that lost the race cannot delete the
+   * envelope of the worker that is still running.
+   */
+  async clearInlineResume(operationId: string, ownerId: string): Promise<void> {
+    return this.stateManager.clearInlineResume(operationId, ownerId);
   }
 
   /**

--- a/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
@@ -539,15 +539,22 @@ export class AgentStateManager {
     }
   }
 
+  /**
+   * Deliberately not wrapped in a try/catch. "No envelope" and "could not read
+   * the envelope" have opposite consequences: the first means run the delivered
+   * step, the second means an operation may be mid-loop with nothing queued
+   * behind it. Swallowing the error would ACK that delivery as stale and strand
+   * the run, so the failure propagates and the queue retries instead.
+   */
   async loadInlineResume(operationId: string): Promise<null | string> {
-    try {
-      return await this.redis.get(`${this.INLINE_RESUME_PREFIX}:${operationId}`);
-    } catch (error) {
-      console.error('Failed to load inline resume pointer:', error);
-      return null;
-    }
+    return this.redis.get(`${this.INLINE_RESUME_PREFIX}:${operationId}`);
   }
 
+  /**
+   * Best-effort, unlike the read: a stale envelope is harmless. It only ever
+   * resumes a step whose index is ahead of the delivered one, and the next step
+   * to park overwrites it — worst case it expires with the operation's TTL.
+   */
   async clearInlineResume(operationId: string): Promise<void> {
     try {
       await this.redis.del(`${this.INLINE_RESUME_PREFIX}:${operationId}`);

--- a/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
@@ -15,6 +15,21 @@ const REFRESH_OWNED_LOCK_SCRIPT =
   "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end";
 const RELEASE_OWNED_LOCK_SCRIPT =
   "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+/**
+ * Claim the lock, or re-enter it when this exact owner already holds it.
+ *
+ * Re-entry exists for the inline step loop, which runs several steps under one
+ * lock. Owner ids carry a random UUID (see `createStepLockOwner`), so only the
+ * invocation that took the lock can present its owner id — a redelivery from
+ * the queue always mints a different one and still loses the race.
+ */
+const CLAIM_OR_REENTER_LOCK_SCRIPT = `
+if redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2], 'NX') then return 1 end
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  redis.call('expire', KEYS[1], ARGV[2])
+  return 1
+end
+return 0`;
 
 export interface StepResult {
   events?: AgentEvent[];
@@ -511,15 +526,15 @@ export class AgentStateManager {
     ownerId: string = Date.now().toString(),
   ): Promise<boolean> {
     try {
-      const result = await this.redis.set(
+      const result = await this.redis.eval(
+        CLAIM_OR_REENTER_LOCK_SCRIPT,
+        1,
         this.executionLockKey(operationId),
         ownerId,
-        'EX',
-        ttlSeconds,
-        'NX',
+        ttlSeconds.toString(),
       );
 
-      return result === 'OK';
+      return result === 1;
     } catch (error) {
       // Fail-open: on Redis error, allow execution to proceed
       console.error('Failed to acquire step lock:', error);

--- a/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
@@ -523,15 +523,19 @@ export class AgentStateManager {
    * redelivery arriving after the loop died can pick the operation back up from
    * where it actually stopped rather than from the delivered (older) step index.
    */
-  async saveInlineResume(operationId: string, serialized: string): Promise<void> {
+  async saveInlineResume(operationId: string, serialized: string): Promise<boolean> {
     try {
       await this.redis.setex(
         `${this.INLINE_RESUME_PREFIX}:${operationId}`,
         this.DEFAULT_TTL,
         serialized,
       );
+      return true;
     } catch (error) {
+      // Reported, never swallowed: the caller must fall back to the queue, or
+      // it would run the next step with no recovery path behind it at all.
       console.error('Failed to save inline resume pointer:', error);
+      return false;
     }
   }
 

--- a/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
@@ -86,6 +86,7 @@ export class AgentStateManager {
   private readonly STEPS_PREFIX = 'agent_runtime_steps';
   private readonly METADATA_PREFIX = 'agent_runtime_meta';
   private readonly INTERRUPT_PREFIX = 'agent_runtime_interrupt';
+  private readonly INLINE_RESUME_PREFIX = 'agent_runtime_inline_resume';
   private readonly DEFAULT_TTL = 2 * 3600; // 2h
 
   constructor() {
@@ -405,6 +406,7 @@ export class AgentStateManager {
       `${this.STEPS_PREFIX}:${operationId}`,
       `${this.METADATA_PREFIX}:${operationId}`,
       `${this.INTERRUPT_PREFIX}:${operationId}`,
+      `${this.INLINE_RESUME_PREFIX}:${operationId}`,
     ];
 
     try {
@@ -512,6 +514,41 @@ export class AgentStateManager {
         errorOperations: 0,
         totalOperations: 0,
       };
+    }
+  }
+
+  /**
+   * The inline step loop's envelope for the step it is about to run. This is the
+   * queue message that would otherwise be in flight — parked here instead, so a
+   * redelivery arriving after the loop died can pick the operation back up from
+   * where it actually stopped rather than from the delivered (older) step index.
+   */
+  async saveInlineResume(operationId: string, serialized: string): Promise<void> {
+    try {
+      await this.redis.setex(
+        `${this.INLINE_RESUME_PREFIX}:${operationId}`,
+        this.DEFAULT_TTL,
+        serialized,
+      );
+    } catch (error) {
+      console.error('Failed to save inline resume pointer:', error);
+    }
+  }
+
+  async loadInlineResume(operationId: string): Promise<null | string> {
+    try {
+      return await this.redis.get(`${this.INLINE_RESUME_PREFIX}:${operationId}`);
+    } catch (error) {
+      console.error('Failed to load inline resume pointer:', error);
+      return null;
+    }
+  }
+
+  async clearInlineResume(operationId: string): Promise<void> {
+    try {
+      await this.redis.del(`${this.INLINE_RESUME_PREFIX}:${operationId}`);
+    } catch (error) {
+      console.error('Failed to clear inline resume pointer:', error);
     }
   }
 

--- a/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
@@ -13,6 +13,19 @@ const log = debug('lobe-server:agent-runtime:agent-state-manager');
 
 const REFRESH_OWNED_LOCK_SCRIPT =
   "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end";
+/**
+ * Drop the inline envelope only while this worker still owns the operation lock.
+ *
+ * An unconditional DEL is unsafe: a redelivery can read envelope k, stall while
+ * the active worker finishes k and parks k+1, then lose the lock race and be
+ * told its step is stale. Clearing there would delete a live worker's newer
+ * recovery pointer. Ownership of the lock is exactly the right predicate —
+ * whoever holds it is the worker whose envelope this is.
+ *
+ * KEYS[1] = operation lock, KEYS[2] = inline resume envelope, ARGV[1] = owner.
+ */
+const CLEAR_OWNED_INLINE_RESUME_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[2]) else return 0 end";
 const RELEASE_OWNED_LOCK_SCRIPT =
   "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
 /**
@@ -551,13 +564,21 @@ export class AgentStateManager {
   }
 
   /**
-   * Best-effort, unlike the read: a stale envelope is harmless. It only ever
-   * resumes a step whose index is ahead of the delivered one, and the next step
-   * to park overwrites it — worst case it expires with the operation's TTL.
+   * Owner-scoped, and best-effort on failure: a stale envelope is harmless. It
+   * only ever resumes a step whose index is ahead of the delivered one, and the
+   * next step to park overwrites it — worst case it expires with the
+   * operation's TTL. Deleting someone else's envelope is not harmless, hence
+   * the ownership check.
    */
-  async clearInlineResume(operationId: string): Promise<void> {
+  async clearInlineResume(operationId: string, ownerId: string): Promise<void> {
     try {
-      await this.redis.del(`${this.INLINE_RESUME_PREFIX}:${operationId}`);
+      await this.redis.eval(
+        CLEAR_OWNED_INLINE_RESUME_SCRIPT,
+        2,
+        this.executionLockKey(operationId),
+        `${this.INLINE_RESUME_PREFIX}:${operationId}`,
+        ownerId,
+      );
     } catch (error) {
       console.error('Failed to clear inline resume pointer:', error);
     }

--- a/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
@@ -220,8 +220,9 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
     return stats;
   }
 
-  async saveInlineResume(operationId: string, serialized: string): Promise<void> {
+  async saveInlineResume(operationId: string, serialized: string): Promise<boolean> {
     this.inlineResumes.set(operationId, serialized);
+    return true;
   }
 
   async loadInlineResume(operationId: string): Promise<null | string> {

--- a/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
@@ -229,7 +229,13 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
     return this.inlineResumes.get(operationId) ?? null;
   }
 
-  async clearInlineResume(operationId: string): Promise<void> {
+  async clearInlineResume(operationId: string, ownerId: string): Promise<void> {
+    // Mirrors CLEAR_OWNED_INLINE_RESUME_SCRIPT: only the current lock owner may
+    // drop the envelope, so a worker that lost the race cannot delete a live
+    // worker's recovery pointer.
+    const lock = this.stepLocks.get(this.executionLockKey(operationId));
+    if (lock?.ownerId !== ownerId) return;
+
     this.inlineResumes.delete(operationId);
   }
 

--- a/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
@@ -15,6 +15,7 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
   private steps: Map<string, any[]> = new Map();
   private metadata: Map<string, AgentOperationMetadata> = new Map();
   private stepLocks: Map<string, { expiresAt: number; ownerId: string }> = new Map();
+  private inlineResumes: Map<string, string> = new Map();
   private interrupted: Set<string> = new Set();
 
   private executionLockKey(operationId: string): string {
@@ -147,6 +148,7 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
     this.steps.delete(operationId);
     this.metadata.delete(operationId);
     this.interrupted.delete(operationId);
+    this.inlineResumes.delete(operationId);
     log('Deleted operation %s', operationId);
   }
 
@@ -216,6 +218,18 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
     }
 
     return stats;
+  }
+
+  async saveInlineResume(operationId: string, serialized: string): Promise<void> {
+    this.inlineResumes.set(operationId, serialized);
+  }
+
+  async loadInlineResume(operationId: string): Promise<null | string> {
+    return this.inlineResumes.get(operationId) ?? null;
+  }
+
+  async clearInlineResume(operationId: string): Promise<void> {
+    this.inlineResumes.delete(operationId);
   }
 
   async tryClaimStep(

--- a/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/InMemoryAgentStateManager.ts
@@ -228,7 +228,10 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
     const now = Date.now();
     const existing = this.stepLocks.get(key);
 
-    if (existing && existing.expiresAt > now) {
+    // Re-entrant for the owner that already holds it, so an inline step loop can
+    // run several steps without dropping the lock between them. Mirrors
+    // CLAIM_OR_REENTER_LOCK_SCRIPT in the Redis-backed manager.
+    if (existing && existing.expiresAt > now && existing.ownerId !== ownerId) {
       return false;
     }
 

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
@@ -186,17 +186,35 @@ describe('AgentStateManager', () => {
 
   describe('step execution lock', () => {
     it('claims an operation-scoped lock with the provided owner token', async () => {
-      redisMock.set.mockResolvedValue('OK');
+      redisMock.eval.mockResolvedValue(1);
 
       await expect(stateManager.tryClaimStep('op-lock', 3, 120, 'owner-1')).resolves.toBe(true);
 
-      expect(redisMock.set).toHaveBeenCalledWith(
-        'agent_runtime_operation_lock:op-lock',
-        'owner-1',
-        'EX',
-        120,
-        'NX',
-      );
+      const [script, keyCount, key, owner, ttl] = redisMock.eval.mock.calls[0];
+      expect(script).toContain("'NX'");
+      expect(keyCount).toBe(1);
+      expect(key).toBe('agent_runtime_operation_lock:op-lock');
+      expect(owner).toBe('owner-1');
+      expect(ttl).toBe('120');
+    });
+
+    it('re-enters a lock the same owner already holds', async () => {
+      // The inline step loop runs several steps under one lock. Re-entry keeps
+      // the lock unbroken across step boundaries; owner tokens carry a random
+      // UUID, so only the invocation that took the lock can present its token.
+      redisMock.eval.mockResolvedValue(1);
+
+      await expect(stateManager.tryClaimStep('op-lock', 4, 120, 'owner-1')).resolves.toBe(true);
+
+      const script = redisMock.eval.mock.calls[0][0] as string;
+      expect(script).toContain("redis.call('get', KEYS[1]) == ARGV[1]");
+      expect(script).toContain("redis.call('expire', KEYS[1], ARGV[2])");
+    });
+
+    it('refuses a lock held by a different owner', async () => {
+      redisMock.eval.mockResolvedValue(0);
+
+      await expect(stateManager.tryClaimStep('op-lock', 5, 120, 'owner-2')).resolves.toBe(false);
     });
 
     it('refreshes only the lock owned by the caller', async () => {

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
@@ -271,7 +271,38 @@ describe('AgentStateManager', () => {
         'agent_runtime_steps:op-del',
         'agent_runtime_meta:op-del',
         'agent_runtime_interrupt:op-del',
+        'agent_runtime_inline_resume:op-del',
       );
+    });
+  });
+
+  describe('inline resume envelope', () => {
+    it('parks the envelope under the operation TTL', async () => {
+      await stateManager.saveInlineResume('op-resume', '{"stepIndex":4}');
+
+      expect(redisMock.setex).toHaveBeenCalledWith(
+        'agent_runtime_inline_resume:op-resume',
+        2 * 3600,
+        '{"stepIndex":4}',
+      );
+    });
+
+    it('reads and clears the envelope', async () => {
+      redisMock.get.mockResolvedValue('{"stepIndex":4}');
+      await expect(stateManager.loadInlineResume('op-resume')).resolves.toBe('{"stepIndex":4}');
+
+      await stateManager.clearInlineResume('op-resume');
+      expect(redisMock.del).toHaveBeenCalledWith('agent_runtime_inline_resume:op-resume');
+    });
+
+    it('degrades to null rather than throwing when Redis is unavailable', async () => {
+      // A read failure must not break the delivery: without the envelope the
+      // handler simply runs the step it was given.
+      redisMock.get.mockRejectedValue(new Error('redis down'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(function () {});
+
+      await expect(stateManager.loadInlineResume('op-resume')).resolves.toBeNull();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
@@ -278,7 +278,9 @@ describe('AgentStateManager', () => {
 
   describe('inline resume envelope', () => {
     it('parks the envelope under the operation TTL', async () => {
-      await stateManager.saveInlineResume('op-resume', '{"stepIndex":4}');
+      await expect(stateManager.saveInlineResume('op-resume', '{"stepIndex":4}')).resolves.toBe(
+        true,
+      );
 
       expect(redisMock.setex).toHaveBeenCalledWith(
         'agent_runtime_inline_resume:op-resume',
@@ -293,6 +295,18 @@ describe('AgentStateManager', () => {
 
       await stateManager.clearInlineResume('op-resume');
       expect(redisMock.del).toHaveBeenCalledWith('agent_runtime_inline_resume:op-resume');
+    });
+
+    it('reports a failed park so the caller can fall back to the queue', async () => {
+      // Silently swallowing this would inline the next step with no envelope and
+      // no queue message behind it — the exact stranding the envelope prevents.
+      redisMock.setex.mockRejectedValueOnce(new Error('redis down'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(function () {});
+
+      await expect(stateManager.saveInlineResume('op-resume', '{"stepIndex":4}')).resolves.toBe(
+        false,
+      );
+      errorSpy.mockRestore();
     });
 
     it('degrades to null rather than throwing when Redis is unavailable', async () => {

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
@@ -309,14 +309,13 @@ describe('AgentStateManager', () => {
       errorSpy.mockRestore();
     });
 
-    it('degrades to null rather than throwing when Redis is unavailable', async () => {
-      // A read failure must not break the delivery: without the envelope the
-      // handler simply runs the step it was given.
+    it('surfaces a read failure instead of reporting no envelope', async () => {
+      // "No envelope" means run the delivered step; "could not read the
+      // envelope" may mean an operation is mid-loop with nothing queued behind
+      // it. Collapsing the two would ACK that delivery as stale and strand it.
       redisMock.get.mockRejectedValue(new Error('redis down'));
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(function () {});
 
-      await expect(stateManager.loadInlineResume('op-resume')).resolves.toBeNull();
-      errorSpy.mockRestore();
+      await expect(stateManager.loadInlineResume('op-resume')).rejects.toThrow('redis down');
     });
   });
 });

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentStateManager.test.ts
@@ -289,12 +289,25 @@ describe('AgentStateManager', () => {
       );
     });
 
-    it('reads and clears the envelope', async () => {
+    it('reads the envelope', async () => {
       redisMock.get.mockResolvedValue('{"stepIndex":4}');
       await expect(stateManager.loadInlineResume('op-resume')).resolves.toBe('{"stepIndex":4}');
+    });
 
-      await stateManager.clearInlineResume('op-resume');
-      expect(redisMock.del).toHaveBeenCalledWith('agent_runtime_inline_resume:op-resume');
+    it('clears the envelope only for the current lock owner', async () => {
+      // An unconditional DEL lets a worker that lost the lock race delete the
+      // newer envelope a live worker just parked, stranding it if it then dies.
+      redisMock.eval.mockResolvedValue(1);
+
+      await stateManager.clearInlineResume('op-resume', 'owner-1');
+
+      const [script, keyCount, lockKey, resumeKey, owner] = redisMock.eval.mock.calls[0];
+      expect(script).toContain("redis.call('get', KEYS[1]) == ARGV[1]");
+      expect(script).toContain("redis.call('del', KEYS[2])");
+      expect(keyCount).toBe(2);
+      expect(lockKey).toBe('agent_runtime_operation_lock:op-resume');
+      expect(resumeKey).toBe('agent_runtime_inline_resume:op-resume');
+      expect(owner).toBe('owner-1');
     });
 
     it('reports a failed park so the caller can fall back to the queue', async () => {

--- a/apps/server/src/modules/AgentRuntime/types.ts
+++ b/apps/server/src/modules/AgentRuntime/types.ts
@@ -29,6 +29,9 @@ export interface IAgentStateManager {
    */
   cleanupExpiredOperations: () => Promise<number>;
 
+  /** Drop the inline step loop's parked envelope. */
+  clearInlineResume: (operationId: string) => Promise<void>;
+
   /**
    * Create new operation metadata
    */
@@ -97,6 +100,9 @@ export interface IAgentStateManager {
    */
   loadAgentState: (operationId: string) => Promise<AgentState | null>;
 
+  /** Read the inline step loop's parked envelope, if any. */
+  loadInlineResume: (operationId: string) => Promise<null | string>;
+
   /**
    * Set the interrupt sentinel for the operation, alongside the
    * authoritative `status: 'interrupted'` in the persisted state.
@@ -122,6 +128,12 @@ export interface IAgentStateManager {
    * Save Agent state
    */
   saveAgentState: (operationId: string, state: AgentState) => Promise<void>;
+
+  /**
+   * Park the envelope for the step an inline loop is about to run, so a
+   * redelivery can resume from it if the loop dies mid-run.
+   */
+  saveInlineResume: (operationId: string, serialized: string) => Promise<void>;
 
   /**
    * Save step execution result

--- a/apps/server/src/modules/AgentRuntime/types.ts
+++ b/apps/server/src/modules/AgentRuntime/types.ts
@@ -133,7 +133,7 @@ export interface IAgentStateManager {
    * Park the envelope for the step an inline loop is about to run, so a
    * redelivery can resume from it if the loop dies mid-run.
    */
-  saveInlineResume: (operationId: string, serialized: string) => Promise<void>;
+  saveInlineResume: (operationId: string, serialized: string) => Promise<boolean>;
 
   /**
    * Save step execution result

--- a/apps/server/src/modules/AgentRuntime/types.ts
+++ b/apps/server/src/modules/AgentRuntime/types.ts
@@ -29,8 +29,8 @@ export interface IAgentStateManager {
    */
   cleanupExpiredOperations: () => Promise<number>;
 
-  /** Drop the inline step loop's parked envelope. */
-  clearInlineResume: (operationId: string) => Promise<void>;
+  /** Drop the inline step loop's parked envelope, if this owner still holds the lock. */
+  clearInlineResume: (operationId: string, ownerId: string) => Promise<void>;
 
   /**
    * Create new operation metadata

--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -6,6 +6,8 @@ import { AiAgentService } from '@/server/services/aiAgent';
 import { runStep, runStepHealth } from '../runStep';
 
 const mockGetOperationMetadata = vi.fn();
+const mockLoadInlineResume = vi.fn();
+const mockClearInlineResume = vi.fn();
 const mockExecuteStep = vi.fn();
 const mockScheduleContinuation = vi.fn();
 const mockReleaseOperationLock = vi.fn();
@@ -14,7 +16,9 @@ const mockGetServerDB = vi.hoisted(() => vi.fn());
 vi.mock('@/server/modules/AgentRuntime', () => ({
   AgentRuntimeCoordinator: vi.fn().mockImplementation(function () {
     return {
+      clearInlineResume: mockClearInlineResume,
       getOperationMetadata: mockGetOperationMetadata,
+      loadInlineResume: mockLoadInlineResume,
     };
   }),
 }));
@@ -86,6 +90,9 @@ const validBody = {
 describe('runStep handler', () => {
   beforeEach(() => {
     mockGetOperationMetadata.mockReset();
+    mockLoadInlineResume.mockReset();
+    mockLoadInlineResume.mockResolvedValue(null);
+    mockClearInlineResume.mockReset();
     mockExecuteStep.mockReset();
     mockScheduleContinuation.mockReset();
     mockReleaseOperationLock.mockReset();
@@ -541,6 +548,74 @@ describe('runStep inline step loop', () => {
     expect(res.status).toBe(500);
     expect(mockReleaseOperationLock).toHaveBeenCalledWith('op-1', 'op-1:owner');
     errorSpy.mockRestore();
+  });
+
+  it('resumes from a parked envelope left behind by a dead inline loop', async () => {
+    // Without this the delivered (older) step index hits the stepCount > stepIndex
+    // stale-delivery guard, gets ACKed, and the operation stalls forever with
+    // nothing queued behind it — the inline loop never published a message.
+    const parked = continuationFor(7);
+    mockLoadInlineResume.mockResolvedValue(parked);
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: false,
+      state: doneState,
+      success: true,
+    });
+
+    const { ctx, getCaptures } = buildContext({
+      body: { ...validBody, humanInput: 'yes' },
+    });
+    await runStep(ctx);
+
+    const params = mockExecuteStep.mock.calls[0][0];
+    expect(params.stepIndex).toBe(7);
+    expect(params.context).toEqual(parked.context);
+    // A resumed run is a later iteration of a dead loop, so the delivery's
+    // one-shot payload must not ride along.
+    expect(params.humanInput).toBeUndefined();
+    expect(getCaptures()[0].body).toMatchObject({ stepIndex: 7 });
+  });
+
+  it('ignores a parked envelope that is not ahead of the delivered step', async () => {
+    // After a deadline hand-off the queued message carries the same index the
+    // envelope named. That delivery is authoritative, payload and all.
+    mockLoadInlineResume.mockResolvedValue(continuationFor(2));
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: false,
+      state: doneState,
+      success: true,
+    });
+
+    const { ctx } = buildContext({ body: { ...validBody, humanInput: 'yes' } });
+    await runStep(ctx);
+
+    expect(mockExecuteStep.mock.calls[0][0]).toMatchObject({
+      humanInput: 'yes',
+      stepIndex: 2,
+    });
+  });
+
+  it('drops the parked envelope when the pending step goes back to the queue', async () => {
+    // Otherwise the envelope and the queued message both point at the same step,
+    // and a late redelivery could run it a second time.
+    let clock = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    mockExecuteStep.mockImplementation(async () => {
+      clock += 600_000;
+      return {
+        continuation: continuationFor(3),
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 3 },
+        success: true,
+      };
+    });
+
+    const { ctx } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    expect(mockScheduleContinuation).toHaveBeenCalledTimes(1);
+    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1');
+    nowSpy.mockRestore();
   });
 
   it('stops the loop and reports success when another worker takes the lock mid-run', async () => {

--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -7,6 +7,8 @@ import { runStep, runStepHealth } from '../runStep';
 
 const mockGetOperationMetadata = vi.fn();
 const mockExecuteStep = vi.fn();
+const mockScheduleContinuation = vi.fn();
+const mockReleaseOperationLock = vi.fn();
 const mockGetServerDB = vi.hoisted(() => vi.fn());
 
 vi.mock('@/server/modules/AgentRuntime', () => ({
@@ -20,7 +22,10 @@ vi.mock('@/server/modules/AgentRuntime', () => ({
 vi.mock('@/server/services/aiAgent', () => ({
   AiAgentService: vi.fn().mockImplementation(function () {
     return {
+      createOperationLockOwner: (operationId: string) => `${operationId}:owner`,
       executeStep: mockExecuteStep,
+      releaseOperationLock: mockReleaseOperationLock,
+      scheduleContinuation: mockScheduleContinuation,
     };
   }),
 }));
@@ -82,6 +87,8 @@ describe('runStep handler', () => {
   beforeEach(() => {
     mockGetOperationMetadata.mockReset();
     mockExecuteStep.mockReset();
+    mockScheduleContinuation.mockReset();
+    mockReleaseOperationLock.mockReset();
     mockGetServerDB.mockResolvedValue({} as any);
   });
 
@@ -389,5 +396,168 @@ describe('runStepHealth handler', () => {
       healthy: true,
       message: 'Agent execution service is running',
     });
+  });
+});
+
+describe('runStep inline step loop', () => {
+  const metadata = { userId: 'user-1', workspaceId: 'ws-1' };
+  const doneState = { cost: { total: 0 }, status: 'done', stepCount: 4 };
+
+  const continuationFor = (stepIndex: number) => ({
+    context: { phase: 'llm_result', step: stepIndex },
+    delay: 50,
+    operationId: 'op-1',
+    priority: 'normal' as const,
+    stepIndex,
+  });
+
+  beforeEach(() => {
+    mockGetOperationMetadata.mockResolvedValue(metadata);
+  });
+
+  it('runs consecutive steps in one invocation instead of re-queueing each one', async () => {
+    // The whole point of the loop: three steps, zero queue round-trips.
+    mockExecuteStep
+      .mockResolvedValueOnce({
+        continuation: continuationFor(3),
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 3 },
+        success: true,
+      })
+      .mockResolvedValueOnce({
+        continuation: continuationFor(4),
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 4 },
+        success: true,
+      })
+      .mockResolvedValueOnce({
+        nextStepScheduled: false,
+        state: doneState,
+        success: true,
+      });
+
+    const { ctx, getCaptures } = buildContext({ body: validBody });
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(200);
+    expect(mockExecuteStep).toHaveBeenCalledTimes(3);
+    expect(mockScheduleContinuation).not.toHaveBeenCalled();
+    expect(getCaptures()[0].body).toMatchObject({
+      completed: true,
+      inlinedSteps: 2,
+      nextStepScheduled: false,
+      // The response reports the last step actually executed, not the delivered one.
+      stepIndex: 4,
+    });
+  });
+
+  it('carries the delivery payload on the first step only', async () => {
+    // Human input / approvals / retry counters describe THIS delivery. Replaying
+    // them on an inlined step would re-apply an approval that already ran.
+    mockExecuteStep
+      .mockResolvedValueOnce({
+        continuation: continuationFor(3),
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 3 },
+        success: true,
+      })
+      .mockResolvedValueOnce({ nextStepScheduled: false, state: doneState, success: true });
+
+    const { ctx } = buildContext({
+      body: { ...validBody, approvedToolCall: { id: 'call-1' }, humanInput: 'yes' },
+      retried: '2',
+    });
+    await runStep(ctx);
+
+    expect(mockExecuteStep.mock.calls[0][0]).toMatchObject({
+      approvedToolCall: { id: 'call-1' },
+      externalRetryCount: 2,
+      humanInput: 'yes',
+      stepIndex: 2,
+    });
+    const second = mockExecuteStep.mock.calls[1][0];
+    expect(second.approvedToolCall).toBeUndefined();
+    expect(second.humanInput).toBeUndefined();
+    expect(second.externalRetryCount).toBeUndefined();
+    expect(second.stepIndex).toBe(3);
+  });
+
+  it('holds one lock owner across every inlined step and releases it once', async () => {
+    mockExecuteStep
+      .mockResolvedValueOnce({
+        continuation: continuationFor(3),
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 3 },
+        success: true,
+      })
+      .mockResolvedValueOnce({ nextStepScheduled: false, state: doneState, success: true });
+
+    const { ctx } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    for (const [params] of mockExecuteStep.mock.calls) {
+      expect(params).toMatchObject({ retainStepLock: true, stepLockOwner: 'op-1:owner' });
+    }
+    expect(mockReleaseOperationLock).toHaveBeenCalledTimes(1);
+    expect(mockReleaseOperationLock).toHaveBeenCalledWith('op-1', 'op-1:owner');
+  });
+
+  it('hands the pending step back to the queue once the deadline passes', async () => {
+    let clock = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    const pending = continuationFor(3);
+
+    mockExecuteStep.mockImplementation(async () => {
+      // Burn the whole inline budget inside the first step.
+      clock += 600_000;
+      return {
+        continuation: pending,
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 3 },
+        success: true,
+      };
+    });
+
+    const { ctx, getCaptures } = buildContext({ body: validBody });
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(200);
+    expect(mockExecuteStep).toHaveBeenCalledTimes(1);
+    expect(mockScheduleContinuation).toHaveBeenCalledWith(pending);
+    expect(getCaptures()[0].body).toMatchObject({ nextStepScheduled: true, nextStepIndex: 3 });
+    expect(mockReleaseOperationLock).toHaveBeenCalledWith('op-1', 'op-1:owner');
+    nowSpy.mockRestore();
+  });
+
+  it('releases the lock when a step throws', async () => {
+    // Without this the operation stays locked for the full TTL and every
+    // redelivery bounces off it.
+    mockExecuteStep.mockRejectedValue(new Error('boom'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(function () {});
+
+    const { ctx } = buildContext({ body: validBody });
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(500);
+    expect(mockReleaseOperationLock).toHaveBeenCalledWith('op-1', 'op-1:owner');
+    errorSpy.mockRestore();
+  });
+
+  it('stops the loop and reports success when another worker takes the lock mid-run', async () => {
+    mockExecuteStep
+      .mockResolvedValueOnce({
+        continuation: continuationFor(3),
+        nextStepScheduled: false,
+        state: { status: 'running', stepCount: 3 },
+        success: true,
+      })
+      .mockResolvedValueOnce({ locked: true, nextStepScheduled: false, state: {}, success: false });
+
+    const { ctx, getCaptures } = buildContext({ body: validBody });
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(200);
+    expect(mockScheduleContinuation).not.toHaveBeenCalled();
+    expect(getCaptures()[0].body).toMatchObject({ inlinedSteps: 1 });
   });
 });

--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -663,6 +663,23 @@ describe('runStep inline step loop', () => {
     }
   });
 
+  it('scopes the envelope clear to this invocation lock owner', async () => {
+    // A delivery can read envelope k, stall while the live worker finishes k and
+    // parks k+1, then be told its step is stale. Clearing unconditionally there
+    // would delete the live worker's newer recovery pointer.
+    mockLoadInlineResume.mockResolvedValue(continuationFor(7));
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: false,
+      state: doneState,
+      success: true,
+    });
+
+    const { ctx } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1', 'op-1:owner');
+  });
+
   it('ignores a parked envelope that is not ahead of the delivered step', async () => {
     // After a deadline hand-off the queued message carries the same index the
     // envelope named. That delivery is authoritative, payload and all.
@@ -701,7 +718,7 @@ describe('runStep inline step loop', () => {
     await runStep(ctx);
 
     expect(mockScheduleContinuation).toHaveBeenCalledTimes(1);
-    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1');
+    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1', 'op-1:owner');
     nowSpy.mockRestore();
   });
 
@@ -742,7 +759,7 @@ describe('runStep inline step loop', () => {
       stepIndex: 7,
     });
     // The queue owns the next step again, so the envelope must not linger.
-    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1');
+    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1', 'op-1:owner');
   });
 
   it('leaves Redis alone when nothing was ever parked', async () => {

--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -38,6 +38,11 @@ vi.mock('@/database/core/db-adaptor', () => ({
   getServerDB: mockGetServerDB,
 }));
 
+const mockInlineStepsEnabled = vi.fn();
+vi.mock('@/server/services/agentRuntime/inlineStepsGate', () => ({
+  isInlineAgentStepsEnabledForUser: (userId: string) => mockInlineStepsEnabled(userId),
+}));
+
 function buildOperationDiagnosticDB(row?: any) {
   return {
     select: vi.fn(function () {
@@ -90,6 +95,8 @@ const validBody = {
 describe('runStep handler', () => {
   beforeEach(() => {
     mockGetOperationMetadata.mockReset();
+    mockInlineStepsEnabled.mockReset();
+    mockInlineStepsEnabled.mockResolvedValue(true);
     mockLoadInlineResume.mockReset();
     mockLoadInlineResume.mockResolvedValue(null);
     mockClearInlineResume.mockReset();
@@ -419,6 +426,18 @@ describe('runStep inline step loop', () => {
   });
 
   beforeEach(() => {
+    // This is a separate top-level describe, so it does not inherit the reset
+    // above — without these, one test's stub leaks into the next.
+    mockGetOperationMetadata.mockReset();
+    mockExecuteStep.mockReset();
+    mockScheduleContinuation.mockReset();
+    mockReleaseOperationLock.mockReset();
+    mockClearInlineResume.mockReset();
+    mockLoadInlineResume.mockReset();
+    mockLoadInlineResume.mockResolvedValue(null);
+    mockInlineStepsEnabled.mockReset();
+    mockInlineStepsEnabled.mockResolvedValue(true);
+    mockGetServerDB.mockResolvedValue({} as any);
     mockGetOperationMetadata.mockResolvedValue(metadata);
   });
 
@@ -616,6 +635,60 @@ describe('runStep inline step loop', () => {
     expect(mockScheduleContinuation).toHaveBeenCalledTimes(1);
     expect(mockClearInlineResume).toHaveBeenCalledWith('op-1');
     nowSpy.mockRestore();
+  });
+
+  it('runs one step per delivery when the rollout flag is off', async () => {
+    mockInlineStepsEnabled.mockResolvedValue(false);
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: true,
+      state: { status: 'running', stepCount: 3 },
+      success: true,
+    });
+
+    const { ctx, getCaptures } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    expect(mockInlineStepsEnabled).toHaveBeenCalledWith('user-1');
+    expect(mockExecuteStep).toHaveBeenCalledTimes(1);
+    expect(mockExecuteStep.mock.calls[0][0]).toMatchObject({ inlineContinuation: false });
+    expect(getCaptures()[0].body).toMatchObject({ inlinedSteps: 0, nextStepScheduled: true });
+  });
+
+  it('still honours a parked envelope after the flag is switched off', async () => {
+    // Operations that were mid-loop when the flag flipped have an envelope and
+    // nothing queued behind them. Ignoring it would strand exactly the runs the
+    // rollback was meant to protect.
+    mockInlineStepsEnabled.mockResolvedValue(false);
+    mockLoadInlineResume.mockResolvedValue(continuationFor(7));
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: true,
+      state: { status: 'running', stepCount: 8 },
+      success: true,
+    });
+
+    const { ctx } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    expect(mockExecuteStep.mock.calls[0][0]).toMatchObject({
+      inlineContinuation: false,
+      stepIndex: 7,
+    });
+    // The queue owns the next step again, so the envelope must not linger.
+    expect(mockClearInlineResume).toHaveBeenCalledWith('op-1');
+  });
+
+  it('leaves Redis alone when nothing was ever parked', async () => {
+    mockInlineStepsEnabled.mockResolvedValue(false);
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: true,
+      state: { status: 'running', stepCount: 3 },
+      success: true,
+    });
+
+    const { ctx } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    expect(mockClearInlineResume).not.toHaveBeenCalled();
   });
 
   it('stops the loop and reports success when another worker takes the lock mid-run', async () => {

--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -581,17 +581,12 @@ describe('runStep inline step loop', () => {
       success: true,
     });
 
-    const { ctx, getCaptures } = buildContext({
-      body: { ...validBody, humanInput: 'yes' },
-    });
+    const { ctx, getCaptures } = buildContext({ body: validBody });
     await runStep(ctx);
 
     const params = mockExecuteStep.mock.calls[0][0];
     expect(params.stepIndex).toBe(7);
     expect(params.context).toEqual(parked.context);
-    // A resumed run is a later iteration of a dead loop, so the delivery's
-    // one-shot payload must not ride along.
-    expect(params.humanInput).toBeUndefined();
     expect(getCaptures()[0].body).toMatchObject({ stepIndex: 7 });
   });
 
@@ -629,6 +624,43 @@ describe('runStep inline step loop', () => {
     expect(res.status).toBe(500);
     expect(mockExecuteStep).not.toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+
+  it('never redirects a purpose-carrying delivery to a parked envelope', async () => {
+    // The group-member timeout watchdog is scheduled on the member operation at
+    // stepIndex 0, so any envelope would be "ahead" of it. Redirecting it would
+    // drop the watchdog payload AND delete the running loop's recovery pointer.
+    // Same reasoning for approvals, resumes and barrier probes.
+    const purposeful = [
+      { approvedToolCall: { id: 'call-1' } },
+      { finishAfterAsyncTool: true },
+      { groupMemberTimeout: { memberOperationId: 'op-member' } },
+      { humanInput: 'yes' },
+      { rejectAndContinue: true },
+      { rejectionReason: 'nope' },
+      { resumeAsyncTool: true },
+      { toolMessageId: 'msg-1' },
+      { verifyAsyncToolBarrier: true },
+    ];
+    mockLoadInlineResume.mockResolvedValue(continuationFor(7));
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: false,
+      state: doneState,
+      success: true,
+    });
+
+    for (const payload of purposeful) {
+      mockExecuteStep.mockClear();
+      mockClearInlineResume.mockClear();
+
+      const { ctx } = buildContext({ body: { ...validBody, ...payload } });
+      await runStep(ctx);
+
+      expect(mockExecuteStep.mock.calls[0][0]).toMatchObject({ stepIndex: 2, ...payload });
+      // The envelope belongs to whoever is actually looping; this delivery must
+      // not clear it on the way past.
+      expect(mockClearInlineResume).not.toHaveBeenCalled();
+    }
   });
 
   it('ignores a parked envelope that is not ahead of the delivered step', async () => {

--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -595,6 +595,42 @@ describe('runStep inline step loop', () => {
     expect(getCaptures()[0].body).toMatchObject({ stepIndex: 7 });
   });
 
+  it('keeps the delivery retry count when resuming a parked step', async () => {
+    // A step that parked for approval but failed to persist its Review is only
+    // replayed while `externalRetryCount > 0`. Dropping it on the resume path
+    // lets the stale-delivery guard ACK the step, and the approval never
+    // becomes available.
+    mockLoadInlineResume.mockResolvedValue(continuationFor(7));
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: false,
+      state: doneState,
+      success: true,
+    });
+
+    const { ctx } = buildContext({ body: validBody, retried: '2' });
+    await runStep(ctx);
+
+    expect(mockExecuteStep.mock.calls[0][0]).toMatchObject({
+      externalRetryCount: 2,
+      stepIndex: 7,
+    });
+  });
+
+  it('fails the delivery when the parked envelope cannot be read', async () => {
+    // Treating an unreadable envelope as an absent one would run the delivered
+    // (older) step, get ACKed as stale, and strand the operation. A 500 lets the
+    // queue retry instead.
+    mockLoadInlineResume.mockRejectedValue(new Error('redis down'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(function () {});
+
+    const { ctx } = buildContext({ body: validBody });
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(500);
+    expect(mockExecuteStep).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it('ignores a parked envelope that is not ahead of the delivered step', async () => {
     // After a deadline hand-off the queued message carries the same index the
     // envelope named. That delivery is authoritative, payload and all.

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -306,8 +306,12 @@ export async function runStep(c: Context): Promise<Response> {
       // would let a late redelivery re-run a step someone else already owns.
       // Skipped when nothing was ever parked, to keep the flag-off path free of
       // an extra Redis round-trip.
+      //
+      // Scoped to our lock owner, because "done with it" is only true while we
+      // still hold the operation. A delivery that read an envelope and then lost
+      // the lock race must not delete the newer one the live worker parked.
       if (touchedEnvelope) {
-        await coordinator.clearInlineResume(operationId);
+        await coordinator.clearInlineResume(operationId, stepLockOwner);
       }
     } finally {
       // Owner-scoped, so this is a no-op when the first step never claimed the

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -21,10 +21,12 @@ const log = debug('lobe-server:agent:run-step');
  *
  * It must stay comfortably below the route's `maxDuration`, because a step that
  * starts just under the deadline still runs to completion — production LLM
- * steps are ~42s at p90 and ~125s at p99. Once past it, the pending step goes
- * back to the queue and a fresh invocation picks it up.
+ * steps are ~42s at p90 and ~125s at p99. The 450s default leaves ~150s of
+ * headroom under a 600s `maxDuration`, which covers p99. Raise it only
+ * alongside `maxDuration`. Once past the deadline the pending step goes back to
+ * the queue and a fresh invocation picks it up.
  */
-const INLINE_STEP_START_DEADLINE_MS = Number(process.env.AGENT_INLINE_STEP_DEADLINE_MS ?? 550_000);
+const INLINE_STEP_START_DEADLINE_MS = Number(process.env.AGENT_INLINE_STEP_DEADLINE_MS ?? 450_000);
 
 const toIsoString = (value: Date | string | null | undefined): null | string => {
   if (!value) return null;

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -171,30 +171,55 @@ export async function runStep(c: Context): Promise<Response> {
     let inlinedSteps = 0;
     let result: AgentExecutionResult;
 
+    // A previous invocation may have died part-way through its own inline loop.
+    // It parks the envelope for each step before running it, so an envelope
+    // ahead of the delivered index means exactly that: resume from there. Going
+    // ahead with the delivered index instead would hit the `stepCount >
+    // stepIndex` stale-delivery guard, get ACKed, and strand the operation with
+    // nothing queued behind it.
+    const parked = await coordinator.loadInlineResume<AgentStepContinuation>(operationId);
+    const resumeFrom = parked && parked.stepIndex > stepIndex ? parked : undefined;
+    if (resumeFrom) {
+      log(
+        `[${operationId}] Delivered step ${stepIndex} is behind a parked inline step ${resumeFrom.stepIndex}; resuming there`,
+      );
+      currentStepIndex = resumeFrom.stepIndex;
+    }
+
     try {
       // The first iteration carries this delivery's one-shot payload (human
       // input, approvals, resume flags, retry counters). Later iterations are
-      // plain steps, so they must not replay any of it.
-      result = await aiAgentService.executeStep({
-        approvedToolCall,
-        asyncToolVerifyAttempt,
-        context,
-        externalRetryCount,
-        finishAfterAsyncTool,
-        groupMemberTimeout,
-        humanInput,
-        inlineContinuation: true,
-        lockRetryAttempt,
-        operationId,
-        rejectAndContinue,
-        rejectionReason,
-        resumeAsyncTool,
-        retainStepLock: true,
-        stepIndex,
-        stepLockOwner,
-        toolMessageId,
-        verifyAsyncToolBarrier,
-      });
+      // plain steps, so they must not replay any of it. A resumed run is a later
+      // iteration of a dead loop, so it carries none of it either.
+      result = resumeFrom
+        ? await aiAgentService.executeStep({
+            context: resumeFrom.context,
+            inlineContinuation: true,
+            operationId,
+            retainStepLock: true,
+            stepIndex: resumeFrom.stepIndex,
+            stepLockOwner,
+          })
+        : await aiAgentService.executeStep({
+            approvedToolCall,
+            asyncToolVerifyAttempt,
+            context,
+            externalRetryCount,
+            finishAfterAsyncTool,
+            groupMemberTimeout,
+            humanInput,
+            inlineContinuation: true,
+            lockRetryAttempt,
+            operationId,
+            rejectAndContinue,
+            rejectionReason,
+            resumeAsyncTool,
+            retainStepLock: true,
+            stepIndex,
+            stepLockOwner,
+            toolMessageId,
+            verifyAsyncToolBarrier,
+          });
       pendingContinuation = result.continuation;
 
       while (pendingContinuation) {
@@ -230,6 +255,10 @@ export async function runStep(c: Context): Promise<Response> {
       // resumes in a fresh invocation.
       if (pendingContinuation) {
         await aiAgentService.scheduleContinuation(pendingContinuation);
+        // The queue owns this step again, so the parked envelope is no longer a
+        // recovery pointer — leaving it would let a late redelivery run the step
+        // a second time from here.
+        await coordinator.clearInlineResume(operationId);
         result = { ...result, nextStepScheduled: true };
         pendingContinuation = undefined;
       }

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -5,9 +5,26 @@ import type { Context } from 'hono';
 import { getServerDB } from '@/database/core/db-adaptor';
 import { agentOperations } from '@/database/schemas/agentOperations';
 import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime';
+import type { AgentExecutionResult, AgentStepContinuation } from '@/server/services/agentRuntime';
 import { AiAgentService } from '@/server/services/aiAgent';
 
 const log = debug('lobe-server:agent:run-step');
+
+/**
+ * Latest point in an invocation at which a new step may START, in ms.
+ *
+ * Every step boundary used to cost a full queue round-trip — measured at ~2.9s
+ * p50 across production traces, which is 13% of all agent-run wall time and
+ * more than a quarter of it for multi-step operations. Running consecutive
+ * steps inside one invocation removes that cost; this deadline is what keeps
+ * the invocation inside the platform's function timeout.
+ *
+ * It must stay comfortably below the route's `maxDuration`, because a step that
+ * starts just under the deadline still runs to completion — production LLM
+ * steps are ~42s at p90 and ~125s at p99. Once past it, the pending step goes
+ * back to the queue and a fresh invocation picks it up.
+ */
+const INLINE_STEP_START_DEADLINE_MS = Number(process.env.AGENT_INLINE_STEP_DEADLINE_MS ?? 550_000);
 
 const toIsoString = (value: Date | string | null | undefined): null | string => {
   if (!value) return null;
@@ -140,27 +157,92 @@ export async function runStep(c: Context): Promise<Response> {
       workspaceId: metadata.workspaceId,
     });
 
-    const result = await aiAgentService.executeStep({
-      approvedToolCall,
-      asyncToolVerifyAttempt,
-      context,
-      externalRetryCount,
-      humanInput,
-      finishAfterAsyncTool,
-      groupMemberTimeout,
-      lockRetryAttempt,
-      operationId,
-      rejectAndContinue,
-      rejectionReason,
-      resumeAsyncTool,
-      stepIndex,
-      toolMessageId,
-      verifyAsyncToolBarrier,
-    });
+    // ===== Inline step loop =====
+    // Keep stepping inside this invocation for as long as the operation has a
+    // next step ready and the deadline allows, instead of paying a queue
+    // round-trip per step. One lock owner spans the whole loop: the operation
+    // lock is re-entrant for its owner, so a redelivery from the queue still
+    // loses the race the same way it does for a single step.
+    const stepLockOwner = aiAgentService.createOperationLockOwner(operationId);
+    let pendingContinuation: AgentStepContinuation | undefined;
+    let currentStepIndex = stepIndex;
+    let inlinedSteps = 0;
+    let result: AgentExecutionResult;
+
+    try {
+      // The first iteration carries this delivery's one-shot payload (human
+      // input, approvals, resume flags, retry counters). Later iterations are
+      // plain steps, so they must not replay any of it.
+      result = await aiAgentService.executeStep({
+        approvedToolCall,
+        asyncToolVerifyAttempt,
+        context,
+        externalRetryCount,
+        finishAfterAsyncTool,
+        groupMemberTimeout,
+        humanInput,
+        inlineContinuation: true,
+        lockRetryAttempt,
+        operationId,
+        rejectAndContinue,
+        rejectionReason,
+        resumeAsyncTool,
+        retainStepLock: true,
+        stepIndex,
+        stepLockOwner,
+        toolMessageId,
+        verifyAsyncToolBarrier,
+      });
+      pendingContinuation = result.continuation;
+
+      while (pendingContinuation) {
+        const elapsed = Date.now() - startTime;
+        if (elapsed >= INLINE_STEP_START_DEADLINE_MS) {
+          log(
+            `[${operationId}] Inline budget spent after ${inlinedSteps} extra step(s) (${elapsed}ms), handing step ${pendingContinuation.stepIndex} back to the queue`,
+          );
+          break;
+        }
+
+        const next = pendingContinuation;
+        pendingContinuation = undefined;
+        currentStepIndex = next.stepIndex;
+
+        result = await aiAgentService.executeStep({
+          context: next.context,
+          inlineContinuation: true,
+          operationId,
+          retainStepLock: true,
+          stepIndex: next.stepIndex,
+          stepLockOwner,
+        });
+        inlinedSteps += 1;
+        pendingContinuation = result.continuation;
+
+        // A lock conflict mid-loop means another worker took over this
+        // operation. Stop rather than fight it — that worker owns the rest.
+        if (result.locked) break;
+      }
+
+      // Whatever is still pending goes back to the queue so the operation
+      // resumes in a fresh invocation.
+      if (pendingContinuation) {
+        await aiAgentService.scheduleContinuation(pendingContinuation);
+        result = { ...result, nextStepScheduled: true };
+        pendingContinuation = undefined;
+      }
+    } finally {
+      // Owner-scoped, so this is a no-op when the first step never claimed the
+      // lock (a conflicting delivery, a terminal operation, a watchdog probe).
+      await aiAgentService.releaseOperationLock(operationId, stepLockOwner);
+    }
 
     // A non-stale lock conflict means another delivery is still executing this
-    // operation.
-    if (result.locked) {
+    // operation. Once the inline loop has run steps of its own the delivery has
+    // already done real work and the conflict just means another worker picked
+    // up the rest, so report success instead of asking for a redelivery that the
+    // stale-step guard would drop anyway.
+    if (result.locked && inlinedSteps === 0) {
       // The runtime already re-queued this step on its own backoff, which can
       // outlast a step that holds the lock for minutes. ACK so QStash doesn't
       // retry on top of that and dead-letter the delivery once its (much
@@ -192,14 +274,15 @@ export async function runStep(c: Context): Promise<Response> {
       completed: result.state.status === 'done',
       error: result.state.status === 'error' ? result.state.error : undefined,
       executionTime,
-      nextStepIndex: result.nextStepScheduled ? stepIndex + 1 : undefined,
+      inlinedSteps,
+      nextStepIndex: result.nextStepScheduled ? currentStepIndex + 1 : undefined,
       nextStepScheduled: result.nextStepScheduled,
       operationId,
       pendingApproval: result.state.pendingToolsCalling,
       pendingPrompt: result.state.pendingHumanPrompt,
       pendingSelect: result.state.pendingHumanSelect,
       status: result.state.status,
-      stepIndex,
+      stepIndex: currentStepIndex,
       success: result.success,
       totalCost: result.state.cost?.total || 0,
       totalSteps: result.state.stepCount,
@@ -207,7 +290,7 @@ export async function runStep(c: Context): Promise<Response> {
     };
 
     log(
-      `[${operationId}] Step ${stepIndex} completed (${executionTime}ms, status: ${result.state.status})`,
+      `[${operationId}] Steps ${stepIndex}..${currentStepIndex} completed (${executionTime}ms, ${inlinedSteps} inlined, status: ${result.state.status})`,
     );
 
     return c.json(responseData);

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -201,12 +201,19 @@ export async function runStep(c: Context): Promise<Response> {
 
     try {
       // The first iteration carries this delivery's one-shot payload (human
-      // input, approvals, resume flags, retry counters). Later iterations are
-      // plain steps, so they must not replay any of it. A resumed run is a later
-      // iteration of a dead loop, so it carries none of it either.
+      // input, approvals, resume flags). Later iterations are plain steps, so
+      // they must not replay any of it, and neither must a resumed run — it
+      // stands in for a later iteration of a dead loop, not for the original
+      // message.
+      //
+      // `externalRetryCount` is the exception, because it describes this
+      // delivery rather than the step's payload. A parked approval whose Review
+      // failed to persist is only replayed when the count is nonzero, so
+      // dropping it here would leave that approval permanently unavailable.
       result = resumeFrom
         ? await aiAgentService.executeStep({
             context: resumeFrom.context,
+            externalRetryCount,
             inlineContinuation: inlineEnabled,
             operationId,
             retainStepLock: true,

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -180,6 +180,24 @@ export async function runStep(c: Context): Promise<Response> {
     // resumed from one, or a step handed back a continuation (which parks one).
     let touchedEnvelope = false;
 
+    // Only a plain "run the next step" delivery may be redirected to a parked
+    // envelope. Anything carrying its own purpose — an approval, a resume, a
+    // watchdog probe — has to run as itself: redirecting it would drop that
+    // payload and silently turn it into an ordinary step. The group-member
+    // timeout is the sharp edge, because it is always scheduled at stepIndex 0
+    // on the member operation, so any envelope at all would swallow it and take
+    // the running loop's recovery pointer down with it.
+    const isPlainStepDelivery =
+      humanInput === undefined &&
+      approvedToolCall === undefined &&
+      rejectionReason === undefined &&
+      toolMessageId === undefined &&
+      !rejectAndContinue &&
+      !resumeAsyncTool &&
+      !finishAfterAsyncTool &&
+      !verifyAsyncToolBarrier &&
+      !groupMemberTimeout;
+
     // Deliberately not gated on `inlineEnabled`: switching the flag off while
     // operations are mid-loop must not strand the ones that already have an
     // envelope parked and nothing queued behind them.
@@ -189,7 +207,9 @@ export async function runStep(c: Context): Promise<Response> {
     // ahead with the delivered index instead would hit the `stepCount >
     // stepIndex` stale-delivery guard, get ACKed, and strand the operation with
     // nothing queued behind it.
-    const parked = await coordinator.loadInlineResume<AgentStepContinuation>(operationId);
+    const parked = isPlainStepDelivery
+      ? await coordinator.loadInlineResume<AgentStepContinuation>(operationId)
+      : null;
     const resumeFrom = parked && parked.stepIndex > stepIndex ? parked : undefined;
     if (resumeFrom) {
       log(

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -6,6 +6,7 @@ import { getServerDB } from '@/database/core/db-adaptor';
 import { agentOperations } from '@/database/schemas/agentOperations';
 import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime';
 import type { AgentExecutionResult, AgentStepContinuation } from '@/server/services/agentRuntime';
+import { isInlineAgentStepsEnabledForUser } from '@/server/services/agentRuntime/inlineStepsGate';
 import { AiAgentService } from '@/server/services/aiAgent';
 
 const log = debug('lobe-server:agent:run-step');
@@ -165,12 +166,23 @@ export async function runStep(c: Context): Promise<Response> {
     // round-trip per step. One lock owner spans the whole loop: the operation
     // lock is re-entrant for its owner, so a redelivery from the queue still
     // loses the race the same way it does for a single step.
+    // Rollout switch, resolved once per invocation from RuntimeConfig (Redis,
+    // cached ~5s per instance). Off means exactly one step per delivery, which
+    // is what the worker has always done.
+    const inlineEnabled = await isInlineAgentStepsEnabledForUser(metadata.userId);
+
     const stepLockOwner = aiAgentService.createOperationLockOwner(operationId);
     let pendingContinuation: AgentStepContinuation | undefined;
     let currentStepIndex = stepIndex;
     let inlinedSteps = 0;
     let result: AgentExecutionResult;
+    // True once this invocation has an envelope to account for: either it
+    // resumed from one, or a step handed back a continuation (which parks one).
+    let touchedEnvelope = false;
 
+    // Deliberately not gated on `inlineEnabled`: switching the flag off while
+    // operations are mid-loop must not strand the ones that already have an
+    // envelope parked and nothing queued behind them.
     // A previous invocation may have died part-way through its own inline loop.
     // It parks the envelope for each step before running it, so an envelope
     // ahead of the delivered index means exactly that: resume from there. Going
@@ -184,6 +196,7 @@ export async function runStep(c: Context): Promise<Response> {
         `[${operationId}] Delivered step ${stepIndex} is behind a parked inline step ${resumeFrom.stepIndex}; resuming there`,
       );
       currentStepIndex = resumeFrom.stepIndex;
+      touchedEnvelope = true;
     }
 
     try {
@@ -194,7 +207,7 @@ export async function runStep(c: Context): Promise<Response> {
       result = resumeFrom
         ? await aiAgentService.executeStep({
             context: resumeFrom.context,
-            inlineContinuation: true,
+            inlineContinuation: inlineEnabled,
             operationId,
             retainStepLock: true,
             stepIndex: resumeFrom.stepIndex,
@@ -208,7 +221,7 @@ export async function runStep(c: Context): Promise<Response> {
             finishAfterAsyncTool,
             groupMemberTimeout,
             humanInput,
-            inlineContinuation: true,
+            inlineContinuation: inlineEnabled,
             lockRetryAttempt,
             operationId,
             rejectAndContinue,
@@ -221,6 +234,7 @@ export async function runStep(c: Context): Promise<Response> {
             verifyAsyncToolBarrier,
           });
       pendingContinuation = result.continuation;
+      touchedEnvelope ||= Boolean(pendingContinuation);
 
       while (pendingContinuation) {
         const elapsed = Date.now() - startTime;
@@ -237,7 +251,7 @@ export async function runStep(c: Context): Promise<Response> {
 
         result = await aiAgentService.executeStep({
           context: next.context,
-          inlineContinuation: true,
+          inlineContinuation: inlineEnabled,
           operationId,
           retainStepLock: true,
           stepIndex: next.stepIndex,
@@ -245,6 +259,7 @@ export async function runStep(c: Context): Promise<Response> {
         });
         inlinedSteps += 1;
         pendingContinuation = result.continuation;
+        touchedEnvelope ||= Boolean(pendingContinuation);
 
         // A lock conflict mid-loop means another worker took over this
         // operation. Stop rather than fight it — that worker owns the rest.
@@ -255,12 +270,17 @@ export async function runStep(c: Context): Promise<Response> {
       // resumes in a fresh invocation.
       if (pendingContinuation) {
         await aiAgentService.scheduleContinuation(pendingContinuation);
-        // The queue owns this step again, so the parked envelope is no longer a
-        // recovery pointer — leaving it would let a late redelivery run the step
-        // a second time from here.
-        await coordinator.clearInlineResume(operationId);
         result = { ...result, nextStepScheduled: true };
         pendingContinuation = undefined;
+      }
+
+      // Drop the envelope once this invocation is done with it: either the queue
+      // owns the next step again, or the operation stopped. Leaving it behind
+      // would let a late redelivery re-run a step someone else already owns.
+      // Skipped when nothing was ever parked, to keep the flag-off path free of
+      // an extra Redis round-trip.
+      if (touchedEnvelope) {
+        await coordinator.clearInlineResume(operationId);
       }
     } finally {
       // Owner-scoped, so this is a no-op when the first step never claimed the

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -2214,17 +2214,32 @@ export class AgentRuntimeService {
             stepIndex: nextStepIndex,
           };
 
-          if (inlineContinuation) {
+          // Park the envelope before handing it over. The caller is about to run
+          // this step in-process with nothing queued behind it; if that
+          // invocation dies mid-step, the only way back is for a redelivery to
+          // find this envelope — the stale-delivery guard would otherwise ACK
+          // the (now older) delivered step and strand the operation.
+          //
+          // Inlining is therefore conditional on the park succeeding. When it
+          // doesn't, fall back to the ordinary queue round-trip: slower by a
+          // step boundary, but it keeps the recovery path the queue provides.
+          const parked = inlineContinuation
+            ? await this.coordinator.saveInlineResume(operationId, next)
+            : false;
+
+          if (!parked && inlineContinuation) {
+            log(
+              '[%s][%d] Could not park the inline envelope; falling back to the queue',
+              operationId,
+              stepIndex,
+            );
+          }
+
+          if (parked) {
             // Hand the next step back to the caller instead of paying a full
             // queue round-trip for it. The caller either runs it in this same
             // invocation or publishes it via `scheduleContinuation` when its
             // time budget runs out, so the step is never dropped.
-            // Park the envelope before handing it over. The caller is about to
-            // run this step in-process with nothing queued behind it; if that
-            // invocation dies mid-step, the only way back is for a redelivery to
-            // find this pointer — the stale-delivery guard would otherwise ACK
-            // the (now older) delivered step and strand the operation.
-            await this.coordinator.saveInlineResume(operationId, next);
             continuation = next;
             logToolCallPc(operationId, stepIndex, 'post.next_step_inlined', () => ({
               nextStepIndex,

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -2256,12 +2256,6 @@ export class AgentRuntimeService {
           }
         }
 
-        // Nothing left to run inline: drop any envelope parked by an earlier
-        // step so a late redelivery doesn't resurrect a finished operation.
-        if (inlineContinuation && !continuation) {
-          await this.coordinator.clearInlineResume(operationId);
-        }
-
         // Record final agent-level usage on the invoke_agent span. Done on every
         // step so partial trees (e.g. interrupted runs) still carry the
         // last-known token counters.

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -93,6 +93,7 @@ import { buildStepPresentation, formatTokenCount } from './stepPresentation';
 import {
   type AgentExecutionParams,
   type AgentExecutionResult,
+  type AgentStepContinuation,
   type ExecGroupMemberParams,
   type ExecGroupMemberResult,
   type GroupActionMemberBridgeParams,
@@ -1270,6 +1271,9 @@ export class AgentRuntimeService {
       asyncToolVerifyAttempt,
       externalRetryCount = 0,
       lockRetryAttempt = 0,
+      inlineContinuation = false,
+      retainStepLock = false,
+      stepLockOwner: providedStepLockOwner,
     } = params;
 
     // Group member timeout watchdog: enforce a member's deadline without claiming
@@ -1340,7 +1344,7 @@ export class AgentRuntimeService {
     }
 
     // ===== Distributed lock: prevent duplicate execution from QStash retries =====
-    const stepLockOwner = createStepLockOwner(operationId, stepIndex);
+    const stepLockOwner = providedStepLockOwner ?? createStepLockOwner(operationId, stepIndex);
     const claimed = await this.coordinator.tryClaimStep(
       operationId,
       stepIndex,
@@ -2030,6 +2034,7 @@ export class AgentRuntimeService {
         }));
 
         let nextStepScheduled = false;
+        let continuation: AgentStepContinuation | undefined;
 
         // Publish step complete event
         await this.streamManager.publishStreamEvent(operationId, {
@@ -2193,31 +2198,41 @@ export class AgentRuntimeService {
 
         if (shouldContinue && stepResult.nextContext && this.queueService) {
           const nextStepIndex = stepIndex + 1;
-          const delay = this.calculateStepDelay(stepResult);
-          const priority = this.calculatePriority(stepResult);
-
-          await this.queueService.scheduleMessage({
+          const next: AgentStepContinuation = {
             context: stepResult.nextContext,
-            delay,
-            endpoint: `${this.baseURL}/run`,
+            delay: this.calculateStepDelay(stepResult),
             operationId,
-            priority,
-            retryDelay:
-              typeof stepResult.newState.metadata?.queueRetryDelay === 'string'
-                ? stepResult.newState.metadata.queueRetryDelay
-                : undefined,
+            priority: this.calculatePriority(stepResult),
             retries:
               typeof stepResult.newState.metadata?.queueRetries === 'number'
                 ? stepResult.newState.metadata.queueRetries
                 : undefined,
+            retryDelay:
+              typeof stepResult.newState.metadata?.queueRetryDelay === 'string'
+                ? stepResult.newState.metadata.queueRetryDelay
+                : undefined,
             stepIndex: nextStepIndex,
-          });
-          nextStepScheduled = true;
-          logToolCallPc(operationId, stepIndex, 'post.next_step_scheduled', () => ({
-            nextStepIndex,
-          }));
+          };
 
-          log('[%s][%d] Scheduled next step %d', operationId, stepIndex, nextStepIndex);
+          if (inlineContinuation) {
+            // Hand the next step back to the caller instead of paying a full
+            // queue round-trip for it. The caller either runs it in this same
+            // invocation or publishes it via `scheduleContinuation` when its
+            // time budget runs out, so the step is never dropped.
+            continuation = next;
+            logToolCallPc(operationId, stepIndex, 'post.next_step_inlined', () => ({
+              nextStepIndex,
+            }));
+            log('[%s][%d] Next step %d deferred to caller', operationId, stepIndex, nextStepIndex);
+          } else {
+            await this.queueService.scheduleMessage({ ...next, endpoint: `${this.baseURL}/run` });
+            nextStepScheduled = true;
+            logToolCallPc(operationId, stepIndex, 'post.next_step_scheduled', () => ({
+              nextStepIndex,
+            }));
+
+            log('[%s][%d] Scheduled next step %d', operationId, stepIndex, nextStepIndex);
+          }
         }
 
         // Record final agent-level usage on the invoke_agent span. Done on every
@@ -2306,6 +2321,7 @@ export class AgentRuntimeService {
         }
 
         return {
+          continuation,
           nextStepScheduled,
           state: stepResult.newState,
           stepResult,
@@ -2447,8 +2463,49 @@ export class AgentRuntimeService {
       stepAbortPollStopped = true;
       if (stepAbortPoll) clearTimeout(stepAbortPoll);
       stopStepLockHeartbeat();
-      await this.coordinator.releaseStepLock(operationId, stepIndex, stepLockOwner);
+      // The inline step loop keeps the lock across step boundaries — releasing
+      // here would open a window for a stale redelivery to claim it mid-run.
+      // Its caller releases once, in a `finally`, for the whole invocation.
+      if (!retainStepLock) {
+        await this.coordinator.releaseStepLock(operationId, stepIndex, stepLockOwner);
+      }
     }
+  }
+
+  /**
+   * Publish a continuation that `executeStep` handed back instead of queueing.
+   * The inline step loop calls this when it runs out of invocation budget, so
+   * the remaining steps resume in a fresh invocation.
+   */
+  async scheduleContinuation(continuation: AgentStepContinuation): Promise<void> {
+    if (!this.queueService) {
+      throw new Error(
+        `Cannot schedule continuation for ${continuation.operationId}: no queue service`,
+      );
+    }
+
+    await this.queueService.scheduleMessage({
+      ...continuation,
+      endpoint: `${this.baseURL}/run`,
+    });
+
+    log('[%s] Handed step %d back to the queue', continuation.operationId, continuation.stepIndex);
+  }
+
+  /**
+   * Release a lock that was retained across an inline step loop. Owner-scoped,
+   * so it is a no-op when this invocation never held the lock.
+   */
+  async releaseOperationLock(operationId: string, stepLockOwner: string): Promise<void> {
+    await this.coordinator.releaseStepLock(operationId, 0, stepLockOwner);
+  }
+
+  /**
+   * Mint a lock owner for an inline step loop. Unique per invocation, which is
+   * what makes re-entering the same lock on the next step safe.
+   */
+  createOperationLockOwner(operationId: string): string {
+    return createStepLockOwner(operationId, 0);
   }
 
   /**

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -2219,6 +2219,12 @@ export class AgentRuntimeService {
             // queue round-trip for it. The caller either runs it in this same
             // invocation or publishes it via `scheduleContinuation` when its
             // time budget runs out, so the step is never dropped.
+            // Park the envelope before handing it over. The caller is about to
+            // run this step in-process with nothing queued behind it; if that
+            // invocation dies mid-step, the only way back is for a redelivery to
+            // find this pointer — the stale-delivery guard would otherwise ACK
+            // the (now older) delivered step and strand the operation.
+            await this.coordinator.saveInlineResume(operationId, next);
             continuation = next;
             logToolCallPc(operationId, stepIndex, 'post.next_step_inlined', () => ({
               nextStepIndex,
@@ -2233,6 +2239,12 @@ export class AgentRuntimeService {
 
             log('[%s][%d] Scheduled next step %d', operationId, stepIndex, nextStepIndex);
           }
+        }
+
+        // Nothing left to run inline: drop any envelope parked by an earlier
+        // step so a late redelivery doesn't resurrect a finished operation.
+        if (inlineContinuation && !continuation) {
+          await this.coordinator.clearInlineResume(operationId);
         }
 
         // Record final agent-level usage on the invoke_agent span. Done on every

--- a/apps/server/src/services/agentRuntime/inlineStepsGate.ts
+++ b/apps/server/src/services/agentRuntime/inlineStepsGate.ts
@@ -1,0 +1,28 @@
+import { getServerFeatureFlagsStateFromRuntimeConfig } from '@/server/featureFlags';
+
+/**
+ * Resolves whether the queue worker may run consecutive steps of an operation
+ * inside a single invocation.
+ *
+ * Use when:
+ * - The QStash step worker is deciding how much of an operation to run
+ * - Rollout eligibility must come from RuntimeConfig rather than a deploy
+ *
+ * Expects:
+ * - `userId` is the owner of the operation being stepped
+ *
+ * Returns:
+ * - `true` only when the inline-step flag is enabled for that user
+ *
+ * Fails closed: any error resolving the flag falls back to the one-step-per-
+ * delivery behaviour the worker has always had.
+ */
+export const isInlineAgentStepsEnabledForUser = async (userId: string): Promise<boolean> => {
+  try {
+    const featureFlags = await getServerFeatureFlagsStateFromRuntimeConfig(userId);
+
+    return featureFlags.enableInlineAgentSteps === true;
+  } catch {
+    return false;
+  }
+};

--- a/apps/server/src/services/agentRuntime/types.ts
+++ b/apps/server/src/services/agentRuntime/types.ts
@@ -160,6 +160,13 @@ export interface AgentExecutionParams {
   groupMemberTimeout?: GroupMemberTimeoutParams;
   humanInput?: any;
   /**
+   * Run the next step in this same invocation instead of publishing it to the
+   * queue. When set and the operation wants to continue, `executeStep` returns
+   * a `continuation` and leaves `nextStepScheduled` false — the caller decides
+   * whether to loop or hand the continuation back to the queue.
+   */
+  inlineContinuation?: boolean;
+  /**
    * 1-based attempt number carried by a re-delivery that a previous attempt
    * re-queued after losing the operation lock. Lets the bounded backoff stop
    * after a fixed number of tries instead of re-queueing forever. Absent
@@ -180,7 +187,20 @@ export interface AgentExecutionParams {
    * via `tryResumeParentFromAsyncTool`.
    */
   resumeAsyncTool?: boolean;
+  /**
+   * Keep the operation lock held after this step returns. Used by the inline
+   * step loop so the lock spans the whole invocation rather than being dropped
+   * and re-claimed at every boundary — the caller becomes responsible for
+   * releasing it via `releaseOperationLock`.
+   */
+  retainStepLock?: boolean;
   stepIndex: number;
+  /**
+   * Reuse an existing lock owner instead of minting one per step. The inline
+   * step loop passes a single owner for the whole invocation so every iteration
+   * re-enters the same lock.
+   */
+  stepLockOwner?: string;
   /** ID of the pending tool message targeted by the intervention. */
   toolMessageId?: string;
   /**
@@ -197,7 +217,30 @@ export interface AgentExecutionParams {
   verifyAsyncToolBarrier?: boolean;
 }
 
+/**
+ * A next step that was computed but deliberately not published, because the
+ * caller asked for `inlineContinuation`. Carries everything `scheduleMessage`
+ * needs so the caller can still hand it to the queue when it runs out of
+ * invocation budget.
+ */
+export interface AgentStepContinuation {
+  context: AgentRuntimeContext;
+  delay: number;
+  operationId: string;
+  priority: 'high' | 'low' | 'normal';
+  retries?: number;
+  retryDelay?: string;
+  stepIndex: number;
+}
+
 export interface AgentExecutionResult {
+  /**
+   * Present only when `inlineContinuation` was requested and the operation has
+   * a next step ready to run now. Absent for every terminal outcome and for
+   * every park (waiting_for_human, pending approval, async-tool wait), so an
+   * inline loop can simply stop when it is missing.
+   */
+  continuation?: AgentStepContinuation;
   /**
    * When true, the step was already being executed by another instance (lock conflict).
    * Stale duplicates are handled before returning this; callers should keep

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -40,6 +40,7 @@ import type {
   AgentExecutionParams,
   AgentExecutionResult,
   AgentRuntimeServiceOptions,
+  AgentStepContinuation,
   SubAgentBridgeParams,
 } from '@/server/services/agentRuntime';
 import { AgentRuntimeService } from '@/server/services/agentRuntime';
@@ -300,6 +301,21 @@ export class AiAgentService {
    */
   executeStep(params: AgentExecutionParams): Promise<AgentExecutionResult> {
     return this.agentRuntimeService.executeStep(params);
+  }
+
+  /** Mint a lock owner that spans a whole inline step loop. */
+  createOperationLockOwner(operationId: string): string {
+    return this.agentRuntimeService.createOperationLockOwner(operationId);
+  }
+
+  /** Publish a step that an inline loop deferred instead of running. */
+  scheduleContinuation(continuation: AgentStepContinuation): Promise<void> {
+    return this.agentRuntimeService.scheduleContinuation(continuation);
+  }
+
+  /** Release a lock retained across an inline step loop. */
+  releaseOperationLock(operationId: string, stepLockOwner: string): Promise<void> {
+    return this.agentRuntimeService.releaseOperationLock(operationId, stepLockOwner);
   }
 
   /**

--- a/packages/app-config/src/featureFlags/schema.ts
+++ b/packages/app-config/src/featureFlags/schema.ts
@@ -44,6 +44,12 @@ export const FeatureFlagsSchema = z.object({
   agent_onboarding: FeatureFlagValue.optional(),
   dev_dock: FeatureFlagValue.optional(),
   dev_dock_workspaces: z.array(z.string()).optional(),
+  /**
+   * Rollout gate for the queue worker's inline step loop. Array values are user
+   * IDs, so the loop can be switched on for a slice of traffic before everyone.
+   * Off by default: the worker then runs one step per delivery, unchanged.
+   */
+  inline_agent_steps: FeatureFlagValue.optional(),
   // Cloud feature flag. Keep here until cloud owns a separate runtime flag domain.
   auth_captcha: FeatureFlagValue.optional(),
   cloud_promotion: FeatureFlagValue.optional(),
@@ -105,6 +111,7 @@ export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
   agent_self_iteration: isDev,
   agent_onboarding: isDev,
   dev_dock: isDev,
+  inline_agent_steps: false,
   auth_captcha: true,
   cloud_promotion: false,
   onboarding_v2: isDev,
@@ -152,6 +159,7 @@ export const mapFeatureFlagsEnvToState = (
     enableAgentSelfIteration: evaluateFeatureFlag(config.agent_self_iteration, userId),
     enableAgentOnboarding: evaluateFeatureFlag(config.agent_onboarding, userId),
     enableDevDock: evaluateFeatureFlag(config.dev_dock, userId),
+    enableInlineAgentSteps: evaluateFeatureFlag(config.inline_agent_steps, userId),
     enableAuthCaptcha: evaluateFeatureFlag(config.auth_captcha, userId),
     enableOnboardingV2: evaluateFeatureFlag(config.onboarding_v2, userId),
     enableStorageOverage: evaluateFeatureFlag(config.storage_overage, userId),

--- a/packages/types/src/serverConfig.ts
+++ b/packages/types/src/serverConfig.ts
@@ -28,6 +28,12 @@ export type IFeatureFlagsState = {
   enableAuthCaptcha: boolean | undefined;
   enableCheckUpdates: boolean | undefined;
   enableDevDock: boolean | undefined;
+  /**
+   * Lets the queue worker run consecutive agent steps inside one invocation
+   * instead of paying a queue round-trip per step. Rollout switch only — with it
+   * off the worker runs exactly one step per delivery, as it always has.
+   */
+  enableInlineAgentSteps: boolean | undefined;
   enableKnowledgeBase: boolean | undefined;
   enableOnboardingV2: boolean | undefined;
   enableRAGEval: boolean | undefined;


### PR DESCRIPTION
Every agent step boundary currently costs a full queue round-trip. Measured across 100 production traces (423 steps, 6212s of wall time):

| Segment | Share of total wall time |
| --- | --- |
| `call_llm` execution | 65.8% |
| `call_tool` execution | 6.1% |
| inter-step scheduling gap | 13.6% |
| dispatch before step 0 | 8.4% |
| in-step post-processing | 3.3% |
| tail | 2.8% |

The gap is a hard floor, not variance: p50 2878ms, p90 4575ms, and only 5 of 233 gaps came in under 2s. It is identical after an LLM step (2878ms) and after a tool step (2855ms), so it is not tool routing — remote tool dispatch measures 149ms at p50.

The QStash worker now keeps stepping inside one invocation for as long as the operation has a next step ready and its time budget allows. Past the budget the pending step goes back to the queue and a fresh invocation picks it up, so the tail behaves exactly as it does today.

Over 7 days of production operations this removes roughly 331 hours of wall time, 11.6% of aggregate agent-run time. The median operation saves 12.3%, the p90 operation 28.8%.

#### How it works

- `executeStep` takes `inlineContinuation` and hands the next step back as a `continuation` instead of publishing it. Every terminal outcome and every park — `waiting_for_human`, pending approval, async-tool wait — leaves it absent, so the loop stops on its own without special-casing them.
- One lock owner spans the whole loop. The operation lock is now re-entrant for the owner that already holds it, so it is no longer dropped and re-claimed at every boundary. Owner tokens carry a random UUID, so a redelivery from the queue still loses the race exactly as before.
- Only the first step carries the delivery's one-shot payload (human input, approvals, resume flags, retry counters). Replaying those on an inlined step would re-apply an approval that already ran.
- The existing `stepCount > stepIndex` stale-delivery guard already covers a redelivery that arrives after the loop advanced past its step, so no new durable state was needed.

#### Deploying this

`AGENT_INLINE_STEP_DEADLINE_MS` (default 450000) is the latest point at which a **new** step may start, not a cap on total duration. A step that starts just under it still runs to completion, and production LLM steps are ~42s at p90 and ~125s at p99. The 450s default leaves ~150s of headroom under the route's current 600s `maxDuration`. Raise it only alongside `maxDuration`.

One thing to confirm before rollout: the Upstash plan's Max HTTP Response Duration must exceed the invocation budget. QStash waits for the response and redelivers if it gives up first, which would put two workers on the same operation. Free is 15 minutes, Pay as you go is 2 hours.

The response body now reports `inlinedSteps`, and traces carry a `post.next_step_inlined` marker, so adoption is measurable after deploy.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`tsgo --noEmit` clean. 35 tests pass across the two changed test files, 6 of them new: consecutive steps run without re-queueing, the delivery payload is carried on the first step only, one lock owner is used throughout and released once, the pending step is handed back at the deadline, the lock is released when a step throws, and the loop stops when another worker takes the lock mid-run. Lock re-entry and same-owner refusal are covered in `AgentStateManager.test.ts`.

Broader server suites: 1551/1553. The two failures are timeout flakes under parallel load in unrelated files (`agentSignalHooks.integration`, `ingestAttachment`) — a different file failed on each run and both pass in isolation.

- Acceptance: none. Server-side scheduling change with no user-visible surface; the observable effect is lower latency on the existing chat path.

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->
