### PR TITLE
🐛 fix(cli, agent-runtime): local store review round 3, plus the loop cost-limit reason

### DIFF
--- a/apps/cli/src/runtime/LocalMessageStore.test.ts
+++ b/apps/cli/src/runtime/LocalMessageStore.test.ts
@@ -42,8 +42,8 @@ describe('LocalMessageStore query scoping', () => {
 
   it('keeps delegated-agent replies in a concrete-topic read', () => {
     const store = new LocalMessageStore();
-    store.insert(base);
-    store.insert({ ...base, agentId: 'delegate-9', content: 'callAgent reply' });
+    store.insert(base, 'id-a');
+    store.insert({ ...base, agentId: 'delegate-9', content: 'callAgent reply' }, 'id-b');
 
     // A concrete topic IS the conversation boundary and may legitimately hold
     // messages from several agents. Scoping a topic read by agentId deletes
@@ -71,8 +71,8 @@ describe('LocalMessageStore query scoping', () => {
 
   it('returns a thread together with its parent messages', () => {
     const store = new LocalMessageStore();
-    const parent = store.insert({ ...base, content: 'the message the thread hangs off' });
-    store.insert({ ...base, content: 'in thread', threadId: 'thread-1' });
+    const parent = store.insert({ ...base, content: 'the message the thread hangs off' }, 'id-a');
+    store.insert({ ...base, content: 'in thread', threadId: 'thread-1' }, 'id-b');
     store.registerThreadParents('thread-1', [parent.id]);
 
     // The server resolves the thread's source message and returns it alongside
@@ -96,16 +96,82 @@ describe('LocalMessageStore query scoping', () => {
     ).toEqual(['in thread']);
   });
 
-  it('orders by creation, keeping insertion order within the same millisecond', () => {
+  it('breaks a timestamp tie by id, not by arrival order', () => {
     const store = new LocalMessageStore();
-    for (const content of ['a', 'b', 'c', 'd']) store.insert({ ...base, content });
+    // Inserted out of id order, all in the same millisecond — what a parallel
+    // tool batch produces.
+    store.insert({ ...base, content: 'third' }, 'id-c');
+    store.insert({ ...base, content: 'first' }, 'id-a');
+    store.insert({ ...base, content: 'second' }, 'id-b');
 
-    expect(store.query({ agentId: 'agent-1', topicId: 'topic-1' }).map((m) => m.content)).toEqual([
-      'a',
-      'b',
-      'c',
-      'd',
+    // `queryWithWhere` orders `(createdAt, id)`. Ordering by arrival instead
+    // would feed the next LLM step a different sequence than the persisted
+    // transcript — and a different one again after a restart re-hydrates them.
+    expect(store.query({ topicId: 'topic-1' }).map((m) => m.content)).toEqual([
+      'first',
+      'second',
+      'third',
     ]);
+  });
+
+  it('survives a rehydration in the same order', () => {
+    const first = new LocalMessageStore();
+    first.insert({ ...base, content: 'b' }, 'id-b');
+    first.insert({ ...base, content: 'a' }, 'id-a');
+    const before = first.query({ topicId: 'topic-1' });
+
+    // Hydrated in the opposite order, as a fresh process reading them back.
+    const second = new LocalMessageStore();
+    second.hydrate([...before].reverse());
+
+    expect(second.query({ topicId: 'topic-1' }).map((m) => m.id)).toEqual(
+      before.map((m) => m.id),
+    );
+  });
+});
+
+describe('LocalMessageStore pagination', () => {
+  const fill = (store: LocalMessageStore, count: number) => {
+    for (let index = 0; index < count; index++) {
+      // Zero-padded so id order matches creation order.
+      store.insert({ ...base, content: `m${index}` }, `id-${String(index).padStart(4, '0')}`);
+    }
+  };
+
+  it('returns the newest page, not everything, at the canonical default', () => {
+    const store = new LocalMessageStore();
+    fill(store, 1200);
+
+    const messages = store.query({ topicId: 'topic-1' });
+
+    // `MessageModel.query` defaults to the newest 1,000 rows. Returning all
+    // 1,200 would give the device a wider context than the server ever has,
+    // and grow every per-step re-query without bound.
+    expect(messages).toHaveLength(1000);
+    expect(messages[0].content).toBe('m200');
+    expect(messages.at(-1)?.content).toBe('m1199');
+  });
+
+  it('honours an explicit page size and offset from the newest end', () => {
+    const store = new LocalMessageStore();
+    fill(store, 10);
+
+    expect(store.query({ pageSize: 3, topicId: 'topic-1' }).map((m) => m.content)).toEqual([
+      'm7',
+      'm8',
+      'm9',
+    ]);
+    // `current: 1` is the page before the newest one.
+    expect(
+      store.query({ current: 1, pageSize: 3, topicId: 'topic-1' }).map((m) => m.content),
+    ).toEqual(['m4', 'm5', 'm6']);
+  });
+
+  it('returns nothing past the last page', () => {
+    const store = new LocalMessageStore();
+    fill(store, 5);
+
+    expect(store.query({ current: 5, pageSize: 3, topicId: 'topic-1' })).toEqual([]);
   });
 });
 

--- a/apps/cli/src/runtime/LocalMessageStore.test.ts
+++ b/apps/cli/src/runtime/LocalMessageStore.test.ts
@@ -96,22 +96,37 @@ describe('LocalMessageStore query scoping', () => {
     ).toEqual(['in thread']);
   });
 
-  it('breaks a timestamp tie by id, not by arrival order', () => {
+  it('orders a same-millisecond batch by creation, not by random id', () => {
     const store = new LocalMessageStore();
-    // Inserted out of id order, all in the same millisecond — what a parallel
-    // tool batch produces.
-    store.insert({ ...base, content: 'third' }, 'id-c');
-    store.insert({ ...base, content: 'first' }, 'id-a');
-    store.insert({ ...base, content: 'second' }, 'id-b');
+    // Ids descend while creation ascends — if ordering fell back to the id
+    // tie-break, these would come out reversed.
+    const created = ['c', 'b', 'a'].map((id, index) =>
+      store.insert({ ...base, content: `m${index}` }, `id-${id}`),
+    );
 
-    // `queryWithWhere` orders `(createdAt, id)`. Ordering by arrival instead
-    // would feed the next LLM step a different sequence than the persisted
-    // transcript — and a different one again after a restart re-hydrates them.
+    // `Date.now()` has millisecond resolution, so a parallel tool batch stamps
+    // rows identically. The server assigns distinct timestamps in delivery
+    // order, so a random tie-break would make the live run read one order and
+    // a restart read another.
     expect(store.query({ topicId: 'topic-1' }).map((m) => m.content)).toEqual([
-      'first',
-      'second',
-      'third',
+      'm0',
+      'm1',
+      'm2',
     ]);
+    expect(new Set(created.map((m) => m.createdAt)).size).toBe(3);
+  });
+
+  it('breaks a genuine timestamp tie by id', () => {
+    const store = new LocalMessageStore();
+    // Hydrated rows carry SERVER timestamps, which really can collide — this is
+    // what the id tie-break is for now that locally created rows get distinct,
+    // monotonic ones.
+    store.hydrate([
+      { ...base, content: 'second', createdAt: 500, id: 'id-b' },
+      { ...base, content: 'first', createdAt: 500, id: 'id-a' },
+    ] as never);
+
+    expect(store.query({ topicId: 'topic-1' }).map((m) => m.content)).toEqual(['first', 'second']);
   });
 
   it('survives a rehydration in the same order', () => {
@@ -165,6 +180,17 @@ describe('LocalMessageStore pagination', () => {
     expect(
       store.query({ current: 1, pageSize: 3, topicId: 'topic-1' }).map((m) => m.content),
     ).toEqual(['m4', 'm5', 'm6']);
+  });
+
+  it('keeps all() outside the page limit', () => {
+    const store = new LocalMessageStore();
+    fill(store, 1200);
+
+    // `all()` seeds a run from prior history. Routing it through the paged
+    // query would hand the caller the newest 1,000 while its name and doc
+    // promise everything — a silent truncation at exactly the wrong moment.
+    expect(store.all()).toHaveLength(1200);
+    expect(store.query({ topicId: 'topic-1' })).toHaveLength(1000);
   });
 
   it('returns nothing past the last page', () => {

--- a/apps/cli/src/runtime/LocalMessageStore.ts
+++ b/apps/cli/src/runtime/LocalMessageStore.ts
@@ -31,13 +31,13 @@ import { merge, nanoid } from '@lobechat/utils';
  *   - `flatten` runs the same `@lobechat/conversation-flow` parser the server
  *     adapter uses, so grouped/tool rows collapse identically.
  */
+/** Same default as `MessageModel.query`. */
+const DEFAULT_PAGE_SIZE = 1000;
+
 export class LocalMessageStore {
   private readonly messages = new Map<string, UIChatMessage>();
   /** `clientId` → message id, for idempotent re-creation of one logical step. */
   private readonly byClientId = new Map<string, string>();
-  /** Monotonic tiebreaker so messages created in the same millisecond keep insertion order. */
-  private sequence = 0;
-  private readonly sequenceById = new Map<string, number>();
   /**
    * `threadId` → the ids a thread read must include alongside its own rows.
    *
@@ -75,7 +75,6 @@ export class LocalMessageStore {
     } as UIChatMessage;
 
     this.messages.set(id, message);
-    this.sequenceById.set(id, this.sequence++);
     if (clientId) this.byClientId.set(clientId, id);
 
     return message;
@@ -87,7 +86,6 @@ export class LocalMessageStore {
 
   delete(id: string): void {
     this.messages.delete(id);
-    this.sequenceById.delete(id);
     for (const [clientId, mappedId] of this.byClientId) {
       if (mappedId === id) this.byClientId.delete(clientId);
     }
@@ -229,12 +227,19 @@ export class LocalMessageStore {
 
     matches.sort((a, b) => {
       if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
-      return (this.sequenceById.get(a.id) ?? 0) - (this.sequenceById.get(b.id) ?? 0);
+      // By id, matching `queryWithWhere`'s `(createdAt, id)` ordering — not by
+      // local insertion order. A parallel tool batch writes several rows in the
+      // same millisecond, and ordering those by arrival would feed the next LLM
+      // step a different sequence than the persisted transcript, and a
+      // different one again after a restart re-hydrates them.
+      return a.id < b.id ? -1 : 1;
     });
 
-    if (!options.flatten) return matches;
+    const page = this.paginate(matches, params);
 
-    const { flatList } = parse(matches as never);
+    if (!options.flatten) return page;
+
+    const { flatList } = parse(page as never);
     return flatList as unknown as UIChatMessage[];
   }
 
@@ -245,10 +250,7 @@ export class LocalMessageStore {
 
   /** Seed prior conversation history fetched once at run start. */
   hydrate(messages: UIChatMessage[]): void {
-    for (const message of messages) {
-      this.messages.set(message.id, message);
-      this.sequenceById.set(message.id, this.sequence++);
-    }
+    for (const message of messages) this.messages.set(message.id, message);
   }
 
   get size(): number {
@@ -257,5 +259,32 @@ export class LocalMessageStore {
 
   private matchesScope(value: string | null | undefined, filter: string | undefined): boolean {
     return filter ? value === filter : value === null || value === undefined;
+  }
+
+  /**
+   * Take the same page the canonical model would.
+   *
+   * `MessageModel.query` defaults to the NEWEST 1,000 rows — it orders
+   * descending, applies `limit`/`offset`, then restores ascending order. A
+   * local store that always returned everything would drift further from the
+   * server's context with every step of a long run, and grow the per-step
+   * re-query and flatten without bound.
+   *
+   * The canonical model additionally aligns a truncated page's lower boundary
+   * to a round start. That is deliberately not reproduced: its stated purpose
+   * is to stop the RENDERER stranding sibling chains, and reproducing it
+   * approximately would be worse than not at all. It only differs past the
+   * page size in a single conversation.
+   */
+  private paginate(matches: UIChatMessage[], params: QueryMessagesInput): UIChatMessage[] {
+    const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+    const current = params.current ?? 0;
+    if (pageSize <= 0) return [];
+
+    // Page from the newest end, then present ascending.
+    const end = matches.length - current * pageSize;
+    if (end <= 0) return [];
+
+    return matches.slice(Math.max(0, end - pageSize), end);
   }
 }

--- a/apps/cli/src/runtime/LocalMessageStore.ts
+++ b/apps/cli/src/runtime/LocalMessageStore.ts
@@ -36,6 +36,8 @@ const DEFAULT_PAGE_SIZE = 1000;
 
 export class LocalMessageStore {
   private readonly messages = new Map<string, UIChatMessage>();
+  /** Monotonic source for local creation timestamps — see `nextCreatedAt`. */
+  private lastCreatedAt = 0;
   /** `clientId` → message id, for idempotent re-creation of one logical step. */
   private readonly byClientId = new Map<string, string>();
   /**
@@ -58,7 +60,7 @@ export class LocalMessageStore {
       if (existing) return existing;
     }
 
-    const now = Date.now();
+    const now = this.nextCreatedAt();
     // `clientId` is the idempotency key, not a message field; `sessionId` is the
     // deprecated predecessor of `agentId` and has no place on `UIChatMessage`.
     // Both are still forwarded to the cloud replica by the transport, which
@@ -225,15 +227,10 @@ export class LocalMessageStore {
       });
     }
 
-    matches.sort((a, b) => {
-      if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
-      // By id, matching `queryWithWhere`'s `(createdAt, id)` ordering — not by
-      // local insertion order. A parallel tool batch writes several rows in the
-      // same millisecond, and ordering those by arrival would feed the next LLM
-      // step a different sequence than the persisted transcript, and a
-      // different one again after a restart re-hydrates them.
-      return a.id < b.id ? -1 : 1;
-    });
+    // `(createdAt, id)`, matching `queryWithWhere`. Local creation timestamps
+    // are monotonic (see `nextCreatedAt`), so the id tie-break only decides
+    // between hydrated rows that genuinely share a server timestamp.
+    this.sorted(matches);
 
     const page = this.paginate(matches, params);
 
@@ -243,9 +240,15 @@ export class LocalMessageStore {
     return flatList as unknown as UIChatMessage[];
   }
 
-  /** Every message, insertion-ordered. Used to seed a run from prior history. */
+  /**
+   * Every message held, ordered `(createdAt, id)`.
+   *
+   * Deliberately NOT routed through {@link query}: that applies the canonical
+   * newest-page limit, which would silently hand a history-seeding caller the
+   * most recent 1,000 rows while claiming to return everything.
+   */
   all(): UIChatMessage[] {
-    return this.query({}, {});
+    return this.sorted([...this.messages.values()]);
   }
 
   /** Seed prior conversation history fetched once at run start. */
@@ -255,6 +258,33 @@ export class LocalMessageStore {
 
   get size(): number {
     return this.messages.size;
+  }
+
+  /**
+   * A creation timestamp that never repeats or goes backwards.
+   *
+   * `Date.now()` has millisecond resolution, so a parallel tool batch stamps
+   * several rows identically and their order falls to the id tie-break — which
+   * is random, while the server assigns distinct timestamps in the order the
+   * queue delivers them. The live run would then read the batch in one order
+   * and a restart would re-read it in another.
+   *
+   * Nudging a collision forward by a millisecond makes local order equal
+   * creation order equal delivery order, which is the order the server ends up
+   * recording. The id tie-break below stays as the final fallback for
+   * hydrated rows that genuinely share a server timestamp.
+   */
+  private nextCreatedAt(): number {
+    const now = Date.now();
+    this.lastCreatedAt = now > this.lastCreatedAt ? now : this.lastCreatedAt + 1;
+    return this.lastCreatedAt;
+  }
+
+  private sorted(messages: UIChatMessage[]): UIChatMessage[] {
+    return messages.sort((a, b) => {
+      if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+      return a.id < b.id ? -1 : 1;
+    });
   }
 
   private matchesScope(value: string | null | undefined, filter: string | undefined): boolean {

--- a/apps/cli/src/runtime/MessageWriteQueue.test.ts
+++ b/apps/cli/src/runtime/MessageWriteQueue.test.ts
@@ -195,6 +195,46 @@ describe('MessageWriteQueue', () => {
     await queue.drain();
   });
 
+  it('creates the log readable only by its owner', async () => {
+    const queue = new MessageWriteQueue({
+      logPath: path.join(dir, 'nested', 'pending.jsonl'),
+      sink: { flush: () => new Promise<void>(() => {}) },
+    });
+
+    await queue.enqueue(op('a'));
+
+    // Every pending operation carries raw conversation content, and a create
+    // may carry tool arguments. The default mode leaves that readable by every
+    // other user on a shared host.
+    const stat = await fs.stat(path.join(dir, 'nested', 'pending.jsonl'));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('keeps the log owner-only after a confirmed batch rewrites it', async () => {
+    let resolveFirst: () => void = () => {};
+    let calls = 0;
+    const queue = new MessageWriteQueue({
+      logPath,
+      sink: {
+        flush: async () => {
+          calls += 1;
+          if (calls === 1) await new Promise<void>((r) => (resolveFirst = r));
+        },
+      },
+    });
+
+    await queue.enqueue(op('a'));
+    await vi.waitFor(() => expect(calls).toBe(1));
+    await queue.enqueue(op('b'));
+    resolveFirst();
+    await vi.waitFor(async () => {
+      // The confirm path replaces the file; a fresh one must not widen it back.
+      const stat = await fs.stat(logPath).catch(() => null);
+      expect(stat === null || (stat.mode & 0o777) === 0o600).toBe(true);
+    });
+    await queue.drain();
+  });
+
   it('recovers the intact entries when the last log line was truncated', async () => {
     // A process killed mid-append leaves a partial trailing line. The entries
     // before it are still deliverable and must not be thrown away with it.

--- a/apps/cli/src/runtime/MessageWriteQueue.test.ts
+++ b/apps/cli/src/runtime/MessageWriteQueue.test.ts
@@ -235,6 +235,21 @@ describe('MessageWriteQueue', () => {
     await queue.drain();
   });
 
+  it('tightens a log left behind by an earlier version', async () => {
+    // An upgrade case: the file already exists at the old permissive mode, and
+    // `mode` on appendFile only applies when the file is created.
+    await fs.writeFile(logPath, '', { encoding: 'utf8', mode: 0o644 });
+    await fs.chmod(logPath, 0o644);
+
+    const queue = new MessageWriteQueue({
+      logPath,
+      sink: { flush: () => new Promise<void>(() => {}) },
+    });
+    await queue.enqueue(op('a'));
+
+    expect((await fs.stat(logPath)).mode & 0o777).toBe(0o600);
+  });
+
   it('recovers the intact entries when the last log line was truncated', async () => {
     // A process killed mid-append leaves a partial trailing line. The entries
     // before it are still deliverable and must not be thrown away with it.

--- a/apps/cli/src/runtime/MessageWriteQueue.ts
+++ b/apps/cli/src/runtime/MessageWriteQueue.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 
 import { MAX_SYNC_BATCH, type MessageSyncOperation, type MessageSyncSink } from './messageSync';
 
+/** Owner-only: the log holds raw conversation content until it is replicated. */
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
 const FLUSH_INTERVAL_MS = 250;
 const MAX_RETRIES = 5;
 const INITIAL_BACKOFF_MS = 500;
@@ -236,8 +240,16 @@ export class MessageWriteQueue {
     if (!logPath) return;
 
     this.logWrites = this.logWrites.then(async () => {
-      await fs.mkdir(path.dirname(logPath), { recursive: true });
-      await fs.appendFile(logPath, `${JSON.stringify(operation)}\n`, 'utf8');
+      await fs.mkdir(path.dirname(logPath), { mode: DIR_MODE, recursive: true });
+      // Owner-only. Every pending operation carries raw conversation content,
+      // and a create may carry tool arguments and whatever they contain. The
+      // default (0o666 less the umask, so usually 0o644) leaves that readable
+      // by every other user on a shared host. `mode` applies on creation, so
+      // this is set on the first append.
+      await fs.appendFile(logPath, `${JSON.stringify(operation)}\n`, {
+        encoding: 'utf8',
+        mode: FILE_MODE,
+      });
     });
 
     try {
@@ -253,7 +265,10 @@ export class MessageWriteQueue {
   private async writeAtomic(filePath: string, content: string): Promise<void> {
     const tmp = `${filePath}.${process.pid}.tmp`;
     try {
-      await fs.writeFile(tmp, content, 'utf8');
+      // Same restriction as the append path — the rewrite replaces the log with
+      // a fresh file, so creating it world-readable would undo it every time a
+      // batch is confirmed.
+      await fs.writeFile(tmp, content, { encoding: 'utf8', mode: FILE_MODE });
       await fs.rename(tmp, filePath);
     } catch (error) {
       await fs.rm(tmp, { force: true }).catch(() => {});

--- a/apps/cli/src/runtime/MessageWriteQueue.ts
+++ b/apps/cli/src/runtime/MessageWriteQueue.ts
@@ -14,6 +14,22 @@ const MAX_BACKOFF_MS = 8_000;
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Narrow an existing artifact's permissions, ignoring one that is not there.
+ *
+ * Only ever tightens: a caller that has deliberately widened the directory is
+ * not the case being defended against, but leaving a legacy world-readable log
+ * in place is.
+ */
+const restrictMode = async (target: string, mode: number): Promise<void> => {
+  try {
+    const stat = await fs.stat(target);
+    if ((stat.mode & 0o777) !== mode) await fs.chmod(target, mode);
+  } catch {
+    // Not created yet — `mkdir`/`appendFile` will apply the mode themselves.
+  }
+};
+
 export interface MessageWriteQueueOptions {
   /** First retry delay; doubles up to {@link MAX_BACKOFF_MS}. Injectable so tests
    *  need not sit through the real schedule. */
@@ -240,7 +256,15 @@ export class MessageWriteQueue {
     if (!logPath) return;
 
     this.logWrites = this.logWrites.then(async () => {
-      await fs.mkdir(path.dirname(logPath), { mode: DIR_MODE, recursive: true });
+      const logDir = path.dirname(logPath);
+      await fs.mkdir(logDir, { mode: DIR_MODE, recursive: true });
+      // `mode` on mkdir/appendFile only applies when the artifact is CREATED.
+      // A log or directory left by an earlier version keeps its old, permissive
+      // mode indefinitely — and it holds unreplicated conversation content, so
+      // "until the next successful confirmation" is not a bound worth relying
+      // on. Tighten whatever is already there.
+      await restrictMode(logDir, DIR_MODE);
+      await restrictMode(logPath, FILE_MODE);
       // Owner-only. Every pending operation carries raw conversation content,
       // and a create may carry tool arguments and whatever they contain. The
       // default (0o666 less the umask, so usually 0o644) leaves that readable

--- a/packages/agent-runtime/src/loop/index.test.ts
+++ b/packages/agent-runtime/src/loop/index.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AgentRuntimeContext, AgentState } from '../types';
+import { AgentRuntime } from '../core/runtime';
+import type {
+  Agent,
+  AgentRuntimeContext,
+  AgentState,
+  Cost,
+  CostCalculationContext,
+  Usage,
+} from '../types';
 import { type AgentLoopStep, resolveStopReason, runAgentLoop } from './index';
 
 const createState = (overrides: Partial<AgentState> = {}): AgentState =>
@@ -55,6 +63,70 @@ describe('resolveStopReason', () => {
     // `warn` and `interrupt` settle up elsewhere; the loop keeps going.
     expect(resolveStopReason(exceeded('warn'), context())).toBeUndefined();
     expect(resolveStopReason(exceeded('interrupt'), context())).toBeUndefined();
+  });
+});
+
+/**
+ * Drives the REAL `AgentRuntime.step` rather than a hand-built state, which is
+ * the only way this case shows up: a `stop` cost policy reports itself through
+ * `status: 'done'`, so a fabricated `running` state with an over-budget cost
+ * never exercises the ordering that matters.
+ */
+describe('runAgentLoop over the real runtime', () => {
+  class OverBudgetAgent implements Agent {
+    async runner(_context: AgentRuntimeContext, state: AgentState) {
+      return { payload: { messages: state.messages }, type: 'call_llm' as const };
+    }
+
+    calculateUsage(_operationType: string, _operationResult: unknown, previousUsage: Usage): Usage {
+      const usage = structuredClone(previousUsage);
+      usage.llm.tokens.total += 1000;
+      return usage;
+    }
+
+    calculateCost(context: CostCalculationContext): Cost {
+      const cost = structuredClone(context.previousCost || ({} as Cost));
+      cost.calculatedAt = new Date().toISOString();
+      cost.currency = 'USD';
+      cost.total = 10;
+      return cost;
+    }
+
+    modelRuntime = async function* () {
+      yield { content: 'test response' };
+    };
+  }
+
+  const runOverBudget = async (onExceeded: 'stop' | 'interrupt') => {
+    const runtime = new AgentRuntime(new OverBudgetAgent());
+    const state = AgentRuntime.createInitialState({
+      costLimit: { currency: 'USD', maxTotalCost: 5, onExceeded },
+      messages: [{ content: 'Hello', role: 'user' }],
+      operationId: 'op-cost',
+    });
+
+    return runAgentLoop({
+      initialContext: context(),
+      state,
+      step: async ({ context: ctx, state: currentState }) => {
+        const result = await runtime.step(currentState, ctx);
+        return { nextContext: result.nextContext, state: result.newState };
+      },
+    });
+  };
+
+  it('reports an exhausted budget as cost_limit, not as an ordinary completion', async () => {
+    const result = await runOverBudget('stop');
+
+    // The runtime signals a `stop` policy by setting `status: 'done'`. Reading
+    // the status first would call this a normal finish and throw away the
+    // budget reason that hosts forward to completion hooks and signals.
+    expect(result.reason).toBe('cost_limit');
+    expect(result.state.status).toBe('done');
+  });
+
+  it('still reports an interrupt policy as interrupted', async () => {
+    expect((await runOverBudget('interrupt')).reason).toBe('interrupted');
   });
 });
 

--- a/packages/agent-runtime/src/loop/index.ts
+++ b/packages/agent-runtime/src/loop/index.ts
@@ -84,13 +84,20 @@ export interface AgentLoopResult {
  * stop would end every loop before it began.
  */
 export const resolveTerminalReason = (state: AgentState): AgentLoopStopReason | undefined => {
-  if (state.status === 'done') return 'done';
   if (state.status === 'error') return 'error';
   if (state.status === 'interrupted') return 'interrupted';
   if (isParkedStatus(state.status)) return 'parked';
 
-  // Exceeding the budget only stops a run that asked to be stopped; other
-  // policies let it continue and settle up elsewhere.
+  // Checked BEFORE `done`, because a `stop` policy expresses itself AS `done`:
+  // `handleCostLimitExceeded` sets that status and clears the next context.
+  // Asking about the status first reported every budget exhaustion as an
+  // ordinary completion — losing exactly the distinction this reason exists to
+  // carry, and only when driving the real `AgentRuntime.step` rather than a
+  // hand-built state.
+  //
+  // Only a `stop` policy ends the run here: `interrupt` surfaces as
+  // `interrupted` above, and `warn` lets the run continue and settle up
+  // elsewhere.
   const costLimit = state.costLimit;
   if (
     costLimit &&
@@ -98,6 +105,8 @@ export const resolveTerminalReason = (state: AgentState): AgentLoopStopReason | 
     costLimit.onExceeded === 'stop'
   )
     return 'cost_limit';
+
+  if (state.status === 'done') return 'done';
 
   return undefined;
 };


### PR DESCRIPTION
Combines #19154 and #19472, and fixes the third review round on top. Both are closed in favour of this one.

Three findings this round, and all three are consequences of the **previous** round's fixes rather than of the original module — worth noting, because it is the second time in this file that a fix has broken a documented contract.

**`all()` inherited the page limit.** It delegates to `query`, so last round's newest-1,000 slicing silently applied to it: a history-seeding caller asking for every message would have got the most recent 1,000 while the name and doc promised everything. It now reads the map directly.

**The id tie-break did not achieve what it was added for.** Locally created rows all take `Date.now()`, so a parallel batch shares a millisecond and falls to a tie-break on *random* ids, while the server assigns distinct timestamps in delivery order — the live run and a restart could still disagree, which is exactly what the tie-break was supposed to prevent.

The suggested remedy — replicate the local timestamp — is not available: `CreateNewMessageParamsSchema` has no `createdAt`, so the server would strip it. (Same trap as the tool-result endpoint in #18899; worth remembering before adding a field to any of these payloads.)

So local creation timestamps are now **monotonic** instead. Local order then equals creation order equals delivery order, which is the order the server ends up recording — no server contract change needed. The id tie-break stays for hydrated rows that genuinely share a server timestamp, and its test now covers that case rather than the one that can no longer occur.

**A legacy log kept its permissive mode.** `mode` on `mkdir`/`appendFile` applies only when the artifact is created, so a log left by an earlier version stayed world-readable while holding unreplicated conversation content. Existing log and directory are now tightened explicitly, and the helper only ever narrows.

#### On combining the two PRs

They touch different packages, which is normally an argument for keeping them apart — a regression in one should be revertable without the other. Both are small, additive and individually tested, so the risk that buys is low against a merge cycle saved. I would not combine a *migration* this way.

#### Test

51 passing across the two packages (36 in the CLI runtime suite, up from 33; 18 in the loop suite, up from 16). Each fix has a regression test, including the 1,200-row `all()` case, the same-millisecond batch ordering, and the pre-existing-`0644`-log upgrade case. Lint clean, type-check adds no errors.

The loop half is unchanged from #19472: the cost-limit reason was masked by the `done` status a `stop` policy sets, and its test drives the real `AgentRuntime.step` because a hand-built state cannot reproduce it.

#### 🔗 Related Issue

Supersedes #19154 and #19472. Follows #18908 and #19153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)