### PR TITLE
🐛 fix(agent-runtime): report an exhausted budget as cost_limit, not done

### DIFF
--- a/packages/agent-runtime/src/loop/index.test.ts
+++ b/packages/agent-runtime/src/loop/index.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AgentRuntimeContext, AgentState } from '../types';
+import { AgentRuntime } from '../core/runtime';
+import type {
+  Agent,
+  AgentRuntimeContext,
+  AgentState,
+  Cost,
+  CostCalculationContext,
+  Usage,
+} from '../types';
 import { type AgentLoopStep, resolveStopReason, runAgentLoop } from './index';
 
 const createState = (overrides: Partial<AgentState> = {}): AgentState =>
@@ -55,6 +63,70 @@ describe('resolveStopReason', () => {
     // `warn` and `interrupt` settle up elsewhere; the loop keeps going.
     expect(resolveStopReason(exceeded('warn'), context())).toBeUndefined();
     expect(resolveStopReason(exceeded('interrupt'), context())).toBeUndefined();
+  });
+});
+
+/**
+ * Drives the REAL `AgentRuntime.step` rather than a hand-built state, which is
+ * the only way this case shows up: a `stop` cost policy reports itself through
+ * `status: 'done'`, so a fabricated `running` state with an over-budget cost
+ * never exercises the ordering that matters.
+ */
+describe('runAgentLoop over the real runtime', () => {
+  class OverBudgetAgent implements Agent {
+    async runner(_context: AgentRuntimeContext, state: AgentState) {
+      return { payload: { messages: state.messages }, type: 'call_llm' as const };
+    }
+
+    calculateUsage(_operationType: string, _operationResult: unknown, previousUsage: Usage): Usage {
+      const usage = structuredClone(previousUsage);
+      usage.llm.tokens.total += 1000;
+      return usage;
+    }
+
+    calculateCost(context: CostCalculationContext): Cost {
+      const cost = structuredClone(context.previousCost || ({} as Cost));
+      cost.calculatedAt = new Date().toISOString();
+      cost.currency = 'USD';
+      cost.total = 10;
+      return cost;
+    }
+
+    modelRuntime = async function* () {
+      yield { content: 'test response' };
+    };
+  }
+
+  const runOverBudget = async (onExceeded: 'stop' | 'interrupt') => {
+    const runtime = new AgentRuntime(new OverBudgetAgent());
+    const state = AgentRuntime.createInitialState({
+      costLimit: { currency: 'USD', maxTotalCost: 5, onExceeded },
+      messages: [{ content: 'Hello', role: 'user' }],
+      operationId: 'op-cost',
+    });
+
+    return runAgentLoop({
+      initialContext: context(),
+      state,
+      step: async ({ context: ctx, state: currentState }) => {
+        const result = await runtime.step(currentState, ctx);
+        return { nextContext: result.nextContext, state: result.newState };
+      },
+    });
+  };
+
+  it('reports an exhausted budget as cost_limit, not as an ordinary completion', async () => {
+    const result = await runOverBudget('stop');
+
+    // The runtime signals a `stop` policy by setting `status: 'done'`. Reading
+    // the status first would call this a normal finish and throw away the
+    // budget reason that hosts forward to completion hooks and signals.
+    expect(result.reason).toBe('cost_limit');
+    expect(result.state.status).toBe('done');
+  });
+
+  it('still reports an interrupt policy as interrupted', async () => {
+    expect((await runOverBudget('interrupt')).reason).toBe('interrupted');
   });
 });
 

--- a/packages/agent-runtime/src/loop/index.ts
+++ b/packages/agent-runtime/src/loop/index.ts
@@ -84,13 +84,20 @@ export interface AgentLoopResult {
  * stop would end every loop before it began.
  */
 export const resolveTerminalReason = (state: AgentState): AgentLoopStopReason | undefined => {
-  if (state.status === 'done') return 'done';
   if (state.status === 'error') return 'error';
   if (state.status === 'interrupted') return 'interrupted';
   if (isParkedStatus(state.status)) return 'parked';
 
-  // Exceeding the budget only stops a run that asked to be stopped; other
-  // policies let it continue and settle up elsewhere.
+  // Checked BEFORE `done`, because a `stop` policy expresses itself AS `done`:
+  // `handleCostLimitExceeded` sets that status and clears the next context.
+  // Asking about the status first reported every budget exhaustion as an
+  // ordinary completion — losing exactly the distinction this reason exists to
+  // carry, and only when driving the real `AgentRuntime.step` rather than a
+  // hand-built state.
+  //
+  // Only a `stop` policy ends the run here: `interrupt` surfaces as
+  // `interrupted` above, and `warn` lets the run continue and settle up
+  // elsewhere.
   const costLimit = state.costLimit;
   if (
     costLimit &&
@@ -98,6 +105,8 @@ export const resolveTerminalReason = (state: AgentState): AgentLoopStopReason | 
     costLimit.onExceeded === 'stop'
   )
     return 'cost_limit';
+
+  if (state.status === 'done') return 'done';
 
   return undefined;
 };


### PR DESCRIPTION
Codex caught this on #19153 after it merged, and it is right on both counts.

A `stop` cost policy expresses itself **through the state**: on crossing the limit, `handleCostLimitExceeded` sets `status: 'done'` and clears the next context. `resolveTerminalReason` asked about the status first, so every budget exhaustion came back as an ordinary completion — losing precisely the distinction the stop reason was introduced to carry, and which hosts forward to completion hooks and signals.

The cost check now runs before `done`. An `interrupt` policy still surfaces as `interrupted` and a `warn` policy still lets the run continue, so only a `stop` ends the run here.

#### Why the original test missed it

It hand-built a `running` state with an over-budget cost, which reaches the cost branch on its own and passes either way. The bug only appears when the state comes out of the real `AgentRuntime.step` — the very thing the reason is meant to describe.

So the new test drives `AgentRuntime.step` through a real cost limit. Verified it fails on the unfixed code and passes after:

```
× reports an exhausted budget as cost_limit, not as an ordinary completion
  Tests  1 failed | 17 passed (18)
```

A second case pins that the `interrupt` policy is still reported as `interrupted`, so the reorder cannot quietly swallow it later.

#### Test

18 passing in the loop suite (was 16); the full `agent-runtime` suite is green at 494. Lint clean.

#### 🔗 Related Issue

Follow-up to #19153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)