### PR TITLE
🐛 fix(working-sidebar): smooth overview transitions

### DIFF
--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -174,12 +174,7 @@ const REVIEW_TREE_STORAGE_KEY = 'lobechat-review-tree';
 const OPEN_TABS_STORAGE_KEY = 'lobechat-working-sidebar-open-tabs-v1';
 const PINNED_TABS_STORAGE_KEY = 'lobechat-working-sidebar-pinned-tabs-v1';
 const OVERVIEW_PANEL_WIDTH = 340;
-const OVERVIEW_SLOT_TRANSITION = { bounce: 0.1, duration: 0.4, type: 'spring' } as const;
-const OVERVIEW_CARD_TRANSITION = {
-  opacity: { bounce: 0, duration: 0.2, type: 'spring' },
-  scale: { bounce: 0.15, duration: 0.45, type: 'spring' },
-} as const;
-const OVERVIEW_CARD_EXIT_TRANSITION = { bounce: 0, duration: 0.15, type: 'spring' } as const;
+const OVERVIEW_TRANSITION = { duration: 0.25, ease: [0.32, 0.72, 0, 1] } as const;
 const MIN_PANEL_WIDTH = 300;
 const MAX_PANEL_WIDTH = 1200;
 // Two-pane Review (diff list + file-tree rail) is cramped below this.
@@ -245,6 +240,9 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     s.status.workingSidebarTab,
     s.status.workingSidebarTabRequest,
   ]);
+  const overviewExitTransition = showRightPanel
+    ? { ...OVERVIEW_TRANSITION, duration: 0.1 }
+    : OVERVIEW_TRANSITION;
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const workspaceId = useActiveWorkspaceId();
   const [
@@ -925,18 +923,18 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
           <m.div
             animate={{ width: overviewWidth + 32 }}
             className={styles.overviewSlot}
-            exit={{ width: 0 }}
+            exit={{ transition: overviewExitTransition, width: 0 }}
             initial={{ width: 0 }}
-            transition={OVERVIEW_SLOT_TRANSITION}
+            transition={OVERVIEW_TRANSITION}
           >
             <m.div
-              animate={{ opacity: 1, scale: 1 }}
+              animate={{ opacity: 1, x: 0 }}
               className={styles.overviewPanel}
-              exit={{ opacity: 0, scale: 0.8, transition: OVERVIEW_CARD_EXIT_TRANSITION }}
-              initial={{ opacity: 0, scale: 0.8 }}
+              exit={{ opacity: 0, transition: overviewExitTransition, x: 12 }}
+              initial={{ opacity: 0, x: 12 }}
               role={'complementary'}
-              style={{ transformOrigin: 'top right', width: overviewWidth }}
-              transition={OVERVIEW_CARD_TRANSITION}
+              style={{ width: overviewWidth }}
+              transition={OVERVIEW_TRANSITION}
             >
               <Flexbox className={styles.overviewBody}>
                 <Overview


### PR DESCRIPTION
Smooth the Overview choreography so the conversation body moves continuously instead of jumping. The slot width, card translation, and opacity now share one 250ms easing; when a working panel opens at narrow widths, Overview exits in 100ms to avoid the previous transient squeeze and rebound.

| Before | After |
| ------ | ----- |
| Spring scale and independently timed width changes made the body movement feel discontinuous. | Edge translation and synchronized width animation keep the body movement continuous; narrow handoff remains mutually exclusive. |

#### Test

- [x] Tested locally: `bun run check src/features/Conversation/WorkingSidebar/index.tsx` (lint clean, 47 tests passed)
- [ ] Added/updated tests
- [x] No tests needed — this is a motion-only adjustment; a source-literal transition snapshot would not provide behavioral signal.
- [x] `git diff --check`

- Acceptance: Skipped at the requester’s explicit direction. The changed behavior was manually verified in an isolated Electron runtime at wide and narrow viewport widths.

#### 🔗 Related Issue

N/A