### PR TITLE
🐛 fix(desktop): canonicalize main hash graph paths

### DIFF
--- a/apps/desktop/scripts/__tests__/mainHash.test.mjs
+++ b/apps/desktop/scripts/__tests__/mainHash.test.mjs
@@ -141,6 +141,32 @@ describe('source main hash', () => {
     }
   });
 
+  it('canonicalizes graph paths before walking package boundaries', async () => {
+    await put('package.json', '{"private":true}');
+    const node = (id) => ({
+      configFiles: [],
+      defines: {},
+      nodes: new Map([
+        [
+          id,
+          {
+            ast: undefined,
+            dynamicImports: [],
+            entry: false,
+            external: false,
+            id,
+            imports: [],
+            retained: false,
+          },
+        ],
+      ]),
+    });
+    const canonical = await hash({ graph: [node(path.join(root, 'package.json'))] });
+    const relative = `${root}/apps/desktop/src/main/../../../../package.json`;
+
+    expect((await hash({ graph: [node(relative)] })).mainHash).toBe(canonical.mainHash);
+  });
+
   it('tracks Cloud runtime sources and dependency declarations without the whole Cloud revision', async () => {
     const cloud = `${root}-cloud`;
     try {

--- a/apps/desktop/scripts/mainHash.mjs
+++ b/apps/desktop/scripts/mainHash.mjs
@@ -292,7 +292,7 @@ export async function collectSourceInputs({
       const file = sourceFile(id);
       if (slash(id).includes('/node_modules/') || node.external) continue;
       if (path.isAbsolute(file)) {
-        let dir = path.dirname(file);
+        let dir = path.dirname(await realpath(file));
         const owner = roots.find(([, root]) => inside(root, dir));
         if (!owner) throw new Error(`Main hash input is outside the source roots: ${file}`);
         while (dir !== owner[1]) {


### PR DESCRIPTION
Canonicalize Vite graph file paths before walking package boundaries for the Renderer OTA mainHash.

Windows Vite module IDs can use a different path spelling from the realpath-normalized source roots. The raw string boundary comparison therefore walked into the OSS and Cloud repository roots and added both root package.json files only on Windows, while macOS and Linux produced matching manifests. Restoring canonicalization keeps all platform manifests on the same input set.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed
- `bun run check apps/desktop/scripts/mainHash.mjs apps/desktop/scripts/__tests__/mainHash.test.mjs` (31 tests passed)
- Acceptance: Not required — build tooling only, with no product behavior change.

#### 🔗 Related Issue

- Failing Canary job: https://github.com/lobehub/lobehub/actions/runs/34680693836/job/103523061601
