### PR TITLE
🐛 fix(desktop): skip the main hash in Vite development mode

### DIFF
--- a/apps/desktop/scripts/mainHash.mjs
+++ b/apps/desktop/scripts/mainHash.mjs
@@ -436,9 +436,9 @@ export async function computeMainHash() {
   return manifest.mainHash;
 }
 
-export async function resolveMainHash() {
+export async function resolveMainHash(mode) {
   if (process.env[collectEnv] === '1') return MAIN_HASH_PLACEHOLDER;
-  if (!process.env.MAIN_HASH) return computeMainHash();
+  if (!process.env.MAIN_HASH) return mode === 'development' ? '' : computeMainHash();
   if (!/^[0-9a-f]{64}$/.test(process.env.MAIN_HASH)) {
     throw new Error('MAIN_HASH must be a 64-character lowercase SHA-256');
   }

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(async (env) => {
   const isDev = mode === 'development';
   const updateChannel = process.env.UPDATE_CHANNEL;
   const isCloudDesktop = isCloudDesktopBuild();
-  const mainHash = await resolveMainHash();
+  const mainHash = await resolveMainHash(mode);
   const externalNavigationHosts =
     process.env.DESKTOP_EXTERNAL_NAVIGATION_HOSTS ?? (isCloudDesktop ? 'stripe.com' : '');
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [ ] ✨ feat
- [ ] 💄 style
- [ ] ♻️ refactor
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

`apps/desktop` dev (`vite build --mode development`) called `resolveMainHash()` unconditionally, so every config load walked the full main-process source graph and threw whenever root `node_modules` drifted from `apps/desktop/pnpm-lock.yaml`:

```
Main hash dependency is not pinned by apps/desktop/pnpm-lock.yaml: @icons-pack/react-simple-icons@13.15.1
```

`resolveMainHash(mode)` now returns an empty hash in development unless `MAIN_HASH` is set explicitly. `RendererUpdateManager` already treats an empty `MAIN_HASH` as "OTA disabled (dev build)", so dev behaviour is unchanged apart from no longer computing (or failing on) the hash. Production builds and the `RENDERER_OTA_COLLECT_INPUTS` re-entry path are untouched.

#### 📝 Test

- [x] Lint clean on the changed files
- [ ] Acceptance: skipped — dev-tooling only, no user-visible product change; `bun run dev` in `apps/desktop` no longer fails on lockfile drift.

https://claude.ai/code/session_01DjXmqHj7t17UfwNuXMjfn3
