### PR TITLE
⬆️ chore(deps): bump @lobehub/ui to 5.43.0 for the global keyboard focus ring

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     "@lobehub/icons": "^5.18.0",
     "@lobehub/market-sdk": "0.41.0",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.42.7",
+    "@lobehub/ui": "^5.43.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",


### PR DESCRIPTION
## Summary

Bump \`@lobehub/ui\` to 5.43.0, which ships [\`installGlobalFocusRing\`](https://github.com/lobehub/lobe-ui/commit/afd7e65b350ca97554be6c9acfb74da1eacef1aa). \`ConfigProvider\` installs it by default (\`config.globalFocusRing\` defaults to \`true\`), and \`src/layout/GlobalProvider/AppTheme.tsx\` already wraps the app in \`ConfigProvider\`, so no code change is needed.

Effect: one document-level keyboard focus ring for every \`:focus-visible\` control — native elements, antd, and Base UI alike — anchored with CSS anchor positioning. Browsers without anchor positioning / \`position-visibility\` / popover keep their existing focus treatment.

## Acceptance

Dependency bump with no product code change; the behavior is owned and verified upstream in lobe-ui. Type-check passes (\`bun run check --type\`).

https://claude.ai/code/session_01F6CQCZ4qgVppo4NeNxXA1b