### PR TITLE
✨ feat(desktop): collect renderer garbage while idle and from the DevDock memory panel

### DIFF
--- a/apps/desktop/src/main/controllers/DevtoolsCtr.ts
+++ b/apps/desktop/src/main/controllers/DevtoolsCtr.ts
@@ -1,6 +1,7 @@
 import type { AppProcessMetrics, GpuStatus, MemoryDump } from '@lobechat/electron-client-ipc';
 import { app } from 'electron';
 
+import { collectRendererGarbage, startIdleRendererGc } from '@/utils/idleRendererGc';
 import { getIpcContext } from '@/utils/ipc';
 import { parseMemoryDump, type TraceEvent } from '@/utils/memoryDump';
 
@@ -58,11 +59,24 @@ export default class DevtoolsCtr extends ControllerModule {
     };
   }
 
+  private rendererSender(what: string) {
+    const contents = getIpcContext()?.sender;
+    if (!contents) throw new Error(`${what} needs a renderer sender`);
+    return contents;
+  }
+
+  @IpcMethod()
+  async collectRendererGarbage(): Promise<void> {
+    await collectRendererGarbage(this.rendererSender('garbage collection'));
+  }
+
+  afterFirstFrame() {
+    startIdleRendererGc();
+  }
+
   @IpcMethod()
   async captureMemoryDump(): Promise<MemoryDump> {
-    const contents = getIpcContext()?.sender;
-    if (!contents) throw new Error('memory dump needs a renderer sender');
-
+    const contents = this.rendererSender('memory dump');
     const dbg = contents.debugger;
     const attachedHere = !dbg.isAttached();
     if (attachedHere) dbg.attach('1.3');

--- a/apps/desktop/src/main/controllers/__tests__/DevtoolsCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/DevtoolsCtr.test.ts
@@ -14,6 +14,7 @@ const { getAppMetricsMock, getGPUFeatureStatusMock, getGPUInfoMock, ipcMainHandl
   }));
 
 vi.mock('electron', () => ({
+  BrowserWindow: {},
   app: {
     getAppMetrics: getAppMetricsMock,
     getGPUFeatureStatus: getGPUFeatureStatusMock,
@@ -151,6 +152,43 @@ describe('DevtoolsCtr', () => {
           devtoolsCtr.getAppProcessMetrics(),
         ),
       ).resolves.toMatchObject({ cpuPercent: 3, gpu: null, rendererResidentMB: 8 });
+    });
+  });
+
+  describe('collectRendererGarbage', () => {
+    it('should run HeapProfiler.collectGarbage over a debugger it attaches and detaches', async () => {
+      const dbg = {
+        attach: vi.fn(),
+        detach: vi.fn(),
+        isAttached: () => false,
+        sendCommand: vi.fn(async () => ({})),
+      };
+      const sender = { debugger: dbg } as any;
+
+      await runWithIpcContext({ event: { sender } as any, sender }, () =>
+        devtoolsCtr.collectRendererGarbage(),
+      );
+
+      expect(dbg.sendCommand).toHaveBeenCalledWith('HeapProfiler.collectGarbage');
+      expect(dbg.attach).toHaveBeenCalledWith('1.3');
+      expect(dbg.detach).toHaveBeenCalledOnce();
+    });
+
+    it('should leave an already attached debugger attached', async () => {
+      const dbg = {
+        attach: vi.fn(),
+        detach: vi.fn(),
+        isAttached: () => true,
+        sendCommand: vi.fn(async () => ({})),
+      };
+      const sender = { debugger: dbg } as any;
+
+      await runWithIpcContext({ event: { sender } as any, sender }, () =>
+        devtoolsCtr.collectRendererGarbage(),
+      );
+
+      expect(dbg.attach).not.toHaveBeenCalled();
+      expect(dbg.detach).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/utils/__tests__/idleRendererGc.test.ts
+++ b/apps/desktop/src/main/utils/__tests__/idleRendererGc.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createIdleRendererGcTick,
+  IDLE_GC_COOLDOWN_MS,
+  IDLE_GC_RESIDENT_BYTES,
+} from '../idleRendererGc';
+
+vi.mock('electron', () => ({ BrowserWindow: {}, app: {} }));
+
+const GB = 1024 ** 3;
+
+const makeWindow = (pid: number) =>
+  ({ webContents: { getOSProcessId: () => pid, isDestroyed: () => false } }) as any;
+
+const setup = (overrides: { focused?: boolean; resident?: number } = {}) => {
+  const collect = vi.fn(async () => {});
+  let now = 0;
+  const tick = createIdleRendererGcTick({
+    collect,
+    getFocusedWindow: () => (overrides.focused ? ({} as any) : null),
+    getResidentBytes: () => new Map([[42, overrides.resident ?? 2 * GB]]),
+    getWindows: () => [makeWindow(42)],
+    now: () => now,
+  });
+  return { advance: (ms: number) => (now += ms), collect, tick };
+};
+
+describe('createIdleRendererGcTick', () => {
+  it('collects a heavy renderer only after two consecutive idle ticks', async () => {
+    const { collect, tick } = setup();
+    await tick();
+    expect(collect).not.toHaveBeenCalled();
+    await tick();
+    expect(collect).toHaveBeenCalledOnce();
+  });
+
+  it('resets the idle streak when a window is focused', async () => {
+    const collect = vi.fn(async () => {});
+    let focused = false;
+    const tick = createIdleRendererGcTick({
+      collect,
+      getFocusedWindow: () => (focused ? ({} as any) : null),
+      getResidentBytes: () => new Map([[42, 2 * GB]]),
+      getWindows: () => [makeWindow(42)],
+      now: () => 0,
+    });
+    await tick();
+    focused = true;
+    await tick();
+    focused = false;
+    await tick();
+    expect(collect).not.toHaveBeenCalled();
+  });
+
+  it('skips renderers below the resident threshold', async () => {
+    const { collect, tick } = setup({ resident: IDLE_GC_RESIDENT_BYTES - 1 });
+    await tick();
+    await tick();
+    expect(collect).not.toHaveBeenCalled();
+  });
+
+  it('honours the per-renderer cooldown', async () => {
+    const { advance, collect, tick } = setup();
+    await tick();
+    await tick();
+    advance(IDLE_GC_COOLDOWN_MS - 1);
+    await tick();
+    expect(collect).toHaveBeenCalledOnce();
+    advance(1);
+    await tick();
+    expect(collect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/utils/idleRendererGc.ts
+++ b/apps/desktop/src/main/utils/idleRendererGc.ts
@@ -1,0 +1,84 @@
+import type { WebContents } from 'electron';
+import { app, BrowserWindow } from 'electron';
+
+import { createLogger } from '@/utils/logger';
+
+const logger = createLogger('utils:idleRendererGc');
+
+export const IDLE_GC_RESIDENT_BYTES = 1.5 * 1024 ** 3;
+export const IDLE_GC_TICK_MS = 30_000;
+export const IDLE_GC_COOLDOWN_MS = 5 * 60_000;
+
+// HeapProfiler.collectGarbage is the DevTools trash icon: a full V8 + Oilpan GC that
+// also decommits the freed blink_gc pages, which plain window.gc() does not.
+export const collectRendererGarbage = async (contents: WebContents) => {
+  const dbg = contents.debugger;
+  const attachedHere = !dbg.isAttached();
+  if (attachedHere) dbg.attach('1.3');
+  try {
+    await dbg.sendCommand('HeapProfiler.collectGarbage');
+  } finally {
+    if (attachedHere) dbg.detach();
+  }
+};
+
+interface IdleRendererGcDeps {
+  collect: (contents: WebContents) => Promise<void>;
+  getFocusedWindow: () => BrowserWindow | null;
+  getResidentBytes: () => Map<number, number>;
+  getWindows: () => BrowserWindow[];
+  now: () => number;
+}
+
+const defaultDeps: IdleRendererGcDeps = {
+  collect: collectRendererGarbage,
+  getFocusedWindow: () => BrowserWindow.getFocusedWindow(),
+  getResidentBytes: () =>
+    new Map(app.getAppMetrics().map((m) => [m.pid, m.memory.workingSetSize * 1024])),
+  getWindows: () => BrowserWindow.getAllWindows(),
+  now: Date.now,
+};
+
+export const createIdleRendererGcTick = (deps: Partial<IdleRendererGcDeps> = {}) => {
+  const { collect, getFocusedWindow, getResidentBytes, getWindows, now } = {
+    ...defaultDeps,
+    ...deps,
+  };
+  let idleTicks = 0;
+  const lastRunAt = new Map<number, number>();
+
+  return async () => {
+    if (getFocusedWindow()) {
+      idleTicks = 0;
+      return;
+    }
+    if (++idleTicks < 2) return;
+
+    const resident = getResidentBytes();
+    const renderers = new Map<number, WebContents>();
+    for (const win of getWindows()) {
+      if (!win.webContents.isDestroyed()) {
+        renderers.set(win.webContents.getOSProcessId(), win.webContents);
+      }
+    }
+
+    for (const [pid, contents] of renderers) {
+      const bytes = resident.get(pid) ?? 0;
+      if (bytes < IDLE_GC_RESIDENT_BYTES) continue;
+      const last = lastRunAt.get(pid);
+      if (last !== undefined && now() - last < IDLE_GC_COOLDOWN_MS) continue;
+      lastRunAt.set(pid, now());
+      try {
+        await collect(contents);
+        logger.info(`Collected renderer ${pid} garbage while idle (resident ${bytes} bytes)`);
+      } catch (error) {
+        logger.warn(`Idle GC failed for renderer ${pid}`, error);
+      }
+    }
+  };
+};
+
+export const startIdleRendererGc = () => {
+  const timer = setInterval(createIdleRendererGcTick(), IDLE_GC_TICK_MS);
+  return () => clearInterval(timer);
+};

--- a/src/features/DevDock/widgets/MemoryPopover/index.tsx
+++ b/src/features/DevDock/widgets/MemoryPopover/index.tsx
@@ -96,17 +96,23 @@ const Breakdown = memo(() => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const capture = async () => {
+  const run = async (task: () => Promise<void>) => {
     setLoading(true);
     setError(null);
     try {
-      setDump(await electronDevtoolsService.captureMemoryDump());
+      await task();
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setLoading(false);
     }
   };
+  const capture = () => run(async () => setDump(await electronDevtoolsService.captureMemoryDump()));
+  const collectGarbage = () =>
+    run(async () => {
+      await electronDevtoolsService.collectRendererGarbage();
+      setDump(await electronDevtoolsService.captureMemoryDump());
+    });
 
   const [caller, ...others] = dump?.processes ?? [];
 
@@ -121,6 +127,9 @@ const Breakdown = memo(() => {
         </span>
         <span style={{ flex: 1 }} />
         {error && <span className={cx(styles.error, styles.mono)}>{error}</span>}
+        <Button disabled={loading} size={'small'} onClick={collectGarbage}>
+          {'GC'}
+        </Button>
         <Button loading={loading} size={'small'} onClick={capture}>
           {dump ? 'Re-capture' : 'Capture'}
         </Button>

--- a/src/services/electron/devtools.ts
+++ b/src/services/electron/devtools.ts
@@ -11,6 +11,10 @@ class DevtoolsService {
     return ensureElectronIpc().devtools.getAppProcessMetrics();
   }
 
+  async collectRendererGarbage(): Promise<void> {
+    return ensureElectronIpc().devtools.collectRendererGarbage();
+  }
+
   async captureMemoryDump(): Promise<MemoryDump> {
     return ensureElectronIpc().devtools.captureMemoryDump();
   }


### PR DESCRIPTION
The desktop renderer sits at ~3G private while a memory-infra dump shows `blink_gc/main/heap` at 1.7G with only ~370M of live objects: Oilpan keeps freed pages committed after large DOM churn. A DevTools "Collect garbage" (`HeapProfiler.collectGarbage`) drops it back to a few hundred MB, so this runs that same command:

- **Idle auto GC** (`apps/desktop/src/main/utils/idleRendererGc.ts`): main-process 30s tick; when no window has focus for two consecutive ticks and a renderer exceeds 1.5G resident, attach the CDP debugger, run `HeapProfiler.collectGarbage`, detach. 5 min cooldown per renderer. Started from `DevtoolsCtr.afterFirstFrame`.
- **Manual GC button** in DevDock → Memory → Breakdown, which re-captures the dump afterwards so the before/after is visible in place.

Only `collectGarbage` is issued (no `Memory.simulatePressureNotification`); verified manually that the plain collect already decommits the blink_gc slack.

| Before | After |
| ------ | ----- |
| blink_gc/main/heap 1.7G, private ~3.0G | drops to live-object size after GC |

#### Test

- [x] Tested locally
- [x] Added/updated tests (`idleRendererGc.test.ts`: two-tick idle gate, focus reset, threshold, cooldown; `DevtoolsCtr.test.ts`: IPC attach/detach)
- [ ] No tests needed

- Acceptance: pending — draft until a round is published.

#### 🔗 Related Issue

None.

https://claude.ai/code/session_01Y6cR5U6xxfWWwJHzeeV5Sa