### PR TITLE
🔧 chore: remove repository Amp configuration

### DIFF
--- a/.amp/settings.json
+++ b/.amp/settings.json
@@ -1,4 +1,0 @@
-{
-  "amp.git.commit.ampThread.enabled": false,
-  "amp.git.commit.coauthor.enabled": false
-}

--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,4 @@ docs/superpowers/
 .auv/
 
 # Amp agent runtime
-.amp/*
-!.amp/settings.json
+.amp/


### PR DESCRIPTION
#### Description of Change

- Remove the tracked `.amp/settings.json` and the now-empty `.amp` directory.
- Ignore the entire `.amp/` directory instead of keeping an exception for settings, so local Amp files are not accidentally committed again.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified that `.amp` is absent, `git diff --check` passes, and `git check-ignore --no-index` ignores both settings and runtime files.

Ran `bun run check .gitignore .amp/settings.json`: completed successfully; no related tests and the remaining file was skipped because no linter applies.

- Acceptance: Not required. This removes repository-local tooling configuration only; application behavior is unchanged.

#### 🔗 Related Issue

None.