### PR TITLE
⚡️ perf(desktop): defer tab strip mount and settle restored tabs instantly

### DIFF
--- a/src/features/Electron/TabHost/TabHost.tsx
+++ b/src/features/Electron/TabHost/TabHost.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent,
   type PointerEvent,
   type ReactNode,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -130,9 +131,14 @@ const TabPane = ({
 
 const TabHost = ({ createRouter = createTabRouter }: TabHostProps) => {
   const { t } = useTranslation('electron');
-  const tabs = useElectronStore((s) => s.tabs);
-  const activeTabId = useElectronStore((s) => s.activeTabId);
-  const splitView = useElectronStore((s) => s.splitView);
+  // Deferred so the strip commits a tab switch before the pane does. Activating a cold
+  // tab mounts its whole router tree; on the urgent lane that mount lands in the same
+  // commit as the strip update, so closing a tab froze mid-spring until the neighbour
+  // finished rendering. As a transition it is time-sliced and, when the page suspends on
+  // a lazy chunk, the outgoing pane stays on screen instead of flashing a fallback.
+  const tabs = useDeferredValue(useElectronStore((s) => s.tabs));
+  const activeTabId = useDeferredValue(useElectronStore((s) => s.activeTabId));
+  const splitView = useDeferredValue(useElectronStore((s) => s.splitView));
   const isPreferenceInit = useUserStore(preferenceSelectors.isPreferenceInit);
   const splitViewEnabled = useUserStore(labPreferSelectors.enableDesktopSplitView);
   const closeSplitView = useElectronStore((s) => s.closeSplitView);

--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -38,6 +38,7 @@ interface TabItemProps {
    * neighbours are still shrinking into place, so the two would overlap by a full tab
    * width and take the whole settle to pull apart.
    */
+  enterWidth: number;
   enterX: number;
   index: number;
   isActive: boolean;
@@ -71,6 +72,7 @@ const TabItem = memo<TabItemProps>(
     totalCount,
     width,
     x,
+    enterWidth,
     enterX,
     onActivate,
     onClose,
@@ -102,7 +104,7 @@ const TabItem = memo<TabItemProps>(
 
     // A newly opened tab springs out from zero rather than popping in at full width; the
     // motion value starts collapsed and is set to the real width on mount.
-    const targetWidth = useMotionValue(0);
+    const targetWidth = useMotionValue(enterWidth);
     const springWidth = useSpring(targetWidth, TAB_SPRING);
     const targetX = useMotionValue(enterX);
     const springX = useSpring(targetX, TAB_SPRING);

--- a/src/features/Electron/titlebar/TabBar/hooks/useStripWidth.ts
+++ b/src/features/Electron/titlebar/TabBar/hooks/useStripWidth.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 type StripRef = (node: HTMLDivElement | null) => void;
 
@@ -17,7 +17,7 @@ export const useStripWidth = (): [number, StripRef] => {
   const [width, setWidth] = useState(0);
   const [node, setNode] = useState<HTMLDivElement | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!node) return;
 
     setWidth(node.clientWidth);

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -119,12 +119,34 @@ const TabBar = () => {
   // Read during render, so it still holds the width the strip had on the previous commit
   // — which is exactly where a tab appended this commit should enter from.
   const previousTotal = useRef(0);
+  // Tabs restored at boot land in the strip's first populated commit; they should sit at
+  // their final geometry rather than spring in from nothing like a tab the user opened.
+  const hasPopulated = useRef(false);
+  const settleInstantly = !hasPopulated.current;
 
   useEffect(() => {
-    targetTotal.set(total);
-    targetDividerX.set(dividerX);
+    if (settleInstantly) {
+      targetTotal.jump(total);
+      springTotal.jump(total);
+      targetDividerX.jump(dividerX);
+      springDividerX.jump(dividerX);
+    } else {
+      targetTotal.set(total);
+      targetDividerX.set(dividerX);
+    }
     previousTotal.current = total;
-  }, [total, dividerX, targetTotal, targetDividerX]);
+    if (tabs.length > 0 && stripWidth > 0) hasPopulated.current = true;
+  }, [
+    total,
+    dividerX,
+    targetTotal,
+    springTotal,
+    targetDividerX,
+    springDividerX,
+    tabs.length,
+    stripWidth,
+    settleInstantly,
+  ]);
 
   const newTabUrl = useMemo(() => {
     const scope = resolveTabScope(location.pathname + location.search);
@@ -230,6 +252,11 @@ const TabBar = () => {
 
   if (tabs.length === 0) return null;
 
+  // The strip's width is only known after it is in the DOM. Mounting the tabs before that
+  // would seed every width spring at the minimum a zero-width strip allows, so the whole
+  // row would visibly widen from compact to full once the measurement lands.
+  const measured = stripWidth > 0;
+
   return (
     <Flexbox
       horizontal
@@ -239,79 +266,84 @@ const TabBar = () => {
       ref={stripRef}
       onPointerEnter={captureVisibleTabPreviews}
     >
-      <DndContext
-        collisionDetection={closestCenter}
-        modifiers={[restrictToHorizontalAxis]}
-        sensors={sensors}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-          {/* One keyed list for pinned and flowing tabs alike. Rendering them as two
+      {measured && (
+        <>
+          <DndContext
+            collisionDetection={closestCenter}
+            modifiers={[restrictToHorizontalAxis]}
+            sensors={sensors}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+              {/* One keyed list for pinned and flowing tabs alike. Rendering them as two
               sibling arrays scoped their keys separately, so pinning unmounted the tab
               from one and mounted a fresh one in the other — losing its springs, which
               is why the tab used to pop rather than travel. */}
-          <m.div className={styles.strip} style={{ width: springTotal }}>
-            {placements.map((placement) => {
-              const tab = tabsById.get(placement.id);
-              if (!tab) return null;
+              <m.div className={styles.strip} style={{ width: springTotal }}>
+                {placements.map((placement) => {
+                  const tab = tabsById.get(placement.id);
+                  if (!tab) return null;
 
-              return (
-                <TabItem
-                  enterX={previousTotal.current}
-                  index={tabIds.indexOf(placement.id)}
-                  isActive={placement.id === activeTabId}
-                  item={tab}
-                  key={placement.id}
-                  pinnedCount={pinnedTabs.length}
-                  splitViewEnabled={splitViewEnabled}
-                  tier={resolveTabTier(placement.width)}
-                  totalCount={tabs.length}
-                  width={placement.width}
-                  x={placement.x}
-                  isSplitVisible={
-                    splitView?.primaryTabId === placement.id ||
-                    splitView?.secondaryTabId === placement.id
-                  }
-                  onActivate={handleActivate}
-                  onClose={handleClose}
-                  onCloseLeft={handleCloseLeft}
-                  onCloseOthers={handleCloseOthers}
-                  onCloseRight={handleCloseRight}
-                  onCloseSplitView={closeSplitView}
-                  onOpenInSplitView={openTabInSplitView}
-                  onTogglePin={handleTogglePin}
+                  return (
+                    <TabItem
+                      enterWidth={settleInstantly ? placement.width : 0}
+                      enterX={settleInstantly ? placement.x : previousTotal.current}
+                      index={tabIds.indexOf(placement.id)}
+                      isActive={placement.id === activeTabId}
+                      item={tab}
+                      key={placement.id}
+                      pinnedCount={pinnedTabs.length}
+                      splitViewEnabled={splitViewEnabled}
+                      tier={resolveTabTier(placement.width)}
+                      totalCount={tabs.length}
+                      width={placement.width}
+                      x={placement.x}
+                      isSplitVisible={
+                        splitView?.primaryTabId === placement.id ||
+                        splitView?.secondaryTabId === placement.id
+                      }
+                      onActivate={handleActivate}
+                      onClose={handleClose}
+                      onCloseLeft={handleCloseLeft}
+                      onCloseOthers={handleCloseOthers}
+                      onCloseRight={handleCloseRight}
+                      onCloseSplitView={closeSplitView}
+                      onOpenInSplitView={openTabInSplitView}
+                      onTogglePin={handleTogglePin}
+                    />
+                  );
+                })}
+                <m.span
+                  className={styles.pinnedDivider}
+                  style={{ opacity: pinnedTabs.length > 0 ? 1 : 0, x: springDividerX }}
                 />
-              );
-            })}
-            <m.span
-              className={styles.pinnedDivider}
-              style={{ opacity: pinnedTabs.length > 0 ? 1 : 0, x: springDividerX }}
-            />
-          </m.div>
-        </SortableContext>
-      </DndContext>
-      <ActionIcon
-        className={cx(electronStylish.nodrag, styles.newTabButton)}
-        disabled={!canCreate}
-        icon={Plus}
-        size="small"
-        title={canCreate ? t('tab.newTab') : reason}
-        onClick={canCreate ? () => handleNewTab() : undefined}
-      />
-      {layout.hiddenCount > 0 && (
-        <DropdownMenu items={overflowItems} placement={'bottomRight'}>
-          <Flexbox
-            horizontal
-            align={'center'}
-            className={cx(electronStylish.nodrag, styles.overflowButton)}
-            gap={2}
-            style={{ width: OVERFLOW_CONTROL_WIDTH }}
-            title={t('tab.overflow', { count: layout.hiddenCount })}
-          >
-            <ChevronDown size={12} />
-            {layout.hiddenCount}
-          </Flexbox>
-        </DropdownMenu>
+              </m.div>
+            </SortableContext>
+          </DndContext>
+          <ActionIcon
+            className={cx(electronStylish.nodrag, styles.newTabButton)}
+            disabled={!canCreate}
+            icon={Plus}
+            size="small"
+            title={canCreate ? t('tab.newTab') : reason}
+            onClick={canCreate ? () => handleNewTab() : undefined}
+          />
+          {layout.hiddenCount > 0 && (
+            <DropdownMenu items={overflowItems} placement={'bottomRight'}>
+              <Flexbox
+                horizontal
+                align={'center'}
+                className={cx(electronStylish.nodrag, styles.overflowButton)}
+                gap={2}
+                style={{ width: OVERFLOW_CONTROL_WIDTH }}
+                title={t('tab.overflow', { count: layout.hiddenCount })}
+              >
+                <ChevronDown size={12} />
+                {layout.hiddenCount}
+              </Flexbox>
+            </DropdownMenu>
+          )}
+        </>
       )}
     </Flexbox>
   );

--- a/src/features/Electron/titlebar/TitleBar.tsx
+++ b/src/features/Electron/titlebar/TitleBar.tsx
@@ -3,6 +3,7 @@ import { Flexbox } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { memo } from 'react';
 
+import { useDeferredMount } from '@/hooks/useDeferredMount';
 import { electronStylish } from '@/styles/electron';
 import { getPlatform } from '@/utils/platform';
 
@@ -19,6 +20,7 @@ const platform = getPlatform();
 
 const TitleBar = memo(() => {
   useWatchThemeUpdate();
+  const tabBarMounted = useDeferredMount();
 
   const { padding, showCustomWinControl } = getTitleBarLayoutConfig(platform);
 
@@ -33,7 +35,7 @@ const TitleBar = memo(() => {
       width={'100%'}
     >
       <NavigationBar />
-      <TabBar />
+      {tabBarMounted && <TabBar />}
 
       <Flexbox horizontal align={'center'} gap={4}>
         <Flexbox horizontal className={electronStylish.nodrag} gap={8}>


### PR DESCRIPTION
Three desktop tab-strip fixes around boot and tab switching:

1. **TabBar is off the first paint.** `TitleBar` gates it behind `useDeferredMount`, so the strip mounts in a deferred render after the navigation frame paints. As a side effect the first TabBar render now already sees the tabs seeded by `useSeedTabsOnBoot` instead of mounting empty and animating them in.
2. **Restored tabs no longer play the entrance animation.** Tabs only mount once the strip is measured (`useStripWidth` moved to `useLayoutEffect`; a zero-width strip used to seed every width spring at the compact minimum and then widen). On the first populated commit every spring is jumped to its target (`enterWidth` / `enterX` on `TabItem`, strip total and pinned divider in `TabBar`). Tabs opened later still spring in as before.
3. **Closing a tab no longer freezes the strip.** `TabHost` reads `tabs` / `activeTabId` / `splitView` through `useDeferredValue`. Activating a cold tab mounts its whole router tree; on the urgent lane that landed in the same commit as the strip update, so the close spring stalled on that frame. As a transition the mount is time-sliced, and when the cold page suspends on a lazy chunk the outgoing pane stays on screen instead of flashing a fallback.

| Before | After |
| ------ | ----- |
| Restored tabs appear compact, then widen to full | Strip appears at final geometry |
| Closing a tab next to a never-opened tab freezes mid-animation | Close animation completes, page mounts after |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Acceptance: https://app.lobehub.com/acceptance/bfd22b44-e0a6-4109-9a2f-f6f6cef8dfde?r=1 — CDP screencast of (a) renderer reload with 10 persisted tabs: strip lands fully laid out in one frame; (b) closing the active tab next to a cold tab: strip animates at frame rate while the neighbour page mounts.

#### 🔗 Related Issue

None.

https://claude.ai/code/session_01AMZ2cLD8cHCaSiK3Pz5LCB
