### PR TITLE
♻️ refactor(mecha): extract agent config resolution into a shared package

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,7 @@
     "@lobechat/llm-generation-tracing": "workspace:*",
     "@lobechat/local-file-shell": "workspace:*",
     "@lobechat/markdown-patch": "workspace:*",
+    "@lobechat/mecha": "workspace:*",
     "@lobechat/memory-user-memory": "workspace:*",
     "@lobechat/model-runtime": "workspace:*",
     "@lobechat/observability-otel": "workspace:*",

--- a/packages/mecha/package.json
+++ b/packages/mecha/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@lobechat/mecha",
+  "version": "0.0.1",
+  "description": "Host-agnostic Mecha layer: resolving an agent's effective run configuration and the context it runs on",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest",
+    "test:coverage": "vitest --coverage --silent='passed-only'"
+  },
+  "dependencies": {
+    "@lobechat/builtin-agents": "workspace:*",
+    "@lobechat/builtin-tool-page-agent": "workspace:*",
+    "@lobechat/builtin-tool-task": "workspace:*",
+    "@lobechat/context-engine": "workspace:*",
+    "@lobechat/types": "workspace:*",
+    "debug": "^4.4.3",
+    "immer": "^10.1.3"
+  }
+}

--- a/packages/mecha/src/index.ts
+++ b/packages/mecha/src/index.ts
@@ -1,0 +1,6 @@
+export type {
+  AgentConfigResolverContext,
+  AgentConfigSnapshot,
+  ResolvedAgentConfig,
+} from './resolveAgentConfig';
+export { resolveAgentConfig } from './resolveAgentConfig';

--- a/packages/mecha/src/resolveAgentConfig.test.ts
+++ b/packages/mecha/src/resolveAgentConfig.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentConfigSnapshot } from './resolveAgentConfig';
+import { resolveAgentConfig } from './resolveAgentConfig';
+
+/**
+ * These rules used to read the browser's Zustand stores directly, which is why
+ * the server re-implemented them against its own models. The point of the
+ * extraction is that they now run anywhere — so this suite builds the snapshot
+ * by hand and never mocks a store. If a store read creeps back in, these fail
+ * where the client-side suite would still pass.
+ */
+const snapshot = (overrides: Partial<AgentConfigSnapshot> = {}): AgentConfigSnapshot => ({
+  agentConfig: { model: 'gpt-5', provider: 'openai', systemRole: 'You are helpful.' } as never,
+  canManage: true,
+  chatConfig: {} as never,
+  ...overrides,
+});
+
+describe('resolveAgentConfig without a host', () => {
+  it('resolves a regular agent from a hand-built snapshot', () => {
+    const resolved = resolveAgentConfig({ agentId: 'agt_1' }, snapshot());
+
+    expect(resolved.isBuiltinAgent).toBe(false);
+    expect(resolved.agentConfig.systemRole).toContain('You are helpful.');
+    expect(resolved.chatConfig).toBeDefined();
+  });
+
+  it('appends the reply-language instruction from the snapshot', () => {
+    const resolved = resolveAgentConfig({ agentId: 'agt_1' }, snapshot({ userLocale: 'zh-CN' }));
+
+    expect(resolved.agentConfig.systemRole).toContain('zh-CN');
+  });
+
+  it('leaves the system role alone when no locale is supplied', () => {
+    const resolved = resolveAgentConfig({ agentId: 'agt_1' }, snapshot());
+
+    expect(resolved.agentConfig.systemRole).toBe('You are helpful.');
+  });
+
+  it('returns no plugins when the caller disables tools', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1', disableTools: true },
+      snapshot({ agentConfig: { plugins: ['lobe-web-browsing'] } as never }),
+    );
+
+    expect(resolved.plugins).toEqual([]);
+  });
+
+  it('carries the agent config plugins through for a regular agent', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1' },
+      snapshot({ agentConfig: { plugins: ['lobe-web-browsing'] } as never }),
+    );
+
+    expect(resolved.plugins).toContain('lobe-web-browsing');
+  });
+
+  it('prefers the caller plugins over the stored ones', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1', plugins: ['lobe-local-system'] },
+      snapshot({ agentConfig: { plugins: ['lobe-web-browsing'] } as never }),
+    );
+
+    expect(resolved.plugins).toEqual(['lobe-local-system']);
+  });
+
+  it('applies a workspace member mode override onto the chat config', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1' },
+      snapshot({
+        agent: { visibility: 'public', workspaceId: 'ws_1' },
+        canManage: false,
+        memberModeOverride: false,
+      }),
+    );
+
+    // The override only applies to a public workspace agent the caller cannot
+    // manage — the shape the server has to reproduce for a gateway run.
+    expect(resolved.chatConfig.enableAgentMode).toBe(false);
+  });
+
+  it('lets a collaborative builtin member keep their own model, even as a manager', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1' },
+      snapshot({
+        // A collaborative builtin needs all three of these to be recognised.
+        agent: { slug: 'inbox', virtual: true, visibility: 'public', workspaceId: 'ws_1' },
+        canManage: true,
+        memberModelOverride: { model: 'my-own-pick', provider: 'openai' },
+      }),
+    );
+
+    // These rows have no shared default to manage, so an admin reads their own
+    // choice like anyone else. A host that cannot express `slug` and `virtual`
+    // in the snapshot would classify this as an ordinary agent and hand the
+    // member the workspace-shared model instead — invisible from the browser,
+    // which happens to pass a richer object.
+    expect(resolved.agentConfig.model).toBe('my-own-pick');
+  });
+
+  it('keeps the shared model for an ordinary workspace agent a manager owns', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1' },
+      snapshot({
+        // Same row minus the collaborative discriminators.
+        agent: { visibility: 'public', workspaceId: 'ws_1' },
+        canManage: true,
+        memberModelOverride: { model: 'my-own-pick', provider: 'openai' },
+      }),
+    );
+
+    expect(resolved.agentConfig.model).toBe('gpt-5');
+  });
+
+  it('treats a legacy row holding a reserved slug as an ordinary agent', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1' },
+      snapshot({
+        // `virtual` is what provisioning writes; a slug alone is not enough.
+        agent: { slug: 'inbox', visibility: 'public', workspaceId: 'ws_1' },
+        canManage: true,
+        memberModelOverride: { model: 'my-own-pick', provider: 'openai' },
+      }),
+    );
+
+    expect(resolved.agentConfig.model).toBe('gpt-5');
+  });
+
+  it('ignores a member mode override when the caller can manage the agent', () => {
+    const resolved = resolveAgentConfig(
+      { agentId: 'agt_1' },
+      snapshot({
+        agent: { visibility: 'public', workspaceId: 'ws_1' },
+        canManage: true,
+        memberModeOverride: false,
+      }),
+    );
+
+    // A manager reads the shared row, so their own member pick stays dormant.
+    expect(resolved.chatConfig.enableAgentMode).toBeUndefined();
+  });
+});

--- a/packages/mecha/src/resolveAgentConfig.ts
+++ b/packages/mecha/src/resolveAgentConfig.ts
@@ -1,0 +1,606 @@
+import { type BuiltinAgentSlug } from '@lobechat/builtin-agents';
+import {
+  BUILTIN_AGENT_SLUGS,
+  getAgentRuntimeConfig,
+  isCollaborativeBuiltinAgentRow,
+} from '@lobechat/builtin-agents';
+import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
+import { TaskIdentifier } from '@lobechat/builtin-tool-task';
+import { type LobeToolManifest } from '@lobechat/context-engine';
+import {
+  type AgentModelConfig,
+  type AgentModelOverride,
+  type ChatCompletionTool,
+  getActivePluginIds,
+  type LobeAgentChatConfig,
+  type LobeAgentConfig,
+  type MessageMapScope,
+  resolveAgentModelConfig,
+} from '@lobechat/types';
+import debug from 'debug';
+import { produce } from 'immer';
+
+const log = debug('mecha:agentConfigResolver');
+
+/**
+ * Set of valid builtin agent slugs for O(1) lookup
+ */
+const VALID_BUILTIN_SLUGS = new Set<string>(Object.values(BUILTIN_AGENT_SLUGS));
+
+/**
+ * Check if a slug is a valid builtin agent slug
+ */
+const isBuiltinAgentSlug = (slug: string): slug is BuiltinAgentSlug => {
+  return VALID_BUILTIN_SLUGS.has(slug);
+};
+
+/**
+ * Applies params adjustments based on chatConfig settings.
+ *
+ * This function handles the conditional enabling/disabling of certain params:
+ * - max_tokens: Only included if chatConfig.enableMaxTokens is true
+ * - reasoning_effort: Only included if chatConfig.enableReasoningEffort is true
+ *
+ * Uses immer to create a new object without mutating the original.
+ */
+const applyParamsFromChatConfig = (
+  agentConfig: LobeAgentConfig,
+  chatConfig: LobeAgentChatConfig,
+): LobeAgentConfig => {
+  // If params is not defined, return agentConfig as-is
+  if (!agentConfig?.params) {
+    return agentConfig;
+  }
+
+  return produce(agentConfig, (draft) => {
+    // Only include max_tokens if enableMaxTokens is true
+    draft.params.max_tokens = chatConfig.enableMaxTokens ? draft.params.max_tokens : undefined;
+
+    // Only include reasoning_effort if enableReasoningEffort is true
+    draft.params.reasoning_effort = chatConfig.enableReasoningEffort
+      ? draft.params.reasoning_effort
+      : undefined;
+  });
+};
+
+/**
+ * Runtime context for resolving agent config
+ */
+/**
+ * Everything the resolution rules read from outside themselves.
+ *
+ * The rules below used to reach into the browser's Zustand stores directly,
+ * which is why the server had to re-implement them against its own database
+ * models. Hoisting the reads into one value is what lets a single
+ * implementation serve the browser, the server, and a device: each host
+ * gathers this however it can, and none of the rules know the difference.
+ *
+ * Deliberately plain data. `canManage` in particular is an INPUT, not
+ * something computed here — the browser answers it from a cache the picker
+ * populates, the server from `isResourceAuthorOrAdmin`, and one of those is
+ * asynchronous.
+ */
+export interface AgentConfigSnapshot {
+  /** The agent row: naming, and the fields the ownership rules read. */
+  agent?: {
+    name?: string | null;
+    /**
+     * The row's own slug. With `virtual` and `workspaceId` this is what marks a
+     * COLLABORATIVE builtin, whose members each keep a personal model choice.
+     *
+     * The same value as the top-level `slug` in practice, but a separate read —
+     * that one resolves the builtin identity, this one discriminates the row.
+     * Kept apart because the rules read them for different purposes and a host
+     * may legitimately know one without the other.
+     */
+    slug?: string | null;
+    title?: string | null;
+    userId?: string | null;
+    /** Written by provisioning; a legacy row merely holding a reserved slug is not collaborative. */
+    virtual?: boolean | null;
+    visibility?: AgentModelConfig['visibility'];
+    workspaceId?: string | null;
+  };
+  /** The agent's stored config, before runtime merging. */
+  agentConfig: LobeAgentConfig;
+  /** Author-or-admin for this agent; see the interface doc. */
+  canManage: boolean;
+  /** The agent's stored chat config. */
+  chatConfig: LobeAgentChatConfig;
+  /** The group named by `groupId`, when the caller is running in group scope. */
+  group?: {
+    agents?: unknown[];
+    id: string;
+    supervisorAgentId?: string | null;
+    title?: string | null;
+  };
+  /** The group's members, for the supervisor's roster of who it can call. */
+  groupMembers?: { id: string; isSupervisor?: boolean; title?: string | null }[];
+  /** Development build — reaches builtin agents as a prompt flag. */
+  isDev?: boolean;
+  /** Workspace member's own model pick, when one applies. */
+  memberModelOverride?: AgentModelOverride | null;
+  /** Workspace member's own mode pick, when one applies. */
+  memberModeOverride?: LobeAgentChatConfig['enableAgentMode'];
+  /**
+   * The agent's slug, which identifies a builtin agent — and, together with
+   * `agent.virtual` and `agent.workspaceId`, a COLLABORATIVE one whose members
+   * each keep a personal model choice. A host that cannot express all three
+   * classifies every collaborative builtin as an ordinary agent, silently
+   * handing its members the workspace-shared model instead of their own.
+   *
+   * Resolves the builtin identity. `agent.slug` discriminates the row for the
+   * collaborative rule; the two hold the same value but are separate reads.
+   */
+  slug?: string;
+  /** The user's preferred reply language, injected into the system role. */
+  userLocale?: string;
+}
+
+export interface AgentConfigResolverContext {
+  /** Agent ID to resolve config for */
+  agentId: string;
+
+  /**
+   * Whether to disable all tools for this agent execution.
+   * When true, returns empty plugins array (used for broadcast scenarios).
+   */
+  disableTools?: boolean;
+
+  // Builtin agent specific context
+  /** Document content for page-agent */
+  documentContent?: string;
+
+  /**
+   * Group ID for supervisor detection.
+   * When provided, used for direct lookup instead of iterating all groups.
+   */
+  groupId?: string;
+
+  /**
+   * Whether this is a sub-agent execution.
+   * When true, filters out the lobe-agent tool (which owns the sub-agent
+   * dispatch APIs) to prevent nested sub-agent creation.
+   */
+  isSubAgent?: boolean;
+
+  /** Current model being used (for template variables) */
+  model?: string;
+  /** Plugins enabled for the agent */
+  plugins?: string[];
+
+  /** Current provider */
+  provider?: string;
+
+  /** Message map scope (e.g., 'page', 'main', 'thread') */
+  scope?: MessageMapScope;
+  /** Target agent config for agent-builder */
+  targetAgentConfig?: LobeAgentConfig;
+}
+
+/**
+ * Resolved agent config with runtime values merged
+ */
+export interface ResolvedAgentConfig {
+  /** The resolved agent config */
+  agentConfig: LobeAgentConfig;
+  /** The chat config */
+  chatConfig: LobeAgentChatConfig;
+  /** Enabled manifests for context engineering (populated by internal_createAgentState) */
+  enabledManifests?: LobeToolManifest[];
+  /** Enabled tool IDs after filtering (populated by internal_createAgentState) */
+  enabledToolIds?: string[];
+  /** Whether this is a builtin agent */
+  isBuiltinAgent: boolean;
+  /**
+   * Final merged plugins for the agent
+   * For builtin agents: runtime plugins (if any) or fallback to agent config plugins
+   * For regular agents: agent config plugins
+   */
+  plugins: string[];
+  /** The agent's slug (if builtin) */
+  slug?: string;
+  /**
+   * The raw sub-agent chatConfig override (`agencyConfig.subagent.chatConfig`).
+   * `chatConfig` above already has it merged in for non-migrated fields; this
+   * copy lets the model-params resolver re-apply the user's explicit sub-agent
+   * reasoning choices on top of the model-instance defaults.
+   */
+  subAgentChatConfigOverride?: Partial<LobeAgentChatConfig>;
+  /** Pre-generated tools array (populated by internal_createAgentState, undefined means tools disabled) */
+  tools?: ChatCompletionTool[];
+}
+
+/**
+ * Resolves the agent config, merging runtime config for builtin agents
+ *
+ * For builtin agents (identified by slug), this will:
+ * 1. Get the base config from the agent store
+ * 2. Get the runtime config from @lobechat/builtin-agents
+ * 3. Merge the runtime systemRole into the agent config
+ *
+ * For regular agents, this simply returns the config from the store.
+ */
+export const resolveAgentConfig = (
+  ctx: AgentConfigResolverContext,
+  snapshot: AgentConfigSnapshot,
+): ResolvedAgentConfig => {
+  const { agentId, model, documentContent, plugins, targetAgentConfig, isSubAgent, disableTools } =
+    ctx;
+
+  log(
+    'resolveAgentConfig called with agentId: %s, scope: %s, isSubAgent: %s, disableTools: %s',
+    agentId,
+    ctx.scope,
+    isSubAgent,
+    disableTools,
+  );
+
+  // Helper to apply plugin filters:
+  // 1. If disableTools is true, return empty array (for broadcast scenarios)
+  // 2. Drop page-agent outside page scope.
+  //
+  // lobe-agent's context trimming (hide `callSubAgent` in group / sub-agent runs)
+  // now lives in its manifest resolver (resolveLobeAgentManifest), applied at
+  // tools-engine build time. That keeps lobe-agent's plan / todo / media-analysis
+  // available to sub-agents — only the nested dispatch API is removed — instead of
+  // dropping the whole tool here.
+  const applyPluginFilters = (pluginIds: string[]) => {
+    if (disableTools) {
+      log('disableTools is true, returning empty plugins');
+      return [];
+    }
+
+    let nextPluginIds = pluginIds;
+
+    if (ctx.scope !== 'page') {
+      nextPluginIds = nextPluginIds.filter((id) => id !== PageAgentIdentifier);
+    }
+
+    return nextPluginIds;
+  };
+
+  const { agent, agentConfig: sharedAgentConfig } = snapshot;
+  // Author-or-admin, mirroring the picker (`useAgentManagementAccess`) and the
+  // server (`isResourceAuthorOrAdmin`) — an admin reads the shared row like
+  // the author does, so client and gateway execution resolve the same config.
+  const { canManage } = snapshot;
+  const isPublicWorkspaceAgent = !!agent?.workspaceId && agent.visibility !== 'private';
+  // A collaborative builtin has no real author (the row is provisioned by
+  // whoever opened the feature first), so its *model* stays personal even for
+  // that member — see `AgentModelConfig.personalModelSelection`. Chat/Agent mode
+  // keeps the ordinary author rule.
+  // Spelled out rather than passed the whole row: these three fields are the
+  // entire contract, and a host filling the snapshot has to see that.
+  const personalModelSelection = isCollaborativeBuiltinAgentRow({
+    slug: agent?.slug,
+    virtual: agent?.virtual,
+    workspaceId: agent?.workspaceId,
+  });
+  const usesWorkspaceMemberSelection = isPublicWorkspaceAgent && !canManage;
+  const memberModelOverride =
+    isPublicWorkspaceAgent && (personalModelSelection || !canManage)
+      ? snapshot.memberModelOverride
+      : undefined;
+  const memberModeOverride = usesWorkspaceMemberSelection ? snapshot.memberModeOverride : undefined;
+  const agentConfig = {
+    ...sharedAgentConfig,
+    ...resolveAgentModelConfig(
+      {
+        ...sharedAgentConfig,
+        canManage,
+        personalModelSelection,
+        visibility: agent?.visibility,
+        workspaceId: agent?.workspaceId,
+      },
+      memberModelOverride,
+    ),
+  };
+  const sharedChatConfig = snapshot.chatConfig;
+  const chatConfig =
+    memberModeOverride === undefined
+      ? sharedChatConfig
+      : { ...sharedChatConfig, enableAgentMode: memberModeOverride };
+
+  // Base plugins from agent config (pinned identifiers only — disabled entries excluded)
+  const basePlugins = getActivePluginIds(agentConfig?.plugins);
+
+  // Check if this is a builtin agent
+  // Priority: supervisor check (when in group scope) > agent store slug
+  let slug: string | undefined;
+
+  // IMPORTANT: When in group scope with groupId, check if this agent is the group's supervisor FIRST
+  // This takes priority because supervisor needs special group-supervisor behavior,
+  // even if the agent has its own slug
+  if (ctx.groupId && ctx.scope === 'group') {
+    const { group } = snapshot;
+
+    log(
+      'checking supervisor FIRST (scope=group): groupId=%s, group=%O, agentId=%s',
+      ctx.groupId,
+      group
+        ? {
+            groupId: group.id,
+            supervisorAgentId: group.supervisorAgentId,
+            title: group.title,
+          }
+        : null,
+      agentId,
+    );
+
+    // Check if this agent is the supervisor of the specified group
+    if (group?.supervisorAgentId === agentId) {
+      slug = BUILTIN_AGENT_SLUGS.groupSupervisor;
+      log(
+        'agentId %s identified as group supervisor for group %s, assigned slug: %s',
+        agentId,
+        ctx.groupId,
+        slug,
+      );
+    }
+  }
+
+  // If not identified as supervisor, check agent store for slug
+  if (!slug) {
+    const storeSlug = snapshot.slug;
+    log('slug from agentStore: %s (agentId: %s)', storeSlug, agentId);
+
+    // Only use the slug if it's a valid builtin agent slug
+    // Regular agents may have random slugs that should be ignored
+    if (storeSlug && isBuiltinAgentSlug(storeSlug)) {
+      slug = storeSlug;
+    } else if (storeSlug) {
+      log('slug %s is not a valid builtin agent slug, treating as regular agent', storeSlug);
+    }
+  }
+
+  if (!slug) {
+    log('agentId %s is not a builtin agent (no valid builtin slug found)', agentId);
+    // Regular agent - use provided plugins if available, fallback to agent's plugins
+    const finalPlugins = plugins && plugins.length > 0 ? plugins : basePlugins;
+
+    // Inject response language preference into system role for regular agents
+    const { userLocale } = snapshot;
+    const localeInstruction = userLocale
+      ? `Preferred reply language: ${userLocale}. Use this language unless the user explicitly asks to switch.`
+      : '';
+    const systemRoleWithLocale = localeInstruction
+      ? agentConfig.systemRole
+        ? `${agentConfig.systemRole}\n\n${localeInstruction}`
+        : localeInstruction
+      : agentConfig.systemRole;
+
+    // Apply params adjustments based on chatConfig
+    let finalAgentConfig = applyParamsFromChatConfig(
+      { ...agentConfig, systemRole: systemRoleWithLocale },
+      chatConfig,
+    );
+    let finalChatConfig = chatConfig;
+
+    // === Page Editor Auto-Injection ===
+    // When custom agent is used in page editor (scope === 'page'),
+    // automatically inject page-agent tools and system role
+    if (ctx.scope === 'page') {
+      // 1. Inject page-agent tool if not already present
+      const pageAgentPlugins = finalPlugins.includes(PageAgentIdentifier)
+        ? finalPlugins
+        : [PageAgentIdentifier, ...finalPlugins];
+
+      // 2. Get page-agent system prompt from builtin agent runtime
+      const pageAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.pageAgent, {});
+      const pageAgentSystemRole = pageAgentRuntime?.systemRole || '';
+
+      // 3. Merge system roles: custom agent's role (with locale) + page-agent role
+      // Only append page-agent role if it exists
+      const mergedSystemRole = pageAgentSystemRole
+        ? systemRoleWithLocale
+          ? `${systemRoleWithLocale}\n\n${pageAgentSystemRole}`
+          : pageAgentSystemRole
+        : systemRoleWithLocale || '';
+
+      finalAgentConfig = {
+        ...finalAgentConfig,
+        systemRole: mergedSystemRole,
+      };
+
+      // 4. Apply chatConfig overrides (same as builtin page-copilot)
+      finalChatConfig = {
+        ...chatConfig,
+        enableHistoryCount: false, // Disable history truncation for full document context
+      };
+
+      return {
+        agentConfig: finalAgentConfig,
+        chatConfig: finalChatConfig,
+        isBuiltinAgent: false,
+        plugins: applyPluginFilters(pageAgentPlugins),
+      };
+    }
+
+    if (ctx.scope === 'task') {
+      const taskAgentPlugins = finalPlugins.includes(TaskIdentifier)
+        ? finalPlugins
+        : [TaskIdentifier, ...finalPlugins];
+      const taskAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.taskAgent, {});
+      const taskAgentSystemRole = taskAgentRuntime?.systemRole || '';
+      const mergedSystemRole = taskAgentSystemRole
+        ? systemRoleWithLocale
+          ? `${systemRoleWithLocale}\n\n${taskAgentSystemRole}`
+          : taskAgentSystemRole
+        : systemRoleWithLocale || '';
+
+      finalAgentConfig = {
+        ...finalAgentConfig,
+        systemRole: mergedSystemRole,
+      };
+
+      return {
+        agentConfig: finalAgentConfig,
+        chatConfig: finalChatConfig,
+        isBuiltinAgent: false,
+        plugins: applyPluginFilters(taskAgentPlugins),
+      };
+    }
+
+    // Not in page scope - return standard config
+    return {
+      agentConfig: finalAgentConfig,
+      chatConfig: finalChatConfig,
+      isBuiltinAgent: false,
+      plugins: applyPluginFilters(finalPlugins),
+    };
+  }
+
+  // Build groupSupervisorContext if this is a group-supervisor agent
+  // Use groupId for direct lookup instead of reverse lookup by supervisorAgentId
+  let groupSupervisorContext;
+  if (slug === BUILTIN_AGENT_SLUGS.groupSupervisor && ctx.groupId) {
+    log('building groupSupervisorContext for agentId: %s, groupId: %s', agentId, ctx.groupId);
+    const { group } = snapshot;
+
+    log(
+      'groupById result for %s: %o',
+      ctx.groupId,
+      group
+        ? {
+            agentsCount: group.agents?.length,
+            groupId: group.id,
+            supervisorAgentId: group.supervisorAgentId,
+            title: group.title,
+          }
+        : null,
+    );
+
+    if (group) {
+      const groupMembers = snapshot.groupMembers ?? [];
+      log(
+        'groupMembers for groupId %s: %o',
+        group.id,
+        groupMembers.map((m) => ({ id: m.id, isSupervisor: m.isSupervisor, title: m.title })),
+      );
+
+      groupSupervisorContext = {
+        availableAgents: groupMembers.map((agent) => ({ id: agent.id, title: agent.title })),
+        groupId: group.id,
+        groupTitle: group.title || 'Group Chat',
+        systemPrompt: agentConfig.systemRole,
+      };
+      log('groupSupervisorContext built: %o', {
+        availableAgentsCount: groupSupervisorContext.availableAgents.length,
+        groupId: groupSupervisorContext.groupId,
+        groupTitle: groupSupervisorContext.groupTitle,
+        hasSystemPrompt: !!groupSupervisorContext.systemPrompt,
+      });
+    } else {
+      log('WARNING: group not found for groupId: %s', ctx.groupId);
+    }
+  }
+
+  // Builtin agent - merge runtime config
+  // Use basePlugins as fallback when ctx.plugins is not provided
+  // This ensures builtin agents (e.g., INBOX) receive user-configured plugins for merging
+  const runtimeConfig = getAgentRuntimeConfig(slug, {
+    // The renameable default assistant must introduce itself by the name the
+    // user gave it, not the hardcoded product default.
+    agentName: agent?.name ?? undefined,
+    agentTitle: agent?.title ?? undefined,
+    documentContent,
+    groupSupervisorContext,
+    isDev: snapshot.isDev ?? false,
+    model,
+    plugins: plugins || basePlugins,
+    targetAgentConfig,
+    userLocale: snapshot.userLocale,
+  });
+
+  // Merge runtime systemRole into agent config
+  let resolvedSystemRole = runtimeConfig?.systemRole ?? agentConfig.systemRole;
+
+  // Merge plugins: runtime plugins take priority, fallback to base plugins
+  let finalPlugins =
+    runtimeConfig?.plugins && runtimeConfig.plugins.length > 0
+      ? runtimeConfig.plugins
+      : basePlugins;
+
+  // Merge chatConfig: runtime chatConfig overrides base chatConfig
+  let resolvedChatConfig: LobeAgentChatConfig = {
+    ...chatConfig,
+    ...runtimeConfig?.chatConfig,
+  };
+  const resolvedAgencyConfig = runtimeConfig?.agencyConfig
+    ? {
+        ...agentConfig.agencyConfig,
+        ...runtimeConfig.agencyConfig,
+      }
+    : agentConfig.agencyConfig;
+
+  // === Page Editor Auto-Injection for Builtin Agents ===
+  // When a builtin agent (other than page-agent itself) is used in page editor,
+  // inject page-agent tools and system role
+  if (ctx.scope === 'page' && slug !== BUILTIN_AGENT_SLUGS.pageAgent) {
+    // 1. Inject page-agent tool if not already present
+    if (!finalPlugins.includes(PageAgentIdentifier)) {
+      finalPlugins = [PageAgentIdentifier, ...finalPlugins];
+    }
+
+    // 2. Get page-agent system prompt
+    const pageAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.pageAgent, {});
+    const pageAgentSystemRole = pageAgentRuntime?.systemRole || '';
+
+    // 3. Merge system roles: builtin agent's role + page-agent role
+    if (pageAgentSystemRole) {
+      resolvedSystemRole = resolvedSystemRole
+        ? `${resolvedSystemRole}\n\n${pageAgentSystemRole}`
+        : pageAgentSystemRole;
+    }
+
+    // 4. Apply chatConfig overrides
+    resolvedChatConfig = {
+      ...resolvedChatConfig,
+      enableHistoryCount: false,
+    };
+  }
+
+  if (ctx.scope === 'task' && slug !== BUILTIN_AGENT_SLUGS.taskAgent) {
+    if (!finalPlugins.includes(TaskIdentifier)) {
+      finalPlugins = [TaskIdentifier, ...finalPlugins];
+    }
+
+    const taskAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.taskAgent, {});
+    const taskAgentSystemRole = taskAgentRuntime?.systemRole || '';
+
+    if (taskAgentSystemRole) {
+      resolvedSystemRole = resolvedSystemRole
+        ? `${resolvedSystemRole}\n\n${taskAgentSystemRole}`
+        : taskAgentSystemRole;
+    }
+  }
+
+  // Merge runtime systemRole into agent config
+  const resolvedAgentConfig: LobeAgentConfig = {
+    ...agentConfig,
+    ...(resolvedAgencyConfig ? { agencyConfig: resolvedAgencyConfig } : {}),
+    systemRole: resolvedSystemRole,
+  };
+
+  // Apply params adjustments based on chatConfig
+  const finalAgentConfig = applyParamsFromChatConfig(resolvedAgentConfig, resolvedChatConfig);
+
+  log('resolveAgentConfig completed for agentId: %s, result: %o', agentId, {
+    isBuiltinAgent: true,
+    pluginsCount: finalPlugins.length,
+    slug,
+  });
+
+  return {
+    agentConfig: finalAgentConfig,
+    chatConfig: resolvedChatConfig,
+    isBuiltinAgent: true,
+    plugins: applyPluginFilters(finalPlugins),
+    slug,
+  };
+};
+
+/**
+ * Get the target agent ID, falling back to active agent if not provided
+ */

--- a/packages/mecha/vitest.config.mts
+++ b/packages/mecha/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
+    environment: 'happy-dom',
+  },
+});

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -1,22 +1,9 @@
-import { type BuiltinAgentSlug } from '@lobechat/builtin-agents';
-import {
-  BUILTIN_AGENT_SLUGS,
-  getAgentRuntimeConfig,
-  isCollaborativeBuiltinAgentRow,
-} from '@lobechat/builtin-agents';
-import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
-import { TaskIdentifier } from '@lobechat/builtin-tool-task';
-import { type LobeToolManifest } from '@lobechat/context-engine';
-import {
-  type ChatCompletionTool,
-  getActivePluginIds,
-  type LobeAgentChatConfig,
-  type LobeAgentConfig,
-  type MessageMapScope,
-  resolveAgentModelConfig,
-} from '@lobechat/types';
-import debug from 'debug';
-import { produce } from 'immer';
+import type {
+  AgentConfigResolverContext,
+  AgentConfigSnapshot,
+  ResolvedAgentConfig,
+} from '@lobechat/mecha';
+import { resolveAgentConfig as resolveFromSnapshot } from '@lobechat/mecha';
 
 import { getRuntimeCanManageAgent } from '@/helpers/agentManagementAccess';
 import { getAgentStoreState } from '@/store/agent';
@@ -31,526 +18,60 @@ import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors, userProfileSelectors } from '@/store/user/selectors';
 import { isDev } from '@/utils/env';
 
-const log = debug('mecha:agentConfigResolver');
+export type { AgentConfigResolverContext, ResolvedAgentConfig };
 
 /**
- * Set of valid builtin agent slugs for O(1) lookup
- */
-const VALID_BUILTIN_SLUGS = new Set<string>(Object.values(BUILTIN_AGENT_SLUGS));
-
-/**
- * Check if a slug is a valid builtin agent slug
- */
-const isBuiltinAgentSlug = (slug: string): slug is BuiltinAgentSlug => {
-  return VALID_BUILTIN_SLUGS.has(slug);
-};
-
-/**
- * Applies params adjustments based on chatConfig settings.
+ * Read everything the resolution rules need out of the client stores.
  *
- * This function handles the conditional enabling/disabling of certain params:
- * - max_tokens: Only included if chatConfig.enableMaxTokens is true
- * - reasoning_effort: Only included if chatConfig.enableReasoningEffort is true
- *
- * Uses immer to create a new object without mutating the original.
+ * This is the whole of what made the rules browser-specific. They now live in
+ * `@lobechat/mecha` — the shared home for this layer, which the server and a
+ * device reach by gathering this value from their own sources rather than
+ * re-implementing the rules against them.
  */
-const applyParamsFromChatConfig = (
-  agentConfig: LobeAgentConfig,
-  chatConfig: LobeAgentChatConfig,
-): LobeAgentConfig => {
-  // If params is not defined, return agentConfig as-is
-  if (!agentConfig?.params) {
-    return agentConfig;
-  }
-
-  return produce(agentConfig, (draft) => {
-    // Only include max_tokens if enableMaxTokens is true
-    draft.params.max_tokens = chatConfig.enableMaxTokens ? draft.params.max_tokens : undefined;
-
-    // Only include reasoning_effort if enableReasoningEffort is true
-    draft.params.reasoning_effort = chatConfig.enableReasoningEffort
-      ? draft.params.reasoning_effort
-      : undefined;
-  });
-};
-
-/**
- * Runtime context for resolving agent config
- */
-export interface AgentConfigResolverContext {
-  /** Agent ID to resolve config for */
-  agentId: string;
-
-  /**
-   * Whether to disable all tools for this agent execution.
-   * When true, returns empty plugins array (used for broadcast scenarios).
-   */
-  disableTools?: boolean;
-
-  // Builtin agent specific context
-  /** Document content for page-agent */
-  documentContent?: string;
-
-  /**
-   * Group ID for supervisor detection.
-   * When provided, used for direct lookup instead of iterating all groups.
-   */
-  groupId?: string;
-
-  /**
-   * Whether this is a sub-agent execution.
-   * When true, filters out the lobe-agent tool (which owns the sub-agent
-   * dispatch APIs) to prevent nested sub-agent creation.
-   */
-  isSubAgent?: boolean;
-
-  /** Current model being used (for template variables) */
-  model?: string;
-  /** Plugins enabled for the agent */
-  plugins?: string[];
-
-  /** Current provider */
-  provider?: string;
-
-  /** Message map scope (e.g., 'page', 'main', 'thread') */
-  scope?: MessageMapScope;
-  /** Target agent config for agent-builder */
-  targetAgentConfig?: LobeAgentConfig;
-}
-
-/**
- * Resolved agent config with runtime values merged
- */
-export interface ResolvedAgentConfig {
-  /** The resolved agent config */
-  agentConfig: LobeAgentConfig;
-  /** The chat config */
-  chatConfig: LobeAgentChatConfig;
-  /** Enabled manifests for context engineering (populated by internal_createAgentState) */
-  enabledManifests?: LobeToolManifest[];
-  /** Enabled tool IDs after filtering (populated by internal_createAgentState) */
-  enabledToolIds?: string[];
-  /** Whether this is a builtin agent */
-  isBuiltinAgent: boolean;
-  /**
-   * Final merged plugins for the agent
-   * For builtin agents: runtime plugins (if any) or fallback to agent config plugins
-   * For regular agents: agent config plugins
-   */
-  plugins: string[];
-  /** The agent's slug (if builtin) */
-  slug?: string;
-  /**
-   * The raw sub-agent chatConfig override (`agencyConfig.subagent.chatConfig`).
-   * `chatConfig` above already has it merged in for non-migrated fields; this
-   * copy lets the model-params resolver re-apply the user's explicit sub-agent
-   * reasoning choices on top of the model-instance defaults.
-   */
-  subAgentChatConfigOverride?: Partial<LobeAgentChatConfig>;
-  /** Pre-generated tools array (populated by internal_createAgentState, undefined means tools disabled) */
-  tools?: ChatCompletionTool[];
-}
-
-/**
- * Resolves the agent config, merging runtime config for builtin agents
- *
- * For builtin agents (identified by slug), this will:
- * 1. Get the base config from the agent store
- * 2. Get the runtime config from @lobechat/builtin-agents
- * 3. Merge the runtime systemRole into the agent config
- *
- * For regular agents, this simply returns the config from the store.
- */
-export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAgentConfig => {
-  const { agentId, model, documentContent, plugins, targetAgentConfig, isSubAgent, disableTools } =
-    ctx;
-
-  log(
-    'resolveAgentConfig called with agentId: %s, scope: %s, isSubAgent: %s, disableTools: %s',
-    agentId,
-    ctx.scope,
-    isSubAgent,
-    disableTools,
-  );
-
-  // Helper to apply plugin filters:
-  // 1. If disableTools is true, return empty array (for broadcast scenarios)
-  // 2. Drop page-agent outside page scope.
-  //
-  // lobe-agent's context trimming (hide `callSubAgent` in group / sub-agent runs)
-  // now lives in its manifest resolver (resolveLobeAgentManifest), applied at
-  // tools-engine build time. That keeps lobe-agent's plan / todo / media-analysis
-  // available to sub-agents — only the nested dispatch API is removed — instead of
-  // dropping the whole tool here.
-  const applyPluginFilters = (pluginIds: string[]) => {
-    if (disableTools) {
-      log('disableTools is true, returning empty plugins');
-      return [];
-    }
-
-    let nextPluginIds = pluginIds;
-
-    if (ctx.scope !== 'page') {
-      nextPluginIds = nextPluginIds.filter((id) => id !== PageAgentIdentifier);
-    }
-
-    return nextPluginIds;
-  };
-
+const collectSnapshot = (ctx: AgentConfigResolverContext): AgentConfigSnapshot => {
   const agentStoreState = getAgentStoreState();
+  const userState = useUserStore.getState();
+  const { agentId } = ctx;
 
-  // Get base config from store
-  const sharedAgentConfig = agentSelectors.getAgentConfigById(agentId)(agentStoreState);
   const agent = agentByIdSelectors.getAgentById(agentId)(agentStoreState);
-  const currentUserId = userProfileSelectors.userId(useUserStore.getState());
-  // Author-or-admin, mirroring the picker (`useAgentManagementAccess`) and the
-  // server (`isResourceAuthorOrAdmin`) — an admin reads the shared row like
-  // the author does, so client and gateway execution resolve the same config.
-  const canManage = getRuntimeCanManageAgent({
-    agentId,
-    agentUserId: agent?.userId,
-    currentUserId,
-  });
-  const isPublicWorkspaceAgent = !!agent?.workspaceId && agent.visibility !== 'private';
-  // A collaborative builtin has no real author (the row is provisioned by
-  // whoever opened the feature first), so its *model* stays personal even for
-  // that member — see `AgentModelConfig.personalModelSelection`. Chat/Agent mode
-  // keeps the ordinary author rule.
-  const personalModelSelection = isCollaborativeBuiltinAgentRow(agent ?? {});
-  const usesWorkspaceMemberSelection = isPublicWorkspaceAgent && !canManage;
-  const memberModelOverride =
-    isPublicWorkspaceAgent && (personalModelSelection || !canManage)
-      ? useUserStore.getState().workspaceUserPreference.agentModelOverrides?.[agentId]
+  const currentUserId = userProfileSelectors.userId(userState);
+
+  // Group rows are only read in group scope or for the supervisor, but both
+  // branches key off `ctx.groupId`, so one lookup up front covers them.
+  const groupStoreState = ctx.groupId ? getChatGroupStoreState() : undefined;
+  const group =
+    ctx.groupId && groupStoreState
+      ? agentGroupByIdSelectors.groupById(ctx.groupId)(groupStoreState)
       : undefined;
-  const memberModeOverride = usesWorkspaceMemberSelection
-    ? useUserStore.getState().workspaceUserPreference.agentModeOverrides?.[agentId]
-    : undefined;
-  const agentConfig = {
-    ...sharedAgentConfig,
-    ...resolveAgentModelConfig(
-      {
-        ...sharedAgentConfig,
-        canManage,
-        personalModelSelection,
-        visibility: agent?.visibility,
-        workspaceId: agent?.workspaceId,
-      },
-      memberModelOverride,
-    ),
-  };
-  const sharedChatConfig = chatConfigByIdSelectors.getChatConfigById(agentId)(agentStoreState);
-  const chatConfig =
-    memberModeOverride === undefined
-      ? sharedChatConfig
-      : { ...sharedChatConfig, enableAgentMode: memberModeOverride };
-
-  // Base plugins from agent config (pinned identifiers only — disabled entries excluded)
-  const basePlugins = getActivePluginIds(agentConfig?.plugins);
-
-  // Check if this is a builtin agent
-  // Priority: supervisor check (when in group scope) > agent store slug
-  let slug: string | undefined;
-
-  // IMPORTANT: When in group scope with groupId, check if this agent is the group's supervisor FIRST
-  // This takes priority because supervisor needs special group-supervisor behavior,
-  // even if the agent has its own slug
-  if (ctx.groupId && ctx.scope === 'group') {
-    const groupStoreState = getChatGroupStoreState();
-    const group = agentGroupByIdSelectors.groupById(ctx.groupId)(groupStoreState);
-
-    log(
-      'checking supervisor FIRST (scope=group): groupId=%s, group=%O, agentId=%s',
-      ctx.groupId,
-      group
-        ? {
-            groupId: group.id,
-            supervisorAgentId: group.supervisorAgentId,
-            title: group.title,
-          }
-        : null,
-      agentId,
-    );
-
-    // Check if this agent is the supervisor of the specified group
-    if (group?.supervisorAgentId === agentId) {
-      slug = BUILTIN_AGENT_SLUGS.groupSupervisor;
-      log(
-        'agentId %s identified as group supervisor for group %s, assigned slug: %s',
-        agentId,
-        ctx.groupId,
-        slug,
-      );
-    }
-  }
-
-  // If not identified as supervisor, check agent store for slug
-  if (!slug) {
-    const storeSlug = agentSelectors.getAgentSlugById(agentId)(agentStoreState) ?? undefined;
-    log('slug from agentStore: %s (agentId: %s)', storeSlug, agentId);
-
-    // Only use the slug if it's a valid builtin agent slug
-    // Regular agents may have random slugs that should be ignored
-    if (storeSlug && isBuiltinAgentSlug(storeSlug)) {
-      slug = storeSlug;
-    } else if (storeSlug) {
-      log('slug %s is not a valid builtin agent slug, treating as regular agent', storeSlug);
-    }
-  }
-
-  if (!slug) {
-    log('agentId %s is not a builtin agent (no valid builtin slug found)', agentId);
-    // Regular agent - use provided plugins if available, fallback to agent's plugins
-    const finalPlugins = plugins && plugins.length > 0 ? plugins : basePlugins;
-
-    // Inject response language preference into system role for regular agents
-    const userLocale = userGeneralSettingsSelectors.currentResponseLanguage(
-      useUserStore.getState(),
-    );
-    const localeInstruction = userLocale
-      ? `Preferred reply language: ${userLocale}. Use this language unless the user explicitly asks to switch.`
-      : '';
-    const systemRoleWithLocale = localeInstruction
-      ? agentConfig.systemRole
-        ? `${agentConfig.systemRole}\n\n${localeInstruction}`
-        : localeInstruction
-      : agentConfig.systemRole;
-
-    // Apply params adjustments based on chatConfig
-    let finalAgentConfig = applyParamsFromChatConfig(
-      { ...agentConfig, systemRole: systemRoleWithLocale },
-      chatConfig,
-    );
-    let finalChatConfig = chatConfig;
-
-    // === Page Editor Auto-Injection ===
-    // When custom agent is used in page editor (scope === 'page'),
-    // automatically inject page-agent tools and system role
-    if (ctx.scope === 'page') {
-      // 1. Inject page-agent tool if not already present
-      const pageAgentPlugins = finalPlugins.includes(PageAgentIdentifier)
-        ? finalPlugins
-        : [PageAgentIdentifier, ...finalPlugins];
-
-      // 2. Get page-agent system prompt from builtin agent runtime
-      const pageAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.pageAgent, {});
-      const pageAgentSystemRole = pageAgentRuntime?.systemRole || '';
-
-      // 3. Merge system roles: custom agent's role (with locale) + page-agent role
-      // Only append page-agent role if it exists
-      const mergedSystemRole = pageAgentSystemRole
-        ? systemRoleWithLocale
-          ? `${systemRoleWithLocale}\n\n${pageAgentSystemRole}`
-          : pageAgentSystemRole
-        : systemRoleWithLocale || '';
-
-      finalAgentConfig = {
-        ...finalAgentConfig,
-        systemRole: mergedSystemRole,
-      };
-
-      // 4. Apply chatConfig overrides (same as builtin page-copilot)
-      finalChatConfig = {
-        ...chatConfig,
-        enableHistoryCount: false, // Disable history truncation for full document context
-      };
-
-      return {
-        agentConfig: finalAgentConfig,
-        chatConfig: finalChatConfig,
-        isBuiltinAgent: false,
-        plugins: applyPluginFilters(pageAgentPlugins),
-      };
-    }
-
-    if (ctx.scope === 'task') {
-      const taskAgentPlugins = finalPlugins.includes(TaskIdentifier)
-        ? finalPlugins
-        : [TaskIdentifier, ...finalPlugins];
-      const taskAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.taskAgent, {});
-      const taskAgentSystemRole = taskAgentRuntime?.systemRole || '';
-      const mergedSystemRole = taskAgentSystemRole
-        ? systemRoleWithLocale
-          ? `${systemRoleWithLocale}\n\n${taskAgentSystemRole}`
-          : taskAgentSystemRole
-        : systemRoleWithLocale || '';
-
-      finalAgentConfig = {
-        ...finalAgentConfig,
-        systemRole: mergedSystemRole,
-      };
-
-      return {
-        agentConfig: finalAgentConfig,
-        chatConfig: finalChatConfig,
-        isBuiltinAgent: false,
-        plugins: applyPluginFilters(taskAgentPlugins),
-      };
-    }
-
-    // Not in page scope - return standard config
-    return {
-      agentConfig: finalAgentConfig,
-      chatConfig: finalChatConfig,
-      isBuiltinAgent: false,
-      plugins: applyPluginFilters(finalPlugins),
-    };
-  }
-
-  // Build groupSupervisorContext if this is a group-supervisor agent
-  // Use groupId for direct lookup instead of reverse lookup by supervisorAgentId
-  let groupSupervisorContext;
-  if (slug === BUILTIN_AGENT_SLUGS.groupSupervisor && ctx.groupId) {
-    log('building groupSupervisorContext for agentId: %s, groupId: %s', agentId, ctx.groupId);
-    const groupStoreState = getChatGroupStoreState();
-    // Direct lookup using groupId
-    const group = agentGroupByIdSelectors.groupById(ctx.groupId)(groupStoreState);
-
-    log(
-      'groupById result for %s: %o',
-      ctx.groupId,
-      group
-        ? {
-            agentsCount: group.agents?.length,
-            groupId: group.id,
-            supervisorAgentId: group.supervisorAgentId,
-            title: group.title,
-          }
-        : null,
-    );
-
-    if (group) {
-      const groupMembers = agentGroupSelectors.getGroupMembers(group.id)(groupStoreState);
-      log(
-        'groupMembers for groupId %s: %o',
-        group.id,
-        groupMembers.map((m) => ({ id: m.id, isSupervisor: m.isSupervisor, title: m.title })),
-      );
-
-      groupSupervisorContext = {
-        availableAgents: groupMembers.map((agent) => ({ id: agent.id, title: agent.title })),
-        groupId: group.id,
-        groupTitle: group.title || 'Group Chat',
-        systemPrompt: agentConfig.systemRole,
-      };
-      log('groupSupervisorContext built: %o', {
-        availableAgentsCount: groupSupervisorContext.availableAgents.length,
-        groupId: groupSupervisorContext.groupId,
-        groupTitle: groupSupervisorContext.groupTitle,
-        hasSystemPrompt: !!groupSupervisorContext.systemPrompt,
-      });
-    } else {
-      log('WARNING: group not found for groupId: %s', ctx.groupId);
-    }
-  }
-
-  // Builtin agent - merge runtime config
-  // Use basePlugins as fallback when ctx.plugins is not provided
-  // This ensures builtin agents (e.g., INBOX) receive user-configured plugins for merging
-  const runtimeConfig = getAgentRuntimeConfig(slug, {
-    // The renameable default assistant must introduce itself by the name the
-    // user gave it, not the hardcoded product default.
-    agentName: agent?.name ?? undefined,
-    agentTitle: agent?.title ?? undefined,
-    documentContent,
-    groupSupervisorContext,
-    isDev,
-    model,
-    plugins: plugins || basePlugins,
-    targetAgentConfig,
-    userLocale: userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),
-  });
-
-  // Merge runtime systemRole into agent config
-  let resolvedSystemRole = runtimeConfig?.systemRole ?? agentConfig.systemRole;
-
-  // Merge plugins: runtime plugins take priority, fallback to base plugins
-  let finalPlugins =
-    runtimeConfig?.plugins && runtimeConfig.plugins.length > 0
-      ? runtimeConfig.plugins
-      : basePlugins;
-
-  // Merge chatConfig: runtime chatConfig overrides base chatConfig
-  let resolvedChatConfig: LobeAgentChatConfig = {
-    ...chatConfig,
-    ...runtimeConfig?.chatConfig,
-  };
-  const resolvedAgencyConfig = runtimeConfig?.agencyConfig
-    ? {
-        ...agentConfig.agencyConfig,
-        ...runtimeConfig.agencyConfig,
-      }
-    : agentConfig.agencyConfig;
-
-  // === Page Editor Auto-Injection for Builtin Agents ===
-  // When a builtin agent (other than page-agent itself) is used in page editor,
-  // inject page-agent tools and system role
-  if (ctx.scope === 'page' && slug !== BUILTIN_AGENT_SLUGS.pageAgent) {
-    // 1. Inject page-agent tool if not already present
-    if (!finalPlugins.includes(PageAgentIdentifier)) {
-      finalPlugins = [PageAgentIdentifier, ...finalPlugins];
-    }
-
-    // 2. Get page-agent system prompt
-    const pageAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.pageAgent, {});
-    const pageAgentSystemRole = pageAgentRuntime?.systemRole || '';
-
-    // 3. Merge system roles: builtin agent's role + page-agent role
-    if (pageAgentSystemRole) {
-      resolvedSystemRole = resolvedSystemRole
-        ? `${resolvedSystemRole}\n\n${pageAgentSystemRole}`
-        : pageAgentSystemRole;
-    }
-
-    // 4. Apply chatConfig overrides
-    resolvedChatConfig = {
-      ...resolvedChatConfig,
-      enableHistoryCount: false,
-    };
-  }
-
-  if (ctx.scope === 'task' && slug !== BUILTIN_AGENT_SLUGS.taskAgent) {
-    if (!finalPlugins.includes(TaskIdentifier)) {
-      finalPlugins = [TaskIdentifier, ...finalPlugins];
-    }
-
-    const taskAgentRuntime = getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.taskAgent, {});
-    const taskAgentSystemRole = taskAgentRuntime?.systemRole || '';
-
-    if (taskAgentSystemRole) {
-      resolvedSystemRole = resolvedSystemRole
-        ? `${resolvedSystemRole}\n\n${taskAgentSystemRole}`
-        : taskAgentSystemRole;
-    }
-  }
-
-  // Merge runtime systemRole into agent config
-  const resolvedAgentConfig: LobeAgentConfig = {
-    ...agentConfig,
-    ...(resolvedAgencyConfig ? { agencyConfig: resolvedAgencyConfig } : {}),
-    systemRole: resolvedSystemRole,
-  };
-
-  // Apply params adjustments based on chatConfig
-  const finalAgentConfig = applyParamsFromChatConfig(resolvedAgentConfig, resolvedChatConfig);
-
-  log('resolveAgentConfig completed for agentId: %s, result: %o', agentId, {
-    isBuiltinAgent: true,
-    pluginsCount: finalPlugins.length,
-    slug,
-  });
 
   return {
-    agentConfig: finalAgentConfig,
-    chatConfig: resolvedChatConfig,
-    isBuiltinAgent: true,
-    plugins: applyPluginFilters(finalPlugins),
-    slug,
+    agent,
+    agentConfig: agentSelectors.getAgentConfigById(agentId)(agentStoreState),
+    // Author-or-admin, mirroring the picker (`useAgentManagementAccess`) and the
+    // server (`isResourceAuthorOrAdmin`) — an admin reads the shared row like
+    // the author does, so client and gateway execution resolve the same config.
+    canManage: getRuntimeCanManageAgent({
+      agentId,
+      agentUserId: agent?.userId,
+      currentUserId,
+    }),
+    chatConfig: chatConfigByIdSelectors.getChatConfigById(agentId)(agentStoreState),
+    group,
+    groupMembers:
+      group && groupStoreState
+        ? agentGroupSelectors.getGroupMembers(group.id)(groupStoreState)
+        : undefined,
+    isDev,
+    memberModeOverride: userState.workspaceUserPreference.agentModeOverrides?.[agentId],
+    memberModelOverride: userState.workspaceUserPreference.agentModelOverrides?.[agentId],
+    slug: agentSelectors.getAgentSlugById(agentId)(agentStoreState) ?? undefined,
+    userLocale: userGeneralSettingsSelectors.currentResponseLanguage(userState),
   };
 };
 
-/**
- * Get the target agent ID, falling back to active agent if not provided
- */
+export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAgentConfig =>
+  resolveFromSnapshot(ctx, collectSnapshot(ctx));
+
 export const getTargetAgentId = (agentId?: string): string => {
   const agentStoreState = getAgentStoreState();
   return agentId || agentStoreState.activeAgentId || '';


### PR DESCRIPTION
Step 1 of unifying the Mecha layer. Pure extraction — no behaviour change, no other host touched.

#### The duplication

There are **two Mecha layers doing the same job against different data sources.**

| | browser | server |
| --- | --- | --- |
| ContextEngineering | `mecha/contextEngineering.ts` 881 | `Mecha/ContextEngineering/` 475 |
| tool composition | `toolSetComposer` 90 + `toolPreload` 126 | `Mecha/AgentToolsEngine/` 557 |
| agent config resolution | `agentConfigResolver.ts` 557 | **inlined in `serverCallLlmContextBuilder.ts` 851** |
| model params / skills | `modelParamsResolver` 77 + `skillEngineering` 110 + `skillPreload` 165 | also inside that 851 |
| total | ~2318 | ~2386 |

Both wrap the same shared `MessagesEngine`, and the primitives underneath (`getActivePluginIds`, `ToolResolver`, `resolveTopicReferences`) were extracted long ago — **only the orchestration above them was left duplicated.** Same pattern as `isParkedStatus` being shared while the loop around it was not.

Spot-checked rather than inferred from size: both sides independently compute `enabledToolIds`, `enabledManifests` and the merged `systemRole` from an agent config, producing the same shape from different sources.

There is also a structural difference worth naming. The browser separates *resolve once per run* from *build per step* — which is why its `ClientContextBuilder` is 155 lines. The server inlines the resolution into its per-step builder, which is why that file is 851 lines and needs six database models. **The browser's shape is the right one**, and it happens to be the shape a device needs.

#### What this PR does

Moves the browser's resolution rules into `@lobechat/mecha` **unchanged**, behind an `AgentConfigSnapshot` of everything they previously read from Zustand. The browser now gathers that snapshot — 76 lines — and delegates.

Nothing else moves: the barrel re-exports the same names so no call site changed, and `getTargetAgentId` stays behind because it reads the active agent rather than resolving anything.

`canManage` is an **input**, not something the rules compute. The browser answers it from the cache its picker populates; the server answers it from `isResourceAuthorOrAdmin`, which is asynchronous. That seam only works if the decision arrives already made, so it is part of the snapshot.

#### On the name, and on not putting it in `agent-runtime`

It takes the name both hosts already use for this layer, because the rest of the layer follows it: context engineering, tool composition and model-parameter resolution are duplicated the same way and belong in the same home. A resolver is the first inhabitant, not the whole tenancy.

It is not part of `@lobechat/agent-runtime` for two reasons:

- **Dependency direction.** The runtime keeps exactly three runtime dependencies (`utils`, `ajv`, `p-map`) and everything heavy is type-only — that is what let the CLI adopt it. These rules need `builtin-agents`, which alone pulls in eight builtin-tool packages. Folding them in inverts the property that makes the runtime portable. Not hypothetical: importing `agent-runtime` in a CLI test already dragged `context-engine → agent-templates` markdown in through the *type-only* path and needed a `raw-md` plugin to load.
- **Ownership.** The runtime never resolves config. It reads `state.metadata?.agentConfig as { chatConfig?: { toolResultMaxLength?: number } }` — an opaque cast for a single field, against a type declared `[key: string]: any`. It treats config as a bag the host filled, so resolution belongs to the host that starts it.

`@lobechat/context-engine` was the other candidate and has the same problem in a different place: it would inherit those eight packages, and both the server and the CLI import it.

#### How the behaviour is pinned

All **77 tests of `agentConfigResolver.test.ts` pass untouched**. They mock the stores, so they exercise the new gathering *and* the extracted rules end to end — which is the property that matters for a move like this.

The package also carries its own suite that builds the snapshot by hand and **never mocks a store**. Without it, "host-agnostic" would be a claim rather than a fact: a store read creeping back in would still pass the client tests and fail only there.

Wider sweeps: 252 in `src/services/chat/mecha`, 532 across `src/services/chat` + `src/store/chat/agents`, 770 in `src/store/chat/slices/agentRun`. Lint clean; type-check reports nothing in the touched or created files, and nothing in the consumers.

#### Next steps, deliberately not here

Server adopts it (and `serverCallLlmContextBuilder` gets to shed the inlined resolution), then a device. One host at a time so a regression stays attributable — the same discipline as the runtime loop migration.

For the device the payoff is the whole point: its context port stops being an 851-line problem and becomes a snapshot to fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)