### PR TITLE
🐛 fix(desktop): apply renderer OTA reliably

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -87,6 +87,7 @@ export default class Browser {
 
   private _browserWindow?: BrowserWindow;
   private hasPresentedFirstFrame = false;
+  private ignoreNextPreventUnload = false;
   private resolveFirstFrame!: () => void;
   private readonly firstFramePromise = new Promise<void>((resolve) => {
     this.resolveFirstFrame = resolve;
@@ -105,6 +106,17 @@ export default class Browser {
     if (this._browserWindow?.isDestroyed()) return null;
     return this._browserWindow?.webContents ?? null;
   }
+
+  reloadIgnoringCache = (ignoreBeforeUnload = false) => {
+    const webContents = this.browserWindow.webContents;
+    this.ignoreNextPreventUnload = ignoreBeforeUnload;
+    try {
+      webContents.reloadIgnoringCache();
+    } catch (error) {
+      this.ignoreNextPreventUnload = false;
+      throw error;
+    }
+  };
 
   // ==================== Constructor ====================
 
@@ -324,12 +336,17 @@ export default class Browser {
 
   private setupWillPreventUnloadListener(browserWindow: BrowserWindow): void {
     logger.debug(`[${this.identifier}] Setting up 'will-prevent-unload' event listener.`);
+    browserWindow.webContents.on('did-start-loading', () => {
+      this.ignoreNextPreventUnload = false;
+    });
     browserWindow.webContents.on('will-prevent-unload', (event) => {
       logger.debug(
         `[${this.identifier}] 'will-prevent-unload' fired. isQuiting: ${this.app.isQuiting}`,
       );
-      if (this.app.isQuiting) {
-        logger.info(`[${this.identifier}] App is quitting, ignoring beforeunload cancellation.`);
+      const ignorePreventUnload = this.ignoreNextPreventUnload;
+      this.ignoreNextPreventUnload = false;
+      if (this.app.isQuiting || ignorePreventUnload) {
+        logger.info(`[${this.identifier}] Ignoring beforeunload cancellation.`);
         event.preventDefault();
       }
     });

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -43,6 +43,7 @@ const {
     webContents: {
       ipc: { once: vi.fn() },
       openDevTools: vi.fn(),
+      reloadIgnoringCache: vi.fn(),
       send: vi.fn(),
       session: {
         webRequest: {
@@ -941,6 +942,20 @@ describe('Browser', () => {
       willPreventUnloadHandler(mockEvent);
 
       expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should bypass beforeunload once for a renderer OTA reload', () => {
+      const reloadEvent = { preventDefault: vi.fn() };
+      const laterEvent = { preventDefault: vi.fn() };
+      mockBrowserWindow.webContents.reloadIgnoringCache.mockImplementationOnce(() => {
+        willPreventUnloadHandler(reloadEvent);
+      });
+
+      browser.reloadIgnoringCache(true);
+      willPreventUnloadHandler(laterEvent);
+
+      expect(reloadEvent.preventDefault).toHaveBeenCalledOnce();
+      expect(laterEvent.preventDefault).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/RendererUpdateManager.ts
@@ -232,7 +232,7 @@ export class RendererUpdateManager {
     this.stagedManifest = null;
     this.state = 'idle';
     this.applyServingRoot();
-    this.reloadAllWindows();
+    this.reloadAllWindows(true);
     // Hot apply is an in-place reload from local disk: the bundle must
     // evaluate within seconds, so a missing load ping fails fast. Cold-boot
     // arming (initialize) keeps only the long mount timeout.
@@ -336,7 +336,7 @@ export class RendererUpdateManager {
       reason = 'notification-failed';
       this.app.browserManager.broadcastToAllWindows('updateReady', {
         kind: 'renderer',
-        version: manifest.appVersion,
+        version: `${manifest.appVersion}_${manifest.version}`,
       });
       outcome = 'staged';
       reason = 'staged';
@@ -651,10 +651,10 @@ export class RendererUpdateManager {
     });
   }
 
-  private reloadAllWindows() {
+  private reloadAllWindows(ignoreBeforeUnload = false) {
     this.app.browserManager.browsers.forEach((browser) => {
       try {
-        browser.browserWindow.webContents.reloadIgnoringCache();
+        browser.reloadIgnoringCache(ignoreBeforeUnload);
       } catch {
         /* window may be destroyed */
       }

--- a/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/rendererOta/__tests__/RendererUpdateManager.int.test.ts
@@ -230,7 +230,7 @@ describe('RendererUpdateManager V2 lifecycle', () => {
       expect(manager.getStatus().staged).toBe('r1');
       expect(app.browserManager.broadcastToAllWindows).toHaveBeenCalledWith('updateReady', {
         kind: 'renderer',
-        version: APP_VERSION,
+        version: `${APP_VERSION}_r1`,
       });
     },
   );
@@ -282,7 +282,7 @@ describe('RendererUpdateManager V2 lifecycle', () => {
     const app = makeApp();
     const reloadIgnoringCache = vi.fn();
     app.browserManager.browsers.set('app', {
-      browserWindow: { webContents: { reloadIgnoringCache } },
+      reloadIgnoringCache,
     });
     const manager = await loadManager(app);
     manager.initialize();
@@ -306,7 +306,7 @@ describe('RendererUpdateManager V2 lifecycle', () => {
     );
     expect(app.browserManager.broadcastToAllWindows).toHaveBeenCalledWith('updateReady', {
       kind: 'renderer',
-      version: APP_VERSION,
+      version: `${APP_VERSION}_r1`,
     });
     const fetchedUrls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]);
     expect(fetchedUrls).toEqual([
@@ -316,7 +316,7 @@ describe('RendererUpdateManager V2 lifecycle', () => {
     expect(fetchedUrls.some((url: string) => url.includes('/renderer/files/'))).toBe(false);
 
     expect(manager.applyStagedNow()).toBe(true);
-    expect(reloadIgnoringCache).toHaveBeenCalledOnce();
+    expect(reloadIgnoringCache).toHaveBeenCalledWith(true);
     expect(
       readFileSync(path.join(otaDir, 'versions', 'r1', 'apps', 'desktop', 'index.html'), 'utf8'),
     ).toBe(entryHtml('v1'));

--- a/locales/en-US/electron.json
+++ b/locales/en-US/electron.json
@@ -155,6 +155,8 @@
   "updater.later": "Later",
   "updater.newVersionAvailable": "New version available",
   "updater.newVersionAvailableDesc": "A new version {{version}} has been found, would you like to download it now?",
+  "updater.rendererReady": "Version {{version}} is ready",
+  "updater.rendererUpdateError": "Couldn't install the update. Try again.",
   "updater.restartAndInstall": "Install updates and restart",
   "updater.updateError": "Update error",
   "updater.updateReady": "A new version is available",

--- a/locales/zh-CN/electron.json
+++ b/locales/zh-CN/electron.json
@@ -155,6 +155,8 @@
   "updater.later": "稍后",
   "updater.newVersionAvailable": "新版本可用",
   "updater.newVersionAvailableDesc": "发现新版本 {{version}}，是否立即下载？",
+  "updater.rendererReady": "新版本 {{version}} 已就绪",
+  "updater.rendererUpdateError": "更新失败，请重试。",
   "updater.restartAndInstall": "安装更新并重启",
   "updater.updateError": "更新错误",
   "updater.updateReady": "有新版本可用",

--- a/packages/locales/src/default/electron.ts
+++ b/packages/locales/src/default/electron.ts
@@ -158,6 +158,8 @@ export default {
   'updater.newVersionAvailable': 'New version available',
   'updater.newVersionAvailableDesc':
     'A new version {{version}} has been found, would you like to download it now?',
+  'updater.rendererReady': 'Version {{version}} is ready',
+  'updater.rendererUpdateError': "Couldn't install the update. Try again.",
   'updater.restartAndInstall': 'Install updates and restart',
   'updater.updateError': 'Update error',
   'updater.updateReady': 'A new version is available',

--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -1,7 +1,7 @@
 import type { UpdateInfo } from '@lobechat/electron-client-ipc';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { Flexbox, Icon, Markdown } from '@lobehub/ui';
-import { Button as BaseButton, createModal, useModalContext } from '@lobehub/ui/base-ui';
+import { Button as BaseButton, createModal, toast, useModalContext } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { t } from 'i18next';
 import { X } from 'lucide-react';
@@ -158,18 +158,26 @@ export const UpdateNotification: React.FC = () => {
   if (updateInfo?.kind === 'renderer') {
     return (
       <div className={styles.installLaterToast}>
-        <span>
-          {tElectron('updater.updateReady')}
-          {isDevMode && updateInfo.version ? ` · ${updateInfo.version}` : ''}
-        </span>
+        <span>{tElectron('updater.rendererReady', { version: updateInfo.version })}</span>
         <BaseButton size={'small'} type={'text'} onClick={() => setUpdateInfo(null)}>
           {tElectron('updater.ignore')}
         </BaseButton>
         <BaseButton
+          loading={isInstalling}
           size={'small'}
           type={'primary'}
-          onClick={() => {
-            rendererOtaService.applyNow().catch(() => {});
+          onClick={async () => {
+            setIsInstalling(true);
+            try {
+              if (!(await rendererOtaService.applyNow())) {
+                toast.error(tElectron('updater.rendererUpdateError'));
+              }
+            } catch (error) {
+              console.error('Failed to apply renderer update:', error);
+              toast.error(tElectron('updater.rendererUpdateError'));
+            } finally {
+              setIsInstalling(false);
+            }
           }}
         >
           {tElectron('updater.upgradeNow')}


### PR DESCRIPTION
Fixes two renderer OTA issues:

- allow an explicitly applying renderer OTA to pass Electron's `beforeunload` guard while preserving normal navigation protection;
- display the actual composite target version (`appVersion_rendererRevision`, for example `2.2.18-canary.6_r7`) instead of repeating the installed App version;
- show progress and an actionable error when applying the staged renderer fails.

| Before | After |
| ------ | ----- |
| `2.2.18-canary.6` → `2.2.18-canary.6`, and unsent input could block the reload | `2.2.18-canary.6` → `2.2.18-canary.6_r7`; only the OTA reload bypasses `beforeunload` |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check` on the 8 touched files: lint clean, 81 tests passed
- `npm run build:main`: passed
- Isolated Electron 43.2.0: signed feed staged `r3`; the visible toast rendered `Version 0.0.0_r3 is ready` with `Update now`
- Real renderer OTA reload with unsent input: `will-prevent-unload` fired, was bypassed only while applying, and the new renderer reached `boot-confirmed`
- Acceptance: https://app.lobehub.com/acceptance/4a071685-5a8f-4746-8054-2a85e0a5222c

Note: the first acceptance round covers the reload path. The corrected composite-version screenshot was verified locally; its upload is pending because the Acceptance workspace currently rejects binary evidence with `storage_block:overage_not_enabled`.

#### 🔗 Related Issue

N/A
