### PR TITLE
🐛 fix: allow selecting custom image models without parameters schema

### DIFF
--- a/src/store/image/slices/generationConfig/action.test.ts
+++ b/src/store/image/slices/generationConfig/action.test.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeImageGenParams,
 } from 'model-bank';
 import { extractDefaultValues, fluxSchnellParamsSchema } from 'model-bank';
+import { nanoBanana2Parameters } from 'model-bank/imageParameters';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useImageStore } from '@/store/image';
@@ -92,6 +93,12 @@ const testImageModels: AIImageModelCard[] = [
     parameters: sizeOnlyModelSchema,
     releasedAt: '2024-01-01',
   },
+  {
+    id: 'user-added-image-model',
+    displayName: 'User Added Image Model',
+    type: 'image',
+    releasedAt: '2024-01-01',
+  },
 ];
 
 const mockProviders = [
@@ -103,7 +110,7 @@ const mockProviders = [
   {
     id: 'custom-provider',
     name: 'Custom Provider',
-    children: [testImageModels[1]],
+    children: [testImageModels[1], testImageModels[4]],
   },
   {
     id: 'single-image-provider',
@@ -242,6 +249,23 @@ describe('GenerationConfigAction', () => {
         prompt: 'initial prompt',
       });
       expect(result.current.parametersSchema).toEqual(fluxSchnellParamsSchema);
+    });
+
+    it('should select a custom image model that has no parameters schema', () => {
+      const { result } = renderHook(() => useImageStore());
+      const nanoBanana2DefaultValues = extractDefaultValues(nanoBanana2Parameters);
+
+      act(() => {
+        result.current.setModelAndProviderOnSelect('user-added-image-model', 'custom-provider');
+      });
+
+      expect(result.current.model).toBe('user-added-image-model');
+      expect(result.current.provider).toBe('custom-provider');
+      expect(result.current.parametersSchema).toEqual(nanoBanana2Parameters);
+      expect(result.current.parameters).toEqual({
+        ...nanoBanana2DefaultValues,
+        prompt: 'initial prompt',
+      });
     });
 
     it('should handle custom model configuration', () => {

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeImageGenParamsKeys,
   type RuntimeImageGenParamsValue,
 } from 'model-bank';
+import { nanoBanana2Parameters } from 'model-bank/imageParameters';
 import { extractDefaultValues } from 'model-bank/standardParameters';
 
 import { aiProviderSelectors, getAiInfraStoreState } from '@/store/aiInfra';
@@ -46,7 +47,10 @@ export function getModelAndDefaults(model: string, provider: string) {
     );
   }
 
-  const parametersSchema = activeModel.parameters as ModelParamsSchema;
+  // User-created image models have no parameters editor, so `parameters` is undefined.
+  // Fall back to the default image schema so selection still applies with prompt-only config.
+  // https://linear.app/lobehub/issue/LOBE-13928
+  const parametersSchema = (activeModel.parameters ?? nanoBanana2Parameters) as ModelParamsSchema;
   const defaultValues = extractDefaultValues(parametersSchema);
 
   return { defaultValues, activeModel, parametersSchema };


### PR DESCRIPTION
Manually added image models could appear in the Image Generation switcher but clicking them did nothing. `setModelAndProviderOnSelect` called `extractDefaultValues` with `model.parameters === undefined` (the Create model form has no image-parameters editor), and the zod parse threw uncaught.

When `parameters` is missing, fall back to the default `nanoBanana2Parameters` schema so user-added image models can be selected with prompt-only config. Does not add a parameters editor to the Create model modal.

| Before | After |
| ------ | ----- |
| Clicking a custom image model silently fails (zod throw) | Custom image models without a parameters schema select successfully |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Acceptance: none needed — no UI change; store-level fallback only.

#### 🔗 Related Issue

Fixes LOBE-13928