### PR TITLE
💄 style(nav-panel): fade the title under hover actions instead of painting a row-colored plate

### DIFF
--- a/src/features/NavPanel/components/NavItem.tsx
+++ b/src/features/NavPanel/components/NavItem.tsx
@@ -21,8 +21,10 @@ const styles = createStaticStyles(({ css }) => ({
     overflow: hidden;
     min-width: 32px;
 
+    /* focus-visible, not focus-within: closing a dropdown hands focus back to its
+       trigger, which would pin the actions open after the pointer has left. */
     &:hover,
-    &:has(.${ACTION_CLASS_NAME}:focus-within),
+    &:has(.${ACTION_CLASS_NAME} :focus-visible),
     &:has([data-popup-open]) {
       .${ACTION_CLASS_NAME} {
         pointer-events: auto;

--- a/src/features/NavPanel/components/NavItem.tsx
+++ b/src/features/NavPanel/components/NavItem.tsx
@@ -13,34 +13,34 @@ import { isModifierClick } from '@/utils/navigation';
 import { type LazyActions, useLazyActions } from './useLazyActions';
 
 const ACTION_CLASS_NAME = 'nav-item-actions';
+const CONTENT_CLASS_NAME = 'nav-item-content';
 
 const styles = createStaticStyles(({ css }) => ({
   container: css`
-    --nav-item-fill: transparent;
-
     user-select: none;
     overflow: hidden;
     min-width: 32px;
 
-    &:hover {
-      --nav-item-fill: ${cssVar.colorFillTertiary};
-
+    &:hover,
+    &:has(.${ACTION_CLASS_NAME}:focus-within),
+    &:has([data-popup-open]) {
       .${ACTION_CLASS_NAME} {
         pointer-events: auto;
         opacity: 1;
       }
-    }
 
-    &[data-active='true'] {
-      --nav-item-fill: ${cssVar.colorFillTertiary};
-
-      &:hover {
-        --nav-item-fill: ${cssVar.colorFillSecondary};
+      /* Fade the covered text itself instead of painting a row-colored plate over it,
+         so the overlay matches any row background (hover / active / none). */
+      .${CONTENT_CLASS_NAME} {
+        mask-image: linear-gradient(
+          to right,
+          #000 calc(100% - 56px),
+          transparent calc(100% - 28px)
+        );
       }
     }
 
-    /* Overlay instead of in-flow so revealing the actions never re-truncates the
-       title. The gradient fades the covered text into the row background. */
+    /* Overlay instead of in-flow so revealing the actions never re-truncates the title. */
     .${ACTION_CLASS_NAME} {
       pointer-events: none;
 
@@ -48,18 +48,9 @@ const styles = createStaticStyles(({ css }) => ({
       inset-block: 0;
       inset-inline-end: 0;
 
-      padding-inline: 24px 6px;
+      padding-inline-end: 6px;
 
       opacity: 0;
-      background:
-        linear-gradient(to right, transparent 0, var(--nav-item-fill) 24px),
-        linear-gradient(to right, transparent 0, ${cssVar.colorBgLayout} 24px);
-
-      &:has([data-popup-open]),
-      &:focus-within {
-        pointer-events: auto;
-        opacity: 1;
-      }
     }
   `,
 }));
@@ -173,7 +164,6 @@ const NavItem = memo<NavItemProps>(
         align={'center'}
         className={cx(styles.container, className)}
         clickable={!disabled}
-        data-active={active}
         gap={8}
         height={description ? undefined : 36}
         paddingBlock={description ? 8 : undefined}
@@ -213,7 +203,14 @@ const NavItem = memo<NavItemProps>(
         )}
 
         {iconPostfix}
-        <Flexbox horizontal align={'center'} flex={1} gap={8} style={{ overflow: 'hidden' }}>
+        <Flexbox
+          horizontal
+          align={'center'}
+          className={CONTENT_CLASS_NAME}
+          flex={1}
+          gap={8}
+          style={{ overflow: 'hidden' }}
+        >
           {titlePrefix}
           {description ? (
             <Flexbox flex={1} gap={3} style={{ overflow: 'hidden' }}>


### PR DESCRIPTION
Follow-up to #19493. The hover-actions overlay painted a gradient plate composed from `--nav-item-fill` over `colorBgLayout`, guessing the row's composite color. Wherever the sidebar background is not `colorBgLayout` (e.g. the dark desktop sidebar) the plate rendered as a black block over the title.

Replace the plate with a `mask-image` on the row content: the title / extra text fades out in the last 28px before the actions, and the actions container has no background at all. This matches any row state (hover, active, active+hover, none) without knowing the fill or base colors, so the `--nav-item-fill` / `data-active` plumbing goes away.

| Before | After |
| ------ | ----- |
| black plate over the title on a dark sidebar | text fades into whatever the row background is |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Acceptance: skipped per author — pure CSS fix (mask fade replacing a gradient plate); the only practical assertion would match stylesheet source strings.

#### 🔗 Related Issue

Related to #19493

https://claude.ai/code/session_017Y2Ya2GtF2hWFAh63kjhhH
