### PR TITLE
💄 style(settings): fix fallback font row inline padding

### DIFF
--- a/src/features/Settings/appearance/features/Font/FallbackFontList.tsx
+++ b/src/features/Settings/appearance/features/Font/FallbackFontList.tsx
@@ -2,6 +2,7 @@
 
 import { Flexbox, SortableList } from '@lobehub/ui';
 import { ActionIcon, Button, Select, type SelectOption, Text } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
 import { PlusIcon, XIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +11,11 @@ import { MAX_FALLBACK_FONTS } from './fontStack';
 import { useFontFallbackStack } from './useFontFallbackStack';
 
 const width = { width: 320 };
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  item: css`
+    padding-inline: ${cssVar.paddingSM} ${cssVar.paddingXXS};
+  `,
+}));
 
 interface FallbackFontListProps {
   ariaLabel: string;
@@ -44,6 +50,7 @@ const FallbackFontList = ({
           <SortableList.Item
             horizontal
             align={'center'}
+            className={styles.item}
             gap={4}
             id={item.id}
             justify={'space-between'}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

The fallback font rows in Settings › Appearance › Font had 4px inline padding on the left and 16px on the right. `SortableList.Item`'s filled variant hardcodes `padding-inline: 4px 16px`, assuming the drag handle sits on the left; this list renders the handle on the right, so the text hugged the left edge while the handle had a wide gap.

Override the item padding with `paddingSM paddingXXS` via `createStaticStyles` so the text gets breathing room and the handle sits flush.

| Before | After |
| --- | --- |
| text 4px from edge, 16px gap after handle | text 12px from edge, 4px gap after handle |

#### 📝 Additional Information

Acceptance skipped: pure CSS padding fix with no behavior change; the only practical assertion would match stylesheet source strings.

https://claude.ai/code/session_01Rf3vs7eC8jwF75kohcS3Ye
