### PR TITLE
🐛 fix(agent): bound tool error messages so a huge tool output can't kill the operation

### DIFF
--- a/apps/server/src/services/queue/__tests__/QueueService.test.ts
+++ b/apps/server/src/services/queue/__tests__/QueueService.test.ts
@@ -248,6 +248,43 @@ describe('QueueService', () => {
       expect(qstashMocks.publishJSON.mock.calls[0][0]).toMatchObject({ delay: 2 });
     });
 
+    it('clamps an oversized body instead of letting the publish blow the QStash quota', async () => {
+      qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
+
+      const { QStashQueueServiceImpl } = await import('../impls/qstash');
+      const impl = new QStashQueueServiceImpl({ qstashToken: 'test-qstash-token' });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // A tool that failed with ~12 MB of command output — the shape that used
+      // to 500 the publish and take the whole operation down with it.
+      const runawayOutput = 'x'.repeat(12 * 1024 * 1024);
+
+      await impl.scheduleMessage({
+        context: {
+          payload: { toolsResult: [{ content: runawayOutput }] },
+          phase: 'llm_result',
+        } as any,
+        delay: 0,
+        endpoint: 'https://example.com/api/agent/run',
+        operationId: 'op-oversized',
+        priority: 'normal',
+        stepIndex: 7,
+      });
+
+      const request = qstashMocks.publishJSON.mock.calls[0][0];
+      const clamped = request.body.context.payload.toolsResult[0].content;
+      expect(clamped.length).toBeLessThan(runawayOutput.length);
+      expect(clamped).toContain('characters omitted so the step could be scheduled');
+      expect(Buffer.byteLength(JSON.stringify(request.body), 'utf8')).toBeLessThan(9 * 1024 * 1024);
+      // Shape is preserved so the worker still reads the step it expects.
+      expect(request.body).toMatchObject({ operationId: 'op-oversized', stepIndex: 7 });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('agent.queue.oversized_message_clamped'),
+      );
+
+      warn.mockRestore();
+    });
+
     it('encodes logical deduplication keys as stable QStash-safe opaque IDs', async () => {
       qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
 

--- a/apps/server/src/services/queue/__tests__/QueueService.test.ts
+++ b/apps/server/src/services/queue/__tests__/QueueService.test.ts
@@ -285,6 +285,40 @@ describe('QueueService', () => {
       warn.mockRestore();
     });
 
+    /**
+     * Fragmented oversize: the MCP contract keeps every raw content block in
+     * `state`, so a body can pass the quota through hundreds of mid-sized
+     * strings that a single generous clamp pass would leave untouched.
+     */
+    it('tightens the clamp until a fragmented oversized body actually fits', async () => {
+      qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
+
+      const { QStashQueueServiceImpl } = await import('../impls/qstash');
+      const impl = new QStashQueueServiceImpl({ qstashToken: 'test-qstash-token' });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const blocks = Array.from({ length: 525 }, () => ({ text: 'y'.repeat(20_000) }));
+
+      await impl.scheduleMessage({
+        context: { payload: { state: { content: blocks } }, phase: 'llm_result' } as any,
+        delay: 0,
+        endpoint: 'https://example.com/api/agent/run',
+        operationId: 'op-fragmented',
+        priority: 'normal',
+        stepIndex: 3,
+      });
+
+      const request = qstashMocks.publishJSON.mock.calls[0][0];
+      expect(Buffer.byteLength(JSON.stringify(request.body), 'utf8')).toBeLessThan(9 * 1024 * 1024);
+      expect(request.body.context.payload.state.content).toHaveLength(525);
+      expect(request.body.context.payload.state.content[0].text).toContain(
+        'characters omitted so the step could be scheduled',
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"stringKeep":4000'));
+
+      warn.mockRestore();
+    });
+
     it('encodes logical deduplication keys as stable QStash-safe opaque IDs', async () => {
       qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
 

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -38,34 +38,41 @@ const toQStashDelaySeconds = (delayMs: number): number | undefined => {
 const QSTASH_MAX_BODY_BYTES = 10 * 1024 * 1024;
 const QSTASH_BODY_BUDGET_BYTES = 9 * 1024 * 1024;
 
-/** What a single string may keep once the body has to be shrunk to fit. */
-const OVERSIZED_STRING_KEEP = 25_000;
+/**
+ * How much a single string may keep, tried in order until the WHOLE body
+ * measures under budget. One pass at a generous limit is not enough: a body
+ * can also be oversized through fragmentation — the MCP contract keeps every
+ * raw content block in `state`, so hundreds of blocks each shorter than the
+ * limit survive an untouched pass and still add up past the quota. Each rung
+ * re-clamps the original body, so the notices never nest.
+ */
+const OVERSIZED_STRING_KEEP_LADDER = [25_000, 4000, 512, 0];
 
 const byteLength = (value: unknown): number =>
   Buffer.byteLength(JSON.stringify(value) ?? '', 'utf8');
 
 /**
- * Shrink a too-large message body by clamping its long strings, depth-first.
- * Oversized bodies are always one or a few runaway strings — a tool result or
- * an error message carrying raw command output — never many small fields, so
- * clamping strings recovers the body while keeping its shape intact for the
- * worker that receives it.
+ * Shrink a too-large message body by clamping every string past `keep`,
+ * depth-first. Strings are the only thing that can run away here — tool
+ * results and error messages carrying raw command output — so clamping them
+ * recovers the body while keeping its shape intact for the worker that
+ * receives it.
  */
-const clampOversizedStrings = (value: unknown): unknown => {
+const clampOversizedStrings = (value: unknown, keep: number): unknown => {
   if (typeof value === 'string') {
-    if (value.length <= OVERSIZED_STRING_KEEP) return value;
-    const omitted = value.length - OVERSIZED_STRING_KEEP;
+    if (value.length <= keep) return value;
+    const omitted = value.length - keep;
 
-    return `${value.slice(0, OVERSIZED_STRING_KEEP)}\n\n[Truncated: ${omitted.toLocaleString()} characters omitted so the step could be scheduled. Original length: ${value.length.toLocaleString()} characters]`;
+    return `${value.slice(0, keep)}\n\n[Truncated: ${omitted.toLocaleString()} characters omitted so the step could be scheduled. Original length: ${value.length.toLocaleString()} characters]`;
   }
 
-  if (Array.isArray(value)) return value.map(clampOversizedStrings);
+  if (Array.isArray(value)) return value.map((entry) => clampOversizedStrings(entry, keep));
 
   if (value && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
         key,
-        clampOversizedStrings(entry),
+        clampOversizedStrings(entry, keep),
       ]),
     );
   }
@@ -145,29 +152,42 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
 
   /**
    * Keep a step schedulable when its body outgrew the QStash message quota:
-   * clamp the long strings rather than let the publish 500 and take the whole
+   * clamp its strings rather than let the publish 500 and take the whole
    * operation down. The step still runs — it just sees a truncated copy of
-   * whatever ran away (see `clampOversizedStrings`).
+   * whatever ran away. Clamping tightens until the body MEASURES under budget,
+   * so a body that is oversized through many mid-sized strings is handled too,
+   * not only one runaway blob.
    */
   private fitBodyToQuota<T extends { body: unknown }>(request: T, operationId: string): T {
     const size = byteLength(request.body);
     if (size <= QSTASH_BODY_BUDGET_BYTES) return request;
 
-    const body = clampOversizedStrings(request.body);
-    const clampedSize = byteLength(body);
+    for (const keep of OVERSIZED_STRING_KEEP_LADDER) {
+      const body = clampOversizedStrings(request.body, keep);
+      const clampedBytes = byteLength(body);
+      if (clampedBytes > QSTASH_BODY_BUDGET_BYTES) continue;
 
-    console.warn(
-      JSON.stringify({
-        bytes: size,
-        clampedBytes: clampedSize,
-        event: 'agent.queue.oversized_message_clamped',
-        fitsAfterClamp: clampedSize <= QSTASH_BODY_BUDGET_BYTES,
-        limitBytes: QSTASH_MAX_BODY_BYTES,
-        operationId,
-      }),
+      console.warn(
+        JSON.stringify({
+          bytes: size,
+          clampedBytes,
+          event: 'agent.queue.oversized_message_clamped',
+          limitBytes: QSTASH_MAX_BODY_BYTES,
+          operationId,
+          stringKeep: keep,
+        }),
+      );
+
+      return { ...request, body };
+    }
+
+    // Unreachable through strings — the last rung drops every string to a
+    // notice. Getting here means the body is huge in its non-string structure,
+    // which no truncation can fix; fail with something diagnosable instead of
+    // an opaque `quota maxMessageSize exceeded` 500 from the provider.
+    throw new Error(
+      `QStash message for operation ${operationId} is ${size} bytes and cannot be reduced under the ${QSTASH_MAX_BODY_BYTES} byte quota`,
     );
-
-    return { ...request, body };
   }
 
   async scheduleBatchMessages(messages: QueueMessage[]): Promise<string[]> {

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -30,6 +30,50 @@ const toQStashDelaySeconds = (delayMs: number): number | undefined => {
 };
 
 /**
+ * QStash rejects any single message above 10 MiB (`quota maxMessageSize
+ * exceeded`) with a 500, so an oversized body used to fail the publish, throw
+ * out of `executeStep` and kill the whole operation at a step boundary. The
+ * budget leaves headroom for the envelope QStash adds around the body.
+ */
+const QSTASH_MAX_BODY_BYTES = 10 * 1024 * 1024;
+const QSTASH_BODY_BUDGET_BYTES = 9 * 1024 * 1024;
+
+/** What a single string may keep once the body has to be shrunk to fit. */
+const OVERSIZED_STRING_KEEP = 25_000;
+
+const byteLength = (value: unknown): number =>
+  Buffer.byteLength(JSON.stringify(value) ?? '', 'utf8');
+
+/**
+ * Shrink a too-large message body by clamping its long strings, depth-first.
+ * Oversized bodies are always one or a few runaway strings — a tool result or
+ * an error message carrying raw command output — never many small fields, so
+ * clamping strings recovers the body while keeping its shape intact for the
+ * worker that receives it.
+ */
+const clampOversizedStrings = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    if (value.length <= OVERSIZED_STRING_KEEP) return value;
+    const omitted = value.length - OVERSIZED_STRING_KEEP;
+
+    return `${value.slice(0, OVERSIZED_STRING_KEEP)}\n\n[Truncated: ${omitted.toLocaleString()} characters omitted so the step could be scheduled. Original length: ${value.length.toLocaleString()} characters]`;
+  }
+
+  if (Array.isArray(value)) return value.map(clampOversizedStrings);
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        clampOversizedStrings(entry),
+      ]),
+    );
+  }
+
+  return value;
+};
+
+/**
  * QStash queue service implementation
  */
 export class QStashQueueServiceImpl implements QueueServiceImpl {
@@ -82,7 +126,7 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
         retries,
         url: endpoint,
       };
-      const response = await qstashClient.publishJSON(request);
+      const response = await qstashClient.publishJSON(this.fitBodyToQuota(request, operationId));
 
       log(
         `[${operationId}] Scheduled step %d to %s with %dms delay (messageId: %s)`,
@@ -97,6 +141,33 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
       log('Failed to schedule step %d for operation %s: %O', stepIndex, operationId, error);
       throw error;
     }
+  }
+
+  /**
+   * Keep a step schedulable when its body outgrew the QStash message quota:
+   * clamp the long strings rather than let the publish 500 and take the whole
+   * operation down. The step still runs — it just sees a truncated copy of
+   * whatever ran away (see `clampOversizedStrings`).
+   */
+  private fitBodyToQuota<T extends { body: unknown }>(request: T, operationId: string): T {
+    const size = byteLength(request.body);
+    if (size <= QSTASH_BODY_BUDGET_BYTES) return request;
+
+    const body = clampOversizedStrings(request.body);
+    const clampedSize = byteLength(body);
+
+    console.warn(
+      JSON.stringify({
+        bytes: size,
+        clampedBytes: clampedSize,
+        event: 'agent.queue.oversized_message_clamped',
+        fitsAfterClamp: clampedSize <= QSTASH_BODY_BUDGET_BYTES,
+        limitBytes: QSTASH_MAX_BODY_BYTES,
+        operationId,
+      }),
+    );
+
+    return { ...request, body };
   }
 
   async scheduleBatchMessages(messages: QueueMessage[]): Promise<string[]> {

--- a/apps/server/src/services/toolExecution/__tests__/index.test.ts
+++ b/apps/server/src/services/toolExecution/__tests__/index.test.ts
@@ -83,6 +83,44 @@ describe('ToolExecutionService', () => {
     expect(result.content).toContain('Content truncated');
   });
 
+  /**
+   * @example A sandbox `rm -rf` against a read-only FS fails with one line per
+   * file — ~29 MB of stderr. The error envelope must not carry it: it rides the
+   * step's nextContext into the QStash publish body, whose 10 MB message quota
+   * would fail the publish and kill the whole operation.
+   */
+  it('clamps the error message of a tool that failed with a huge output', async () => {
+    const runawayOutput = `Command failed with exit code 1\n\nStderr:\n${'rm: cannot remove\n'.repeat(200_000)}`;
+    const builtinToolsExecutor = {
+      execute: vi.fn().mockResolvedValue({
+        content: runawayOutput,
+        success: false,
+      }),
+    };
+    const service = new ToolExecutionService({
+      builtinToolsExecutor: builtinToolsExecutor as any,
+      mcpService: {} as any,
+    });
+
+    const result = await service.executeTool(
+      {
+        apiName: 'runCommand',
+        arguments: '{}',
+        id: 'tool-call-1',
+        identifier: 'lobe-skills',
+        type: 'builtin',
+      },
+      { skipResultTruncation: true, toolManifestMap: {} },
+    );
+
+    const message = (result.error as { message: string }).message;
+    expect(message.length).toBeLessThan(5000);
+    expect(message).toContain('Command failed with exit code 1');
+    expect(message).toContain('Content truncated');
+    // The archival opt-out covers the LLM-facing content, never the error.
+    expect(result.content).toBe(runawayOutput);
+  });
+
   /** @example A missing remote device remains machine-readable to the calling agent runtime. */
   it('preserves structured unavailable-device data in the normalized error envelope', async () => {
     const builtinToolsExecutor = {

--- a/apps/server/src/services/toolExecution/index.ts
+++ b/apps/server/src/services/toolExecution/index.ts
@@ -40,16 +40,33 @@ interface ToolExecutionServiceDeps {
   mcpService: MCPService;
 }
 
+/**
+ * Hard bound on the `error.message` of a failed tool call. The (already
+ * truncated) `content` is what the LLM reads; the error is metadata, so it
+ * never needs the full payload — and an unbounded one is dangerous: a tool
+ * that fails with megabytes of output (e.g. `rm -rf` on a read-only sandbox
+ * FS, one `cannot remove` line per file) rides the step's `nextContext` into
+ * the QStash publish body and blows the provider's 10 MB message quota, which
+ * fails the whole operation at the step boundary instead of just that one tool
+ * call. Deliberately NOT subject to `skipResultTruncation` — that opt-out is
+ * about the LLM context budget, this is a transport safety bound.
+ */
+const TOOL_ERROR_MESSAGE_MAX_LENGTH = 4000;
+
+const clampErrorMessage = (message: string | undefined): string | undefined =>
+  message === undefined ? undefined : truncateToolResult(message, TOOL_ERROR_MESSAGE_MAX_LENGTH);
+
 const normalizeExecutionError = (error: unknown, fallbackMessage: string) => {
   const normalized = classifyToolError(error || fallbackMessage);
-  const message = fallbackMessage || normalized.message;
+  // Classification reads the raw error above; only the carried copy is clamped.
+  const message = clampErrorMessage(fallbackMessage || normalized.message);
 
   if (error && typeof error === 'object') {
     if (error instanceof Error) {
       return {
         code: normalized.code,
         kind: normalized.kind,
-        message: error.message || message,
+        message: clampErrorMessage(error.message) || message,
         name: error.name,
       };
     }
@@ -60,12 +77,12 @@ const normalizeExecutionError = (error: unknown, fallbackMessage: string) => {
       ...plainError,
       code: (plainError.code as string | undefined) || normalized.code,
       kind: normalized.kind,
-      message: (plainError.message as string | undefined) || message,
+      message: clampErrorMessage(plainError.message as string | undefined) || message,
     };
   }
 
   if (typeof error === 'string') {
-    return { code: normalized.code, kind: normalized.kind, message: error };
+    return { code: normalized.code, kind: normalized.kind, message: clampErrorMessage(error) };
   }
 
   return { code: normalized.code, kind: normalized.kind, message };


### PR DESCRIPTION
A failed tool's `content` is truncated to 25k, but its `error.message` was built from the **raw** output. A command that fails with megabytes of stderr carried all of it into the step's `nextContext`, which goes straight into the QStash publish body. Past the 10 MiB message quota the publish 500s with `quota maxMessageSize exceeded`, `scheduleMessage` throws out of `executeStep`, and the whole operation dies at a step boundary.

Real case: `op_1789214172711_agt_S386D6WAedBw_tpc_mHZRfX3xPzYe_rqFgFVvb` — 120 steps and 24 minutes of work thrown away on the last step. A cloud-sandbox `rm -rf` hit a read-only filesystem and emitted one `rm: cannot remove ...` line per file: 29,454,124 bytes of stderr, a 29,480,903 byte publish body. The tool `content` in that step was a healthy 25,668 bytes; only the error envelope was unbounded.

Two layers, because either one alone still leaves a hole:

- `normalizeExecutionError` clamps `error.message` to 4k. Deliberately not subject to `skipResultTruncation` — that opt-out is about the LLM context budget, this is a transport safety bound. Classification still reads the raw error, only the carried copy is clamped.
- The QStash publish guards itself. A body over budget gets its long strings clamped depth-first and logs `agent.queue.oversized_message_clamped`, so the step still runs instead of taking the operation down. This also covers any other field that runs away in future.

| Before | After |
| ------ | ----- |
| tool fails with 29 MB of stderr → publish 500 → operation `error`, all prior steps wasted | error message clamped to 4k; oversized bodies clamped and logged; the step continues |

#### Test

- [x] Added/updated tests

`ToolExecutionService` — a failing tool with ~3.8 MB of output keeps its full `content` under `skipResultTruncation` but carries a clamped `error.message`.
`QStashQueueServiceImpl` — a 12 MB context is clamped under the 9 MB budget before publish, keeps its shape, and warns.

```
bunx vitest run apps/server/src/services/toolExecution/__tests__/index.test.ts apps/server/src/services/queue/__tests__/QueueService.test.ts
Test Files  2 passed (2)     Tests  50 passed (50)
```

`bun run type-check` reports only pre-existing unrelated errors (`@lobechat/mecha` module resolution in `src/services/chat/mecha/`), none in the changed files.

- Acceptance: not user-visible — the failure mode is an operation dying at a step boundary; covered by unit tests at both layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)