### PR TITLE
✨ feat(message): accept a caller-supplied creation time on create

### DIFF
--- a/apps/cli/src/runtime/CliMessageTransport.test.ts
+++ b/apps/cli/src/runtime/CliMessageTransport.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CliMessageTransport } from './CliMessageTransport';
+import type { MessageSyncOperation } from './messageSync';
+import { MessageWriteQueue } from './MessageWriteQueue';
+
+type CreateOperation = Extract<MessageSyncOperation, { type: 'createMessage' }>;
+
+describe('CliMessageTransport replication payload', () => {
+  let queued: MessageSyncOperation[];
+  let queue: MessageWriteQueue;
+  let transport: CliMessageTransport;
+
+  beforeEach(() => {
+    queued = [];
+    queue = new MessageWriteQueue({
+      sink: {
+        flush: async (operations) => {
+          queued.push(...operations);
+        },
+      },
+    });
+    transport = new CliMessageTransport({ queue });
+  });
+
+  const creates = (): CreateOperation[] =>
+    queued.filter((op): op is CreateOperation => op.type === 'createMessage');
+
+  it('replicates the locally assigned creation time, not just the id', async () => {
+    const ref = await transport.createAssistantMessage({
+      content: 'hello',
+      role: 'assistant',
+      topicId: 'topic-1',
+    });
+    await queue.drain();
+
+    const stored = transport.store.get(ref.id);
+    // Replication runs behind the run, so the server's arrival time would record
+    // when the batch was flushed rather than when the work happened. Sending the
+    // local time is what keeps the replica describing the run.
+    expect(creates()[0].message.createdAt).toBe(stored?.createdAt);
+    expect(creates()[0].message.id).toBe(ref.id);
+  });
+
+  it('replicates a tool row the same way', async () => {
+    const ref = await transport.createToolMessage({
+      content: 'tool output',
+      role: 'tool',
+      topicId: 'topic-1',
+    });
+    await queue.drain();
+
+    expect(creates()[0].message.createdAt).toBe(transport.store.get(ref.id)?.createdAt);
+  });
+
+  it('keeps a batch distinguishable in the replicated payload', async () => {
+    for (let index = 0; index < 3; index++) {
+      await transport.createToolMessage({
+        content: `result ${index}`,
+        role: 'tool',
+        topicId: 'topic-1',
+      });
+    }
+    await queue.drain();
+
+    // A parallel batch lands inside one millisecond. The local clock is
+    // monotonic, so the timestamps it replicates are distinct and ascending —
+    // which is what lets the server's copy order the batch the way the run did.
+    const timestamps = creates().map((op) => op.message.createdAt as number);
+    expect(new Set(timestamps).size).toBe(3);
+    expect([...timestamps].sort((a, b) => a - b)).toEqual(timestamps);
+  });
+});

--- a/apps/cli/src/runtime/CliMessageTransport.ts
+++ b/apps/cli/src/runtime/CliMessageTransport.ts
@@ -44,6 +44,12 @@ export interface CliMessageTransportOptions {
  * create return without waiting: the id the executor anchors its follow-up
  * writes to is already known, and the same id is what the replica is
  * eventually written under, so a replay rewrites rather than duplicates.
+ *
+ * Creation timestamps travel with the id, for the same reason. Replication runs
+ * behind the agent, so the server's arrival time records when a batch was
+ * flushed rather than when the work happened — a retry or an offline stretch
+ * would collapse a long run into one cluster. Sending the local time keeps the
+ * replica's transcript describing the run instead of the sync.
  */
 export class CliMessageTransport implements MessageTransport {
   readonly store: LocalMessageStore;
@@ -69,7 +75,7 @@ export class CliMessageTransport implements MessageTransport {
     // must not be told to create it twice.
     if (this.store.size > before) {
       await this.queue?.enqueue({
-        message: { ...withClientId, id: message.id },
+        message: { ...withClientId, createdAt: message.createdAt, id: message.id },
         type: 'createMessage',
       });
     }
@@ -79,7 +85,10 @@ export class CliMessageTransport implements MessageTransport {
 
   async createToolMessage(params: CreateMessageParams): Promise<RuntimeMessageRef> {
     const message = this.store.insert(params, nanoid());
-    await this.queue?.enqueue({ message: { ...params, id: message.id }, type: 'createMessage' });
+    await this.queue?.enqueue({
+      message: { ...params, createdAt: message.createdAt, id: message.id },
+      type: 'createMessage',
+    });
     return toRef(message);
   }
 

--- a/packages/types/src/message/ui/params.test.ts
+++ b/packages/types/src/message/ui/params.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { CreateNewMessageParamsSchema } from './params';
+
+const base = { content: 'hello', role: 'assistant' as const };
+
+describe('CreateNewMessageParamsSchema createdAt', () => {
+  it('keeps a caller-supplied creation time', () => {
+    const parsed = CreateNewMessageParamsSchema.parse({ ...base, createdAt: 1_788_000_000_000 });
+
+    // `z.object` strips anything undeclared, which is what silently dropped this
+    // before: `MessageModel.create` has always honoured the field, so the whole
+    // gap was the router schema.
+    expect(parsed.createdAt).toBe(1_788_000_000_000);
+  });
+
+  it('leaves it absent when the caller does not send one', () => {
+    expect(CreateNewMessageParamsSchema.parse(base).createdAt).toBeUndefined();
+  });
+
+  it('accepts a clock that runs ahead of the server', () => {
+    const ahead = Date.now() + 10 * 60 * 1000;
+
+    // A device minutes ahead is ordinary. Rejecting it would leave that device
+    // unable to replicate at all, which is worse than a slightly-off transcript
+    // on data scoped to its own owner.
+    expect(CreateNewMessageParamsSchema.parse({ ...base, createdAt: ahead }).createdAt).toBe(ahead);
+  });
+
+  it.each([0, -1, 1.5, '1788000000000', null])('rejects %p', (createdAt) => {
+    expect(() => CreateNewMessageParamsSchema.parse({ ...base, createdAt })).toThrow();
+  });
+});

--- a/packages/types/src/message/ui/params.ts
+++ b/packages/types/src/message/ui/params.ts
@@ -242,6 +242,23 @@ export const CreateNewMessageParamsSchema = z
     // front so parentId chains resolve without a create→backfill round-trip).
     // Omitted → the DB generates one.
     id: z.string().optional(),
+    /**
+     * Caller-supplied creation time, epoch milliseconds. Omitted → the server
+     * stamps it on arrival.
+     *
+     * Exists for write-behind producers, where arrival time is the wrong answer:
+     * a device running an agent locally replicates its messages in background
+     * batches, so a retry or an offline stretch would record an hour of work as
+     * one cluster of timestamps at flush time. `MessageModel.create` has always
+     * honoured this field for in-process callers; this only stops the router
+     * schema from stripping it.
+     *
+     * Only bounded to a positive integer. A device whose clock runs ahead is
+     * ordinary, and rejecting it would leave that device unable to replicate at
+     * all — a worse outcome than a transcript a few minutes out, on data scoped
+     * to its own owner.
+     */
+    createdAt: z.number().int().positive().optional(),
     // agentId is required, but can be resolved from sessionId in the router
     agentId: z.string().optional(),
     /**


### PR DESCRIPTION
Stacked on #19473 — see the dependency note below, it is load-bearing. Retarget to canary once that merges.

#### What it buys

A write-behind producer needs the recorded time to be **when the work happened, not when it synced.** A device running an agent locally replicates in background batches, so the server's arrival time made it record an hour of work as one cluster at flush time — a retry or an offline stretch and the transcript describes the sync rather than the run.

Note this is a *different* problem from ordering, which #19473 already fixes with a monotonic local clock. That one makes the order right; this one makes the timestamps mean something.

#### Almost nothing had to change

`MessageModel.create` has always honoured `createdAt` — `splitCreateMessageParams` destructures it and `buildMessageInsertValue` converts it to a `Date`. The whole gap was the router schema: `z.object` strips anything undeclared, so the field never survived to the model. So this declares it and has the CLI transport send the timestamp alongside the id it already mints.

Same trap as the tool-result endpoint in #18899. Two for two now, which is probably worth remembering before adding a field to any of these payloads.

#### On the trust boundary

Bounded only to a positive integer, deliberately. A device whose clock runs a few minutes ahead is ordinary, and rejecting it would leave that device unable to replicate **at all** — a worse outcome than a slightly-off transcript, on data scoped to its own owner. The schema feeds two procedures (`batchMutate` and `createMessage`), and the model already accepted caller timestamps from in-process callers, so this does not widen what the storage layer trusts.

#### The dependency is real, not bookkeeping

This must not land before #19473. Locally created rows all took `Date.now()` before that PR, so a parallel batch shares one millisecond — replicating those timestamps would copy **identical** values and destroy an ordering the server would otherwise have supplied from delivery order. Replicating the timestamp is only an improvement once the local clock is monotonic.

I found this by running the batch test against canary, where it failed. It now passes on the stacked base, so the constraint is enforced by a test rather than by a comment.

#### Test

39 passing in the CLI runtime suite (up from 36) and 8 new schema tests. The transport test inspects the queued create payload, as the review on #19154 asked for, and covers all three points: the assistant row, a tool row, and a batch remaining distinct and ascending in what gets replicated. Schema tests cover survival, absence, a clock running ahead, and rejection of garbage.

Lint clean; type-check clean on both packages.

#### 🔗 Related Issue

Builds on #19473. Follows #18908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)