### PR TITLE
♻️ refactor(motion): import `m` from `motion/react-m` instead of the barrel

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,9 +39,9 @@ const performanceRestrictedImportPaths = [
   },
   {
     allowTypeImports: true,
-    importNames: ['motion'],
+    importNames: ['motion', 'm'],
     message:
-      'The app runs under <LazyMotion features={domMax}>; `motion` bundles every feature again. Use `m` from "motion/react" (or "motion/react-m").',
+      'The app runs under <LazyMotion features={domMax}>; `motion` bundles every feature again and `m` from the barrel drags it along. Use `import * as m from "motion/react-m"`.',
     name: 'motion/react',
   },
   {

--- a/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/index.test.tsx
@@ -30,14 +30,15 @@ vi.mock('@lobehub/ui', async (importOriginal) => ({
 
 vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  m: {
-    div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
-      <div {...props}>{children}</div>
-    ),
-    span: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
-      <span {...props}>{children}</span>
-    ),
-  },
+}));
+
+vi.mock('motion/react-m', () => ({
+  div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
+  ),
+  span: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <span {...props}>{children}</span>
+  ),
 }));
 
 vi.mock('@/const/version', () => ({ isDesktop: false }));

--- a/src/features/Billboard/Carousel.tsx
+++ b/src/features/Billboard/Carousel.tsx
@@ -5,7 +5,7 @@ import { ActionIcon, Button } from '@lobehub/ui/base-ui';
 import { Carousel as AntCarousel } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { X } from 'lucide-react';
-import { m } from 'motion/react';
+import * as m from 'motion/react-m';
 import {
   type ComponentRef,
   memo,

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -85,14 +85,15 @@ vi.mock('@lobehub/ui/base-ui', async (importOriginal) => ({
 
 vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  m: {
-    div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
-      <div {...props}>{children}</div>
-    ),
-    span: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
-      <span {...props}>{children}</span>
-    ),
-  },
+}));
+
+vi.mock('motion/react-m', () => ({
+  div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
+  ),
+  span: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <span {...props}>{children}</span>
+  ),
 }));
 
 vi.mock('react-i18next', () => ({

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -3,7 +3,8 @@ import { Accordion, AccordionItem, Block, Flexbox, Icon } from '@lobehub/ui';
 import { ActionIcon, Text } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Check, HandIcon, Maximize2, Minimize2, X } from 'lucide-react';
-import { AnimatePresence, m as motion } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as motion from 'motion/react-m';
 import { type Key, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/Conversation/Messages/components/SearchGrounding.tsx
+++ b/src/features/Conversation/Messages/components/SearchGrounding.tsx
@@ -2,7 +2,8 @@ import { Flexbox, Icon, SearchResultCards } from '@lobehub/ui';
 import { Tag } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDown, ChevronRight, Globe, Images } from 'lucide-react';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/Conversation/WorkingSidebar/Review/FileRow.tsx
+++ b/src/features/Conversation/WorkingSidebar/Review/FileRow.tsx
@@ -3,7 +3,8 @@
 import type { GitWorkingTreePatch } from '@lobechat/electron-client-ipc';
 import { createStaticStyles } from 'antd-style';
 import { ChevronRightIcon } from 'lucide-react';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { type KeyboardEvent, memo, useCallback } from 'react';
 
 import type { ComposerTarget } from '../../types';

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -117,11 +117,12 @@ const globalStore = vi.hoisted(() => ({
 
 vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  m: {
-    div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
-      <div {...props}>{children}</div>
-    ),
-  },
+}));
+
+vi.mock('motion/react-m', () => ({
+  div: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
+  ),
 }));
 
 vi.mock('@/features/RightPanel', () => ({

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -23,7 +23,8 @@ import {
   SquareTerminalIcon,
   XIcon,
 } from 'lucide-react';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import {
   Activity,
   lazy,

--- a/src/features/Electron/system/ZoomHUD/index.test.tsx
+++ b/src/features/Electron/system/ZoomHUD/index.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ZoomHUD from './index';
@@ -13,21 +14,15 @@ vi.mock('@lobechat/electron-client-ipc', () => ({
   },
 }));
 
-vi.mock('motion/react', async () => {
-  const React = await import('react');
-  return {
-    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    m: new Proxy(
-      {},
-      {
-        get:
-          () =>
-          ({ children, ...rest }: any) =>
-            React.createElement('div', rest, children),
-      },
-    ),
-  };
-});
+vi.mock('motion/react', () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('motion/react-m', () => ({
+  div: ({ children, ...rest }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...rest}>{children}</div>
+  ),
+}));
 
 const emit = (factor: number, level: number) => {
   act(() => {

--- a/src/features/Electron/system/ZoomHUD/index.tsx
+++ b/src/features/Electron/system/ZoomHUD/index.tsx
@@ -2,7 +2,8 @@
 
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/GlobalApprovalNotification/index.tsx
+++ b/src/features/GlobalApprovalNotification/index.tsx
@@ -3,7 +3,8 @@
 import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { ActionIcon } from '@lobehub/ui/base-ui';
 import { ChevronUp } from 'lucide-react';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/PageEditor/RightPanel/index.tsx
+++ b/src/features/PageEditor/RightPanel/index.tsx
@@ -2,7 +2,8 @@
 
 import { Freeze } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { AnimatePresence, m, useIsPresent } from 'motion/react';
+import { AnimatePresence, useIsPresent } from 'motion/react';
+import * as m from 'motion/react-m';
 import { type ReactNode } from 'react';
 import { memo, useMemo, useRef } from 'react';
 

--- a/src/features/Settings/proxy/features/SaveBar.tsx
+++ b/src/features/Settings/proxy/features/SaveBar.tsx
@@ -2,7 +2,8 @@
 
 import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/TaskDock/index.tsx
+++ b/src/features/TaskDock/index.tsx
@@ -9,7 +9,8 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from 'lucide-react';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
+++ b/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { AnimatePresence, m as motion } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as motion from 'motion/react-m';
 import type { ComponentType, CSSProperties } from 'react';
 import { memo } from 'react';
 import { useMatch } from 'react-router';

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -4,7 +4,8 @@ import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Skeleton, Tag, Text } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, useTheme } from 'antd-style';
 import { HashIcon, MessageSquareDashed } from 'lucide-react';
-import { AnimatePresence, m } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { memo, Suspense, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

The app runs under `<LazyMotion features={domMax}>`, and every `ConfigProvider` already injects `m` from `motion/react-m`. A dozen components still imported `m` from the `motion/react` barrel, which drags the whole barrel into their chunks.

- Switch all 12 remaining `m` / `m as motion` imports to `import * as m from 'motion/react-m'`. `AnimatePresence` / hooks keep coming from `motion/react` (no subpath exists for them).
- Extend the `no-restricted-imports` rule for `motion/react` to also ban `m`, pointing at `motion/react-m`.
- Move the `m` test mocks onto `vi.mock('motion/react-m', …)`. Note: a module-level `Proxy` mock makes vitest hang forever (its `get` returns a function for `then`, so the mock is awaited as a thenable) — the ZoomHUD mock is now an explicit `div`.

#### 📝 Additional Information

Pure refactor with no user-visible outcome — no acceptance run. Affected unit tests pass (ZoomHUD, AgentSidebar Topic Item, WorkingSidebar). `WorkflowCollapse.test.tsx` fails on `canary` before and after with an unrelated `@lobechat/mecha` resolution error.

https://claude.ai/code/session_01CBf64aWmQCjiQ6sLaibBGR
